### PR TITLE
fix(confluence): fix user sync premature termination due to incorrect totalSize

### DIFF
--- a/backend/python/app/connectors/sources/atlassian/confluence_cloud/connector.py
+++ b/backend/python/app/connectors/sources/atlassian/confluence_cloud/connector.py
@@ -460,8 +460,9 @@ class ConfluenceConnector(BaseConnector):
                 start += batch_size
 
                 # Check if we've reached the end
-                total_size = response_data.get("totalSize", 0)
-                if start >= total_size:
+                # FIX: Do not rely on totalSize as it returns incorrect values (e.g. 100) for /search/user
+                # Instead, stop if we received fewer results than requested
+                if len(users_data) < batch_size:
                     break
 
             self.logger.info(f"✅ User sync complete. Synced: {total_synced}, Skipped (no email): {total_skipped}")


### PR DESCRIPTION
## Summary

Fixes [#1189](https://github.com/pipeshub-ai/pipeshub-ai/issues/1189)

Fixes a critical bug where Confluence user synchronization would terminate prematurely after the first batch (100 users), preventing new users from being synced and causing missing permission issues.

## Root Cause

The `_sync_users` method relied on the `totalSize` field returned by the Confluence Search API (`/wiki/rest/api/search/user`) to determine when to stop pagination.
However, this API endpoint has a known behavior where `totalSize` incorrectly reflects the number of results on the *current page* (e.g., 100) rather than the total number of matches across all pages. This caused the loop condition `if start >= total_size: break` to evaluate to true after the first page, terminating the sync.

## Changes

- Modified `backend/python/app/connectors/sources/atlassian/confluence_cloud/connector.py`:
  - Removed reliance on `totalSize` for loop termination.
  - Implemented standard pagination check: break the loop if the number of returned users is less than the requested `batch_size`.

## Verification

- **Environment**: Full clean redeploy.
- **Logs**: Verified that the user sync now iterates through multiple batches (offsets 0, 100, 200, ...).
- **Data**: Confirmed that previously missing users are now successfully present in the database.
- **Count**: Confirmed complete synchronization of all valid users (filtering out service accounts).

