### PR TITLE
Fix: frontend-new/collection

### DIFF
--- a/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
+++ b/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
@@ -2232,6 +2232,26 @@ components:
         - origin
         - orgId
 
+    UpdateRecordEnrichment:
+      type: object
+      description: |
+        Fields merged into successful record-update responses (Node gateway and Local KB connector).
+      properties:
+        timestamp:
+          type: integer
+          format: int64
+          description: Epoch milliseconds when the response was generated
+        fileUpdated:
+          type: boolean
+        location:
+          type: string
+          enum: [kb_root, folder]
+        kb:
+          type: object
+          additionalProperties: true
+        userPermission:
+          type: string
+
     RecordsResponse:
       type: object
       description: Paginated response for records listing
@@ -11635,14 +11655,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                  message:
-                    type: string
-                  record:
-                    $ref: '#/components/schemas/Record'
+                allOf:
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                      message:
+                        type: string
+                      record:
+                        $ref: '#/components/schemas/Record'
+                  - $ref: '#/components/schemas/UpdateRecordEnrichment'
         '400':
           description: Invalid request
         '401':
@@ -12243,6 +12265,86 @@ paths:
                     description: Maximum file size in bytes (default 30MB)
         '401':
           description: Unauthorized
+
+  # Same contract as GET /knowledgeBase/limits (clients may use lowercase path under /api/v1)
+  /knowledgebase/limits:
+    get:
+      tags:
+        - Upload
+      summary: Get upload limits
+      description: Alias path for <code>GET /knowledgeBase/limits</code>.
+      operationId: getUploadLimitsKnowledgebaseAlias
+      security:
+        - bearerAuth: []
+        - oauth2: [kb:read]
+      responses:
+        '200':
+          description: Upload limits retrieved
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  maxFilesPerRequest:
+                    type: integer
+                    example: 1000
+                  maxFileSizeBytes:
+                    type: integer
+                    example: 31457280
+        '401':
+          description: Unauthorized
+
+  # Local KB connector — router prefix /api/v1/kb (PUT response includes UpdateRecordEnrichment)
+  /kb/record/{recordId}:
+    put:
+      tags:
+        - Records
+      summary: Update record (Local KB connector)
+      description: |
+        Python connector route <code>PUT /api/v1/kb/record/{record_id}</code>. Successful JSON body includes
+        <code>UpdateRecordEnrichment</code> (<code>timestamp</code>, <code>fileUpdated</code>, etc.).
+      operationId: updateRecordKbConnector
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: recordId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                updates:
+                  type: object
+                  additionalProperties: true
+                fileMetadata:
+                  type: object
+                  nullable: true
+                  additionalProperties: true
+      responses:
+        '200':
+          description: Record updated successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      success:
+                        type: boolean
+                  - $ref: '#/components/schemas/UpdateRecordEnrichment'
+        '400':
+          description: Invalid request
+        '401':
+          description: Unauthorized
+        '403':
+          description: Insufficient permissions
+        '404':
+          description: Record not found
 
   # -------------------- Reindex/Sync Endpoints --------------------
   /knowledgeBase/reindex/record/{recordId}:

--- a/backend/python/app/connectors/sources/localKB/api/kb_router.py
+++ b/backend/python/app/connectors/sources/localKB/api/kb_router.py
@@ -1342,6 +1342,7 @@ async def update_record(
             enriched_result = {
                 **result,
                 "fileUpdated": file_updated,
+                "timestamp": get_epoch_timestamp_in_ms(),
                 "location": location,
                 "kb": kb_info,
                 "userPermission": user_permission,
@@ -1357,6 +1358,7 @@ async def update_record(
             return {
                 **result,
                 "fileUpdated": body.get("fileMetadata") is not None,
+                "timestamp": get_epoch_timestamp_in_ms(),
                 "location": "kb_root",
                 "kb": {},
                 "userPermission": "NONE",

--- a/backend/python/app/connectors/sources/localKB/handlers/kb_service.py
+++ b/backend/python/app/connectors/sources/localKB/handlers/kb_service.py
@@ -986,6 +986,24 @@ class KnowledgeBaseService:
                 if not role or role not in valid_roles:
                     return {"success": False, "reason": f"Invalid role: {role}. Role is required for users.", "code": 400}
 
+            self.logger.info(f"Looking up requester for create_kb_permissions: {requester_id}")
+            requester = await self.graph_provider.get_user_by_user_id(user_id=requester_id)
+            if not requester:
+                self.logger.warning(f"⚠️ User not found for user_id: {requester_id}")
+                return {
+                    "success": False,
+                    "code": 404,
+                    "reason": f"User not found for user_id: {requester_id}",
+                }
+            requester_key = requester.get("id") or requester.get("_key")
+            requester_role = await self.graph_provider.get_user_kb_permission(kb_id, requester_key)
+            if requester_role not in ["OWNER"]:
+                return {
+                    "success": False,
+                    "reason": "Only KB owners can grant permissions",
+                    "code": 403,
+                }
+
             # Step 2: Single AQL query to do everything at once
             # Pass role even if only teams (it will be ignored for teams)
             result = await self.graph_provider.create_kb_permissions(

--- a/backend/python/app/services/graph_db/neo4j/neo4j_provider.py
+++ b/backend/python/app/services/graph_db/neo4j/neo4j_provider.py
@@ -8287,15 +8287,34 @@ class Neo4jProvider(IGraphDBProvider):
         user_id: str,
         transaction: str | None = None
     ) -> str | None:
-        """Get user's permission role on a knowledge base"""
+        """Get user's effective role on a KB: max(direct user edge, team-derived), same idea as Arango."""
         try:
             self.logger.info(f"🔍 Checking permissions for user {user_id} on KB {kb_id}")
 
-            # Check for direct user permission first
+            # Direct user->KB and user->team->KB both contribute; return highest-priority role (not direct-only).
             query = """
-            MATCH (u:User {id: $user_id})-[r:PERMISSION {type: "USER"}]->(kb:RecordGroup {id: $kb_id})
-            RETURN r.role AS role
+            MATCH (u:User {id: $user_id})
+            MATCH (kb:RecordGroup {id: $kb_id})
+            OPTIONAL MATCH (u)-[d:PERMISSION {type: "USER"}]->(kb)
+            WITH u, kb, d.role AS direct_role
+            OPTIONAL MATCH (u)-[ut:PERMISSION {type: "USER"}]->(team:Teams)-[tb:PERMISSION {type: "TEAM"}]->(kb)
+            WITH direct_role, collect(DISTINCT ut.role) AS team_roles
+            WITH CASE WHEN direct_role IS NOT NULL THEN [direct_role] ELSE [] END +
+                 [x IN team_roles WHERE x IS NOT NULL] AS candidates
+            UNWIND candidates AS cand
+            WITH DISTINCT cand AS role
+            WHERE role IS NOT NULL
+            WITH role,
+                 CASE role
+                   WHEN 'OWNER' THEN 4
+                   WHEN 'WRITER' THEN 3
+                   WHEN 'READER' THEN 2
+                   WHEN 'COMMENTER' THEN 1
+                   ELSE 0
+                 END AS priority
+            ORDER BY priority DESC
             LIMIT 1
+            RETURN role AS role
             """
 
             results = await self.client.execute_query(
@@ -8306,36 +8325,8 @@ class Neo4jProvider(IGraphDBProvider):
 
             if results:
                 role = results[0].get("role")
-                self.logger.info(f"✅ Found direct permission: user {user_id} has role '{role}' on KB {kb_id}")
+                self.logger.info(f"✅ Effective KB role for user {user_id} on KB {kb_id}: '{role}'")
                 return role
-
-            # If no direct permission, check via teams (Neo4j label is "Teams")
-            team_query = """
-            MATCH (u:User {id: $user_id})-[r1:PERMISSION {type: "USER"}]->(team:Teams)
-            MATCH (team)-[r2:PERMISSION {type: "TEAM"}]->(kb:RecordGroup {id: $kb_id})
-            WITH r1.role AS team_role,
-                 CASE r1.role
-                     WHEN "OWNER" THEN 4
-                     WHEN "WRITER" THEN 3
-                     WHEN "READER" THEN 2
-                     WHEN "COMMENTER" THEN 1
-                     ELSE 0
-                 END AS priority
-            ORDER BY priority DESC
-            RETURN team_role
-            LIMIT 1
-            """
-
-            team_results = await self.client.execute_query(
-                team_query,
-                parameters={"user_id": user_id, "kb_id": kb_id},
-                txn_id=transaction
-            )
-
-            if team_results:
-                team_role = team_results[0].get("team_role")
-                self.logger.info(f"✅ Found team-based permission: user {user_id} has role '{team_role}' on KB {kb_id} via teams")
-                return team_role
 
             self.logger.warning(f"⚠️ No permission found for user {user_id} on KB {kb_id}")
             return None

--- a/backend/python/tests/unit/connectors/sources/localKB/test_kb_service.py
+++ b/backend/python/tests/unit/connectors/sources/localKB/test_kb_service.py
@@ -635,6 +635,10 @@ class TestDeleteRecordsInFolder:
 class TestCreateKbPermissions:
     @pytest.mark.asyncio
     async def test_success(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(return_value={
             "success": True, "grantedCount": 2
         })
@@ -856,6 +860,10 @@ class TestDeleteRecordsInFolderException:
 class TestCreateKbPermissionsException:
     @pytest.mark.asyncio
     async def test_exception(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(side_effect=Exception("db error"))
         result = await service.create_kb_permissions("kb1", "req1", ["u1"], [], "READER")
         assert result["success"] is False

--- a/backend/python/tests/unit/connectors/sources/localKB/test_kb_service_full_coverage.py
+++ b/backend/python/tests/unit/connectors/sources/localKB/test_kb_service_full_coverage.py
@@ -920,6 +920,10 @@ class TestDeleteRecordsInFolder:
 class TestCreateKbPermissions:
     @pytest.mark.asyncio
     async def test_success_users(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(
             return_value={"success": True, "grantedCount": 2}
         )
@@ -930,6 +934,10 @@ class TestCreateKbPermissions:
 
     @pytest.mark.asyncio
     async def test_success_teams_only(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(
             return_value={"success": True, "grantedCount": 1}
         )
@@ -951,6 +959,10 @@ class TestCreateKbPermissions:
 
     @pytest.mark.asyncio
     async def test_deduplicates_users(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(
             return_value={"success": True, "grantedCount": 1}
         )
@@ -962,6 +974,10 @@ class TestCreateKbPermissions:
 
     @pytest.mark.asyncio
     async def test_service_returns_failure(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(
             return_value={"success": False, "reason": "denied"}
         )
@@ -971,6 +987,10 @@ class TestCreateKbPermissions:
 
     @pytest.mark.asyncio
     async def test_exception(self, service):
+        service.graph_provider.get_user_by_user_id = AsyncMock(
+            return_value={"id": "rk1", "_key": "rk1"}
+        )
+        service.graph_provider.get_user_kb_permission = AsyncMock(return_value="OWNER")
         service.graph_provider.create_kb_permissions = AsyncMock(side_effect=Exception("err"))
         result = await service.create_kb_permissions("kb1", "req1", ["u1"], [], "READER")
         assert result["success"] is False

--- a/frontend-new/app/(main)/@sidebar/knowledge-base/page.tsx
+++ b/frontend-new/app/(main)/@sidebar/knowledge-base/page.tsx
@@ -10,7 +10,42 @@ import { refreshKbTree } from '../../knowledge-base/utils/refresh-kb-tree';
 import { buildNavUrl, getIsAllRecordsMode } from '../../knowledge-base/utils/nav';
 import { useCallback, useMemo, Suspense, useEffect, useRef, useState } from 'react';
 import { toast } from '@/lib/store/toast-store';
-import type { NodeType, EnhancedFolderTreeNode } from '../../knowledge-base/types';
+import type { NodeType, EnhancedFolderTreeNode, CategorizedNodes } from '../../knowledge-base/types';
+
+/**
+ * Find a node in the categorized tree and return its nodeType + root KB ancestor ID.
+ * Root-level nodes (KB collections) have no rootKbId since they ARE the KB.
+ */
+function findNodeWithRootKb(
+  categorizedNodes: CategorizedNodes | null,
+  targetId: string
+): { nodeType: NodeType; rootKbId: string | null } | null {
+  if (!categorizedNodes) return null;
+
+  const searchTree = (
+    nodes: EnhancedFolderTreeNode[],
+    rootKbId: string | null
+  ): { nodeType: NodeType; rootKbId: string | null } | null => {
+    for (const node of nodes) {
+      if (node.id === targetId) {
+        return { nodeType: node.nodeType, rootKbId };
+      }
+      if (node.children?.length) {
+        // For children of a root node, the rootKbId is the root node's ID
+        const childRootKbId = rootKbId ?? node.id;
+        const found = searchTree(node.children as EnhancedFolderTreeNode[], childRootKbId);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+
+  // Root-level nodes: rootKbId is null (they are the KB themselves)
+  return (
+    searchTree(categorizedNodes.shared, null) ||
+    searchTree(categorizedNodes.private, null)
+  );
+}
 
 function KnowledgeBaseSidebarSlotContent() {
   const router = useRouter();
@@ -375,28 +410,44 @@ function KnowledgeBaseSidebarSlotContent() {
   /** Rename: call API directly (no confirmation dialog needed) */
   const handleSidebarRename = useCallback(async (nodeId: string, newName: string) => {
     try {
-      await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
-      toast.success('Collection renamed successfully');
+      // Find node in tree to determine type and root KB
+      const state = useKnowledgeBaseStore.getState();
+      const nodeInfo = findNodeWithRootKb(state.categorizedNodes, nodeId);
 
-      // Clear stale cache for breadcrumb path
+      if (nodeInfo && nodeInfo.nodeType === 'folder' && nodeInfo.rootKbId) {
+        await KnowledgeBaseApi.renameFolder(nodeInfo.rootKbId, nodeId, newName);
+        toast.success('Folder renamed successfully');
+      } else {
+        await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
+        toast.success('Collection renamed successfully');
+      }
+
+      // Clear stale cache: breadcrumb path + parent of renamed node (so re-expand shows new name)
       const currentState = useKnowledgeBaseStore.getState();
+      const cacheIdsToClear: string[] = [];
       if (currentState.tableData?.breadcrumbs) {
-        clearNodeCacheEntries(currentState.tableData.breadcrumbs.map(bc => bc.id));
+        cacheIdsToClear.push(...currentState.tableData.breadcrumbs.map(bc => bc.id));
+      }
+      if (nodeInfo?.rootKbId) {
+        cacheIdsToClear.push(nodeInfo.rootKbId);
+      }
+      if (cacheIdsToClear.length > 0) {
+        clearNodeCacheEntries(cacheIdsToClear);
       }
 
       // Refresh Collections via the KB app children (unified API call)
       await refreshKbTree(reMergeCachedChildrenIntoTree);
     } catch (error: unknown) {
       const httpError = error as { response?: { data?: { message?: string } }; message?: string };
-      toast.error(httpError?.response?.data?.message || 'Failed to rename collection');
+      toast.error(httpError?.response?.data?.message || 'Failed to rename');
       throw error;
     }
   }, [clearNodeCacheEntries, reMergeCachedChildrenIntoTree]);
 
   /** Delete: set pending action → page.tsx picks it up and opens dialog */
   const handleSidebarDelete = useCallback((nodeId: string) => {
+    const state = useKnowledgeBaseStore.getState();
     const findNodeName = (): string => {
-      const state = useKnowledgeBaseStore.getState();
       const searchTree = (nodes: EnhancedFolderTreeNode[]): string | null => {
         for (const n of nodes) {
           if (n.id === nodeId) return n.name;
@@ -413,7 +464,14 @@ function KnowledgeBaseSidebarSlotContent() {
       }
       return nodeId;
     };
-    setPendingSidebarAction({ type: 'delete', nodeId, nodeName: findNodeName() });
+    const nodeInfo = findNodeWithRootKb(state.categorizedNodes, nodeId);
+    setPendingSidebarAction({
+      type: 'delete',
+      nodeId,
+      nodeName: findNodeName(),
+      nodeType: nodeInfo?.nodeType,
+      rootKbId: nodeInfo?.rootKbId ?? undefined,
+    });
   }, [setPendingSidebarAction]);
 
   /** Add private collection: set pending action → page.tsx picks it up and opens dialog */

--- a/frontend-new/app/(main)/@sidebar/knowledge-base/page.tsx
+++ b/frontend-new/app/(main)/@sidebar/knowledge-base/page.tsx
@@ -8,44 +8,10 @@ import { MORE_CONNECTORS } from '../../knowledge-base/mock-data';
 import { categorizeNode, mergeChildrenIntoTree } from '../../knowledge-base/utils/tree-builder';
 import { refreshKbTree } from '../../knowledge-base/utils/refresh-kb-tree';
 import { buildNavUrl, getIsAllRecordsMode } from '../../knowledge-base/utils/nav';
+import { findNodeInCategorized } from '../../knowledge-base/utils/find-node';
 import { useCallback, useMemo, Suspense, useEffect, useRef, useState } from 'react';
 import { toast } from '@/lib/store/toast-store';
-import type { NodeType, EnhancedFolderTreeNode, CategorizedNodes } from '../../knowledge-base/types';
-
-/**
- * Find a node in the categorized tree and return its nodeType + root KB ancestor ID.
- * Root-level nodes (KB collections) have no rootKbId since they ARE the KB.
- */
-function findNodeWithRootKb(
-  categorizedNodes: CategorizedNodes | null,
-  targetId: string
-): { nodeType: NodeType; rootKbId: string | null } | null {
-  if (!categorizedNodes) return null;
-
-  const searchTree = (
-    nodes: EnhancedFolderTreeNode[],
-    rootKbId: string | null
-  ): { nodeType: NodeType; rootKbId: string | null } | null => {
-    for (const node of nodes) {
-      if (node.id === targetId) {
-        return { nodeType: node.nodeType, rootKbId };
-      }
-      if (node.children?.length) {
-        // For children of a root node, the rootKbId is the root node's ID
-        const childRootKbId = rootKbId ?? node.id;
-        const found = searchTree(node.children as EnhancedFolderTreeNode[], childRootKbId);
-        if (found) return found;
-      }
-    }
-    return null;
-  };
-
-  // Root-level nodes: rootKbId is null (they are the KB themselves)
-  return (
-    searchTree(categorizedNodes.shared, null) ||
-    searchTree(categorizedNodes.private, null)
-  );
-}
+import type { NodeType, EnhancedFolderTreeNode } from '../../knowledge-base/types';
 
 function KnowledgeBaseSidebarSlotContent() {
   const router = useRouter();
@@ -376,23 +342,10 @@ function KnowledgeBaseSidebarSlotContent() {
 
   /** Reindex: set pending action → page.tsx picks it up and opens dialog */
   const handleSidebarReindex = useCallback((nodeId: string) => {
-    // Find the node info from categorized trees or app cache
     const findNodeInfo = (): { name: string; nodeType?: NodeType } => {
       const state = useKnowledgeBaseStore.getState();
-      const searchTree = (nodes: EnhancedFolderTreeNode[]): EnhancedFolderTreeNode | null => {
-        for (const n of nodes) {
-          if (n.id === nodeId) return n;
-          if (n.children?.length) {
-            const found = searchTree(n.children as EnhancedFolderTreeNode[]);
-            if (found) return found;
-          }
-        }
-        return null;
-      };
-      if (state.categorizedNodes) {
-        const node = searchTree(state.categorizedNodes.shared) || searchTree(state.categorizedNodes.private);
-        if (node) return { name: node.name, nodeType: node.nodeType };
-      }
+      const { node } = findNodeInCategorized(state.categorizedNodes, nodeId);
+      if (node) return { name: node.name, nodeType: node.nodeType };
       // Check app nodes / app children cache
       const appNode = state.appNodes.find((n) => n.id === nodeId);
       if (appNode) return { name: appNode.name, nodeType: appNode.nodeType };
@@ -410,17 +363,18 @@ function KnowledgeBaseSidebarSlotContent() {
   /** Rename: call API directly (no confirmation dialog needed) */
   const handleSidebarRename = useCallback(async (nodeId: string, newName: string) => {
     try {
-      // Find node in tree to determine type and root KB
       const state = useKnowledgeBaseStore.getState();
-      const nodeInfo = findNodeWithRootKb(state.categorizedNodes, nodeId);
+      const { node, rootKbId } = findNodeInCategorized(state.categorizedNodes, nodeId);
 
-      if (nodeInfo && nodeInfo.nodeType === 'folder' && nodeInfo.rootKbId) {
-        await KnowledgeBaseApi.renameFolder(nodeInfo.rootKbId, nodeId, newName);
-        toast.success('Folder renamed successfully');
-      } else {
-        await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
-        toast.success('Collection renamed successfully');
-      }
+      await KnowledgeBaseApi.renameNode({
+        nodeId,
+        newName,
+        nodeType: node?.nodeType,
+        rootKbId: rootKbId ?? undefined,
+      });
+      toast.success(
+        node?.nodeType === 'folder' ? 'Folder renamed successfully' : 'Collection renamed successfully'
+      );
 
       // Clear stale cache: breadcrumb path + parent of renamed node (so re-expand shows new name)
       const currentState = useKnowledgeBaseStore.getState();
@@ -428,8 +382,8 @@ function KnowledgeBaseSidebarSlotContent() {
       if (currentState.tableData?.breadcrumbs) {
         cacheIdsToClear.push(...currentState.tableData.breadcrumbs.map(bc => bc.id));
       }
-      if (nodeInfo?.rootKbId) {
-        cacheIdsToClear.push(nodeInfo.rootKbId);
+      if (rootKbId) {
+        cacheIdsToClear.push(rootKbId);
       }
       if (cacheIdsToClear.length > 0) {
         clearNodeCacheEntries(cacheIdsToClear);
@@ -447,30 +401,13 @@ function KnowledgeBaseSidebarSlotContent() {
   /** Delete: set pending action → page.tsx picks it up and opens dialog */
   const handleSidebarDelete = useCallback((nodeId: string) => {
     const state = useKnowledgeBaseStore.getState();
-    const findNodeName = (): string => {
-      const searchTree = (nodes: EnhancedFolderTreeNode[]): string | null => {
-        for (const n of nodes) {
-          if (n.id === nodeId) return n.name;
-          if (n.children?.length) {
-            const found = searchTree(n.children as EnhancedFolderTreeNode[]);
-            if (found) return found;
-          }
-        }
-        return null;
-      };
-      if (state.categorizedNodes) {
-        const name = searchTree(state.categorizedNodes.shared) || searchTree(state.categorizedNodes.private);
-        if (name) return name;
-      }
-      return nodeId;
-    };
-    const nodeInfo = findNodeWithRootKb(state.categorizedNodes, nodeId);
+    const { node, rootKbId } = findNodeInCategorized(state.categorizedNodes, nodeId);
     setPendingSidebarAction({
       type: 'delete',
       nodeId,
-      nodeName: findNodeName(),
-      nodeType: nodeInfo?.nodeType,
-      rootKbId: nodeInfo?.rootKbId ?? undefined,
+      nodeName: node?.name ?? nodeId,
+      nodeType: node?.nodeType,
+      rootKbId: rootKbId ?? undefined,
     });
   }, [setPendingSidebarAction]);
 

--- a/frontend-new/app/(main)/knowledge-base/api.ts
+++ b/frontend-new/app/(main)/knowledge-base/api.ts
@@ -341,6 +341,15 @@ export const KnowledgeHubApi = {
  * folders, and records (upload, create, update, delete, permissions).
  */
 export const KnowledgeBaseApi = {
+  // Get upload limits from server (file size, batch size)
+  async getUploadLimits() {
+    const { data } = await apiClient.get<{ maxFilesPerRequest: number; maxFileSizeBytes?: number }>(
+      '/api/v1/knowledgebase/limits',
+      { suppressErrorToast: true }
+    );
+    return data;
+  },
+
   // List all knowledge bases
   async listKnowledgeBases() {
     const { data } = await apiClient.get<{ knowledgeBases: Record<string, unknown>[]; total: number }>(BASE_URL);

--- a/frontend-new/app/(main)/knowledge-base/api.ts
+++ b/frontend-new/app/(main)/knowledge-base/api.ts
@@ -1,12 +1,13 @@
 // Knowledge Base API - Action Operations (CRUD)
 
 import { apiClient } from '@/lib/api';
-import type { 
+import type {
   KnowledgeHubApiResponse,
-  NodeType, 
+  NodeType,
   KnowledgeHubQueryParams,
   RecordDetailsResponse,
 } from './types';
+import { DEFAULT_PAGE_SIZE } from './store';
 
 const BASE_URL = '/api/v1/knowledgeBase';
 
@@ -67,7 +68,7 @@ export const KnowledgeHubApi = {
           // TEMPORARY: onlyContainers disabled until API is fixed
           // onlyContainers: true,
           page: 1,
-          limit: 50,
+          limit: DEFAULT_PAGE_SIZE,
           include: 'counts',
         },
         suppressErrorToast: true,
@@ -102,7 +103,7 @@ export const KnowledgeHubApi = {
           // TEMPORARY: onlyContainers disabled until API is fixed
           // onlyContainers: true,
           page: 1,
-          limit: 50,
+          limit: DEFAULT_PAGE_SIZE,
         },
       }
     );
@@ -138,7 +139,7 @@ export const KnowledgeHubApi = {
       {
         params: {
           page: 1,
-          limit: 50,
+          limit: DEFAULT_PAGE_SIZE,
           include: 'counts,permissions,breadcrumbs,availableFilters',
           // Data area: Never use onlyContainers (we need both folders AND files)
           ...params,
@@ -182,7 +183,7 @@ export const KnowledgeHubApi = {
       {
         params: {
           page: 1,
-          limit: 50,
+          limit: DEFAULT_PAGE_SIZE,
           include: 'counts,permissions,availableFilters',
           // Data area: Never use onlyContainers (we need all record types)
           ...params,
@@ -273,7 +274,7 @@ export const KnowledgeHubApi = {
       {
         params: {
           page: 1,
-          limit: 50,
+          limit: DEFAULT_PAGE_SIZE,
           include: 'counts,permissions,breadcrumbs,availableFilters',
           // Data area: Never use onlyContainers (we need all root items including records)
           ...params,
@@ -341,9 +342,9 @@ export const KnowledgeHubApi = {
  * folders, and records (upload, create, update, delete, permissions).
  */
 export const KnowledgeBaseApi = {
-  // Get upload limits from server (file size, batch size)
+  // Get upload limits from server (max file size)
   async getUploadLimits() {
-    const { data } = await apiClient.get<{ maxFilesPerRequest: number; maxFileSizeBytes?: number }>(
+    const { data } = await apiClient.get<{ maxFileSizeBytes?: number }>(
       '/api/v1/knowledgebase/limits',
       { suppressErrorToast: true }
     );
@@ -595,6 +596,40 @@ export const KnowledgeBaseApi = {
       suppressErrorToast: true,
     });
     return data;
+  },
+
+  /**
+   * Unified rename dispatcher — dispatches to renameKnowledgeBase or renameFolder
+   * based on nodeType and whether the node is the root KB itself.
+   */
+  async renameNode(args: {
+    nodeId: string;
+    newName: string;
+    nodeType?: string;
+    rootKbId?: string;
+  }) {
+    const { nodeId, newName, nodeType, rootKbId } = args;
+    const isFolderLike = nodeType === 'folder' || nodeType === 'recordGroup';
+    if (isFolderLike && rootKbId && rootKbId !== nodeId) {
+      return this.renameFolder(rootKbId, nodeId, newName);
+    }
+    return this.renameKnowledgeBase(nodeId, newName);
+  },
+
+  /**
+   * Unified delete dispatcher — dispatches to deleteKnowledgeBase or deleteFolder
+   * based on nodeType and whether the node is the root KB itself.
+   */
+  async deleteNode(args: {
+    nodeId: string;
+    nodeType?: string;
+    rootKbId?: string;
+  }) {
+    const { nodeId, nodeType, rootKbId } = args;
+    if (nodeType === 'folder' && rootKbId && rootKbId !== nodeId) {
+      return this.deleteFolder(rootKbId, nodeId);
+    }
+    return this.deleteKnowledgeBase(nodeId);
   },
 
   // Rename record (file)

--- a/frontend-new/app/(main)/knowledge-base/components/dialogs/folder-details-sidebar.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/dialogs/folder-details-sidebar.tsx
@@ -62,14 +62,6 @@ function formatTimestamp(timestamp: number | undefined): string | undefined {
   return `${pad(date.getMonth() + 1)}/${pad(date.getDate())}/${date.getFullYear()}, ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
 }
 
-function getCountByLabels(counts: KnowledgeHubApiResponse['counts'], labels: string[]): string | undefined {
-  if (!counts?.items) return undefined;
-  const total = counts.items
-    .filter(item => labels.some(l => item.label.toLowerCase().includes(l)))
-    .reduce((sum, item) => sum + item.count, 0);
-  return total > 0 ? total.toString() : '0';
-}
-
 export function FolderDetailsSidebar({ open, onOpenChange, tableData }: FolderDetailsSidebarProps) {
   const currentNode = tableData?.currentNode;
   const breadcrumbs = tableData?.breadcrumbs;
@@ -77,8 +69,7 @@ export function FolderDetailsSidebar({ open, onOpenChange, tableData }: FolderDe
   const counts = tableData?.counts;
 
   const originName = breadcrumbs && breadcrumbs.length > 0 ? breadcrumbs[0].name : undefined;
-  const collectionsCount = getCountByLabels(counts, ['folder', 'collection', 'kb']);
-  const filesCount = getCountByLabels(counts, ['file', 'record']);
+  const totalItems = counts?.total != null ? counts.total.toString() : undefined;
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -183,8 +174,7 @@ export function FolderDetailsSidebar({ open, onOpenChange, tableData }: FolderDe
                   <DetailRow label="Record Type" value={formatNodeType(currentNode.nodeType)} />
                   <DetailRow label="Origin" value={originName} />
                   <DetailRow label="Indexing Status" value={currentNode.indexingStatus} />
-                  <DetailRow label="No. of Collections inside" value={collectionsCount} />
-                  <DetailRow label="No. of files inside" value={filesCount} />
+                  <DetailRow label="Total items" value={totalItems} />
                   <DetailRow label="Version" value={currentNode.version?.toString()} />
                   <DetailRow label="Created At" value={formatTimestamp(currentNode.createdAt)} />
                   <DetailRow label="Updated At" value={formatTimestamp(currentNode.updatedAt)} />

--- a/frontend-new/app/(main)/knowledge-base/components/dialogs/replace-file-dialog.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/dialogs/replace-file-dialog.tsx
@@ -6,7 +6,7 @@ import { LoadingButton } from '@/app/components/ui/loading-button';
 import { MaterialIcon } from '@/app/components/ui/MaterialIcon';
 import { FileIcon } from '@/app/components/ui/file-icon';
 import type { KnowledgeHubNode } from '../../types';
-import { KnowledgeBaseApi } from '../../api';
+import { useUploadLimits } from '@/lib/hooks/use-upload-limits';
 
 // File type to MIME type mapping
 const FILE_TYPE_MIME_MAP: Record<string, string[]> = {
@@ -27,9 +27,6 @@ const FILE_TYPE_MIME_MAP: Record<string, string[]> = {
   MARKDOWN: ['text/markdown', 'text/x-markdown', 'application/x-markdown', 'text/plain'],
   MDX: ['text/mdx', 'text/markdown', 'text/plain'],
 };
-
-const DEFAULT_MAX_FILE_SIZE_MB = 30;
-const DEFAULT_MAX_FILE_SIZE_BYTES = DEFAULT_MAX_FILE_SIZE_MB * 1024 * 1024;
 
 interface ReplaceFileDialogProps {
   open: boolean;
@@ -57,10 +54,8 @@ export function ReplaceFileDialog({
   const [isDragOver, setIsDragOver] = useState(false);
   const [isCurrentFileHovered, setIsCurrentFileHovered] = useState(false);
   const [isReplacementFileHovered, setIsReplacementFileHovered] = useState(false);
-  const [maxFileSizeBytes, setMaxFileSizeBytes] = useState(DEFAULT_MAX_FILE_SIZE_BYTES);
+  const { maxFileSizeBytes, maxFileSizeMB } = useUploadLimits();
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const maxFileSizeMB = Math.round(maxFileSizeBytes / (1024 * 1024));
 
   // Get accepted MIME types based on current file type
   const fileType = item?.extension?.toUpperCase() || 'PDF';
@@ -76,22 +71,6 @@ export function ReplaceFileDialog({
     },
     [acceptedMimeTypes, fileType]
   );
-  // Fetch upload limits from server
-  useEffect(() => {
-    let mounted = true;
-    KnowledgeBaseApi.getUploadLimits()
-      .then((resp) => {
-        const s = Number(resp?.maxFileSizeBytes);
-        if (mounted && Number.isFinite(s) && s > 0) {
-          setMaxFileSizeBytes(s);
-        }
-      })
-      .catch(() => {
-        // fallback to default silently
-      });
-    return () => { mounted = false; };
-  }, []);
-
   // Reset state when dialog closes
   useEffect(() => {
     if (!open) {

--- a/frontend-new/app/(main)/knowledge-base/components/dialogs/replace-file-dialog.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/dialogs/replace-file-dialog.tsx
@@ -6,6 +6,7 @@ import { LoadingButton } from '@/app/components/ui/loading-button';
 import { MaterialIcon } from '@/app/components/ui/MaterialIcon';
 import { FileIcon } from '@/app/components/ui/file-icon';
 import type { KnowledgeHubNode } from '../../types';
+import { KnowledgeBaseApi } from '../../api';
 
 // File type to MIME type mapping
 const FILE_TYPE_MIME_MAP: Record<string, string[]> = {
@@ -27,8 +28,8 @@ const FILE_TYPE_MIME_MAP: Record<string, string[]> = {
   MDX: ['text/mdx', 'text/markdown', 'text/plain'],
 };
 
-const MAX_FILE_SIZE_MB = 30;
-const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE_MB = 30;
+const DEFAULT_MAX_FILE_SIZE_BYTES = DEFAULT_MAX_FILE_SIZE_MB * 1024 * 1024;
 
 interface ReplaceFileDialogProps {
   open: boolean;
@@ -56,7 +57,10 @@ export function ReplaceFileDialog({
   const [isDragOver, setIsDragOver] = useState(false);
   const [isCurrentFileHovered, setIsCurrentFileHovered] = useState(false);
   const [isReplacementFileHovered, setIsReplacementFileHovered] = useState(false);
+  const [maxFileSizeBytes, setMaxFileSizeBytes] = useState(DEFAULT_MAX_FILE_SIZE_BYTES);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const maxFileSizeMB = Math.round(maxFileSizeBytes / (1024 * 1024));
 
   // Get accepted MIME types based on current file type
   const fileType = item?.extension?.toUpperCase() || 'PDF';
@@ -72,6 +76,21 @@ export function ReplaceFileDialog({
     },
     [acceptedMimeTypes, fileType]
   );
+  // Fetch upload limits from server
+  useEffect(() => {
+    let mounted = true;
+    KnowledgeBaseApi.getUploadLimits()
+      .then((resp) => {
+        const s = Number(resp?.maxFileSizeBytes);
+        if (mounted && Number.isFinite(s) && s > 0) {
+          setMaxFileSizeBytes(s);
+        }
+      })
+      .catch(() => {
+        // fallback to default silently
+      });
+    return () => { mounted = false; };
+  }, []);
 
   // Reset state when dialog closes
   useEffect(() => {
@@ -102,7 +121,7 @@ export function ReplaceFileDialog({
       const files = e.dataTransfer.files;
       if (files.length > 0) {
         const file = files[0];
-        if (file.size <= MAX_FILE_SIZE_BYTES && isAcceptedFile(file)) {
+        if (file.size <= maxFileSizeBytes && isAcceptedFile(file)) {
           setReplacementFile(file);
         }
       }
@@ -119,7 +138,7 @@ export function ReplaceFileDialog({
       const files = e.target.files;
       if (files && files.length > 0) {
         const file = files[0];
-        if (file.size <= MAX_FILE_SIZE_BYTES && isAcceptedFile(file)) {
+        if (file.size <= maxFileSizeBytes && isAcceptedFile(file)) {
           setReplacementFile(file);
         }
       }
@@ -328,7 +347,7 @@ export function ReplaceFileDialog({
                   Replace File
                 </Text>
                 <Text size="1" style={{ color: 'var(--slate-9)' }}>
-                  You can upload files up to the limit of {MAX_FILE_SIZE_MB} MB
+                  You can upload files up to the limit of {maxFileSizeMB} MB
                 </Text>
               </Flex>
               <Box style={{ height: '1px', background: 'var(--olive-3)' }} />

--- a/frontend-new/app/(main)/knowledge-base/components/dialogs/upload-data-sidebar.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/dialogs/upload-data-sidebar.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useState, useRef, useCallback } from 'react';
+import React, { useState, useRef, useCallback, useEffect } from 'react';
 import { Flex, Box, Text, Button, IconButton, Dialog, VisuallyHidden } from '@radix-ui/themes';
 import { LoadingButton } from '@/app/components/ui/loading-button';
 import { MaterialIcon } from '@/app/components/ui/MaterialIcon';
 import { FileIcon } from '@/app/components/ui/file-icon';
+import { KnowledgeBaseApi } from '../../api';
 
 // Supported file types
 const SUPPORTED_FILE_TYPES = ['TXT', 'PDF', 'DOC', 'DOCX', 'PNG', 'JPEG', 'JPG', 'SVG', 'XLS', 'XLSX', 'CSV', 'HTML', 'PPT', 'PPTX', 'MD', 'MDX'];
@@ -33,8 +34,8 @@ const SUPPORTED_MIME_TYPES = [
 const SUPPORTED_EXTENSIONS = [
   'txt', 'pdf', 'doc', 'docx', 'png', 'jpeg', 'jpg', 'svg', 'xls', 'xlsx', 'csv', 'html', 'htm', 'ppt', 'pptx', 'md', 'markdown', 'mdx',
 ];
-const MAX_FILE_SIZE_MB = 30;
-const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+const DEFAULT_MAX_FILE_SIZE_MB = 30;
+const DEFAULT_MAX_FILE_SIZE_BYTES = DEFAULT_MAX_FILE_SIZE_MB * 1024 * 1024;
 
 function isSupportedFile(file: File): boolean {
   if (SUPPORTED_MIME_TYPES.includes(file.type)) return true;
@@ -63,9 +64,10 @@ interface DropZoneProps {
   type: 'file' | 'folder';
   onDrop: (items: UploadFileItem[]) => void;
   isEmpty: boolean;
+  maxFileSizeBytes: number;
 }
 
-function DropZone({ type, onDrop, isEmpty }: DropZoneProps) {
+function DropZone({ type, onDrop, isEmpty, maxFileSizeBytes }: DropZoneProps) {
   const [isDragOver, setIsDragOver] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -88,7 +90,7 @@ function DropZone({ type, onDrop, isEmpty }: DropZoneProps) {
 
       if (type === 'file') {
         fileArray.forEach((file) => {
-          if (file.size <= MAX_FILE_SIZE_BYTES && isSupportedFile(file)) {
+          if (file.size <= maxFileSizeBytes && isSupportedFile(file)) {
             items.push({
               id: `file-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
               name: file.name,
@@ -160,7 +162,7 @@ function DropZone({ type, onDrop, isEmpty }: DropZoneProps) {
 
             await readDirectory(entry as FileSystemDirectoryEntry);
 
-            if (totalSize <= MAX_FILE_SIZE_BYTES) {
+            if (totalSize <= maxFileSizeBytes) {
               folderItems.push({
                 id: `folder-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
                 name: entry.name,
@@ -208,7 +210,7 @@ function DropZone({ type, onDrop, isEmpty }: DropZoneProps) {
           const items: UploadFileItem[] = [];
           folderMap.forEach((folderFiles, folderName) => {
             const totalSize = folderFiles.reduce((sum, f) => sum + f.file.size, 0);
-            if (totalSize <= MAX_FILE_SIZE_BYTES) {
+            if (totalSize <= maxFileSizeBytes) {
               items.push({
                 id: `folder-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
                 name: folderName,
@@ -398,6 +400,25 @@ export function UploadDataSidebar({
 }: UploadDataSidebarProps) {
   const [fileItems, setFileItems] = useState<UploadFileItem[]>([]);
   const [folderItems, setFolderItems] = useState<UploadFileItem[]>([]);
+  const [maxFileSizeBytes, setMaxFileSizeBytes] = useState(DEFAULT_MAX_FILE_SIZE_BYTES);
+
+  // Fetch upload limits from server
+  useEffect(() => {
+    let mounted = true;
+    KnowledgeBaseApi.getUploadLimits()
+      .then((resp) => {
+        const s = Number(resp?.maxFileSizeBytes);
+        if (mounted && Number.isFinite(s) && s > 0) {
+          setMaxFileSizeBytes(s);
+        }
+      })
+      .catch(() => {
+        // fallback to default silently
+      });
+    return () => { mounted = false; };
+  }, []);
+
+  const maxFileSizeMB = Math.round(maxFileSizeBytes / (1024 * 1024));
 
   const handleAddFiles = useCallback((items: UploadFileItem[]) => {
     setFileItems((prev) => [...prev, ...items]);
@@ -539,7 +560,7 @@ export function UploadDataSidebar({
                 Upload Files
               </Text>
               <Text size="1" style={{ color: 'var(--slate-9)' }}>
-                You can upload files up to the limit of {MAX_FILE_SIZE_MB} MB
+                You can upload files up to the limit of {maxFileSizeMB} MB
               </Text>
             </Flex>
             <Box style={{ height: '1px', background: 'var(--olive-3)' }} />
@@ -564,7 +585,7 @@ export function UploadDataSidebar({
 
             {/* File drop zone - expands when empty, fixed when has items */}
             <Box style={{ ...(fileItems.length === 0 ? { flex: 1 } : {}), ...(fileItems.length > 0 ? { minHeight: '120px' } : {}) }}>
-              <DropZone type="file" onDrop={handleAddFiles} isEmpty={fileItems.length === 0} />
+              <DropZone type="file" onDrop={handleAddFiles} isEmpty={fileItems.length === 0} maxFileSizeBytes={maxFileSizeBytes} />
             </Box>
           </Flex>
 
@@ -596,7 +617,7 @@ export function UploadDataSidebar({
                 Upload Folders
               </Text>
               <Text size="1" style={{ color: 'var(--slate-9)' }}>
-                You can upload folders up to the limit of {MAX_FILE_SIZE_MB} MB
+                You can upload folders up to the limit of {maxFileSizeMB} MB
               </Text>
             </Flex>
             <Box style={{ height: '1px', background: 'var(--olive-3)' }} />
@@ -621,7 +642,7 @@ export function UploadDataSidebar({
 
             {/* Folder drop zone - expands when empty, fixed when has items */}
             <Box style={{ ...(folderItems.length === 0 ? { flex: 1 } : {}), ...(folderItems.length > 0 ? { minHeight: '120px' } : {}) }}>
-              <DropZone type="folder" onDrop={handleAddFolders} isEmpty={folderItems.length === 0} />
+              <DropZone type="folder" onDrop={handleAddFolders} isEmpty={folderItems.length === 0} maxFileSizeBytes={maxFileSizeBytes} />
             </Box>
           </Flex>
         </Box>

--- a/frontend-new/app/(main)/knowledge-base/components/dialogs/upload-data-sidebar.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/dialogs/upload-data-sidebar.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import React, { useState, useRef, useCallback, useEffect } from 'react';
+import React, { useState, useRef, useCallback } from 'react';
 import { Flex, Box, Text, Button, IconButton, Dialog, VisuallyHidden } from '@radix-ui/themes';
 import { LoadingButton } from '@/app/components/ui/loading-button';
 import { MaterialIcon } from '@/app/components/ui/MaterialIcon';
 import { FileIcon } from '@/app/components/ui/file-icon';
-import { KnowledgeBaseApi } from '../../api';
+import { useUploadLimits } from '@/lib/hooks/use-upload-limits';
 
 // Supported file types
 const SUPPORTED_FILE_TYPES = ['TXT', 'PDF', 'DOC', 'DOCX', 'PNG', 'JPEG', 'JPG', 'SVG', 'XLS', 'XLSX', 'CSV', 'HTML', 'PPT', 'PPTX', 'MD', 'MDX'];
@@ -34,9 +34,6 @@ const SUPPORTED_MIME_TYPES = [
 const SUPPORTED_EXTENSIONS = [
   'txt', 'pdf', 'doc', 'docx', 'png', 'jpeg', 'jpg', 'svg', 'xls', 'xlsx', 'csv', 'html', 'htm', 'ppt', 'pptx', 'md', 'markdown', 'mdx',
 ];
-const DEFAULT_MAX_FILE_SIZE_MB = 30;
-const DEFAULT_MAX_FILE_SIZE_BYTES = DEFAULT_MAX_FILE_SIZE_MB * 1024 * 1024;
-
 function isSupportedFile(file: File): boolean {
   if (SUPPORTED_MIME_TYPES.includes(file.type)) return true;
   const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
@@ -400,25 +397,7 @@ export function UploadDataSidebar({
 }: UploadDataSidebarProps) {
   const [fileItems, setFileItems] = useState<UploadFileItem[]>([]);
   const [folderItems, setFolderItems] = useState<UploadFileItem[]>([]);
-  const [maxFileSizeBytes, setMaxFileSizeBytes] = useState(DEFAULT_MAX_FILE_SIZE_BYTES);
-
-  // Fetch upload limits from server
-  useEffect(() => {
-    let mounted = true;
-    KnowledgeBaseApi.getUploadLimits()
-      .then((resp) => {
-        const s = Number(resp?.maxFileSizeBytes);
-        if (mounted && Number.isFinite(s) && s > 0) {
-          setMaxFileSizeBytes(s);
-        }
-      })
-      .catch(() => {
-        // fallback to default silently
-      });
-    return () => { mounted = false; };
-  }, []);
-
-  const maxFileSizeMB = Math.round(maxFileSizeBytes / (1024 * 1024));
+  const { maxFileSizeBytes, maxFileSizeMB } = useUploadLimits();
 
   const handleAddFiles = useCallback((items: UploadFileItem[]) => {
     setFileItems((prev) => [...prev, ...items]);

--- a/frontend-new/app/(main)/knowledge-base/components/kb-data-table.tsx
+++ b/frontend-new/app/(main)/knowledge-base/components/kb-data-table.tsx
@@ -136,12 +136,25 @@ export function KbDataTable({
   const handleDeleteConfirm = async () => {
     if (!itemToDelete) return;
 
+    // Get KB ID - we need it for folder deletion and root-collection detection
+    const storeBreadcrumbs = useKnowledgeBaseStore.getState().tableData?.breadcrumbs;
+    const kbId = storeBreadcrumbs && storeBreadcrumbs.length > 1
+      ? storeBreadcrumbs[1].id
+      : isKnowledgeHubNode(itemToDelete) && 'parentId' in itemToDelete
+      ? itemToDelete.parentId
+      : undefined;
+
     const isFolder = isKnowledgeHubNode(itemToDelete)
       ? ['kb', 'app', 'folder', 'recordGroup'].includes(itemToDelete.nodeType)
       : itemToDelete.type === 'folder';
 
+    const isRootCollection =
+      isKnowledgeHubNode(itemToDelete) &&
+      itemToDelete.nodeType === 'recordGroup' &&
+      kbId === itemToDelete.id;
+
     const nodeType = isKnowledgeHubNode(itemToDelete)
-      ? itemToDelete.nodeType === 'kb'
+      ? itemToDelete.nodeType === 'kb' || isRootCollection
         ? 'kb'
         : isFolder
         ? 'folder'
@@ -150,35 +163,30 @@ export function KbDataTable({
       ? 'folder'
       : 'record';
 
-    // Get KB ID - we need it for folder deletion
-    const storeBreadcrumbs = useKnowledgeBaseStore.getState().tableData?.breadcrumbs;
-    const kbId = storeBreadcrumbs && storeBreadcrumbs.length > 1
-      ? storeBreadcrumbs[1].id
-      : isKnowledgeHubNode(itemToDelete) && 'parentId' in itemToDelete
-      ? itemToDelete.parentId
-      : undefined;
-
     try {
       await deleteNode(itemToDelete.id, nodeType, kbId || undefined, refreshData);
       setDeleteDialogOpen(false);
       setItemToDelete(null);
-    } catch (error) {
-      // Error is handled in the store
-      console.error('Delete failed:', error);
+    } catch (error: unknown) {
+      // Error toast is already handled in the store action.
+      // Close the dialog on permission-denied responses so users aren't stuck
+      // with an action they cannot perform.
+      const err = error as {
+        statusCode?: number;
+        response?: { status?: number; data?: { message?: string } };
+        message?: string;
+      };
+      const status = err.statusCode ?? err.response?.status;
+      const message = (err.response?.data?.message ?? err.message ?? '').toLowerCase();
+      const isPermissionDenied = status === 403 || message.includes('permission');
+      if (isPermissionDenied) {
+        setDeleteDialogOpen(false);
+        setItemToDelete(null);
+      }
     }
   };
 
-  const getWarningMessage = (item: TableItem): string | undefined => {    
-    const isFolder = isKnowledgeHubNode(item)
-      ? ['kb', 'app', 'folder', 'recordGroup'].includes(item.nodeType)
-      : item.type === 'folder';
-
-    if (isFolder && item.hasChildren) {
-      // TODO: Get actual counts from API or state
-      return 'You have 4 Collections, 35 Files inside this collection folder';
-    }
-    return undefined;
-  };
+  const getWarningMessage = (_item: TableItem): string | undefined => undefined;
 
   // Show refreshing state
   if (isRefreshing) {
@@ -374,7 +382,7 @@ export function KbDataTable({
           onReindex={onReindex}
           onReplace={onReplace}
           onMove={onMove}
-          onDelete={handleDeleteClick}
+          onDelete={_onDelete ? handleDeleteClick : undefined}
           onDownload={onDownload}
         />
       ) : (
@@ -396,7 +404,7 @@ export function KbDataTable({
           onReindex={onReindex}
           onReplace={onReplace}
           onMove={onMove}
-          onDelete={handleDeleteClick}
+          onDelete={_onDelete ? handleDeleteClick : undefined}
           onDownload={onDownload}
         />
       )}

--- a/frontend-new/app/(main)/knowledge-base/page.tsx
+++ b/frontend-new/app/(main)/knowledge-base/page.tsx
@@ -25,7 +25,7 @@ import type { UploadFileItem } from './components';
 import { useUploadStore, generateUploadId } from '@/lib/store/upload-store';
 import { KnowledgeBaseApi, KnowledgeHubApi, type FileMetadata } from './api';
 // import KnowledgeBaseSidebar from './sidebar';
-import { useKnowledgeBaseStore } from './store';
+import { useKnowledgeBaseStore, DEFAULT_PAGE_SIZE } from './store';
 import type {
   KnowledgeBaseItem,
   FolderTreeNode,
@@ -57,6 +57,7 @@ import {
 } from './url-params';
 import { getIsAllRecordsMode } from './utils/nav';
 import { refreshKbTree } from './utils/refresh-kb-tree';
+import { toast } from '@/lib/store/toast-store';
 import { FilePreviewSidebar, FilePreviewFullscreen } from '@/app/components/file-preview';
 import { isPresentationFile, isDocxFile } from '@/app/components/file-preview/utils';
 import { useDebouncedSearch } from './hooks/use-debounced-search';
@@ -429,7 +430,6 @@ function KnowledgeBasePageContent() {
       } catch (error) {
         console.error('Error fetching app nodes:', error);
         // Use toast rather than overwriting the table error state
-        const { toast } = await import('@/lib/store/toast-store');
         toast.error('Failed to load sidebar', {
           description: 'Could not load app sections. Please refresh the page.',
         });
@@ -588,7 +588,7 @@ function KnowledgeBasePageContent() {
 
   // All Records mode: Re-fetch when pagination limit changes
   useEffect(() => {
-    if (isAllRecordsMode && allRecordsPagination.limit !== 50) {
+    if (isAllRecordsMode && allRecordsPagination.limit !== DEFAULT_PAGE_SIZE) {
       fetchAllRecordsTableData(allRecordsNodeType ?? undefined, allRecordsNodeId ?? undefined);
     }
   }, [allRecordsPagination.limit]);
@@ -612,6 +612,15 @@ function KnowledgeBasePageContent() {
     // Apply client-side filters (size, date) since API may not support them
     return applyClientSideFilters(transformed, allRecordsFilter);
   }, [isAllRecordsMode, allRecordsTableData, appNodes, appChildrenCache, allRecordsFilter]);
+
+  // Shared 403 handler: clears stale table state, notifies user, refreshes the
+  // sidebar tree, and navigates away from the now-inaccessible collection.
+  const handleAccessRevoked = useCallback(async () => {
+    clearTableData();
+    toast.error('You no longer have access to this collection');
+    await refreshKbTree();
+    router.push('/knowledge-base');
+  }, [clearTableData, refreshKbTree, router]);
 
   // Fetch table data when node is selected
   const fetchTableData = useCallback(
@@ -780,12 +789,7 @@ function KnowledgeBasePageContent() {
         // ProcessedError from apiClient interceptor has statusCode (not response.status)
         const status = (error as { statusCode?: number })?.statusCode;
         if (status === 403) {
-          // Access revoked — clear state, notify, and navigate to KB root
-          const { toast } = await import('@/lib/store/toast-store');
-          clearTableData();
-          toast.error('You no longer have access to this collection');
-          await refreshKbTree();
-          router.push('/knowledge-base');
+          await handleAccessRevoked();
         } else {
           console.error('Failed to fetch table data:', error);
           setTableDataError('Failed to load items. Please try again.');
@@ -808,8 +812,7 @@ function KnowledgeBasePageContent() {
       cacheNodeChildren,
       addNodes,
       setCategorizedNodes,
-      clearTableData,
-      router,
+      handleAccessRevoked,
     ]
   );
 
@@ -962,11 +965,6 @@ function KnowledgeBasePageContent() {
     router.push(`/knowledge-base?${urlParams.toString()}`);
   }, [router]);
 
-  // Handle navigation back to home
-  const _handleHome = useCallback(() => {
-    router.push('/');
-  }, [router]);
-
   // Handle find - opens search bar
   const handleFind = useCallback(() => {
     setIsSearchOpen(true);
@@ -1084,12 +1082,6 @@ function KnowledgeBasePageContent() {
     }
   }, [tableData]);
 
-  // Handle add from sidebar PRIVATE section - always creates root collection
-  const _handleAddPrivateCollection = useCallback(() => {
-    setCreateFolderContext({ type: 'collection' });
-    setIsCreateFolderDialogOpen(true);
-  }, []);
-
   // Handle create folder submission
   const handleCreateFolderSubmit = useCallback(
     async (name: string, description: string) => {
@@ -1114,8 +1106,7 @@ function KnowledgeBasePageContent() {
           );
 
           // Show success toast
-          const { toast } = await import('@/lib/store/toast-store');
-          toast.success('Folder created successfully', {
+            toast.success('Folder created successfully', {
             description: `"${name.trim()}" has been created`,
           });
 
@@ -1156,7 +1147,6 @@ function KnowledgeBasePageContent() {
         setIsCreatingFolder(false);
 
         // Show error toast
-        const { toast } = await import('@/lib/store/toast-store');
         const err = error as { response?: { data?: { message?: string } }; message?: string };
         toast.error('Failed to create folder', {
           description: err?.response?.data?.message || err?.message || 'An error occurred',
@@ -1359,6 +1349,12 @@ function KnowledgeBasePageContent() {
     return createKBShareAdapter(nodeId);
   }, [selectedNode?.nodeId, selectedNode?.nodeType]);
 
+  // Share controls are owner-only for collections.
+  const isSelectedKbOwner = !isAllRecordsMode && tableData?.permissions?.role === 'OWNER';
+  const canManageSelectedKbSharing = !!shareAdapter && isSelectedKbOwner;
+  const canEditSelectedNode = !isAllRecordsMode && tableData?.permissions?.canEdit !== false;
+  const canDeleteSelectedNode = !isAllRecordsMode && tableData?.permissions?.canDelete !== false;
+
   // Whether the selected KB is in the private section (no shared members to fetch)
   // TODO - consider using a json map ds instead of an array for more efficient lookups as the number of nodes grows
   const isSelectedKbPrivate = useMemo(() => {
@@ -1368,14 +1364,20 @@ function KnowledgeBasePageContent() {
   }, [selectedNode?.nodeId, selectedNode?.nodeType, categorizedNodes]);
 
   const handleShare = useCallback(() => {
-    if (!shareAdapter) return;
+    if (!canManageSelectedKbSharing) return;
     setIsShareSidebarOpen(true);
-  }, [shareAdapter]);
+  }, [canManageSelectedKbSharing]);
+
+  useEffect(() => {
+    if (!canManageSelectedKbSharing && isShareSidebarOpen) {
+      setIsShareSidebarOpen(false);
+    }
+  }, [canManageSelectedKbSharing, isShareSidebarOpen]);
 
   // Load shared members whenever the selected KB changes.
   // If we get a 403, access was revoked — navigate the user away.
   useEffect(() => {
-    if (!shareAdapter || isSelectedKbPrivate) {
+    if (!canManageSelectedKbSharing || isSelectedKbPrivate) {
       setSharedMembers([]);
       return;
     }
@@ -1388,14 +1390,10 @@ function KnowledgeBasePageContent() {
       // ProcessedError from apiClient interceptor has statusCode (not response.status)
       const status = (error as { statusCode?: number })?.statusCode;
       if (status === 403) {
-        const { toast } = await import('@/lib/store/toast-store');
-        clearTableData();
-        toast.error('You no longer have access to this collection');
-        await refreshKbTree();
-        router.push('/knowledge-base');
+        await handleAccessRevoked();
       }
     });
-  }, [shareAdapter, isSelectedKbPrivate, clearTableData, router]);
+  }, [canManageSelectedKbSharing, isSelectedKbPrivate, handleAccessRevoked, shareAdapter]);
 
   // Handle file preview
   const handlePreviewFile = useCallback(async (item: KnowledgeBaseItem | KnowledgeHubNode) => {
@@ -1557,7 +1555,6 @@ function KnowledgeBasePageContent() {
     item: KnowledgeBaseItem | KnowledgeHubNode | AllRecordItem,
     newName: string
   ) => {
-    const { toast } = await import('@/lib/store/toast-store');
 
     try {
       const isHub = 'nodeType' in item && 'origin' in item;
@@ -1566,12 +1563,12 @@ function KnowledgeBasePageContent() {
         const hubItem = item as KnowledgeHubNode;
         if (hubItem.nodeType === 'folder' || hubItem.nodeType === 'recordGroup') {
           if (!selectedKbId) throw new Error('No collection context for rename');
-          if (hubItem.id === selectedKbId) {
-            // Root KB collection — use KB rename API
-            await KnowledgeBaseApi.renameKnowledgeBase(hubItem.id, newName);
-          } else {
-            await KnowledgeBaseApi.renameFolder(selectedKbId, hubItem.id, newName);
-          }
+          await KnowledgeBaseApi.renameNode({
+            nodeId: hubItem.id,
+            newName,
+            nodeType: hubItem.nodeType,
+            rootKbId: selectedKbId,
+          });
         } else if (hubItem.nodeType === 'record') {
           await KnowledgeBaseApi.renameRecord(hubItem.id, newName);
         }
@@ -1605,17 +1602,16 @@ function KnowledgeBasePageContent() {
     nodeType: string,
     newName: string
   ) => {
-    const { toast } = await import('@/lib/store/toast-store');
 
     try {
       if (nodeType === 'folder' || nodeType === 'recordGroup') {
         if (!selectedKbId) throw new Error('No collection context for rename');
-        if (nodeId === selectedKbId) {
-          // Root KB collection — use KB rename API
-          await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
-        } else {
-          await KnowledgeBaseApi.renameFolder(selectedKbId, nodeId, newName);
-        }
+        await KnowledgeBaseApi.renameNode({
+          nodeId,
+          newName,
+          nodeType,
+          rootKbId: selectedKbId,
+        });
       }
 
       toast.success('Renamed successfully', {
@@ -1656,7 +1652,6 @@ function KnowledgeBasePageContent() {
 
   // Handle reindex - directly reindexes the item with loading/success/error toasts
   const handleReindexClick = useCallback(async (item: KnowledgeBaseItem | KnowledgeHubNode | AllRecordItem) => {
-    const { toast } = await import('@/lib/store/toast-store');
 
     const toastId = toast.loading('Re-indexing...', {
       description: `Collection ${item.name} is getting re-indexed. This may take a few seconds`,
@@ -1723,7 +1718,6 @@ function KnowledgeBasePageContent() {
         );
 
         // Show success toast
-        const { toast } = await import('@/lib/store/toast-store');
         toast.success('Item moved successfully', {
           description: `"${itemToMove.name}" has been moved`,
         });
@@ -1739,7 +1733,6 @@ function KnowledgeBasePageContent() {
         console.error('Failed to move item:', error);
 
         // Show error toast
-        const { toast } = await import('@/lib/store/toast-store');
         const err = error as { response?: { data?: { message?: string } }; message?: string };
         toast.error('Failed to move item', {
           description: err?.response?.data?.message || err?.message || 'An error occurred',
@@ -1774,7 +1767,6 @@ function KnowledgeBasePageContent() {
         );
 
         // Show success toast
-        const { toast } = await import('@/lib/store/toast-store');
         toast.success('File replaced successfully', {
           description: `"${item.name}" has been replaced with "${newFile.name}"`,
         });
@@ -1789,7 +1781,6 @@ function KnowledgeBasePageContent() {
         console.error('Failed to replace file:', error);
         
         // Show error toast
-        const { toast } = await import('@/lib/store/toast-store');
         const err = error as { response?: { data?: { message?: string } }; message?: string };
         toast.error('Failed to replace file', {
           description: err?.response?.data?.message || err?.message || 'An error occurred',
@@ -1803,7 +1794,6 @@ function KnowledgeBasePageContent() {
 
   // Handle download
   const handleDownload = useCallback(async (item: KnowledgeBaseItem | KnowledgeHubNode | AllRecordItem) => {
-    const { toast } = await import('@/lib/store/toast-store');
     try {
       await KnowledgeBaseApi.streamDownloadRecord(item.id, item.name);
     } catch (error: unknown) {
@@ -1824,93 +1814,16 @@ function KnowledgeBasePageContent() {
   // Sidebar Action Handlers
   // ========================================
 
-  // Helper to find a node in categorized trees
-  const findNodeInTrees = useCallback((nodeId: string): EnhancedFolderTreeNode | null => {
-    if (!categorizedNodes) return null;
-    const searchTree = (nodes: EnhancedFolderTreeNode[]): EnhancedFolderTreeNode | null => {
-      for (const node of nodes) {
-        if (node.id === nodeId) return node;
-        const found = searchTree(node.children as EnhancedFolderTreeNode[]);
-        if (found) return found;
-      }
-      return null;
-    };
-    return searchTree(categorizedNodes.shared) || searchTree(categorizedNodes.private);
-  }, [categorizedNodes]);
-
-  // Sidebar: Reindex handler
-  const _handleSidebarReindex = useCallback((nodeId: string) => {
-    const node = findNodeInTrees(nodeId);
-    if (node) {
-      handleReindexClick({ id: node.id, name: node.name, nodeType: node.nodeType } as KnowledgeHubNode);
-    }
-  }, [findNodeInTrees, handleReindexClick]);
-
-  // Helper: find node and its root KB ancestor in categorized trees
-  const findNodeRootKb = useCallback((nodeId: string): string | null => {
-    if (!categorizedNodes) return null;
-    const searchTree = (nodes: EnhancedFolderTreeNode[], rootKbId: string | null): string | null => {
-      for (const node of nodes) {
-        if (node.id === nodeId) return rootKbId;
-        if (node.children?.length) {
-          const found = searchTree(node.children as EnhancedFolderTreeNode[], rootKbId ?? node.id);
-          if (found) return found;
-        }
-      }
-      return null;
-    };
-    return searchTree(categorizedNodes.shared, null) || searchTree(categorizedNodes.private, null);
-  }, [categorizedNodes]);
-
-  // Sidebar: Rename handler
-  const _handleSidebarRename = useCallback(async (nodeId: string, newName: string) => {
-    const { toast } = await import('@/lib/store/toast-store');
-    try {
-      const node = findNodeInTrees(nodeId);
-      if (node?.nodeType === 'folder') {
-        const rootKbId = findNodeRootKb(nodeId);
-        if (rootKbId) {
-          await KnowledgeBaseApi.renameFolder(rootKbId, nodeId, newName);
-          toast.success('Folder renamed successfully');
-        }
-      } else {
-        await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
-        toast.success('Collection renamed successfully');
-      }
-      await refreshData();
-    } catch (error: unknown) {
-      const err = error as { response?: { data?: { message?: string } }; message?: string };
-      toast.error(err?.response?.data?.message || 'Failed to rename');
-      throw error;
-    }
-  }, [refreshData, findNodeInTrees, findNodeRootKb]);
-
-  // Sidebar: Delete handler
-  const _handleSidebarDelete = useCallback((nodeId: string) => {
-    const node = findNodeInTrees(nodeId);
-    if (node) {
-      const rootKbId = findNodeRootKb(nodeId);
-      setItemToDelete({
-        id: node.id,
-        name: node.name,
-        nodeType: node.nodeType,
-        rootKbId: rootKbId ?? undefined,
-      });
-      setIsDeleteDialogOpen(true);
-    }
-  }, [findNodeInTrees, findNodeRootKb]);
-
   // Sidebar: Delete confirm handler
   const handleSidebarDeleteConfirm = useCallback(async () => {
     if (!itemToDelete) return;
     setIsDeleting(true);
-    const { toast } = await import('@/lib/store/toast-store');
     try {
-      if (itemToDelete.nodeType === 'folder' && itemToDelete.rootKbId) {
-        await KnowledgeBaseApi.deleteFolder(itemToDelete.rootKbId, itemToDelete.id);
-      } else {
-        await KnowledgeBaseApi.deleteKnowledgeBase(itemToDelete.id);
-      }
+      await KnowledgeBaseApi.deleteNode({
+        nodeId: itemToDelete.id,
+        nodeType: itemToDelete.nodeType,
+        rootKbId: itemToDelete.rootKbId,
+      });
       toast.success(`"${itemToDelete.name}" deleted successfully`);
       setIsDeleteDialogOpen(false);
 
@@ -2074,7 +1987,7 @@ function KnowledgeBasePageContent() {
               // Collections mode only props
               onCreateFolder={handleCreateFolder}
               onUpload={handleUpload}
-              onShare={shareAdapter ? handleShare : undefined}
+              onShare={canManageSelectedKbSharing ? handleShare : undefined}
               sharedMembers={sharedMembers}
               onRename={
                 !isAllRecordsMode && tableData?.permissions?.canEdit !== false
@@ -2136,14 +2049,14 @@ function KnowledgeBasePageContent() {
           onItemClick={handleItemClick}
           onPreview={handlePreviewFile}
           onRename={
-            !isAllRecordsMode && tableData?.permissions?.canEdit !== false
+            canEditSelectedNode
               ? handleRename
               : undefined
           }
           onReindex={handleReindexClick}
-          onReplace={isAllRecordsMode ? undefined : (item) => handleReplaceClick(item as KnowledgeHubNode)}
-          onMove={isAllRecordsMode ? undefined : handleMoveClick}
-          onDelete={isAllRecordsMode ? undefined : handleDelete}
+          onReplace={canEditSelectedNode ? (item) => handleReplaceClick(item as KnowledgeHubNode) : undefined}
+          onMove={canEditSelectedNode ? handleMoveClick : undefined}
+          onDelete={canDeleteSelectedNode ? handleDelete : undefined}
           onDownload={handleDownload}
           onCreateFolder={isAllRecordsMode ? undefined : handleCreateFolder}
           onUpload={isAllRecordsMode ? undefined : handleUpload}
@@ -2311,7 +2224,7 @@ function KnowledgeBasePageContent() {
       />
 
       {/* Share Sidebar */}
-      {shareAdapter && (
+      {canManageSelectedKbSharing && shareAdapter && (
         <ShareSidebar
           open={isShareSidebarOpen}
           onOpenChange={setIsShareSidebarOpen}

--- a/frontend-new/app/(main)/knowledge-base/page.tsx
+++ b/frontend-new/app/(main)/knowledge-base/page.tsx
@@ -398,8 +398,6 @@ function KnowledgeBasePageContent() {
   // Upload store actions
   const { addItems: addUploadItems, startUpload, completeUpload, failUpload, clearCompleted, updateItemStatus, bulkUpdateItemStatus } = useUploadStore();
 
-  // Refs to track previous page values (to detect user-initiated page changes vs initial mount)
-  const prevCollectionsPageRef = useRef(collectionsPagination.page);
   const prevAllRecordsPageRef = useRef(allRecordsPagination.page);
 
   // Sync current folder from URL params (Collections mode only).
@@ -543,6 +541,10 @@ function KnowledgeBasePageContent() {
     // They are still in deps so fetchAllRecordsTableData re-memoizes when they change, triggering the fetch effect.
     allRecordsFilter,
     allRecordsSort,
+    setIsLoadingAllRecordsTable,
+    setAllRecordsTableError,
+    setAllRecordsTableData,
+    syncAllRecordsPaginationMeta,
   ]);
 
   // Extract stable primitive values from URL to avoid re-firing effects
@@ -574,6 +576,22 @@ function KnowledgeBasePageContent() {
     }
     fetchAllRecordsTableData(allRecordsNodeType ?? undefined, allRecordsNodeId ?? undefined);
   }, [allRecordsFilter, allRecordsSort]);
+
+  // All Records mode: Re-fetch when pagination page changes
+  useEffect(() => {
+    if (isAllRecordsMode) {
+      if (allRecordsPagination.page === prevAllRecordsPageRef.current) return;
+      prevAllRecordsPageRef.current = allRecordsPagination.page;
+      fetchAllRecordsTableData(allRecordsNodeType ?? undefined, allRecordsNodeId ?? undefined);
+    }
+  }, [allRecordsPagination.page]);
+
+  // All Records mode: Re-fetch when pagination limit changes
+  useEffect(() => {
+    if (isAllRecordsMode && allRecordsPagination.limit !== 50) {
+      fetchAllRecordsTableData(allRecordsNodeType ?? undefined, allRecordsNodeId ?? undefined);
+    }
+  }, [allRecordsPagination.limit]);
 
   // All Records mode: Transform API response items to include source display info
   const allRecordsItems = useMemo(() => {
@@ -777,9 +795,22 @@ function KnowledgeBasePageContent() {
         setIsLoadingTableData(false);
       }
     },
-    // filter/sort are read from getState() inside the function to avoid stale closure on initial load.
-    // They are still in deps so fetchTableData re-memoizes when they change, triggering the fetch effect.
-    [filter, sort, setTableData, setIsLoadingTableData, setTableDataError, setSelectedNode, setCollectionsPagination, setCurrentFolderId, expandFolderExclusive, cacheNodeChildren, addNodes, setCategorizedNodes, clearTableData, router]
+    // Pagination/filter/sort read via getState() — keep this callback stable so the searchParams
+    // effect is the only collections refetch trigger (avoids double fetch with page/limit effects).
+    [
+      setTableData,
+      setIsLoadingTableData,
+      setTableDataError,
+      setSelectedNode,
+      setCollectionsPagination,
+      setCurrentFolderId,
+      expandFolderExclusive,
+      cacheNodeChildren,
+      addNodes,
+      setCategorizedNodes,
+      clearTableData,
+      router,
+    ]
   );
 
   // Helper to build navigation URLs that preserve view mode
@@ -869,39 +900,7 @@ function KnowledgeBasePageContent() {
     setIsSearchOpen(false);
   }, [pageViewMode, setSearchQuery, setAllRecordsSearchQuery]);
 
-  // Collections mode: Re-fetch when pagination page changes
-  useEffect(() => {
-    if (!isAllRecordsMode && selectedNode) {
-      // Skip if page hasn't actually changed (initial mount)
-      if (collectionsPagination.page === prevCollectionsPageRef.current) return;
-      prevCollectionsPageRef.current = collectionsPagination.page;
-      fetchTableData(selectedNode.nodeType, selectedNode.nodeId);
-    }
-  }, [collectionsPagination.page]);
-
-  // All Records mode: Re-fetch when pagination page changes
-  useEffect(() => {
-    if (isAllRecordsMode) {
-      // Skip if page hasn't actually changed (initial mount)
-      if (allRecordsPagination.page === prevAllRecordsPageRef.current) return;
-      prevAllRecordsPageRef.current = allRecordsPagination.page;
-      fetchAllRecordsTableData(allRecordsNodeType ?? undefined, allRecordsNodeId ?? undefined);
-    }
-  }, [allRecordsPagination.page]);
-
-  // Collections mode: Re-fetch when pagination limit changes
-  useEffect(() => {
-    if (!isAllRecordsMode && selectedNode && collectionsPagination.limit !== 50) {
-      fetchTableData(selectedNode.nodeType, selectedNode.nodeId);
-    }
-  }, [collectionsPagination.limit]);
-
-  // All Records mode: Re-fetch when pagination limit changes
-  useEffect(() => {
-    if (isAllRecordsMode && allRecordsPagination.limit !== 50) {
-      fetchAllRecordsTableData(allRecordsNodeType ?? undefined, allRecordsNodeId ?? undefined);
-    }
-  }, [allRecordsPagination.limit]);
+  // Collections: page/limit changes go through URL sync → searchParams; no separate pagination effects (avoids double fetch).
 
   // Helper function to convert EnhancedFolderTreeNode to FolderTreeNode format for move dialog
   const convertEnhancedToFolderTree = useCallback(

--- a/frontend-new/app/(main)/knowledge-base/page.tsx
+++ b/frontend-new/app/(main)/knowledge-base/page.tsx
@@ -370,7 +370,7 @@ function KnowledgeBasePageContent() {
 
   // Single delete confirmation dialog state (sidebar)
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-  const [itemToDelete, setItemToDelete] = useState<{ id: string; name: string } | null>(null);
+  const [itemToDelete, setItemToDelete] = useState<{ id: string; name: string; nodeType?: NodeType; rootKbId?: string } | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
   // Bulk delete confirmation dialog state
@@ -759,16 +759,27 @@ function KnowledgeBasePageContent() {
         }
 
       } catch (error) {
-        console.error('Failed to fetch table data:', error);
-        setTableDataError('Failed to load items. Please try again.');
-        setTableData(null);
+        // ProcessedError from apiClient interceptor has statusCode (not response.status)
+        const status = (error as { statusCode?: number })?.statusCode;
+        if (status === 403) {
+          // Access revoked — clear state, notify, and navigate to KB root
+          const { toast } = await import('@/lib/store/toast-store');
+          clearTableData();
+          toast.error('You no longer have access to this collection');
+          await refreshKbTree();
+          router.push('/knowledge-base');
+        } else {
+          console.error('Failed to fetch table data:', error);
+          setTableDataError('Failed to load items. Please try again.');
+          setTableData(null);
+        }
       } finally {
         setIsLoadingTableData(false);
       }
     },
     // filter/sort are read from getState() inside the function to avoid stale closure on initial load.
     // They are still in deps so fetchTableData re-memoizes when they change, triggering the fetch effect.
-    [filter, sort, setTableData, setIsLoadingTableData, setTableDataError, setSelectedNode, setCollectionsPagination, setCurrentFolderId, expandFolderExclusive, cacheNodeChildren, addNodes, setCategorizedNodes]
+    [filter, sort, setTableData, setIsLoadingTableData, setTableDataError, setSelectedNode, setCollectionsPagination, setCurrentFolderId, expandFolderExclusive, cacheNodeChildren, addNodes, setCategorizedNodes, clearTableData, router]
   );
 
   // Helper to build navigation URLs that preserve view mode
@@ -836,11 +847,11 @@ function KnowledgeBasePageContent() {
       setCreateFolderContext({ type: 'collection' });
       setIsCreateFolderDialogOpen(true);
     } else {
-      const { type, nodeId, nodeName, nodeType } = pendingSidebarAction;
+      const { type, nodeId, nodeName, nodeType, rootKbId } = pendingSidebarAction;
       if (type === 'reindex') {
         handleReindexClick({ id: nodeId, name: nodeName, nodeType } as KnowledgeHubNode);
       } else if (type === 'delete') {
-        setItemToDelete({ id: nodeId, name: nodeName });
+        setItemToDelete({ id: nodeId, name: nodeName, nodeType, rootKbId });
         setIsDeleteDialogOpen(true);
       }
     }
@@ -1362,7 +1373,8 @@ function KnowledgeBasePageContent() {
     setIsShareSidebarOpen(true);
   }, [shareAdapter]);
 
-  // Load shared members whenever the selected KB changes
+  // Load shared members whenever the selected KB changes.
+  // If we get a 403, access was revoked — navigate the user away.
   useEffect(() => {
     if (!shareAdapter || isSelectedKbPrivate) {
       setSharedMembers([]);
@@ -1372,10 +1384,19 @@ function KnowledgeBasePageContent() {
       setSharedMembers(
       members.map((m) => ({ id: m.id, name: m.name, avatarUrl: m.avatarUrl, type: m.type }))
       );
-    }).catch(() => {
+    }).catch(async (error) => {
       setSharedMembers([]);
+      // ProcessedError from apiClient interceptor has statusCode (not response.status)
+      const status = (error as { statusCode?: number })?.statusCode;
+      if (status === 403) {
+        const { toast } = await import('@/lib/store/toast-store');
+        clearTableData();
+        toast.error('You no longer have access to this collection');
+        await refreshKbTree();
+        router.push('/knowledge-base');
+      }
     });
-  }, [shareAdapter, isSelectedKbPrivate]);
+  }, [shareAdapter, isSelectedKbPrivate, clearTableData, router]);
 
   // Handle file preview
   const handlePreviewFile = useCallback(async (item: KnowledgeBaseItem | KnowledgeHubNode) => {
@@ -1546,7 +1567,12 @@ function KnowledgeBasePageContent() {
         const hubItem = item as KnowledgeHubNode;
         if (hubItem.nodeType === 'folder' || hubItem.nodeType === 'recordGroup') {
           if (!selectedKbId) throw new Error('No collection context for rename');
-          await KnowledgeBaseApi.renameFolder(selectedKbId, hubItem.id, newName);
+          if (hubItem.id === selectedKbId) {
+            // Root KB collection — use KB rename API
+            await KnowledgeBaseApi.renameKnowledgeBase(hubItem.id, newName);
+          } else {
+            await KnowledgeBaseApi.renameFolder(selectedKbId, hubItem.id, newName);
+          }
         } else if (hubItem.nodeType === 'record') {
           await KnowledgeBaseApi.renameRecord(hubItem.id, newName);
         }
@@ -1585,7 +1611,12 @@ function KnowledgeBasePageContent() {
     try {
       if (nodeType === 'folder' || nodeType === 'recordGroup') {
         if (!selectedKbId) throw new Error('No collection context for rename');
-        await KnowledgeBaseApi.renameFolder(selectedKbId, nodeId, newName);
+        if (nodeId === selectedKbId) {
+          // Root KB collection — use KB rename API
+          await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
+        } else {
+          await KnowledgeBaseApi.renameFolder(selectedKbId, nodeId, newName);
+        }
       }
 
       toast.success('Renamed successfully', {
@@ -1816,28 +1847,59 @@ function KnowledgeBasePageContent() {
     }
   }, [findNodeInTrees, handleReindexClick]);
 
+  // Helper: find node and its root KB ancestor in categorized trees
+  const findNodeRootKb = useCallback((nodeId: string): string | null => {
+    if (!categorizedNodes) return null;
+    const searchTree = (nodes: EnhancedFolderTreeNode[], rootKbId: string | null): string | null => {
+      for (const node of nodes) {
+        if (node.id === nodeId) return rootKbId;
+        if (node.children?.length) {
+          const found = searchTree(node.children as EnhancedFolderTreeNode[], rootKbId ?? node.id);
+          if (found) return found;
+        }
+      }
+      return null;
+    };
+    return searchTree(categorizedNodes.shared, null) || searchTree(categorizedNodes.private, null);
+  }, [categorizedNodes]);
+
   // Sidebar: Rename handler
   const _handleSidebarRename = useCallback(async (nodeId: string, newName: string) => {
     const { toast } = await import('@/lib/store/toast-store');
     try {
-      await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
-      toast.success('Collection renamed successfully');
+      const node = findNodeInTrees(nodeId);
+      if (node?.nodeType === 'folder') {
+        const rootKbId = findNodeRootKb(nodeId);
+        if (rootKbId) {
+          await KnowledgeBaseApi.renameFolder(rootKbId, nodeId, newName);
+          toast.success('Folder renamed successfully');
+        }
+      } else {
+        await KnowledgeBaseApi.renameKnowledgeBase(nodeId, newName);
+        toast.success('Collection renamed successfully');
+      }
       await refreshData();
     } catch (error: unknown) {
       const err = error as { response?: { data?: { message?: string } }; message?: string };
-      toast.error(err?.response?.data?.message || 'Failed to rename collection');
+      toast.error(err?.response?.data?.message || 'Failed to rename');
       throw error;
     }
-  }, [refreshData]);
+  }, [refreshData, findNodeInTrees, findNodeRootKb]);
 
   // Sidebar: Delete handler
   const _handleSidebarDelete = useCallback((nodeId: string) => {
     const node = findNodeInTrees(nodeId);
     if (node) {
-      setItemToDelete({ id: node.id, name: node.name });
+      const rootKbId = findNodeRootKb(nodeId);
+      setItemToDelete({
+        id: node.id,
+        name: node.name,
+        nodeType: node.nodeType,
+        rootKbId: rootKbId ?? undefined,
+      });
       setIsDeleteDialogOpen(true);
     }
-  }, [findNodeInTrees]);
+  }, [findNodeInTrees, findNodeRootKb]);
 
   // Sidebar: Delete confirm handler
   const handleSidebarDeleteConfirm = useCallback(async () => {
@@ -1845,7 +1907,11 @@ function KnowledgeBasePageContent() {
     setIsDeleting(true);
     const { toast } = await import('@/lib/store/toast-store');
     try {
-      await KnowledgeBaseApi.deleteKnowledgeBase(itemToDelete.id);
+      if (itemToDelete.nodeType === 'folder' && itemToDelete.rootKbId) {
+        await KnowledgeBaseApi.deleteFolder(itemToDelete.rootKbId, itemToDelete.id);
+      } else {
+        await KnowledgeBaseApi.deleteKnowledgeBase(itemToDelete.id);
+      }
       toast.success(`"${itemToDelete.name}" deleted successfully`);
       setIsDeleteDialogOpen(false);
 
@@ -1860,6 +1926,9 @@ function KnowledgeBasePageContent() {
       setItemToDelete(null);
 
       if (deletedCurrentView) {
+        // Clear selectedNode immediately to prevent stale API calls
+        // (e.g. permissions fetch for the now-deleted node)
+        clearTableData();
         await refreshKbTree();
         router.push(buildNavUrl({}));
       } else {
@@ -1867,11 +1936,11 @@ function KnowledgeBasePageContent() {
       }
     } catch (error: unknown) {
       const err = error as { response?: { data?: { message?: string } }; message?: string };
-      toast.error(err?.response?.data?.message || 'Failed to delete collection');
+      toast.error(err?.response?.data?.message || `Failed to delete ${itemToDelete.nodeType === 'folder' ? 'folder' : 'collection'}`);
     } finally {
       setIsDeleting(false);
     }
-  }, [itemToDelete, refreshData, refreshKbTree, searchParams, tableData?.breadcrumbs, router, buildNavUrl]);
+  }, [itemToDelete, refreshData, refreshKbTree, clearTableData, searchParams, tableData?.breadcrumbs, router, buildNavUrl]);
 
   // Handle create sub-folder from move dialog
   // ========================================
@@ -2124,7 +2193,7 @@ function KnowledgeBasePageContent() {
           }}
           onConfirm={handleSidebarDeleteConfirm}
           itemName={itemToDelete.name}
-          itemType="KB"
+          itemType={itemToDelete.nodeType === 'folder' ? 'folder' : 'KB'}
           isDeleting={isDeleting}
         />
       )}
@@ -2259,6 +2328,9 @@ function KnowledgeBasePageContent() {
                   type: m.type,
                 }))
               );
+            }).catch(() => {
+              // Access may have been revoked — clear stale members silently
+              setSharedMembers([]);
             });
           }}
         />

--- a/frontend-new/app/(main)/knowledge-base/share-adapter.ts
+++ b/frontend-new/app/(main)/knowledge-base/share-adapter.ts
@@ -20,7 +20,7 @@ export function createKBShareAdapter(kbId: string): ShareAdapter {
     supportsTeams: true,
 
     async getSharedMembers(): Promise<SharedMember[]> {
-      const { data } = await apiClient.get(`${BASE}/${kbId}/permissions`);
+      const { data } = await apiClient.get(`${BASE}/${kbId}/permissions`, { suppressErrorToast: true });
       // Transform API response to SharedMember[]
       const permissions = Array.isArray(data) ? data : data.permissions ?? [];
       return permissions.map((p: Record<string, unknown>) => {

--- a/frontend-new/app/(main)/knowledge-base/store.ts
+++ b/frontend-new/app/(main)/knowledge-base/store.ts
@@ -127,7 +127,7 @@ interface KnowledgeBaseState {
 
   // Sidebar → Page action bridge (for dialogs rendered in page.tsx)
   pendingSidebarAction:
-    | { type: 'reindex' | 'delete'; nodeId: string; nodeName: string; nodeType?: NodeType }
+    | { type: 'reindex' | 'delete'; nodeId: string; nodeName: string; nodeType?: NodeType; rootKbId?: string }
     | { type: 'create-collection' }
     | null;
 
@@ -248,7 +248,7 @@ interface KnowledgeBaseActions {
   setIsDeletingNode: (nodeId: string, deleting: boolean) => void;
 
   // Sidebar → Page action bridge
-  setPendingSidebarAction: (action: { type: 'reindex' | 'delete'; nodeId: string; nodeName: string; nodeType?: NodeType } | { type: 'create-collection' } | null) => void;
+  setPendingSidebarAction: (action: { type: 'reindex' | 'delete'; nodeId: string; nodeName: string; nodeType?: NodeType; rootKbId?: string } | { type: 'create-collection' } | null) => void;
   clearPendingSidebarAction: () => void;
 
   // Bulk actions

--- a/frontend-new/app/(main)/knowledge-base/store.ts
+++ b/frontend-new/app/(main)/knowledge-base/store.ts
@@ -5,6 +5,13 @@ import { devtools } from 'zustand/middleware';
 import { immer } from 'zustand/middleware/immer';
 import { enableMapSet } from 'immer';
 import { categorizeNode, mergeChildrenIntoTree } from './utils/tree-builder';
+
+/**
+ * Default page size for KB and all-records pagination. Shared across store
+ * initial state and page-level effects so they stay in sync.
+ */
+export const DEFAULT_PAGE_SIZE = 50;
+
 import type {
   KnowledgeBase,
   KnowledgeBaseItem,
@@ -294,7 +301,7 @@ const initialState: KnowledgeBaseState = {
   selectedNode: null,
   collectionsPagination: {
     page: 1,
-    limit: 50,
+    limit: DEFAULT_PAGE_SIZE,
     totalItems: 0,
     totalPages: 0,
     hasNext: false,
@@ -320,7 +327,7 @@ const initialState: KnowledgeBaseState = {
   allRecordsSearchQuery: '',
   allRecordsPagination: {
     page: 1,
-    limit: 50,
+    limit: DEFAULT_PAGE_SIZE,
     totalItems: 0,
     totalPages: 0,
     hasNext: false,

--- a/frontend-new/app/(main)/knowledge-base/utils.ts
+++ b/frontend-new/app/(main)/knowledge-base/utils.ts
@@ -11,6 +11,9 @@ import type {
   DateFilterType,
 } from './types';
 
+/** Must match backend `MIN_SEARCH_QUERY_LENGTH` in `knowledge_hub_router.py`. */
+export const KB_MIN_SEARCH_QUERY_LENGTH = 2;
+
 /**
  * Size range buckets in bytes
  * All ranges include both gte and lte bounds to match API format: "gte:X,lte:Y"
@@ -145,9 +148,10 @@ export function buildFilterParams(
     include: 'counts,permissions,breadcrumbs,availableFilters',
   };
 
-  // Search query
-  if (filter.searchQuery?.trim()) {
-    params.q = filter.searchQuery.trim();
+  // Search query (omit `q` until long enough — backend returns 400 otherwise)
+  const searchTrimmed = filter.searchQuery?.trim();
+  if (searchTrimmed && searchTrimmed.length >= KB_MIN_SEARCH_QUERY_LENGTH) {
+    params.q = searchTrimmed;
   }
 
   // Node types (CSV string)
@@ -231,9 +235,9 @@ export function buildAllRecordsFilterParams(
     include: 'counts,permissions,breadcrumbs,availableFilters',
   };
 
-  // Search query
-  if (filter.searchQuery?.trim()) {
-    params.q = filter.searchQuery.trim();
+  const searchTrimmedAll = filter.searchQuery?.trim();
+  if (searchTrimmedAll && searchTrimmedAll.length >= KB_MIN_SEARCH_QUERY_LENGTH) {
+    params.q = searchTrimmedAll;
   }
 
   // Node types (CSV string)

--- a/frontend-new/app/(main)/knowledge-base/utils/all-records-transformer.ts
+++ b/frontend-new/app/(main)/knowledge-base/utils/all-records-transformer.ts
@@ -11,6 +11,7 @@ import type {
   AppNodeGroup,
 } from '../types';
 import { resolveConnectorType } from '@/app/components/ui/ConnectorIcon';
+import { KB_MIN_SEARCH_QUERY_LENGTH } from '../utils';
 
 /**
  * Connector group for sidebar display
@@ -146,9 +147,9 @@ export function buildAllRecordsQueryParams(
     sortOrder: sort.order,
   };
 
-  // Search query
-  if (searchQuery && searchQuery.trim()) {
-    params.q = searchQuery.trim();
+  const sq = searchQuery?.trim();
+  if (sq && sq.length >= KB_MIN_SEARCH_QUERY_LENGTH) {
+    params.q = sq;
   }
 
   // Sidebar selection drives primary filtering

--- a/frontend-new/app/(main)/knowledge-base/utils/find-node.ts
+++ b/frontend-new/app/(main)/knowledge-base/utils/find-node.ts
@@ -1,0 +1,39 @@
+import type { CategorizedNodes, EnhancedFolderTreeNode } from '../types';
+
+export interface FindNodeResult {
+  node: EnhancedFolderTreeNode | null;
+  rootKbId: string | null;
+}
+
+/**
+ * Find a node by id in the categorized tree (shared + private).
+ * Returns the node and its root KB ancestor id (null for top-level KB/app nodes).
+ */
+export function findNodeInCategorized(
+  categorizedNodes: CategorizedNodes | null,
+  targetId: string
+): FindNodeResult {
+  if (!categorizedNodes) return { node: null, rootKbId: null };
+
+  const walk = (
+    nodes: EnhancedFolderTreeNode[],
+    currentRootKbId: string | null
+  ): FindNodeResult | null => {
+    for (const node of nodes) {
+      if (node.id === targetId) {
+        return { node, rootKbId: currentRootKbId };
+      }
+      if (node.children?.length) {
+        const childRootKbId = currentRootKbId ?? node.id;
+        const found = walk(node.children as EnhancedFolderTreeNode[], childRootKbId);
+        if (found) return found;
+      }
+    }
+    return null;
+  };
+
+  return (
+    walk(categorizedNodes.shared, null) ??
+    walk(categorizedNodes.private, null) ?? { node: null, rootKbId: null }
+  );
+}

--- a/frontend-new/app/components/file-preview/file-details-tab.tsx
+++ b/frontend-new/app/components/file-preview/file-details-tab.tsx
@@ -145,7 +145,7 @@ export function FileDetailsTab({ recordDetails }: FileDetailsTabProps) {
         <Flex direction="column" gap="2">
           <DetailRow label="Name" value={record.recordName} />
           <DetailRow label="Record ID" value={record.id} />
-          <DetailRow label="Record Type" value={record.mimeType} />
+          <DetailRow label="Record Type" value={record.recordType} />
           <DetailRow label="Origin" value={record.origin} />
           <DetailRow label="Indexing Status" value={record.indexingStatus} />
           <DetailRow label="Version" value={record.version?.toString()} />

--- a/frontend-new/app/components/share/role-dropdown-menu.tsx
+++ b/frontend-new/app/components/share/role-dropdown-menu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { createPortal } from 'react-dom';
 import { Text, Flex, Box } from '@radix-ui/themes';
 import { MaterialIcon } from '@/app/components/ui/MaterialIcon';
 import type { ShareRole } from './types';
@@ -66,31 +67,29 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
     };
   }, [open, handleClickOutside, handleKeyDown]);
 
-  // Calculate anchor position when opening with anchorRef
+  // Calculate fixed position from trigger (or anchorRef) using viewport coordinates.
+  // The dropdown is portaled to document.body, so fixed positioning works correctly.
   useEffect(() => {
-    if (open && anchorRef?.current) {
-      const rect = anchorRef.current.getBoundingClientRect();
-      setAnchorRect({ top: rect.bottom + 4, left: rect.left, width: rect.width });
-    } else if (!open) {
+    if (open) {
+      const el = anchorRef?.current ?? triggerRef.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        if (anchorRef?.current) {
+          setAnchorRect({ top: rect.bottom + 4, left: rect.left, width: rect.width });
+        } else {
+          // Align dropdown right edge with trigger right edge, min width 320
+          const dropdownWidth = 320;
+          setAnchorRect({
+            top: rect.bottom + 4,
+            left: Math.max(8, rect.right - dropdownWidth),
+            width: dropdownWidth,
+          });
+        }
+      }
+    } else {
       setAnchorRect(null);
     }
   }, [open, anchorRef]);
-
-  const useFixedPosition = !!anchorRef && !!anchorRect;
-
-  const menuPositionStyle: React.CSSProperties = useFixedPosition
-    ? {
-        position: 'fixed',
-        top: anchorRect.top,
-        left: anchorRect.left,
-        width: anchorRect.width,
-      }
-    : {
-        position: 'absolute',
-        top: 'calc(100% + 4px)',
-        right: 0,
-        width: 320,
-      };
 
   return (
     <Box style={{ position: 'relative' }}>
@@ -123,12 +122,17 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
         <MaterialIcon name="expand_more" size={16} color="var(--slate-11)" />
       </button>
 
-      {/* Dropdown popover */}
-      {open && (
+      {/* Dropdown popover — portaled to body to escape Dialog overflow clipping */}
+      {open && anchorRect && createPortal(
         <Box
           ref={menuRef}
+          data-role-dropdown-portal
           style={{
-            ...menuPositionStyle,
+            position: 'fixed',
+            top: anchorRect.top,
+            left: anchorRect.left,
+            width: anchorRect.width,
+            pointerEvents: 'auto',
             backgroundColor: 'var(--olive-2)',
             border: '1px solid var(--olive-3)',
             borderRadius: 'var(--radius-2)',
@@ -136,7 +140,7 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
               '0px 12px 32px -16px rgba(0, 9, 50, 0.12), 0px 12px 60px 0px rgba(0, 0, 0, 0.15)',
             padding: 0,
             overflow: 'hidden',
-            zIndex: 100,
+            zIndex: 9999,
           }}
         >
           {isNoRoles ? (
@@ -250,7 +254,8 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
               </Flex>
             </>
           )}
-        </Box>
+        </Box>,
+        document.body
       )}
     </Box>
   );

--- a/frontend-new/app/components/share/role-dropdown-menu.tsx
+++ b/frontend-new/app/components/share/role-dropdown-menu.tsx
@@ -25,19 +25,37 @@ interface RoleDropdownMenuProps {
    * this element's edges (used for search-bar alignment).
    */
   anchorRef?: React.RefObject<HTMLElement | null>;
+  /**
+   * Fires when the dropdown open state changes. Parents can use this to
+   * gate outside-click handling on portaled elements.
+   */
+  onOpenChange?: (open: boolean) => void;
 }
 
 const SELECTABLE_ROLES: ShareRole[] = ['OWNER', 'WRITER', 'READER'];
+const MENU_WIDTH = 292;
+const MIN_HORIZONTAL_MARGIN = 8;
+const MIN_VERTICAL_MARGIN = 8;
 
-export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false, noRolesInfo, anchorRef }: RoleDropdownMenuProps) {
+export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false, noRolesInfo, anchorRef, onOpenChange }: RoleDropdownMenuProps) {
   // Treat as no-roles when isTeam or noRolesInfo is provided
   const isNoRoles = isTeam || !!noRolesInfo;
   const noRolesTitle = noRolesInfo?.title ?? 'Team';
   const noRolesDescription = noRolesInfo?.description ?? 'Teams do not have roles';
-  const [open, setOpen] = useState(false);
+  const [open, setOpenState] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const [anchorRect, setAnchorRect] = useState<{ top: number; left: number; width: number } | null>(null);
+
+  const setOpen = useCallback((next: boolean | ((prev: boolean) => boolean)) => {
+    setOpenState((prev) =>
+      typeof next === 'function' ? (next as (p: boolean) => boolean)(prev) : next
+    );
+  }, []);
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [open, onOpenChange]);
 
   // Close on outside click
   const handleClickOutside = useCallback((e: MouseEvent) => {
@@ -49,12 +67,12 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
     ) {
       setOpen(false);
     }
-  }, []);
+  }, [setOpen]);
 
   // Close on Escape
   const handleKeyDown = useCallback((e: KeyboardEvent) => {
     if (e.key === 'Escape') setOpen(false);
-  }, []);
+  }, [setOpen]);
 
   useEffect(() => {
     if (open) {
@@ -68,28 +86,58 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
   }, [open, handleClickOutside, handleKeyDown]);
 
   // Calculate fixed position from trigger (or anchorRef) using viewport coordinates.
-  // The dropdown is portaled to document.body, so fixed positioning works correctly.
+  // Re-measures on scroll/resize so the dropdown stays anchored to its trigger.
   useEffect(() => {
-    if (open) {
-      const el = anchorRef?.current ?? triggerRef.current;
-      if (el) {
-        const rect = el.getBoundingClientRect();
-        if (anchorRef?.current) {
-          setAnchorRect({ top: rect.bottom + 4, left: rect.left, width: rect.width });
-        } else {
-          // Align dropdown right edge with trigger right edge, min width 320
-          const dropdownWidth = 320;
-          setAnchorRect({
-            top: rect.bottom + 4,
-            left: Math.max(8, rect.right - dropdownWidth),
-            width: dropdownWidth,
-          });
-        }
-      }
-    } else {
+    if (!open) {
       setAnchorRect(null);
+      return;
     }
-  }, [open, anchorRef]);
+    const el = anchorRef?.current ?? triggerRef.current;
+    if (!el) return;
+
+    const update = () => {
+      const rect = el.getBoundingClientRect();
+      const dropdownWidth = MENU_WIDTH;
+      const left = Math.min(
+        window.innerWidth - dropdownWidth - MIN_HORIZONTAL_MARGIN,
+        Math.max(MIN_HORIZONTAL_MARGIN, rect.right - dropdownWidth)
+      );
+      const estimatedMenuHeight = onRemove ? 220 : 190;
+      const measuredMenuHeight = menuRef.current?.offsetHeight || estimatedMenuHeight;
+      const preferredTop = rect.bottom + 4;
+      const maxTop = window.innerHeight - measuredMenuHeight - MIN_VERTICAL_MARGIN;
+      let top = preferredTop;
+
+      // If opening downward would overflow viewport, open upward and keep attached
+      // to the trigger. Fallback to clamped viewport bounds when necessary.
+      if (preferredTop > maxTop) {
+        const upwardTop = rect.top - measuredMenuHeight - 4;
+        top =
+          upwardTop >= MIN_VERTICAL_MARGIN
+            ? upwardTop
+            : Math.max(MIN_VERTICAL_MARGIN, maxTop);
+      }
+      setAnchorRect({
+        top,
+        left,
+        width: dropdownWidth,
+      });
+    };
+
+    update();
+    // Re-measure after the menu mounts so we use real height, not only estimate.
+    const rafId = requestAnimationFrame(update);
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    return () => {
+      cancelAnimationFrame(rafId);
+      ro.disconnect();
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+    };
+  }, [open, anchorRef, onRemove]);
 
   return (
     <Box style={{ position: 'relative' }}>
@@ -102,17 +150,17 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
           display: 'inline-flex',
           alignItems: 'center',
           gap: 4,
-          height: 24,
+          height: 28,
           padding: '0 8px',
           borderRadius: 'var(--radius-1)',
           backgroundColor: 'var(--slate-a4)',
           border: 'none',
           cursor: 'pointer',
           fontFamily: 'var(--default-font-family)',
-          fontSize: 12,
+          fontSize: 11,
           fontWeight: 400,
-          lineHeight: '16px',
-          letterSpacing: '0.04px',
+          lineHeight: '14px',
+          letterSpacing: '0.02px',
           color: 'var(--slate-11)',
           flexShrink: 0,
           userSelect: 'none',
@@ -126,12 +174,12 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
       {open && anchorRect && createPortal(
         <Box
           ref={menuRef}
-          data-role-dropdown-portal
           style={{
             position: 'fixed',
             top: anchorRect.top,
             left: anchorRect.left,
             width: anchorRect.width,
+            maxHeight: 'min(320px, calc(100vh - 16px))',
             pointerEvents: 'auto',
             backgroundColor: 'var(--olive-2)',
             border: '1px solid var(--olive-3)',
@@ -139,7 +187,8 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
             boxShadow:
               '0px 12px 32px -16px rgba(0, 9, 50, 0.12), 0px 12px 60px 0px rgba(0, 0, 0, 0.15)',
             padding: 0,
-            overflow: 'hidden',
+            overflowY: 'auto',
+            overflowX: 'hidden',
             zIndex: 9999,
           }}
         >
@@ -147,12 +196,12 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
             /* No-roles mode: show informational label only */
             <Flex
               direction="column"
-              style={{ padding: '12px 16px', paddingBottom: onRemove ? 8 : 12 }}
+              style={{ padding: '10px 12px', paddingBottom: onRemove ? 8 : 10 }}
             >
-              <Text size="2" weight="medium" style={{ color: 'var(--slate-12)' }}>
+              <Text size="1" weight="medium" style={{ color: 'var(--slate-12)', fontSize: 13, lineHeight: '16px' }}>
                 {noRolesTitle}
               </Text>
-              <Text size="1" style={{ color: 'var(--slate-11)' }}>
+              <Text size="1" style={{ color: 'var(--slate-11)', fontSize: 12, lineHeight: '16px' }}>
                 {noRolesDescription}
               </Text>
             </Flex>
@@ -167,10 +216,10 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
                 setOpen(false);
               }}
               style={{
-                padding: '8px 16px',
-                paddingTop: index === 0 ? 12 : 8,
+                padding: '6px 12px',
+                paddingTop: index === 0 ? 8 : 6,
                 paddingBottom:
-                  index === SELECTABLE_ROLES.length - 1 && !onRemove ? 12 : 8,
+                  index === SELECTABLE_ROLES.length - 1 && !onRemove ? 8 : 6,
                 cursor: 'pointer',
               }}
               onMouseEnter={(e) => {
@@ -183,13 +232,13 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
               {/* Label + description */}
               <Flex direction="column" gap="1" style={{ flex: 1, minWidth: 0 }}>
                 <Text
-                  size="2"
+                  size="1"
                   weight={r === role ? 'medium' : 'regular'}
-                  style={{ color: 'var(--slate-12)' }}
+                  style={{ color: 'var(--slate-12)', fontSize: 13, lineHeight: '16px' }}
                 >
                   {SHARE_ROLE_LABELS[r].label}
                 </Text>
-                <Text size="1" style={{ color: 'var(--slate-11)' }}>
+                <Text size="1" style={{ color: 'var(--slate-11)', fontSize: 12, lineHeight: '15px' }}>
                   {SHARE_ROLE_LABELS[r].description}
                 </Text>
               </Flex>
@@ -197,8 +246,8 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
               {/* Radio indicator */}
               <Box
                 style={{
-                  width: 16,
-                  height: 16,
+                  width: 14,
+                  height: 14,
                   borderRadius: '50%',
                   border: `2px solid ${r === role ? 'var(--accent-9)' : 'var(--slate-7)'}`,
                   display: 'flex',
@@ -210,8 +259,8 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
                 {r === role && (
                   <Box
                     style={{
-                      width: 8,
-                      height: 8,
+                      width: 6,
+                      height: 6,
                       borderRadius: '50%',
                       backgroundColor: 'var(--accent-9)',
                     }}
@@ -238,7 +287,7 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
                   setOpen(false);
                 }}
                 style={{
-                  padding: '12px 16px',
+                  padding: '10px 12px',
                   cursor: 'pointer',
                 }}
                 onMouseEnter={(e) => {
@@ -248,7 +297,7 @@ export function RoleDropdownMenu({ role, onRoleChange, onRemove, isTeam = false,
                   (e.currentTarget as HTMLElement).style.backgroundColor = 'transparent';
                 }}
               >
-                <Text size="2" style={{ color: 'var(--red-11)' }}>
+                <Text size="1" style={{ color: 'var(--red-11)', fontSize: 13, lineHeight: '16px' }}>
                   Remove
                 </Text>
               </Flex>

--- a/frontend-new/app/components/share/share-search-input.tsx
+++ b/frontend-new/app/components/share/share-search-input.tsx
@@ -39,11 +39,10 @@ export function ShareSearchInput({
   onEmailSubmit,
 }: ShareSearchInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const roleAnchorRef = useRef<HTMLDivElement>(null);
 
   return (
     <Flex
-      ref={containerRef}
       align="center"
       onClick={() => inputRef.current?.focus()}
       style={{
@@ -136,11 +135,11 @@ export function ShareSearchInput({
 
       {/* Role picker - fixed on the right (shown when items are selected and roles are supported) */}
       {selections.length > 0 && supportsRoles && (
-        <Box style={{ flexShrink: 0, paddingRight: 4 }}>
+        <Box ref={roleAnchorRef} style={{ flexShrink: 0, paddingRight: 4 }}>
           <RoleDropdownMenu
             role={selectedRole}
             onRoleChange={onRoleChange}
-            anchorRef={containerRef}
+            anchorRef={roleAnchorRef}
           />
         </Box>
       )}

--- a/frontend-new/app/components/share/share-sidebar.tsx
+++ b/frontend-new/app/components/share/share-sidebar.tsx
@@ -308,6 +308,13 @@ export function ShareSidebar({
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content
+        onPointerDownOutside={(e) => {
+          // Prevent dialog from closing when clicking portaled role dropdown.
+          // Check if any role dropdown portal exists in the DOM (it's only mounted when open).
+          if (document.querySelector('[data-role-dropdown-portal]')) {
+            e.preventDefault();
+          }
+        }}
         style={{
           position: 'fixed',
           top: 10,
@@ -513,9 +520,9 @@ export function ShareSidebar({
                           }
                           subtitle={member.email}
                           avatarUrl={member.avatarUrl}
-                          isOwner={member.isOwner}
+                          isOwner={false}
                           role={member.role}
-                          showRoleDropdown={!member.isOwner && !member.isCurrentUser}
+                          showRoleDropdown={!member.isCurrentUser}
                           noRolesInfo={
                             !adapter.supportsRoles && member.type === 'user'
                               ? { title: 'Full Access', description: 'Chats do not have roles' }
@@ -527,7 +534,7 @@ export function ShareSidebar({
                               : undefined
                           }
                           onRemove={
-                            !member.isOwner && !member.isCurrentUser
+                            !member.isCurrentUser
                               ? () => handleRemoveMember(member.id, member.type)
                               : undefined
                           }

--- a/frontend-new/app/components/share/share-sidebar.tsx
+++ b/frontend-new/app/components/share/share-sidebar.tsx
@@ -48,6 +48,9 @@ export function ShareSidebar({
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedItems, setSelectedItems] = useState<ShareSelection[]>([]);
   const [selectedRole, setSelectedRole] = useState<ShareRole>('READER');
+  // Tracks whether any portaled role dropdown is open — used to suppress the
+  // dialog's outside-click handler while the dropdown is active.
+  const [isRoleDropdownOpen, setIsRoleDropdownOpen] = useState(false);
 
   // Fetched data
   const [suggestedTeams, setSuggestedTeams] = useState<ShareTeam[]>([]);
@@ -253,7 +256,9 @@ export function ShareSidebar({
     }
   }, [selectedItems, selectedRole, adapter, onShareSuccess, updateSearchQuery]);
 
-  // Update role for existing member
+  // Update role for existing member.
+  // Note: the "at least one owner must remain" invariant is enforced server-side;
+  // a failed update surfaces through the catch block's toast.
   const handleRoleChange = useCallback(
     async (memberId: string, memberType: 'user' | 'team', newRole: ShareRole) => {
       if (!adapter.updateRole) return;
@@ -261,19 +266,25 @@ export function ShareSidebar({
       try {
         await adapter.updateRole(memberId, memberType, newRole);
         setExistingMembers((prev) =>
-          prev.map((m) => (m.id === memberId ? { ...m, role: newRole } : m))
+          prev.map((m) =>
+            m.id === memberId ? { ...m, role: newRole, isOwner: newRole === 'OWNER' } : m
+          )
         );
         toast.success('Role updated', {
           description: `${member?.name ?? 'Member'} is now a ${newRole.toLowerCase()}`,
         });
-      } catch {
-        toast.error('Failed to update role', { description: 'Could not update role. Please try again.' });
+      } catch (error) {
+        const message =
+          (error as { response?: { data?: { message?: string } }; message?: string })?.response?.data?.message
+          ?? 'Could not update role. Please try again.';
+        toast.error('Failed to update role', { description: message });
       }
     },
     [adapter, existingMembers]
   );
 
-  // Remove member
+  // Remove member.
+  // Note: the "at least one owner must remain" invariant is enforced server-side.
   const handleRemoveMember = useCallback(
     async (memberId: string, memberType: 'user' | 'team') => {
       const member = existingMembers.find((m) => m.id === memberId);
@@ -284,8 +295,11 @@ export function ShareSidebar({
           description: `${member?.name ?? 'Member'} no longer has access`,
         });
         onShareSuccess?.();
-      } catch {
-        toast.error('Failed to revoke access', { description: 'Could not remove access. Please try again.' });
+      } catch (error) {
+        const message =
+          (error as { response?: { data?: { message?: string } }; message?: string })?.response?.data?.message
+          ?? 'Could not remove access. Please try again.';
+        toast.error('Failed to revoke access', { description: message });
       }
     },
     [adapter, existingMembers, onShareSuccess]
@@ -309,9 +323,8 @@ export function ShareSidebar({
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
       <Dialog.Content
         onPointerDownOutside={(e) => {
-          // Prevent dialog from closing when clicking portaled role dropdown.
-          // Check if any role dropdown portal exists in the DOM (it's only mounted when open).
-          if (document.querySelector('[data-role-dropdown-portal]')) {
+          // Prevent dialog from closing while a portaled role dropdown is open.
+          if (isRoleDropdownOpen) {
             e.preventDefault();
           }
         }}
@@ -520,9 +533,9 @@ export function ShareSidebar({
                           }
                           subtitle={member.email}
                           avatarUrl={member.avatarUrl}
-                          isOwner={false}
+                          
                           role={member.role}
-                          showRoleDropdown={!member.isCurrentUser}
+                          showRoleDropdown
                           noRolesInfo={
                             !adapter.supportsRoles && member.type === 'user'
                               ? { title: 'Full Access', description: 'Chats do not have roles' }
@@ -533,11 +546,8 @@ export function ShareSidebar({
                               ? (newRole) => handleRoleChange(member.id, member.type, newRole)
                               : undefined
                           }
-                          onRemove={
-                            !member.isCurrentUser
-                              ? () => handleRemoveMember(member.id, member.type)
-                              : undefined
-                          }
+                          onRemove={() => handleRemoveMember(member.id, member.type)}
+                          onRoleDropdownOpenChange={setIsRoleDropdownOpen}
                         />
                       ))}
                     </>

--- a/frontend-new/app/components/share/shareable-row.tsx
+++ b/frontend-new/app/components/share/shareable-row.tsx
@@ -34,6 +34,8 @@ interface ShareableRowProps {
   onInvite?: () => void;
   /** Callback for remove action */
   onRemove?: () => void;
+  /** Fires when the role dropdown open state changes */
+  onRoleDropdownOpenChange?: (open: boolean) => void;
 }
 
 export function ShareableRow({
@@ -52,6 +54,7 @@ export function ShareableRow({
   onRoleChange,
   onInvite,
   onRemove,
+  onRoleDropdownOpenChange,
 }: ShareableRowProps) {
   return (
     <Flex
@@ -146,17 +149,18 @@ export function ShareableRow({
         </Box>
       )}
 
-      {showRoleDropdown && role && !isOwner && (
+      {showRoleDropdown && role && (
         <RoleDropdownMenu
           role={role}
           onRoleChange={onRoleChange}
           onRemove={onRemove}
           isTeam={type === 'team'}
           noRolesInfo={noRolesInfo}
+          onOpenChange={onRoleDropdownOpenChange}
         />
       )}
 
-      {isOwner && (
+      {isOwner && !showRoleDropdown && (
         <Text size="2" style={{ color: 'var(--slate-9)', flexShrink: 0 }}>
           Owner
         </Text>

--- a/frontend-new/lib/hooks/use-upload-limits.ts
+++ b/frontend-new/lib/hooks/use-upload-limits.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+import { KnowledgeBaseApi } from '@/app/(main)/knowledge-base/api';
+
+const DEFAULT_MAX_FILE_SIZE_MB = 30;
+export const DEFAULT_MAX_FILE_SIZE_BYTES = DEFAULT_MAX_FILE_SIZE_MB * 1024 * 1024;
+
+interface UploadLimitsResponse {
+  maxFileSizeBytes?: number;
+}
+
+// Module-level cache to avoid duplicate fetches when multiple components mount the hook.
+let cachedPromise: Promise<UploadLimitsResponse | null> | null = null;
+
+/**
+ * Fetches KB upload limits from the backend once and memoizes the result.
+ * Returns both the raw byte limit and a rounded MB value for display.
+ */
+export function useUploadLimits() {
+  const [maxFileSizeBytes, setMaxFileSizeBytes] = useState(DEFAULT_MAX_FILE_SIZE_BYTES);
+
+  useEffect(() => {
+    let mounted = true;
+    if (!cachedPromise) {
+      cachedPromise = KnowledgeBaseApi.getUploadLimits()
+        .then((resp) => resp as UploadLimitsResponse)
+        .catch(() => null);
+    }
+    cachedPromise.then((resp) => {
+      if (!mounted) return;
+      const s = Number(resp?.maxFileSizeBytes);
+      if (Number.isFinite(s) && s > 0) setMaxFileSizeBytes(s);
+    });
+    return () => { mounted = false; };
+  }, []);
+
+  return {
+    maxFileSizeBytes,
+    maxFileSizeMB: Math.round(maxFileSizeBytes / (1024 * 1024)),
+  };
+}


### PR DESCRIPTION
## Description

fixed issue in new frontend

Fix KB deletion triggering permission API after successful deletion, causing access denied errors
Fix folder deletion not working from sidebar
Fix folder rename not working from sidebar
Fix KB record rename failing due to missing timestamp in request(backend issue)
Fix permission API failing for removed team members after KB access revocation, fixed by redirecting to base route
Fix upload limit showing static default (30) instead of configured value
Fix owner type permission — allow update and delete owner also while ensuring at least one owner remains
Fix folder details showing incorrect file/folder count due to per-page pagination — now shows total count
Fix record type not displaying in file details page
Fix KB permission role assignment dialog hidden below panel
Fix non-owners able to create permissions (backend issue)
Fix permission resolution not using highest role when user has both direct and team permissions on a KB (backend issue)
Handle minimum search query length of 2 characters in frontend to prevent backend validation errors on every character fail
Fix duplicate API calls on pagination/sort change in record table
Permission change panel diaplaying for all type of users
Delete ,replace ,move ,rename button for record and folder showing for all type of users
kb permission dropdown styling not matching with ui also going outside of screen
