### PR TITLE
embedding delete fix

### DIFF
--- a/services/nodejs/apps/src/modules/knowledge_base/services/records_events.service.ts
+++ b/services/nodejs/apps/src/modules/knowledge_base/services/records_events.service.ts
@@ -7,7 +7,7 @@ import { KafkaConfig, KafkaMessage } from '../../../libs/types/kafka.types';
 export enum EventType {
   NewRecordEvent = 'newRecord',
   UpdateRecordEvent = 'updateRecord',
-  DeletedRecordEvent = 'deletedRecord',
+  DeletedRecordEvent = 'deleteRecord',
   ReindexRecordEvent = 'reindexRecord'
 }
 

--- a/services/python/app/events/events.py
+++ b/services/python/app/events/events.py
@@ -157,12 +157,6 @@ class EventProcessor:
                 self.logger.error("❌ No record ID provided in event data")
                 return
 
-            # Handle delete event
-            if event_type == EventTypes.DELETE_RECORD.value:
-                self.logger.info(f"🗑️ Deleting embeddings for record {record_id}")
-                await self.processor.indexing_pipeline.delete_embeddings(record_id)
-                return
-
             # For both create and update events, we need to process the document
             if event_type == EventTypes.UPDATE_RECORD.value:
                 # For updates, first delete existing embeddings

--- a/services/python/app/services/kafka_consumer.py
+++ b/services/python/app/services/kafka_consumer.py
@@ -15,6 +15,7 @@ from app.config.configuration_service import (
 )
 from app.config.utils.named_constants.arangodb_constants import (
     CollectionNames,
+    EventTypes,
     ProgressStatus,
 )
 from app.exceptions.indexing_exceptions import IndexingError
@@ -179,6 +180,12 @@ class KafkaConsumerManager:
                 f"Processing record {record_id} with event type: {event_type}. "
                 f"Message ID: {message_id}"
             )
+
+            # Handle delete event
+            if event_type == EventTypes.DELETE_RECORD.value:
+                self.logger.info(f"🗑️ Deleting embeddings for record {record_id}")
+                await self.event_processor.processor.indexing_pipeline.delete_embeddings(record_id)
+                return True
 
             # Signed URL handling
             if payload_data and payload_data.get("signedUrlRoute"):


### PR DESCRIPTION
Moved delete embedding method call 
from events.py to kafka_consumer.py 
for removing unnecessary requirement of signedurl for deletion.

also changed named constant in node. deletedRecord -> deleteRecord