### PR TITLE
[ISSUE-578] PDF render bugfix

### DIFF
--- a/backend/nodejs/apps/src/app.ts
+++ b/backend/nodejs/apps/src/app.ts
@@ -50,6 +50,7 @@ import { registerStorageSwagger } from './modules/storage/docs/swagger';
 import { CrawlingManagerContainer } from './modules/crawling_manager/container/cm_container';
 import createCrawlingManagerRouter from './modules/crawling_manager/routes/cm_routes';
 import { MigrationService } from './modules/configuration_manager/services/migration.service';
+import { createStreamRouter } from './modules/knowledge_base/routes/kb.routes';
 
 const loggerConfig = {
   service: 'Application',
@@ -349,6 +350,11 @@ export class Application {
     this.app.use(
       '/api/v1/crawlingManager',
       createCrawlingManagerRouter(this.crawlingManagerContainer),
+    );
+
+    this.app.use(
+      '/api/v1/stream',
+      createStreamRouter(this.knowledgeBaseContainer),
     );
   }
 

--- a/backend/nodejs/apps/src/app.ts
+++ b/backend/nodejs/apps/src/app.ts
@@ -329,6 +329,12 @@ export class Application {
       createConnectorRouter(this.tokenManagerContainer),
     );
 
+    // streaming route
+    this.app.use(
+      '/api/v1/stream',
+      createStreamRouter(this.knowledgeBaseContainer),
+    );
+
     // knowledge base routes
     this.app.use(
       '/api/v1/knowledgeBase',
@@ -350,11 +356,6 @@ export class Application {
     this.app.use(
       '/api/v1/crawlingManager',
       createCrawlingManagerRouter(this.crawlingManagerContainer),
-    );
-
-    this.app.use(
-      '/api/v1/stream',
-      createStreamRouter(this.knowledgeBaseContainer),
     );
   }
 

--- a/backend/nodejs/apps/src/modules/knowledge_base/routes/kb.routes.ts
+++ b/backend/nodejs/apps/src/modules/knowledge_base/routes/kb.routes.ts
@@ -362,3 +362,19 @@ export function createKnowledgeBaseRouter(container: Container): Router {
 
   return router;
 }
+
+export function createStreamRouter(container: Container): Router {
+  const router = Router();
+  const appConfig = container.get<AppConfig>('AppConfig');
+  const authMiddleware = container.get<AuthMiddleware>('AuthMiddleware');
+
+  router.get(
+    '/record/:recordId',
+    authMiddleware.authenticate,
+    metricsMiddleware(container),
+    ValidationMiddleware.validate(getRecordByIdSchema),
+    getRecordBuffer(appConfig.connectorBackend),
+  );
+
+  return router;
+}

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -78,6 +78,7 @@ services:
     volumes:
       - pipeshub_data:/data/pipeshub
       - pipeshub_root_local:/root/.local
+      - ../../frontend:/app/frontend
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -90,7 +91,7 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
     volumes:
-      - mongodb_data:/data/db
+      - ../../data/mongodb_data:/data/db
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 5s
@@ -107,7 +108,7 @@ services:
     command: >
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}
     volumes:
-      - redis_data:/data
+      - ../../data/redis_data:/data
 
   arango:
     image: arangodb:3.12.4
@@ -117,7 +118,7 @@ services:
     environment:
       - ARANGO_ROOT_PASSWORD=${ARANGO_PASSWORD:-your_password}
     volumes:
-      - arango_data:/var/lib/arangodb3
+      - ../../data/arango_data:/var/lib/arangodb3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8529/_api/version"]
       interval: 5s
@@ -140,7 +141,7 @@ services:
       --initial-advertise-peer-urls http://0.0.0.0:2380
       --initial-cluster etcd-node=http://0.0.0.0:2380
     volumes:
-      - etcd_data:/etcd-data
+      - ../../data/etcd_data:/etcd-data
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.9.0
@@ -182,7 +183,7 @@ services:
     environment:
       - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY:-your_qdrant_secret_api_key}
     volumes:
-      - qdrant_storage:/qdrant/storage
+      - ../../data/qdrant_storage:/qdrant/storage
     ulimits:
       nofile:
         soft: 50000

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -91,7 +91,7 @@ services:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
     volumes:
-      - ../../data/mongodb_data:/data/db
+      - mongodb_data:/data/db
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 5s
@@ -108,7 +108,7 @@ services:
     command: >
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}
     volumes:
-      - ../../data/redis_data:/data
+      - redis_data:/data
 
   arango:
     image: arangodb:3.12.4
@@ -118,7 +118,7 @@ services:
     environment:
       - ARANGO_ROOT_PASSWORD=${ARANGO_PASSWORD:-your_password}
     volumes:
-      - ../../data/arango_data:/var/lib/arangodb3
+      - arango_data:/var/lib/arangodb3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8529/_api/version"]
       interval: 5s
@@ -141,7 +141,7 @@ services:
       --initial-advertise-peer-urls http://0.0.0.0:2380
       --initial-cluster etcd-node=http://0.0.0.0:2380
     volumes:
-      - ../../data/etcd_data:/etcd-data
+      - etcd_data:/etcd-data
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.9.0
@@ -183,7 +183,7 @@ services:
     environment:
       - QDRANT__SERVICE__API_KEY=${QDRANT_API_KEY:-your_qdrant_secret_api_key}
     volumes:
-      - ../../data/qdrant_storage:/qdrant/storage
+      - qdrant_storage:/qdrant/storage
     ulimits:
       nofile:
         soft: 50000

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -10,7 +10,7 @@ services:
       - "8088:8088"
       - "3000:3000"
       - "8001:8000"
-      - "80:3000"
+
     environment:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-development}
@@ -19,10 +19,7 @@ services:
 
       # Security settings - allow override with custom secret
       - SECRET_KEY=${SECRET_KEY:-your_random_encryption_secret_key}
-      - JWT_ALGORITHM=HS256
-      - SECRET_KEYS=["your_random_encryption_secret_key"]   # JSON array
-      - SCOPED_JWT_SECRET=your_random_encryption_secret_key
-
+      
       # Public endpoints
       - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-https://orisonenterprise.ngrok.app}
       - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-https://orisonenterprise.ngrok.app}

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -23,6 +23,8 @@ services:
       # Public endpoints
       - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-https://orisonenterprise.ngrok.app}
       - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-https://orisonenterprise.ngrok.app}
+      - GOOGLE_REDIRECT_URI=https://orisonenterprise.ngrok.app/api/v1/connectors/googleWorkspace/oauth2/callback
+      - ALLOWED_ORIGINS=https://orisonenterprise.ngrok.app
 
       # Internal service URLs
       - QUERY_BACKEND=http://localhost:8000

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -19,6 +19,9 @@ services:
 
       # Security settings - allow override with custom secret
       - SECRET_KEY=${SECRET_KEY:-your_random_encryption_secret_key}
+      - JWT_ALGORITHM=HS256
+      - SECRET_KEYS=["your_random_encryption_secret_key"]   # JSON array
+      - SCOPED_JWT_SECRET=your_random_encryption_secret_key
 
       # Public endpoints
       - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-https://orisonenterprise.ngrok.app}

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -10,6 +10,7 @@ services:
       - "8088:8088"
       - "3000:3000"
       - "8001:8000"
+      - "80:3000"
     environment:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-development}

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   pipeshub-ai:
-    # image: pipeshub-ai:latest
+    image: pipeshub-ai:latest
     restart: always
     build:
       context: ../../
@@ -10,7 +10,6 @@ services:
       - "8088:8088"
       - "3000:3000"
       - "8001:8000"
-
     environment:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-development}
@@ -19,10 +18,10 @@ services:
 
       # Security settings - allow override with custom secret
       - SECRET_KEY=${SECRET_KEY:-your_random_encryption_secret_key}
-      
+
       # Public endpoints
-      - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-https://orisonenterprise.ngrok.app}
-      - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-https://orisonenterprise.ngrok.app}
+      - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-}
+      - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-}
 
       # Internal service URLs
       - QUERY_BACKEND=http://localhost:8000
@@ -76,7 +75,6 @@ services:
     volumes:
       - pipeshub_data:/data/pipeshub
       - pipeshub_root_local:/root/.local
-      - ../../frontend:/app/frontend
     extra_hosts:
       - "host.docker.internal:host-gateway"
 

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -23,8 +23,6 @@ services:
       # Public endpoints
       - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-https://orisonenterprise.ngrok.app}
       - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-https://orisonenterprise.ngrok.app}
-      - GOOGLE_REDIRECT_URI=https://orisonenterprise.ngrok.app/api/v1/connectors/googleWorkspace/oauth2/callback
-      - ALLOWED_ORIGINS=https://orisonenterprise.ngrok.app
 
       # Internal service URLs
       - QUERY_BACKEND=http://localhost:8000

--- a/deployment/docker-compose/docker-compose.dev.yml
+++ b/deployment/docker-compose/docker-compose.dev.yml
@@ -1,6 +1,6 @@
 services:
   pipeshub-ai:
-    image: pipeshub-ai:latest
+    # image: pipeshub-ai:latest
     restart: always
     build:
       context: ../../
@@ -21,8 +21,8 @@ services:
       - SECRET_KEY=${SECRET_KEY:-your_random_encryption_secret_key}
 
       # Public endpoints
-      - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-}
-      - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-}
+      - CONNECTOR_PUBLIC_BACKEND=${CONNECTOR_PUBLIC_BACKEND:-https://orisonenterprise.ngrok.app}
+      - FRONTEND_PUBLIC_URL=${FRONTEND_PUBLIC_URL:-https://orisonenterprise.ngrok.app}
 
       # Internal service URLs
       - QUERY_BACKEND=http://localhost:8000


### PR DESCRIPTION
Context:
Running a VM instance on google compute engine and started pipeshub using dev docker compose.
Using Ngrok to forward port 3000 on a doman url
Google workspace syncs correctly and AI query goes through with a response and citations

Issue:
Upon viewing the citation I see Error loading pdf.
I sent backend logs to cursor and it came up with the following explanation

Cursor Output:
Perfect! I found the issue. The streaming route does exist in the knowledge base routes, but it's mounted at the wrong path. Looking at the code:
// In kb.routes.ts - this route exists: router.get( '/stream/record/:recordId', authMiddleware.authenticate, metricsMiddleware(container), ValidationMiddleware.validate(getRecordByIdSchema), getRecordBuffer(appConfig.connectorBackend), );

But in your app.ts, the knowledge base routes are mounted at /api/v1/knowledgeBase, so the full path becomes:
/api/v1/knowledgeBase/stream/record/:recordId
But the frontend is calling:
/api/v1/stream/record/:recordId
The Fix
You need to add a separate route for streaming at the root level. Update your app.ts: