### PR TITLE
Revert "Bump protobuf from 3.20.3 to 6.33.5 in /backend/python"

### DIFF
--- a/backend/python/pyproject.toml
+++ b/backend/python/pyproject.toml
@@ -90,7 +90,7 @@ dependencies = [
     "pagerduty>=5.0.0",
     "pandas==2.2.3",
     "pdf2image==1.17.0",
-    "protobuf==6.33.5",
+    "protobuf==3.20.3",
     "pydantic==2.12.5",
     "py-trello==0.20.1",
     "PyMuPDF==1.24.14",


### PR DESCRIPTION
Reverts pipeshub-ai/pipeshub-ai#1420

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency rollback may affect any code relying on `protobuf` 6.x APIs or generated stubs, but the change is isolated to a single version pin in `pyproject.toml`. Runtime risk is mostly around compatibility and serialization edge cases.
> 
> **Overview**
> Reverts the backend Python service dependency bump by pinning `protobuf` back from `6.33.5` to `3.20.3` in `backend/python/pyproject.toml`, restoring the prior Protobuf runtime version for builds and deployments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2eb004119abd2a7f11cb07f9805a0cca6980ca56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->