### PR TITLE
handling malformed & bare citations -> [source](ref5,ref6) , refN, https://refN.xyz

### DIFF
--- a/backend/python/app/utils/citations.py
+++ b/backend/python/app/utils/citations.py
@@ -130,8 +130,8 @@ def normalize_malformed_citations(text: str) -> str:
     Handled patterns (non-exhaustive):
 
     * Multiple refs in one link  ``[source](ref1, ref2)``  →  ``[source](ref1) [source](ref2)``
-    * Bare refN token            ``ref5``                   →  ``[ref5](ref5)``
-    * Bare tiny web-ref URL      ``https://ref5.xyz``       →  ``[ref5](https://ref5.xyz)``
+    * Bare refN token            ``ref5``                   →  ``[source](ref5)``
+    * Bare tiny web-ref URL      ``https://ref5.xyz``       →  ``[source](https://ref5.xyz)``
     """
     text = _expand_multi_ref_links(text)
     text = _wrap_bare_refs(text)
@@ -562,6 +562,9 @@ def _normalize_markdown_link_citations(
                 content = content[0]
             elif not isinstance(content, str):
                 content = _safe_stringify_content(value=content)
+
+            if not content:
+                continue
 
             new_citations.append({
                 "content": "Image" if is_base64_image(content) else content,

--- a/backend/python/app/utils/citations.py
+++ b/backend/python/app/utils/citations.py
@@ -48,6 +48,28 @@ _CONSECUTIVE_MD_LINKS_RE = re.compile(
     r'(\[[^\]]+\]\((ref\d+|https?://[^)]+)\))'   # Grp 4: second md link; Grp 5: second target
 )
 
+# ── Malformed citation normalization ──────────────────────────────────────────
+# Matches a markdown link whose target is a comma- or whitespace-separated list
+# of two or more refs/URLs — a common LLM slip-up e.g. [source](ref1, ref2).
+_MULTI_REF_IN_LINK_RE = re.compile(
+    r'\[([^\]]*?)\]\(('
+    r'(?:ref\d+|https?://[^\s,)]+)'
+    r'(?:(?:\s*,\s*|\s+)(?:ref\d+|https?://[^\s,)]+))+'
+    r')\)'
+)
+
+# Single-pass pattern used to wrap bare refN tokens and bare https://refN.xyz
+# URLs that the LLM emitted outside proper markdown link syntax.
+# Alternative 1 (Grp 1) matches an already-valid markdown link so the cursor
+# skips over it — preventing double-processing of refs inside `[text](refN)`.
+# Alternative 2 (Grp 2) matches a bare tiny web-ref URL.
+# Alternative 3 (Grp 3) matches a bare refN word token.
+_BARE_CITATION_NORMALIZE_RE = re.compile(
+    r'(\[[^\]]*?\]\((?:ref\d+|https?://[^)]+)\))'  # Grp 1: existing valid md link — skip
+    r'|(https?://ref\d+\.xyz/?)'                    # Grp 2: bare tiny URL
+    r'|\b(ref\d+)\b'                               # Grp 3: bare refN token
+)
+
 
 def extract_tiny_ref(target: str) -> str | None:
     """Return the inner refN from a tiny web-ref URL like https://ref1.xyz, else None."""
@@ -60,6 +82,60 @@ def extract_tiny_ref(target: str) -> str | None:
 def build_tiny_web_ref_url(ref: str) -> str:
     """Wrap a refN token into its LLM-facing tiny URL form (https://refN.xyz)."""
     return f"https://{ref}.xyz"
+
+
+def _expand_multi_ref_links(text: str) -> str:
+    """Split ``[label](ref1, ref2)`` style links into separate ``[label](ref1) [label](ref2)`` links.
+
+    Handles comma-separated and whitespace-separated ref lists inside a single
+    markdown link target — a common LLM formatting mistake.
+    """
+    def _replacer(m: re.Match) -> str:
+        link_text = m.group(1)
+        targets = [t.strip() for t in re.split(r'[\s,]+', m.group(2)) if t.strip()]
+        if len(targets) <= 1:
+            return m.group(0)
+        return ' '.join(f'[{link_text}]({t})' for t in targets)
+
+    return _MULTI_REF_IN_LINK_RE.sub(_replacer, text)
+
+
+def _wrap_bare_refs(text: str) -> str:
+    """Wrap bare ``refN`` tokens and bare ``https://refN.xyz`` URLs in markdown link syntax.
+
+    Already-valid markdown links are left untouched (matched by the first
+    alternative in ``_BARE_CITATION_NORMALIZE_RE`` so the cursor advances past them).
+    """
+    def _replacer(m: re.Match) -> str:
+        if m.group(1) is not None:
+            return m.group(1)   # existing valid markdown link — keep as-is
+        if m.group(2):
+            url = m.group(2)
+            inner = extract_tiny_ref(url) or url
+            return f'[source]({url})'
+        if m.group(3):
+            ref = m.group(3)
+            return f'[source]({ref})'
+        return m.group(0)
+
+    return _BARE_CITATION_NORMALIZE_RE.sub(_replacer, text)
+
+
+def normalize_malformed_citations(text: str) -> str:
+    """Coerce malformed LLM citation formats into standard ``[label](refN)`` links.
+
+    Runs before the main citation resolution pipeline so that all subsequent
+    steps see only well-formed markdown links.
+
+    Handled patterns (non-exhaustive):
+
+    * Multiple refs in one link  ``[source](ref1, ref2)``  →  ``[source](ref1) [source](ref2)``
+    * Bare refN token            ``ref5``                   →  ``[ref5](ref5)``
+    * Bare tiny web-ref URL      ``https://ref5.xyz``       →  ``[ref5](https://ref5.xyz)``
+    """
+    text = _expand_multi_ref_links(text)
+    text = _wrap_bare_refs(text)
+    return text
 
 
 def display_url_for_llm(url: str, ref_mapper: "object | None") -> str:
@@ -343,6 +419,7 @@ def normalize_citations_and_chunks(
     if virtual_record_id_to_result is None:
         virtual_record_id_to_result = {}
 
+    answer_text = normalize_malformed_citations(answer_text)
     answer_text = _clean_duplicate_citation_links(answer_text, ref_to_url)
     md_matches = list(re.finditer(_MD_LINK_PATTERN, answer_text))
 
@@ -486,10 +563,6 @@ def _normalize_markdown_link_citations(
             elif not isinstance(content, str):
                 content = _safe_stringify_content(value=content)
 
-            if not content:
-                logger.warning("🔎 [KB-CITE] normalize(chat): empty content for matched URL | url=%s", url)
-                continue
-
             new_citations.append({
                 "content": "Image" if is_base64_image(content) else content,
                 "chunkIndex": new_citation_num,
@@ -560,6 +633,7 @@ def normalize_citations_and_chunks_for_agent(
     if virtual_record_id_to_result is None:
         virtual_record_id_to_result = {}
 
+    answer_text = normalize_malformed_citations(answer_text)
     answer_text = _clean_duplicate_citation_links(answer_text, ref_to_url)
     md_matches = list(re.finditer(_MD_LINK_PATTERN, answer_text))
 

--- a/backend/python/tests/unit/utils/test_citations.py
+++ b/backend/python/tests/unit/utils/test_citations.py
@@ -883,7 +883,13 @@ class TestNormalizeCitationsAndChunksForAgent:
 # Added tests to raise coverage
 # ---------------------------------------------------------------------------
 
-from app.utils.citations import _resolve_ref, _safe_stringify_content  # noqa: E402  # pylint: disable=wrong-import-position
+from app.utils.citations import (  # noqa: E402  # pylint: disable=wrong-import-position
+    _expand_multi_ref_links,
+    _resolve_ref,
+    _safe_stringify_content,
+    _wrap_bare_refs,
+    normalize_malformed_citations,
+)
 
 
 class TestResolveRef:
@@ -1166,6 +1172,190 @@ class TestNormalizeAgentCitationsExtra:
         assert url in result_text
         assert len(citations) == 1
         assert citations[0]["content"] == "agent content"
+
+
+# ---------------------------------------------------------------------------
+# normalize_malformed_citations — pre-processing step
+# ---------------------------------------------------------------------------
+
+class TestExpandMultiRefLinks:
+    """Unit tests for _expand_multi_ref_links()."""
+
+    def test_comma_separated_refs_split(self):
+        text = "[source](ref632, ref633)"
+        result = _expand_multi_ref_links(text)
+        assert result == "[source](ref632) [source](ref633)"
+
+    def test_three_comma_separated_refs(self):
+        text = "[source](ref1, ref2, ref3)"
+        result = _expand_multi_ref_links(text)
+        assert result == "[source](ref1) [source](ref2) [source](ref3)"
+
+    def test_space_separated_refs_split(self):
+        text = "[source](ref5 ref6)"
+        result = _expand_multi_ref_links(text)
+        assert result == "[source](ref5) [source](ref6)"
+
+    def test_mixed_ref_and_url_split(self):
+        text = "[source](ref1, https://example.com/page)"
+        result = _expand_multi_ref_links(text)
+        assert result == "[source](ref1) [source](https://example.com/page)"
+
+    def test_two_tiny_urls_split(self):
+        text = "[source](https://ref1.xyz, https://ref2.xyz)"
+        result = _expand_multi_ref_links(text)
+        assert result == "[source](https://ref1.xyz) [source](https://ref2.xyz)"
+
+    def test_single_ref_unchanged(self):
+        text = "[source](ref1)"
+        assert _expand_multi_ref_links(text) == text
+
+    def test_no_refs_unchanged(self):
+        text = "Plain text with no links."
+        assert _expand_multi_ref_links(text) == text
+
+    def test_multiple_multi_ref_links_in_text(self):
+        text = "See [a](ref1, ref2) and [b](ref3, ref4)."
+        result = _expand_multi_ref_links(text)
+        assert "[a](ref1)" in result
+        assert "[a](ref2)" in result
+        assert "[b](ref3)" in result
+        assert "[b](ref4)" in result
+
+    def test_preserves_link_text(self):
+        text = "[My Link Text](ref10, ref11)"
+        result = _expand_multi_ref_links(text)
+        assert result == "[My Link Text](ref10) [My Link Text](ref11)"
+
+
+class TestWrapBareRefs:
+    """Unit tests for _wrap_bare_refs()."""
+
+    def test_bare_ref_wrapped(self):
+        result = _wrap_bare_refs("See ref5 for details.")
+        assert "[ref5](ref5)" in result
+
+    def test_bare_tiny_url_wrapped(self):
+        result = _wrap_bare_refs("See https://ref5.xyz for details.")
+        assert "[ref5](https://ref5.xyz)" in result
+
+    def test_existing_markdown_link_untouched(self):
+        text = "See [source](ref5) here."
+        result = _wrap_bare_refs(text)
+        assert result == text
+
+    def test_existing_tiny_url_link_untouched(self):
+        text = "[source](https://ref5.xyz)"
+        result = _wrap_bare_refs(text)
+        assert result == text
+
+    def test_ref_in_word_not_matched(self):
+        # "reference5" should not be matched because 'e' follows 'ref' not a digit
+        result = _wrap_bare_refs("See reference5 here.")
+        assert "[ref" not in result
+
+    def test_multiple_bare_refs(self):
+        result = _wrap_bare_refs("Data from ref1 and ref2.")
+        assert "[ref1](ref1)" in result
+        assert "[ref2](ref2)" in result
+
+    def test_bare_ref_at_end_of_sentence(self):
+        result = _wrap_bare_refs("Supported by ref7.")
+        assert "[ref7](ref7)" in result
+
+    def test_bare_ref_in_parentheses(self):
+        result = _wrap_bare_refs("(ref8)")
+        assert "[ref8](ref8)" in result
+
+    def test_no_refs_unchanged(self):
+        text = "No citations here."
+        assert _wrap_bare_refs(text) == text
+
+
+class TestNormalizeMalformedCitations:
+    """Integration tests for normalize_malformed_citations()."""
+
+    def test_multi_ref_link_expanded_and_not_double_wrapped(self):
+        text = "[source](ref1, ref2)"
+        result = normalize_malformed_citations(text)
+        assert result == "[source](ref1) [source](ref2)"
+
+    def test_bare_ref_wrapped(self):
+        result = normalize_malformed_citations("Fact from ref3.")
+        assert "[ref3](ref3)" in result
+
+    def test_bare_tiny_url_wrapped(self):
+        result = normalize_malformed_citations("See https://ref3.xyz.")
+        assert "[ref3](https://ref3.xyz)" in result
+
+    def test_existing_valid_link_untouched(self):
+        text = "See [1](ref5) here."
+        result = normalize_malformed_citations(text)
+        assert result == text
+
+    def test_combined_malformed_and_valid(self):
+        text = "Good [1](ref1). Also [source](ref2, ref3) and bare ref4."
+        result = normalize_malformed_citations(text)
+        assert "[1](ref1)" in result           # existing link untouched
+        assert "[source](ref2)" in result      # split multi-ref
+        assert "[source](ref3)" in result
+        assert "[ref4](ref4)" in result        # bare ref wrapped
+
+    def test_end_to_end_resolution_multi_ref(self):
+        """[source](ref1, ref2) resolves both citations through the full pipeline."""
+        url1 = _url(REC1, 0)
+        url2 = _url(REC2, 3)
+        docs = [
+            _make_doc(REC1, 0, "first chunk", block_web_url=url1),
+            _make_doc(REC2, 3, "second chunk", block_web_url=url2),
+        ]
+        answer = "[source](ref1, ref2)"
+        result_text, citations = normalize_citations_and_chunks(
+            answer, docs, ref_to_url={"ref1": url1, "ref2": url2}
+        )
+        assert len(citations) == 2
+        assert citations[0]["content"] == "first chunk"
+        assert citations[1]["content"] == "second chunk"
+
+    def test_end_to_end_resolution_bare_ref(self):
+        """A bare refN in text is resolved into a proper citation."""
+        url = _url(REC1, 0)
+        docs = [_make_doc(REC1, 0, "chunk content", block_web_url=url)]
+        answer = "Supported by ref1."
+        result_text, citations = normalize_citations_and_chunks(
+            answer, docs, ref_to_url={"ref1": url}
+        )
+        assert len(citations) == 1
+        assert citations[0]["content"] == "chunk content"
+        assert url in result_text
+
+    def test_end_to_end_resolution_bare_tiny_url(self):
+        """A bare https://refN.xyz in text is resolved into a proper citation."""
+        url = _url(REC1, 0)
+        docs = [_make_doc(REC1, 0, "chunk content", block_web_url=url)]
+        answer = "Supported by https://ref1.xyz."
+        result_text, citations = normalize_citations_and_chunks(
+            answer, docs, ref_to_url={"ref1": url}
+        )
+        assert len(citations) == 1
+        assert citations[0]["content"] == "chunk content"
+        assert url in result_text
+
+    def test_end_to_end_agent_multi_ref(self):
+        """Multi-ref link resolves through the agent pipeline."""
+        url1 = _url(REC1, 0)
+        url2 = _url(REC2, 3)
+        docs = [
+            _make_doc(REC1, 0, "agent chunk 1", block_web_url=url1),
+            _make_doc(REC2, 3, "agent chunk 2", block_web_url=url2),
+        ]
+        answer = "Evidence [source](ref1, ref2)."
+        result_text, citations = normalize_citations_and_chunks_for_agent(
+            answer, docs, ref_to_url={"ref1": url1, "ref2": url2}
+        )
+        assert len(citations) == 2
+        assert citations[0]["content"] == "agent chunk 1"
+        assert citations[1]["content"] == "agent chunk 2"
 
 
 class _TruthyButEmptyStr:

--- a/backend/python/tests/unit/utils/test_citations.py
+++ b/backend/python/tests/unit/utils/test_citations.py
@@ -1233,11 +1233,11 @@ class TestWrapBareRefs:
 
     def test_bare_ref_wrapped(self):
         result = _wrap_bare_refs("See ref5 for details.")
-        assert "[ref5](ref5)" in result
+        assert "[source](ref5)" in result
 
     def test_bare_tiny_url_wrapped(self):
         result = _wrap_bare_refs("See https://ref5.xyz for details.")
-        assert "[ref5](https://ref5.xyz)" in result
+        assert "[source](https://ref5.xyz)" in result
 
     def test_existing_markdown_link_untouched(self):
         text = "See [source](ref5) here."
@@ -1256,16 +1256,16 @@ class TestWrapBareRefs:
 
     def test_multiple_bare_refs(self):
         result = _wrap_bare_refs("Data from ref1 and ref2.")
-        assert "[ref1](ref1)" in result
-        assert "[ref2](ref2)" in result
+        assert "[source](ref1)" in result
+        assert "[source](ref2)" in result
 
     def test_bare_ref_at_end_of_sentence(self):
         result = _wrap_bare_refs("Supported by ref7.")
-        assert "[ref7](ref7)" in result
+        assert "[source](ref7)" in result
 
     def test_bare_ref_in_parentheses(self):
         result = _wrap_bare_refs("(ref8)")
-        assert "[ref8](ref8)" in result
+        assert "[source](ref8)" in result
 
     def test_no_refs_unchanged(self):
         text = "No citations here."
@@ -1282,11 +1282,11 @@ class TestNormalizeMalformedCitations:
 
     def test_bare_ref_wrapped(self):
         result = normalize_malformed_citations("Fact from ref3.")
-        assert "[ref3](ref3)" in result
+        assert "[source](ref3)" in result
 
     def test_bare_tiny_url_wrapped(self):
         result = normalize_malformed_citations("See https://ref3.xyz.")
-        assert "[ref3](https://ref3.xyz)" in result
+        assert "[source](https://ref3.xyz)" in result
 
     def test_existing_valid_link_untouched(self):
         text = "See [1](ref5) here."
@@ -1299,7 +1299,7 @@ class TestNormalizeMalformedCitations:
         assert "[1](ref1)" in result           # existing link untouched
         assert "[source](ref2)" in result      # split multi-ref
         assert "[source](ref3)" in result
-        assert "[ref4](ref4)" in result        # bare ref wrapped
+        assert "[source](ref4)" in result       # bare ref wrapped
 
     def test_end_to_end_resolution_multi_ref(self):
         """[source](ref1, ref2) resolves both citations through the full pipeline."""


### PR DESCRIPTION
This pull request introduces a normalization layer to handle malformed LLM citations, such as multiple references within a single markdown link, bare reference tokens, and bare tiny URLs. The changes include new regex patterns and helper functions integrated into the citation resolution pipeline.