### PR TITLE
Record summary indexing

### DIFF
--- a/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
+++ b/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
@@ -4396,6 +4396,9 @@ components:
         blockType:
           type: string
           nullable: true
+          description: |
+            Block type for this hit. Common values: `text`, `image`, `table_row`, `table`,
+            `record_summary` (whole-record semantic summary chunk — no block index).
         bounding_box:
           type: array
           nullable: true
@@ -4486,6 +4489,13 @@ components:
         isBlockGroup:
           type: boolean
           nullable: true
+        isRecordSummary:
+          type: boolean
+          nullable: true
+          description: |
+            Set to `true` by the indexing pipeline when this vector chunk represents a
+            whole-record semantic summary rather than an individual block. When true,
+            `blockIndex` is absent and `block_type` on the parent hit is `record_summary`.
         kbId:
           type: string
           nullable: true
@@ -4554,6 +4564,9 @@ components:
         block_type:
           type: string
           nullable: true
+          description: |
+            Block type for this hit. Common values: `text`, `image`, `table_row`, `table`,
+            `record_summary` (whole-record semantic summary — `block_index` is `null` for these hits).
         block_index:
           type: integer
           nullable: true
@@ -4870,6 +4883,9 @@ components:
         blockType:
           type: string
           nullable: true
+          description: |
+            Block type for this citation. Common values: `text`, `image`, `table_row`, `table`,
+            `record_summary` (whole-record semantic summary chunk).
         blockText:
           type: string
           nullable: true

--- a/backend/python/app/api/routes/chatbot.py
+++ b/backend/python/app/api/routes/chatbot.py
@@ -43,6 +43,7 @@ from app.utils.chat_helpers import (
     CitationRefMapper,
     build_message_content_array,
     enrich_virtual_record_id_to_result_with_fk_children,
+    flattened_result_sort_key,
     get_flattened_results,
     get_message_content,
     record_to_message_content,
@@ -162,14 +163,14 @@ def create_internal_search_tool(
             existing_keys = {
                 (r["virtual_record_id"], r["block_index"]) for r in final_results
             }
-            temp_final_results = sorted(flattened_results, key=lambda x: (x["virtual_record_id"], x["block_index"]))
+            temp_final_results = sorted(flattened_results, key=flattened_result_sort_key)
             
             for r in flattened_results:
                 key = (r["virtual_record_id"], r["block_index"])
                 if key not in existing_keys:
                     final_results.append(r)
                     existing_keys.add(key)
-            final_results.sort(key=lambda x: (x["virtual_record_id"], x["block_index"]))
+            final_results.sort(key=flattened_result_sort_key)
 
             message_content_array, _ = build_message_content_array(temp_final_results, virtual_record_id_to_result,is_multimodal_llm=is_multimodal_llm, ref_mapper=ref_mapper,from_tool=True)
 
@@ -892,7 +893,7 @@ async def _generate_internal_search_stream(
                     virtual_record_id_to_result, blob_store, org_id, graph_provider, flattened_results
                 )
 
-                final_results = sorted(flattened_results, key=lambda x: (x["virtual_record_id"], x["block_index"]))
+                final_results = sorted(flattened_results, key=flattened_result_sort_key)
 
                 has_sql_connector = await has_sql_connector_configured(graph_provider, user_id, org_id)
                 tools = []

--- a/backend/python/app/models/blocks.py
+++ b/backend/python/app/models/blocks.py
@@ -22,7 +22,7 @@ class BlockType(str, Enum):
     TEXT = "text"
     IMAGE = "image"
     TABLE_ROW = "table_row"
-
+    RECORD_SUMMARY = "record_summary"
     # Do not use these types as currently not supported
     PARAGRAPH = "paragraph"
     TEXTSECTION = "textsection"

--- a/backend/python/app/modules/qna/prompt_templates.py
+++ b/backend/python/app/modules/qna/prompt_templates.py
@@ -236,7 +236,6 @@ qna_prompt_context = """<record>
 {% if context_metadata %}
 {{ context_metadata }}
 {% endif %}
-Record blocks (sorted):
 """
 
 qna_prompt_with_retrieval_tool_second_part = """

--- a/backend/python/app/modules/transformers/vectorstore.py
+++ b/backend/python/app/modules/transformers/vectorstore.py
@@ -22,7 +22,7 @@ from app.exceptions.indexing_exceptions import (
     MetadataProcessingError,
     VectorStoreError,
 )
-from app.models.blocks import BlocksContainer
+from app.models.blocks import BlocksContainer, SemanticMetadata
 from app.modules.extraction.prompt_template import prompt_for_image_description
 from app.modules.transformers.transformer import TransformContext, Transformer
 from app.services.vector_db.interface.vector_db import IVectorDBService
@@ -61,6 +61,7 @@ _DEFAULT_DOCUMENT_BATCH_SIZE = 50
 _DEFAULT_CONCURRENCY_LIMIT = 5
 # Small batch size for local/CPU embedding models to avoid memory/CPU thrashing
 _LOCAL_CPU_DOCUMENT_BATCH_SIZE = 3
+RECORD_SUMMARY_BLOCK_ID_SUFFIX = ":record_summary"
 
 class VectorStore(Transformer):
 
@@ -158,7 +159,6 @@ class VectorStore(Transformer):
         virtual_record_id = record.virtual_record_id
         block_containers = record.block_containers
         org_id = record.org_id
-        mime_type = record.mime_type
 
         block_ids_to_delete = None
         is_reconciliation = False
@@ -184,10 +184,61 @@ class VectorStore(Transformer):
             )
 
         return await self.index_documents(
-            block_containers, org_id, record_id, virtual_record_id, mime_type,
+            block_containers,
+            org_id,
+            record_id,
+            virtual_record_id,
             block_ids_to_delete=block_ids_to_delete,
             is_reconciliation=is_reconciliation,
+            record=record,
         )
+
+    @staticmethod
+    def record_summary_block_id(record_id: str) -> str:
+        return f"{record_id}{RECORD_SUMMARY_BLOCK_ID_SUFFIX}"
+
+    @staticmethod
+    def _build_record_summary_document(
+        record_id: str,
+        virtual_record_id: str,
+        org_id: str,
+        semantic_metadata: SemanticMetadata,
+    ) -> Document | None:
+        summary = (semantic_metadata.summary or "").strip()
+        if not summary:
+            return None
+
+        metadata: dict = {
+            "virtualRecordId": virtual_record_id,
+            "blockId": VectorStore.record_summary_block_id(virtual_record_id),
+            "orgId": org_id,
+            "isBlockGroup": False,
+            "isBlock": False,
+            "isRecordSummary": True,
+        }
+
+        return Document(page_content=summary, metadata=metadata)
+
+    async def _refresh_record_summary_documents(
+        self,
+        documents_to_embed: list,
+        record,
+        org_id: str,
+        record_id: str,
+        virtual_record_id: str,
+    ) -> None:
+        semantic_metadata = getattr(record, "semantic_metadata", None)
+        if semantic_metadata is None:
+            return
+
+        summary_doc = self._build_record_summary_document(
+            record_id, virtual_record_id, org_id, semantic_metadata
+        )
+        if summary_doc is None:
+            return
+
+        documents_to_embed.append(summary_doc)
+        self.logger.info("✅ Added record summary document for embedding")
 
     @Language.component("custom_sentence_boundary")
     def custom_sentence_boundary(doc) -> Doc:
@@ -997,9 +1048,9 @@ class VectorStore(Transformer):
         org_id: str,
         record_id: str,
         virtual_record_id: str,
-        mime_type: str,
         block_ids_to_delete: Optional[set] = None,
         is_reconciliation: bool = False,
+        record=None,
     ) -> bool | None:
         try:
             is_multimodal_embedding = await self.get_embedding_model_instance()
@@ -1304,6 +1355,11 @@ class VectorStore(Transformer):
                                     "isBlockGroup": False,
                                 },
                             ))
+
+            if record is not None:
+                await self._refresh_record_summary_documents(
+                    documents_to_embed, record, org_id, record_id, virtual_record_id
+                )
 
             if not documents_to_embed:
                 self.logger.warning("⚠️ No documents to embed after filtering by block type")

--- a/backend/python/app/modules/transformers/vectorstore.py
+++ b/backend/python/app/modules/transformers/vectorstore.py
@@ -1074,6 +1074,20 @@ class VectorStore(Transformer):
         block_groups = block_containers.block_groups
 
         try:
+            if block_ids_to_delete or is_reconciliation:
+                summary_block_id_set = {f"{virtual_record_id}{RECORD_SUMMARY_BLOCK_ID_SUFFIX}"}
+                await self.delete_blocks_by_ids(summary_block_id_set, virtual_record_id)
+
+                if record is not None:
+                    semantic_metadata = getattr(record, "semantic_metadata", None)
+                    if semantic_metadata:
+                        summary_doc = self._build_record_summary_document(
+                            record_id, virtual_record_id, org_id, semantic_metadata
+                        )
+                        if summary_doc:
+                            await self._process_document_chunks([summary_doc])
+                        
+
             if not blocks and not block_groups:
                 if block_ids_to_delete:
                     await self.delete_blocks_by_ids(block_ids_to_delete, virtual_record_id)
@@ -1357,7 +1371,7 @@ class VectorStore(Transformer):
                                 },
                             ))
 
-            if record is not None:
+            if record is not None and not (is_reconciliation or block_ids_to_delete):
                 await self._refresh_record_summary_documents(
                     documents_to_embed, record, org_id, record_id, virtual_record_id
                 )

--- a/backend/python/app/modules/transformers/vectorstore.py
+++ b/backend/python/app/modules/transformers/vectorstore.py
@@ -2,7 +2,7 @@ import asyncio
 import re
 import time
 import uuid
-from typing import List, Optional
+from typing import Any, List, Optional
 
 import httpx
 import spacy
@@ -23,6 +23,7 @@ from app.exceptions.indexing_exceptions import (
     VectorStoreError,
 )
 from app.models.blocks import BlocksContainer, SemanticMetadata
+from app.models.entities import Record
 from app.modules.extraction.prompt_template import prompt_for_image_description
 from app.modules.transformers.transformer import TransformContext, Transformer
 from app.services.vector_db.interface.vector_db import IVectorDBService
@@ -221,8 +222,8 @@ class VectorStore(Transformer):
 
     async def _refresh_record_summary_documents(
         self,
-        documents_to_embed: list,
-        record,
+        documents_to_embed: list[Document | dict[str, Any]],
+        record: Record,
         org_id: str,
         record_id: str,
         virtual_record_id: str,
@@ -1050,7 +1051,7 @@ class VectorStore(Transformer):
         virtual_record_id: str,
         block_ids_to_delete: Optional[set] = None,
         is_reconciliation: bool = False,
-        record=None,
+        record: Optional[Record] = None,
     ) -> bool | None:
         try:
             is_multimodal_embedding = await self.get_embedding_model_instance()

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -65,6 +65,23 @@ def build_block_web_url(frontend_url: str, record_id: str, block_index: int) -> 
     return f"{base}/record/{record_id}/preview#blockIndex={block_index}"
 
 
+def build_record_page_web_url(frontend_url: str, record_id: str) -> str:
+    """Construct the record landing URL for metadata/header fields (Summary, Topics, etc.)."""
+    base = frontend_url.rstrip("/") if frontend_url else ""
+    if not base or not record_id:
+        return ""
+    return f"{base}/record/{record_id}"
+
+
+def flattened_result_sort_key(result: dict[str, Any]) -> tuple[str, int]:
+    """Sort flattened search results; None block_index (e.g. record summaries) sorts before block 0."""
+    block_index = result.get("block_index")
+    return (
+        result.get("virtual_record_id") or "",
+        -1 if block_index is None else block_index,
+    )
+
+
 
 
 def is_base64_image(s: str) -> bool:
@@ -739,6 +756,28 @@ async def get_flattened_results(result_set: List[Dict[str, Any]], blob_store: Bl
 
         meta = result.get("metadata")
 
+        if meta.get("isRecordSummary"):
+            chunk_id = f"{virtual_record_id}-record_summary"
+            if chunk_id in seen_chunks:
+                continue
+            seen_chunks.add(chunk_id)
+            record = virtual_record_id_to_result.get(virtual_record_id)
+            if record is None:
+                continue
+            content_text = result.get("content", "")
+            if not content_text:
+                continue
+            flattened_results.append({
+                "content": content_text,
+                "block_type": BlockType.RECORD_SUMMARY.value,
+                "virtual_record_id": virtual_record_id,
+                "block_index": None,
+                "metadata": get_enhanced_metadata(record=record,block=None, meta=meta),
+                "score": float(result.get("score", 0.0)),
+                "citationType": "vectordb|document",
+            })
+            continue
+
         if virtual_record_id not in adjacent_chunks:
             adjacent_chunks[virtual_record_id] = []
 
@@ -1091,16 +1130,16 @@ async def get_flattened_results(result_set: List[Dict[str, Any]], blob_store: Bl
 
     return flattened_results
 
-def get_enhanced_metadata(record:dict[str, Any],block:dict[str, Any],meta:dict[str, Any]) -> dict[str, Any]:
+def get_enhanced_metadata(record:dict[str, Any],block:dict[str, Any]|None,meta:dict[str, Any]) -> dict[str, Any]:
         try:
             virtual_record_id = record.get("virtual_record_id", "")
-            block_type = block.get("type")
-            citation_metadata = block.get("citation_metadata")
+            block_type = block.get("type") if block else BlockType.RECORD_SUMMARY.value
+            citation_metadata = block.get("citation_metadata") if block else None
             if citation_metadata:
                 page_num =  citation_metadata.get("page_number",None)
             else:
                 page_num = None
-            data = block.get("data")
+            data = block.get("data") if block else None
             if data:
                 if block_type == GroupType.TABLE.value:
                     # Handle both dict and string data types
@@ -1146,7 +1185,7 @@ def get_enhanced_metadata(record:dict[str, Any],block:dict[str, Any],meta:dict[s
                     else:
                         block_num = [0]
                 else:
-                    block_num = [block.get("index", 0) + 1]
+                    block_num = [block.get("index", 0) + 1] if block else None
 
             preview_renderable = meta.get("previewRenderable")
             if preview_renderable is None:
@@ -1164,7 +1203,7 @@ def get_enhanced_metadata(record:dict[str, Any],block:dict[str, Any],meta:dict[s
             record_type = record.get("record_type", "")
             if hide_weburl and recordId:
                 web_url = f"/record/{recordId}"
-            elif web_url and origin != "UPLOAD" and record_type != RecordType.MAIL.value:
+            elif web_url and origin != "UPLOAD" and record_type != RecordType.MAIL.value and block_type != BlockType.RECORD_SUMMARY.value:
                 web_url = generate_text_fragment_url(web_url, block_text)
 
             enhanced_metadata = {
@@ -1179,7 +1218,7 @@ def get_enhanced_metadata(record:dict[str, Any],block:dict[str, Any],meta:dict[s
                         "connectorId": meta.get("connectorId") or record.get("connector_id", ""),
                         "blockText": block_text,
                         "blockType": str(block_type),
-                        "bounding_box": extract_bounding_boxes(block.get("citation_metadata")),
+                        "bounding_box": extract_bounding_boxes(block.get("citation_metadata")) if block else None,
                         "pageNum":[page_num],
                         "extension": extension,
                         "mimeType": mime_type,
@@ -1677,7 +1716,7 @@ def record_to_message_content(record: dict[str, Any], ref_mapper: CitationRefMap
         context_metadata = record.get("context_metadata", "")
         content.append({
             "type": "text",
-            "text": f"""<record>\n{context_metadata}
+            "text": f"""<record>\n{context_metadata}\n\n
 Record blocks (sorted):\n\n"""
         })
         # Process blocks
@@ -1980,14 +2019,46 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
     seen_blocks = set()
     current_frontend_url = ""
     current_record_id = ""
+    pending_record_blocks_sorted_header = False
+    record_page_url_for_summary: str | None = None
+    summary_citation_insert_index: int | None = None
+    current_record_has_blocks = False
+
+    def insert_summary_citation_if_needed() -> None:
+        nonlocal record_page_url_for_summary, summary_citation_insert_index, current_record_has_blocks
+        if (
+            record_page_url_for_summary
+            and not current_record_has_blocks
+            and summary_citation_insert_index is not None
+        ):
+            overview_ref = ref_mapper.get_or_create_ref(record_page_url_for_summary)
+            content.insert(summary_citation_insert_index, {
+                "type": "text",
+                "text": (
+                    f"* Citation ID for summary: {overview_ref}\n"
+                ),
+            })
+        record_page_url_for_summary = None
+        summary_citation_insert_index = None
+        current_record_has_blocks = False
+
+    def prepend_record_blocks_sorted_header(text: str) -> str:
+        nonlocal pending_record_blocks_sorted_header
+        if pending_record_blocks_sorted_header:
+            pending_record_blocks_sorted_header = False
+            return f"Record blocks (sorted):\n{text}"
+        return text
+
     for i,result in enumerate(flattened_results):
         virtual_record_id = result.get("virtual_record_id")
         if virtual_record_id not in seen_virtual_record_ids:
             if i > 0:
+                insert_summary_citation_if_needed()
                 content.append({
                     "type": "text",
                     "text": "</record>"
                 })
+                pending_record_blocks_sorted_header = True
                 all_contents.append(content)
                 content = []
             seen_virtual_record_ids.add(virtual_record_id)
@@ -2006,7 +2077,11 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
                 "type": "text",
                 "text": rendered_form
             })
-
+            record_page_url_for_summary = build_record_page_web_url(
+                current_frontend_url, current_record_id
+            ) or None
+            summary_citation_insert_index = len(content)
+            current_record_has_blocks = False
 
         result_id = f"{virtual_record_id}_{result.get('block_index')}"
         if result_id not in seen_blocks:
@@ -2019,9 +2094,12 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
             result["citation_ref"] = ref
             if block_type == BlockType.IMAGE.value:
                 if is_base64_image(result.get("content")) and is_multimodal_llm and not from_tool:
+                    current_record_has_blocks = True
                     content.append({
                         "type": "text",
-                        "text": f"* Block Index: {block_index}\n* Citation ID: {ref}\n* Block Type: {block_type}\n* Block Content:"
+                        "text": prepend_record_blocks_sorted_header(
+                            f"* Block Index: {block_index}\n* Citation ID: {ref}\n* Block Type: {block_type}\n* Block Content:"
+                        ),
                     })
                     content.append({
                         "type": "image_url",
@@ -2030,9 +2108,12 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
                 else:
                     if is_base64_image(result.get("content")):
                         continue
+                    current_record_has_blocks = True
                     content.append({
                         "type": "text",
-                        "text": f"* Block Index: {block_index}\n* Citation ID: {ref}\n* Block Type: image description\n* Block Content: {result.get('content')}\n\n"
+                        "text": prepend_record_blocks_sorted_header(
+                            f"* Block Index: {block_index}\n* Citation ID: {ref}\n* Block Type: image description\n* Block Content: {result.get('content')}\n\n"
+                        ),
                     })
             elif block_type == GroupType.TABLE.value:
                 table_summary,child_results = result.get("content")
@@ -2050,14 +2131,18 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
                     table_summary=table_summary,
                     table_rows=child_results,
                 )
+                current_record_has_blocks = True
                 content.append({
                     "type": "text",
-                    "text": f"{rendered_form}{fk_info}\n\n"
+                    "text": prepend_record_blocks_sorted_header(f"{rendered_form}{fk_info}\n\n"),
                 })
             elif block_type == BlockType.TEXT.value:
+                current_record_has_blocks = True
                 content.append({
                     "type": "text",
-                    "text": f"* Block Index: {block_index}\n* Citation ID: {ref}\n* Block Type: {block_type}\n* Block Content: {result.get('content')}\n\n"
+                    "text": prepend_record_blocks_sorted_header(
+                        f"* Block Index: {block_index}\n* Citation ID: {ref}\n* Block Type: {block_type}\n* Block Content: {result.get('content')}\n\n"
+                    ),
                 })
             elif block_type in valid_group_labels:
                 block_group_index = result.get("block_group_index")
@@ -2074,9 +2159,10 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
                     label=block_type,
                     blocks=group_blocks,
                 )
+                current_record_has_blocks = True
                 content.append({
                     "type": "text",
-                    "text": f"{rendered_form}\n\n"
+                    "text": prepend_record_blocks_sorted_header(f"{rendered_form}\n\n"),
                 })
             else:
                 continue
@@ -2084,6 +2170,7 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
             continue
 
     if content:
+        insert_summary_citation_if_needed()
         content.append({
             "type": "text",
             "text": "</record>"

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -2019,7 +2019,9 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
     seen_blocks = set()
     current_frontend_url = ""
     current_record_id = ""
-    pending_record_blocks_sorted_header = False
+    # True so the first record's blocks get "Record blocks (sorted):"; later records reopen
+    # pending via the i > 0 branch before the next record's metadata.
+    pending_record_blocks_sorted_header = True
     record_page_url_for_summary: str | None = None
     summary_citation_insert_index: int | None = None
     current_record_has_blocks = False

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -1203,7 +1203,12 @@ def get_enhanced_metadata(record:dict[str, Any],block:dict[str, Any]|None,meta:d
             record_type = record.get("record_type", "")
             if hide_weburl and recordId:
                 web_url = f"/record/{recordId}"
-            elif web_url and origin != "UPLOAD" and record_type != RecordType.MAIL.value and block_type != BlockType.RECORD_SUMMARY.value:
+            elif (
+                web_url 
+                and origin != "UPLOAD" 
+                and record_type != RecordType.MAIL.value 
+                and block_type != BlockType.RECORD_SUMMARY.value
+            ):
                 web_url = generate_text_fragment_url(web_url, block_text)
 
             enhanced_metadata = {
@@ -1716,8 +1721,7 @@ def record_to_message_content(record: dict[str, Any], ref_mapper: CitationRefMap
         context_metadata = record.get("context_metadata", "")
         content.append({
             "type": "text",
-            "text": f"""<record>\n{context_metadata}\n\n
-Record blocks (sorted):\n\n"""
+            "text": f"""<record>\n{context_metadata}\n\nRecord blocks (sorted):\n\n"""
         })
         # Process blocks
         block_containers = record.get("block_containers", {})

--- a/backend/python/app/utils/citations.py
+++ b/backend/python/app/utils/citations.py
@@ -384,7 +384,7 @@ def _append_record_page_citation(
     citation_num: int,
 ) -> int:
     """Build citation metadata for /record/{id} (header / landing page), not a specific block."""
-    snippet = record.get("semantic_metadata",{}).get("summary") or record.get("record_name") or "Record"
+    snippet = (record.get("semantic_metadata") or {}).get("summary") or record.get("record_name") or "Record"
     if not isinstance(snippet, str):
         snippet = _safe_stringify_content(value=snippet)
     snippet = snippet.strip() or (record.get("record_name") or "Record")

--- a/backend/python/app/utils/citations.py
+++ b/backend/python/app/utils/citations.py
@@ -350,11 +350,58 @@ def _extract_block_index_from_url(url: str) -> int | None:
     return None
 
 def _extract_record_id_from_url(url: str) -> str | None:
-    """Extract recordId from a block web URL like /record/abc123/preview#blockIndex=5"""
+    """Extract recordId from block preview or record landing URLs."""
     m = re.search(r'/record/([^/]+)/preview', url)
     if m:
         return m.group(1)
+    m = re.search(r'/record/([^/?#]+)', url)
+    if m:
+        return m.group(1)
     return None
+
+
+def _find_record_by_id(
+    record_id: str,
+    records: list[dict[str, Any]],
+    virtual_record_id_to_result: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    
+    if virtual_record_id_to_result:
+        for rec in virtual_record_id_to_result.values():
+            if rec and rec.get("id") == record_id:
+                return rec
+    for r in records:
+        if r.get("id") == record_id:
+            return r
+    return None
+
+
+def _append_record_page_citation(
+    record: dict[str, Any],
+    url: str,
+    new_citations: list[dict[str, Any]],
+    url_to_citation_num: dict[str, int],
+    citation_num: int,
+) -> int:
+    """Build citation metadata for /record/{id} (header / landing page), not a specific block."""
+    snippet = record.get("semantic_metadata",{}).get("summary") or record.get("record_name") or "Record"
+    if not isinstance(snippet, str):
+        snippet = _safe_stringify_content(value=snippet)
+    snippet = snippet.strip() or (record.get("record_name") or "Record")
+    display_content = snippet
+    meta = get_enhanced_metadata(
+        record,
+        None,
+        {"webUrl": url, "blockText": display_content, },
+    )
+    new_citations.append({
+        "content": display_content,
+        "chunkIndex": citation_num,
+        "metadata": meta,
+        "citationType": "vectordb|document",
+    })
+    url_to_citation_num[url] = citation_num
+    return citation_num + 1
 
 
 def _find_web_record_by_url(
@@ -610,10 +657,24 @@ def _normalize_markdown_link_citations(
             url_to_citation_num[url] = new_citation_num
             new_citation_num += 1
         else:
-            # Try matching by record_id + block_index extracted from URL
+            # Try matching by record_id + block_index extracted from URL,
+            # or record landing URL /record/{id} (record-level / header citation).
             record_id = _extract_record_id_from_url(url)
             block_index = _extract_block_index_from_url(url)
-            if record_id is not None and block_index is not None:
+            if record_id is not None and block_index is None:
+                rec = _find_record_by_id(record_id, records, virtual_record_id_to_result)
+                if rec and url not in url_to_citation_num:
+                    new_citation_num = _append_record_page_citation(
+                        rec, url, new_citations, url_to_citation_num, new_citation_num
+                    )
+                elif not rec:
+                    logger.warning(
+                        "🔎 [KB-CITE] normalize(chat): DROPPED record-page citation | url=%s record_id=%s records_len=%d vrid_map_len=%d",
+                        url, record_id,
+                        len(records) if records else 0,
+                        len(virtual_record_id_to_result) if virtual_record_id_to_result else 0,
+                    )
+            elif record_id is not None and block_index is not None:
                 _matched = False
                 for r in records:
                     if r.get("id") == record_id:
@@ -806,7 +867,20 @@ def _normalize_markdown_link_citations_for_agent(
         else:
             record_id = _extract_record_id_from_url(url)
             block_index = _extract_block_index_from_url(url)
-            if record_id is not None and block_index is not None:
+            if record_id is not None and block_index is None:
+                rec = _find_record_by_id(record_id, records, virtual_record_id_to_result)
+                if rec and url not in url_to_citation_num:
+                    new_citation_num = _append_record_page_citation(
+                        rec, url, new_citations, url_to_citation_num, new_citation_num
+                    )
+                elif not rec:
+                    logger.warning(
+                        "🔎 [KB-CITE] normalize(agent): DROPPED record-page citation | url=%s record_id=%s records_len=%d vrid_map_len=%d",
+                        url, record_id,
+                        len(records) if records else 0,
+                        len(virtual_record_id_to_result) if virtual_record_id_to_result else 0,
+                    )
+            elif record_id is not None and block_index is not None:
                 # Search in records from tool calls
                 for r in records:
                     if r.get("id") == record_id:

--- a/backend/python/app/utils/streaming.py
+++ b/backend/python/app/utils/streaming.py
@@ -39,6 +39,7 @@ from app.utils.chat_helpers import (
     CitationRefMapper,
     build_message_content_array,
     count_tokens,
+    flattened_result_sort_key,
     get_flattened_results,
     record_to_message_content,
 )
@@ -724,7 +725,7 @@ async def execute_tool_calls(
 
                 if search_results:
                     flatten_search_results = await get_flattened_results(search_results, blob_store, org_id, is_multimodal_llm, virtual_record_id_to_result, from_tool=True)
-                    final_tool_results = sorted(flatten_search_results, key=lambda x: (x['virtual_record_id'], x['block_index']))
+                    final_tool_results = sorted(flatten_search_results, key=flattened_result_sort_key)
 
                     message_contents, ref_mapper = build_message_content_array(final_tool_results, virtual_record_id_to_result, is_multimodal_llm=is_multimodal_llm, ref_mapper=ref_mapper, from_tool=True)
 

--- a/backend/python/tests/unit/api/routes/test_chatbot.py
+++ b/backend/python/tests/unit/api/routes/test_chatbot.py
@@ -1503,6 +1503,75 @@ class TestAskAI:
         assert exc.value.status_code == 503
 
 
+@pytest.mark.asyncio
+class TestCreateInternalSearchTool:
+    """Coverage for create_internal_search_tool merge + sort of flattened results."""
+
+    async def test_merges_into_final_results_and_sorts_by_flattened_key(self):
+        from app.api.routes.chatbot import create_internal_search_tool
+        from app.models.blocks import BlockType
+
+        retrieval = AsyncMock()
+        retrieval.search_with_filters = AsyncMock(
+            return_value={
+                "searchResults": [{"dummy": True}],
+                "virtual_to_record_map": {},
+                "status_code": 200,
+            }
+        )
+        blob_store = MagicMock()
+        virtual_record_id_to_result = {
+            "vr-1": {
+                "id": "rec-1",
+                "frontend_url": "http://app.example.com",
+                "context_metadata": "",
+                "block_containers": {"blocks": [], "block_groups": []},
+            },
+        }
+        graph_provider = MagicMock()
+        ref_mapper = MagicMock()
+        final_results = [
+            {"virtual_record_id": "vr-1", "block_index": 0, "content": "keep"},
+        ]
+        flattened = [
+            {"virtual_record_id": "vr-1", "block_index": 0, "content": "duplicate skipped"},
+            {"virtual_record_id": "vr-1", "block_index": 1, "content": "new"},
+            {
+                "virtual_record_id": "vr-1",
+                "block_index": None,
+                "block_type": BlockType.RECORD_SUMMARY.value,
+                "content": "overview",
+            },
+        ]
+
+        with patch("app.api.routes.chatbot.get_flattened_results", new_callable=AsyncMock) as gf:
+            with patch(
+                "app.api.routes.chatbot.enrich_virtual_record_id_to_result_with_fk_children",
+                new_callable=AsyncMock,
+            ):
+                with patch("app.api.routes.chatbot.build_message_content_array") as bmc:
+                    gf.return_value = flattened
+                    bmc.return_value = ([[{"type": "text", "text": "x"}]], ref_mapper)
+
+                    tool_fn = create_internal_search_tool(
+                        retrieval,
+                        "org-1",
+                        "user-1",
+                        10,
+                        None,
+                        blob_store,
+                        False,
+                        virtual_record_id_to_result,
+                        graph_provider,
+                        ref_mapper,
+                        final_results,
+                    )
+                    out = await tool_fn.ainvoke({"query": "q", "reason": "r"})
+
+        assert out == [{"type": "text", "text": "x"}]
+        assert len(final_results) == 3
+        keys = [(r["virtual_record_id"], r["block_index"]) for r in final_results]
+        assert keys == [("vr-1", None), ("vr-1", 0), ("vr-1", 1)]
 
 
 

--- a/backend/python/tests/unit/api/routes/test_chatbot_extended_95_coverage.py
+++ b/backend/python/tests/unit/api/routes/test_chatbot_extended_95_coverage.py
@@ -1,0 +1,3143 @@
+"""Targeted coverage for app.api.routes.chatbot (attachments, web search stream, helpers)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.blocks import BlockType
+
+# ---------------------------------------------------------------------------
+# Helpers: collapse, MIME, attachment extension, estimate tokens
+# ---------------------------------------------------------------------------
+
+
+class TestCollapseSingleTextUserContent:
+    def test_empty_parts_returns_empty_string(self):
+        from app.api.routes.chatbot import _collapse_single_text_user_content
+
+        assert _collapse_single_text_user_content([]) == ""
+
+    def test_single_text_block_returns_plain_string(self):
+        from app.api.routes.chatbot import _collapse_single_text_user_content
+
+        assert (
+            _collapse_single_text_user_content([{"type": "text", "text": "hello"}])
+            == "hello"
+        )
+
+    def test_multiple_parts_returns_list(self):
+        from app.api.routes.chatbot import _collapse_single_text_user_content
+
+        parts = [{"type": "text", "text": "a"}, {"type": "image_url", "image_url": {}}]
+        assert _collapse_single_text_user_content(parts) is parts
+
+
+class TestEstimateRecordTokens:
+    def test_counts_uri_string_chars(self):
+        from app.api.routes.chatbot import _estimate_record_tokens
+
+        rec = {"block_containers": {"blocks": [{"data": {"uri": "abcd"}}]}}
+        assert _estimate_record_tokens(rec) >= 1
+
+    def test_string_data_chars(self):
+        from app.api.routes.chatbot import _estimate_record_tokens
+
+        rec = {"block_containers": {"blocks": [{"data": "x" * 40}]}}
+        assert _estimate_record_tokens(rec) == 10
+
+    def test_non_dict_data(self):
+        from app.api.routes.chatbot import _estimate_record_tokens
+
+        rec = {"block_containers": {"blocks": [{"data": 12345}]}}
+        assert _estimate_record_tokens(rec) == 1
+
+
+class TestAttachmentMimeHelpers:
+    def test_supported_mimes(self):
+        from app.api.routes.chatbot import _is_supported_attachment_mime
+
+        assert _is_supported_attachment_mime("application/pdf") is True
+        assert _is_supported_attachment_mime("IMAGE/PNG") is True
+
+    def test_image_detection(self):
+        from app.api.routes.chatbot import _is_image_attachment
+
+        assert _is_image_attachment("image/webp") is True
+
+    def test_extension_prefers_suffix(self):
+        from app.api.routes.chatbot import _attachment_extension
+
+        assert _attachment_extension("Report.PDF", "application/pdf") == "pdf"
+
+    def test_extension_from_mime_fallbacks(self):
+        from app.api.routes.chatbot import _attachment_extension
+
+        assert _attachment_extension("no_suffix", "application/pdf") == "pdf"
+        assert _attachment_extension("x", "image/jpeg") == "jpg"
+        assert _attachment_extension("x", "image/png") == "png"
+        assert _attachment_extension("plain", "application/octet-stream") == "bin"
+
+
+@pytest.mark.parametrize("mime,expected_subtype", [
+    ("image/jpeg", "image/jpeg"),
+    ("image/png", "image/png"),
+])
+def test_build_image_blocks_mime_paths(mime, expected_subtype):
+    from app.api.routes.chatbot import _build_image_blocks
+
+    raw = b"\x89PNG\r\n\x1a\n" if "png" in mime else b"\xff\xd8\xff\xd9"
+    container = _build_image_blocks(raw, mime)
+    assert container.blocks[0].data["uri"].startswith(f"data:{expected_subtype}")
+
+
+@pytest.mark.parametrize("needs_ocr_per_page,len_pages,expect", [
+    (True, 1, True),
+    (False, 2, False),
+])
+def test_pdf_has_any_ocr_page_mocked_doc(needs_ocr_per_page, len_pages, expect):
+    """ocr_count / total >= 0.5 when all scanned pages."""
+    from app.api.routes.chatbot import _pdf_has_any_ocr_page
+
+    mock_doc = MagicMock()
+    mock_doc.__len__ = MagicMock(return_value=len_pages)
+    mock_doc.__iter__ = MagicMock(
+        return_value=iter([MagicMock() for _ in range(len_pages)]),
+    )
+
+    class FakeOpen:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return mock_doc
+
+        def __exit__(self, *_):
+            pass
+
+    with patch("app.api.routes.chatbot.fitz.open", FakeOpen):
+        with patch(
+            "app.api.routes.chatbot.OCRStrategy.needs_ocr",
+            return_value=needs_ocr_per_page,
+        ):
+            assert _pdf_has_any_ocr_page(b"%PDF-x") is expect
+
+
+def test_pdf_has_any_empty_doc():
+    from app.api.routes.chatbot import _pdf_has_any_ocr_page
+
+    mock_doc = MagicMock()
+    mock_doc.__len__ = MagicMock(return_value=0)
+
+    class FakeOpen:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return mock_doc
+
+        def __exit__(self, *_):
+            pass
+
+    with patch("app.api.routes.chatbot.fitz.open", FakeOpen):
+        assert _pdf_has_any_ocr_page(b"%PDF-empty") is False
+
+
+def test_pdf_page_count_fixture():
+    from app.api.routes.chatbot import _pdf_page_count
+
+    mock_doc = MagicMock()
+    mock_doc.__len__ = MagicMock(return_value=5)
+
+    class FakeOpen:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return mock_doc
+
+        def __exit__(self, *_):
+            pass
+
+    with patch("app.api.routes.chatbot.fitz.open", FakeOpen):
+        assert _pdf_page_count(b"%PDF-x") == 5
+
+
+def test_build_pdf_image_blocks_one_page():
+    from app.api.routes.chatbot import _build_pdf_image_blocks
+
+    mock_pix = MagicMock()
+    mock_pix.tobytes.return_value = b"fakepng"
+
+    mock_page = MagicMock()
+    mock_page.get_pixmap.return_value = mock_pix
+
+    mock_doc = MagicMock()
+    mock_doc.__iter__ = MagicMock(return_value=iter([mock_page]))
+
+    class FakeOpen:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        def __enter__(self):
+            return mock_doc
+
+        def __exit__(self, *_):
+            pass
+
+    with patch("app.api.routes.chatbot.fitz.open", FakeOpen):
+        with patch("app.api.routes.chatbot.fitz.Matrix"):
+            bc = _build_pdf_image_blocks(b"%PDF-sample")
+            assert len(bc.blocks) == 1
+            assert bc.blocks[0].type == BlockType.IMAGE
+
+
+@pytest.mark.parametrize("append_citations", [True, False])
+def test_build_system_prompt_time_and_citations(append_citations):
+    from app.api.routes.chatbot import _build_system_prompt
+
+    with patch("app.api.routes.chatbot.build_llm_time_context", return_value="TZ context"):
+        out = _build_system_prompt(
+            "standard",
+            {"customSystemPrompt": "CUSTOM"},
+            "2026-05-01T00:00:00Z",
+            "UTC",
+            append_citation_rules=append_citations,
+        )
+    assert "CUSTOM" in out
+    assert "TZ context" in out
+    if append_citations:
+        assert "## Citation Rules" in out
+
+
+@pytest.mark.asyncio
+class TestCreateInternalSearchToolErrors:
+
+    async def test_bad_status_returns_error_dict(self):
+        from app.api.routes.chatbot import create_internal_search_tool
+
+        retrieval = AsyncMock()
+        retrieval.search_with_filters = AsyncMock(
+            return_value={
+                "searchResults": [{}],
+                "status_code": 404,
+                "message": "no hits",
+            },
+        )
+
+        fn = create_internal_search_tool(
+            retrieval,
+            "org",
+            "user",
+            None,
+            {},
+            MagicMock(),
+            False,
+            {},
+            MagicMock(),
+            MagicMock(),
+            [],
+        )
+        out = await fn.ainvoke({"query": "q"})
+        assert out["ok"] is False
+        assert out["result_type"] == "internal_search"
+
+    async def test_exception_in_search_returns_error_dict(self):
+        from app.api.routes.chatbot import create_internal_search_tool
+
+        retrieval = AsyncMock()
+        retrieval.search_with_filters = AsyncMock(
+            return_value={
+                "searchResults": [{}],
+                "virtual_to_record_map": {},
+                "status_code": 200,
+            },
+        )
+
+        with patch(
+            "app.api.routes.chatbot.get_flattened_results",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("flatten boom"),
+        ):
+            fn = create_internal_search_tool(
+                retrieval,
+                "org",
+                "user",
+                None,
+                {},
+                MagicMock(),
+                False,
+                {},
+                MagicMock(),
+                MagicMock(),
+                [],
+            )
+            out = await fn.ainvoke({"query": "q"})
+        assert "Internal search failed" in out["error"]
+
+
+@pytest.mark.asyncio
+async def test_append_conversation_pdf_history_with_logger_warning():
+    from app.api.routes.chatbot import CitationRefMapper, _append_conversation_history
+
+    log = MagicMock()
+    bs = AsyncMock()
+    bs.get_record_from_storage = AsyncMock(return_value={"id": "r1"})
+
+    conv = [
+        {
+            "role": "user_query",
+            "content": "prior",
+            "attachments": [{"virtualRecordId": "vr1", "mimeType": "application/pdf"}],
+        },
+    ]
+    msgs: list = [{"role": "system", "content": ""}]
+    vmap: dict = {}
+    mapper = CitationRefMapper()
+
+    with patch("app.api.routes.chatbot.record_to_message_content") as rtc:
+        rtc.side_effect = RuntimeError("parse fail")
+
+        prev = await _append_conversation_history(
+            msgs,
+            conv,
+            blob_store=bs,
+            org_id="o",
+            ref_mapper=mapper,
+            virtual_record_id_to_result=vmap,
+            logger=log,
+            is_multimodal_llm=False,
+        )
+
+    assert prev is False
+    log.warning.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_append_multimodal_list_sets_flag():
+    from app.api.routes.chatbot import _append_conversation_history
+
+    cq_spec = [
+        {
+            "role": "user_query",
+            "content": "hello",
+            "attachments": [{"virtualRecordId": "x", "mimeType": "image/png"}],
+        },
+    ]
+    msgs: list = [{"role": "system", "content": "s"}]
+
+    with patch(
+        "app.utils.chat_helpers.build_multimodal_user_content",
+        new_callable=AsyncMock,
+        return_value=[{"type": "image_url", "image_url": {"url": "x"}}],
+    ):
+        bs = AsyncMock()
+
+        prev = await _append_conversation_history(
+            msgs,
+            cq_spec,
+            is_multimodal_llm=True,
+            blob_store=bs,
+            org_id="o1",
+            ref_mapper=None,
+            virtual_record_id_to_result=None,
+        )
+
+    assert prev is True
+    assert isinstance(msgs[1]["content"], list)
+
+
+@pytest.mark.asyncio
+async def test_build_attachment_llm_messages_pdf_and_image_captions():
+    from app.api.routes.chatbot import ChatQuery, _build_attachment_llm_messages
+
+    q_pdf = ChatQuery(
+        query="look at pdf",
+        attachments=[{"virtualRecordId": "vr-pdf", "mimeType": "application/pdf"}],
+    )
+    log = MagicMock()
+    bs = AsyncMock()
+
+    bs.get_record_from_storage = AsyncMock(
+        return_value={"id": "r", "block_containers": {"blocks": []}},
+    )
+
+    with patch("app.api.routes.chatbot.record_to_message_content") as rtc_pdf:
+        rtc_pdf.return_value = ([{"type": "text", "text": "**block**"}], MagicMock())
+        msgs, _mapper = await _build_attachment_llm_messages(
+            q_pdf,
+            {},
+            "",
+            log,
+            is_multimodal_llm=True,
+            blob_store=bs,
+            org_id="org",
+            has_attachments=True,
+            virtual_record_id_to_result={},
+        )
+
+    user_parts = msgs[-1]["content"]
+    assert isinstance(user_parts, list)
+    user_text_blob = "".join(
+        str(p.get("text", "")) if isinstance(p, dict) else str(p) for p in user_parts
+    )
+    assert "Attached PDF documents" in user_text_blob
+
+    q_img = ChatQuery(
+        query="with images",
+        attachments=[{"virtualRecordId": "i", "mimeType": "image/png"}],
+    )
+    with patch(
+        "app.utils.chat_helpers.build_multimodal_user_content",
+        new_callable=AsyncMock,
+        return_value=[{"type": "image_url", "image_url": {"url": "u"}}],
+    ):
+        msgs2, _ = await _build_attachment_llm_messages(
+            q_img,
+            {},
+            "",
+            MagicMock(),
+            is_multimodal_llm=True,
+            blob_store=AsyncMock(),
+            org_id="org",
+            has_attachments=False,
+            virtual_record_id_to_result={},
+        )
+
+    u_parts = msgs2[-1]["content"]
+    captions = "".join(str(p.get("text", "")) if isinstance(p, dict) else str(p) for p in u_parts)
+    assert "Attachments/Image queries" in captions
+
+
+@pytest.mark.asyncio
+async def test_append_pdf_history_collapses_when_multipart_content_exists():
+    from app.api.routes.chatbot import CitationRefMapper, _append_conversation_history
+
+    bs = AsyncMock()
+    bs.get_record_from_storage = AsyncMock(return_value={"id": "pdfrec"})
+
+    conv = [
+        {
+            "role": "user_query",
+            "content": "prior",
+            "attachments": [{"virtualRecordId": "vpdf", "mimeType": "application/pdf"}],
+        },
+    ]
+    msgs: list = [{"role": "system", "content": "s"}]
+
+    mapper = CitationRefMapper()
+    parts_vmap = {}
+
+    with patch(
+        "app.utils.chat_helpers.build_multimodal_user_content",
+        new_callable=AsyncMock,
+        return_value=[
+            {"type": "image_url", "image_url": {"url": "u"}},
+            {"type": "text", "text": "cap"},
+        ],
+    ):
+        with patch("app.api.routes.chatbot.record_to_message_content") as rtc:
+            rtc.return_value = ([{"type": "text", "text": "**pdfblocks**"}], mapper)
+
+            prev = await _append_conversation_history(
+                msgs,
+                conv,
+                is_multimodal_llm=True,
+                blob_store=bs,
+                org_id="o",
+                ref_mapper=CitationRefMapper(),
+                virtual_record_id_to_result=parts_vmap,
+                logger=MagicMock(),
+            )
+
+    assert prev is True
+    user_msg = msgs[1]["content"]
+    assert isinstance(user_msg, list)
+
+
+@pytest.mark.asyncio
+async def test_build_web_search_messages():
+    from app.api.routes.chatbot import ChatQuery, _build_web_search_messages
+
+    q = ChatQuery(query="weather", timezone="Etc/UTC", currentTime="2026-05-01T12:00:00Z")
+
+    msgs = await _build_web_search_messages(q, {}, "weather today")
+    assert msgs[0]["role"] == "system"
+    assert msgs[-1]["role"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_build_chat_llm_messages_image_blocks_kwarg():
+
+    from app.api.routes.chatbot import ChatQuery, _build_chat_llm_messages
+
+    q = ChatQuery(
+        query="describe",
+        attachments=[{"virtualRecordId": "z", "mimeType": "image/jpeg"}],
+    )
+
+    fake_img = [
+        {"type": "text", "text": "embedded"},
+        {"type": "image_url", "image_url": {"url": "u"}},
+    ]
+
+    with patch(
+        "app.utils.chat_helpers.build_multimodal_user_content",
+        new_callable=AsyncMock,
+        return_value=fake_img,
+    ):
+        with patch("app.api.routes.chatbot.get_message_content") as gmc:
+            gmc.return_value = ("combined", MagicMock())
+            _, _ref = await _build_chat_llm_messages(
+                q,
+                {},
+                [],
+                {},
+                "",
+                MagicMock(),
+                is_multimodal_llm=True,
+                blob_store=MagicMock(),
+                org_id="o",
+            )
+
+    ib = gmc.call_args.kwargs["image_blocks"]
+    assert isinstance(ib, list)
+    assert any(p.get("type") == "image_url" for p in ib)
+
+
+@pytest.mark.asyncio
+async def test_generate_web_search_stream_success():
+    from app.api.routes.chatbot import ChatQuery, _generate_web_search_stream
+
+    qi = ChatQuery(query="news", chatMode="web_search")
+
+    req = MagicMock()
+    req.state.user = {"orgId": "o", "userId": "u"}
+    req.app.container.logger.return_value = MagicMock()
+
+    cfg = AsyncMock()
+    cfg.get_config = AsyncMock(
+        side_effect=[
+            {"llm": [{
+                "modelKey": "k",
+                "configuration": {"model": "gpt"},
+                "provider": "openai",
+                "isMultimodal": False,
+                "contextLength": 8192,
+            }]},
+            {"providers": [{"isDefault": True, "provider": "x", "configuration": {}}]},
+        ],
+    )
+
+    async def sse_stream(**kwargs):
+        yield {"event": "token", "data": {"text": "a"}}
+
+    with patch(
+        "app.api.routes.chatbot.get_llm_for_chat",
+        new_callable=AsyncMock,
+        return_value=(
+            MagicMock(),
+            {"provider": "openai", "isMultimodal": False, "contextLength": 1000},
+            {},
+        ),
+    ):
+        with patch(
+            "app.api.routes.chatbot.stream_llm_response_with_tools",
+            return_value=sse_stream(),
+        ):
+            with patch("app.api.routes.chatbot.create_web_search_tool"):
+                with patch("app.api.routes.chatbot.create_fetch_url_tool"):
+                    chunks: list[str] = []
+                    async for ch in _generate_web_search_stream(req, qi, cfg):
+                        chunks.append(ch)
+
+    assert chunks
+
+
+@pytest.mark.asyncio
+async def test_generate_web_search_stream_setup_error_emits_sse():
+    from app.api.routes.chatbot import ChatQuery, _generate_web_search_stream
+
+    qi = ChatQuery(query="news", chatMode="web_search")
+    req = MagicMock()
+    req.app.container.logger.return_value = MagicMock()
+    cfg = AsyncMock()
+
+    with patch(
+        "app.api.routes.chatbot.get_llm_for_chat",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("llm boom"),
+    ):
+        out = []
+        async for ch in _generate_web_search_stream(req, qi, cfg):
+            out.append(ch)
+
+    assert any("boom" in c for c in out)
+
+
+@pytest.mark.asyncio
+async def test_generate_web_search_no_default_provider_warning():
+
+    """Config without default provider triggers warning branch (covers 1037-1038)."""
+
+    from app.api.routes.chatbot import ChatQuery, _generate_web_search_stream
+
+    qi = ChatQuery(query="q", chatMode="web_search")
+
+    req = MagicMock()
+
+    req.state.user = {"orgId": "o", "userId": "u"}
+
+    req.app.container.logger.return_value = MagicMock()
+
+    cfg = AsyncMock()
+
+    cfg.get_config = AsyncMock(
+        side_effect=[
+            {
+                "llm": [{
+                    "modelKey": "k",
+                    "configuration": {"model": "gpt"},
+                    "provider": "openai",
+
+                    "isMultimodal": False,
+
+                    "contextLength": 8192,
+
+                }],
+            },
+
+            {},  # no providers key -> warning branch
+
+        ],
+    )
+
+
+
+    async def sse(**kwargs):
+
+        yield {"event": "done", "data": {}}
+
+    with patch(
+
+        "app.api.routes.chatbot.get_llm_for_chat",
+
+        new_callable=AsyncMock,
+
+        return_value=(
+
+            MagicMock(),
+
+            {"provider": "openai", "isMultimodal": False, "contextLength": 1000},
+
+            {},
+
+        ),
+
+    ):
+        with patch(
+            "app.api.routes.chatbot.stream_llm_response_with_tools",
+            return_value=sse(),
+        ):
+            with patch("app.api.routes.chatbot.create_web_search_tool"):
+                with patch("app.api.routes.chatbot.create_fetch_url_tool"):
+                    out = []
+
+                    async for ch in _generate_web_search_stream(req, qi, cfg):
+
+                        out.append(ch)
+
+                    assert len(out) >= 1
+
+@pytest.mark.asyncio
+async def test_generate_web_search_stream_iteration_error():
+    from app.api.routes.chatbot import ChatQuery, _generate_web_search_stream
+
+    qi = ChatQuery(query="q", chatMode="web_search")
+    req = MagicMock()
+    req.state.user = {"orgId": "o", "userId": "u"}
+    req.app.container.logger.return_value = MagicMock()
+
+    cfg = AsyncMock()
+    cfg.get_config = AsyncMock(
+        side_effect=[
+            {"llm": [{
+                "modelKey": "k",
+                "configuration": {"model": "gpt"},
+                "provider": "openai",
+                "isMultimodal": False,
+                "contextLength": 8192,
+            }]},
+            {"providers": [{"isDefault": True, "provider": "x", "configuration": {}}]},
+        ],
+    )
+
+    async def boom_stream(**kwargs):
+        raise RuntimeError("stream iterate fail")
+        yield  # pragma: no cover
+
+    with patch(
+        "app.api.routes.chatbot.get_llm_for_chat",
+        new_callable=AsyncMock,
+        return_value=(
+            MagicMock(),
+            {"provider": "openai", "isMultimodal": False, "contextLength": 8192},
+            {},
+        ),
+    ):
+        with patch(
+            "app.api.routes.chatbot.stream_llm_response_with_tools",
+            return_value=boom_stream(),
+        ):
+            with patch("app.api.routes.chatbot.create_web_search_tool"):
+                with patch("app.api.routes.chatbot.create_fetch_url_tool"):
+                    chunks: list[str] = []
+                    async for ch in _generate_web_search_stream(req, qi, cfg):
+                        chunks.append(ch)
+
+    assert any("stream iterate fail" in c or "iterate fail" in c for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_internal_search_outer_except_after_first_yield():
+    from app.api.routes.chatbot import _generate_internal_search_stream
+
+    class BrokenQI:
+        modelKey = None
+        modelName = None
+        chatMode = "internal_search"
+        mode = "json"
+        query = "hello"
+        limit = 50
+        filters = None
+        conversationId = None
+
+        @property
+        def attachments(self):  # type: ignore[override]
+            raise RuntimeError("bad attachments accessor")
+
+        @property
+        def previousConversations(self):  # type: ignore[override]
+            return []
+
+    retrieval = AsyncMock()
+    cfg = AsyncMock()
+    graph_p = AsyncMock()
+    req = MagicMock()
+    req.state.user = {"orgId": "o1", "userId": "u1"}
+    req.query_params = {}
+    req.app.container.logger.return_value = MagicMock()
+
+    chunks: list[str] = []
+    with patch(
+        "app.api.routes.chatbot.get_llm_for_chat",
+        new_callable=AsyncMock,
+        return_value=(
+            MagicMock(),
+            {"provider": "openai", "isMultimodal": False, "contextLength": 4096},
+            {},
+        ),
+    ):
+        async for ch in _generate_internal_search_stream(
+            req,
+            BrokenQI(),
+            retrieval,
+            graph_p,
+            cfg,
+        ):
+            chunks.append(ch)
+
+    assert len(chunks) >= 2
+    assert any("bad attachments accessor" in c for c in chunks)
+
+
+@pytest.mark.asyncio
+async def test_ask_ai_stream_dispatches_web_search():
+    from fastapi.responses import StreamingResponse
+
+    from app.api.routes.chatbot import askAIStream
+
+    async def fake_web(**kwargs):
+
+        _ = kwargs
+
+        yield "sse"
+
+    rr = MagicMock()
+    rr.json = AsyncMock(return_value={"query": "q", "chatMode": "web_search"})
+
+    with patch(
+        "app.api.routes.chatbot._generate_web_search_stream",
+        side_effect=fake_web,
+    ):
+        resp = await askAIStream(rr, AsyncMock(), AsyncMock(), AsyncMock())
+
+    assert isinstance(resp, StreamingResponse)
+
+
+@pytest.mark.asyncio
+async def test_upload_chat_attachments_json_and_payload_errors():
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+    r1 = MagicMock()
+    r1.json = AsyncMock(side_effect=ValueError("bad"))
+    with pytest.raises(HTTPException) as exc:
+        await upload_chat_attachments(r1, AsyncMock(), AsyncMock())
+    assert exc.value.status_code == 400
+
+    r2 = MagicMock()
+    r2.json = AsyncMock(return_value={"conversationId": "c"})
+    with pytest.raises(HTTPException) as exc:
+        await upload_chat_attachments(r2, AsyncMock(), AsyncMock())
+    assert "attachments" in str(exc.value.detail).lower()
+
+
+@pytest.mark.asyncio
+async def test_upload_chat_attachments_missing_org():
+    import base64
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+    png_b64 = base64.b64encode(b"x" * 8).decode("ascii")
+    body = MagicMock()
+    body.json = AsyncMock(
+        return_value={
+            "attachments": [
+                {
+                    "fileName": "x.png",
+                    "mimeType": "image/png",
+                    "size": 50,
+                    "contentBase64": png_b64,
+                },
+            ],
+        },
+    )
+    body.state.user = {}
+    with pytest.raises(HTTPException) as exc:
+        await upload_chat_attachments(body, AsyncMock(), AsyncMock())
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_upload_png_happy_mocked_sink():
+    import base64
+
+    from app.models.blocks import BlocksContainer
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+    png_b64 = base64.b64encode(b"z" * 32).decode("ascii")
+    req = MagicMock()
+    req.json = AsyncMock(
+        return_value={
+            "conversationId": "conv-z",
+            "attachments": [
+                {
+                    "fileName": "f.png",
+                    "mimeType": "image/png",
+                    "size": 32,
+                    "contentBase64": png_b64,
+                },
+            ],
+        },
+    )
+    req.state.user = {"orgId": "org-x", "userId": "u-x", "isServiceAccount": False}
+
+    gp = AsyncMock()
+
+    gp.get_user_by_user_id = AsyncMock(return_value={"_key": "gk"})
+
+    gp.batch_upsert_nodes = AsyncMock()
+    gp.batch_create_edges = AsyncMock()
+
+    cont = MagicMock()
+    req.app.container = cont
+    cont.logger.return_value = MagicMock()
+
+    with patch(
+        "app.api.routes.chatbot.BlobStorage",
+    ) as mock_bs_cls:
+
+        bs_inst = AsyncMock()
+
+        bs_inst.save_binary_to_storage = AsyncMock(return_value=("ext", None))
+
+        mock_bs_cls.return_value = bs_inst
+
+        with patch(
+            "app.api.routes.chatbot.GraphDBTransformer",
+            return_value=MagicMock(),
+        ):
+            orch = AsyncMock()
+
+            orch.apply = AsyncMock()
+
+            fake_rec = MagicMock()
+
+            fake_rec.block_containers = BlocksContainer(blocks=[], block_groups=[])
+
+            with patch(
+                "app.api.routes.chatbot.SinkOrchestrator",
+                return_value=orch,
+            ):
+                with patch(
+                    "app.api.routes.chatbot.convert_record_dict_to_record",
+                    return_value=fake_rec,
+                ):
+                    with patch(
+                        "app.api.routes.chatbot.TransformContext",
+                        MagicMock(side_effect=lambda **_: MagicMock()),
+                    ):
+                        out = await upload_chat_attachments(req, gp, AsyncMock())
+
+    assert out["conversationId"] == "conv-z"
+    assert len(out["attachments"]) == 1
+    orch.apply.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_grant_revoke_attachment_permissions():
+
+    import app.api.routes.chatbot as cr
+
+    from app.api.routes.chatbot import grant_attachment_permissions, revoke_attachment_permissions
+
+    req_g = MagicMock()
+
+    req_g.json = AsyncMock(return_value={"userIds": ["u"], "recordIds": ["rec"]})
+
+    gp = AsyncMock()
+
+    gp.get_user_by_user_id = AsyncMock(return_value={"_key": "k1"})
+
+    gp.batch_create_edges = AsyncMock()
+
+    gp.batch_delete_edges = AsyncMock()
+
+    with patch.object(cr.logger, "warning", MagicMock()):
+
+        r1 = await grant_attachment_permissions(req_g, gp)
+        assert r1["granted"] == 1
+
+    req_none = MagicMock()
+
+    req_none.json = AsyncMock(return_value={"userIds": [], "recordIds": []})
+
+    r2 = await grant_attachment_permissions(req_none, gp)
+    assert r2["granted"] == 0
+
+    gp.get_user_by_user_id = AsyncMock(return_value=None)
+    req_skip = MagicMock()
+
+    req_skip.json = AsyncMock(return_value={"userIds": ["u"], "recordIds": ["rec"]})
+
+    with patch.object(cr.logger, "warning", MagicMock()):
+
+        r3 = await grant_attachment_permissions(req_skip, gp)
+
+    assert r3["granted"] == 0
+
+    req_r = MagicMock()
+
+    req_r.json = AsyncMock(return_value={"userIds": ["x"], "recordIds": ["y"]})
+
+    gp.get_user_by_user_id = AsyncMock(return_value={"_key": "kk"})
+
+    out_r = await revoke_attachment_permissions(req_r, gp)
+    gp.batch_delete_edges.assert_awaited()
+    assert out_r["revoked"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_delete_chat_attachment_paths():
+    from app.api.routes.chatbot import delete_chat_attachment
+
+    r = MagicMock()
+    r.state.user = {}
+    with pytest.raises(HTTPException) as ex:
+        await delete_chat_attachment("rid", r, AsyncMock())
+    assert ex.value.status_code == 400
+
+    gp = AsyncMock()
+
+    gp.get_document = AsyncMock(return_value={"orgId": "other"})
+    rr = MagicMock()
+    rr.state.user = {"orgId": "mine"}
+    with pytest.raises(HTTPException) as ex:
+
+        await delete_chat_attachment("rid", rr, gp)
+
+    assert ex.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_internal_stream_sql_deferred_execute_tool():
+    from types import SimpleNamespace
+
+    from app.api.routes.chatbot import _generate_internal_search_stream
+
+    captured: dict[str, object] = {}
+
+    qi = SimpleNamespace(
+        attachments=[{"virtualRecordId": "vx", "mimeType": "application/pdf"}],
+        previousConversations=[],
+
+
+        chatMode="internal_search",
+
+
+        mode="simple",
+
+        query="q",
+
+        modelKey=None,
+
+        modelName=None,
+
+        limit=None,
+
+        filters=None,
+
+        conversationId=None,
+    )
+
+
+    def stream_effect(*args, **kwargs):
+
+        captured["defer_name"] = kwargs.get("defer_tool_until_called_name")
+
+
+        deferred = kwargs.get("deferred_tool")
+
+
+        captured["defer_len"] = len(deferred) if deferred else 0
+
+        captured["max_hops"] = kwargs.get("max_hops")
+
+        async def _gen():
+
+            yield {"event": "done", "data": {}}
+
+        return _gen()
+
+    req = MagicMock()
+
+    req.state.user = {"orgId": "o", "userId": "u"}
+    req.query_params = {}
+
+    req.app.container.logger.return_value = MagicMock()
+
+
+
+
+    retrieval = AsyncMock()
+
+
+    gp = AsyncMock()
+
+
+    cfg = AsyncMock()
+
+
+    with patch(
+        "app.api.routes.chatbot.stream_llm_response_with_tools",
+        side_effect=stream_effect,
+    ):
+        with patch(
+            "app.api.routes.chatbot._build_attachment_llm_messages",
+
+            new_callable=AsyncMock,
+            return_value=(
+                [{"role": "system", "content": "s"}, {"role": "user", "content": []}],
+                MagicMock(),
+            ),
+
+        ):
+            with patch(
+                "app.api.routes.chatbot.create_internal_search_tool",
+                return_value=MagicMock(),
+            ):
+                with patch(
+                    "app.api.routes.chatbot.create_fetch_full_record_tool",
+
+                    return_value=MagicMock(),
+
+                ):
+                    with patch(
+                        "app.api.routes.chatbot.create_execute_query_tool",
+                        return_value=MagicMock(),
+
+                    ):
+                        with patch(
+                            "app.api.routes.chatbot.has_sql_connector_configured",
+                            new_callable=AsyncMock,
+                            return_value=True,
+                        ):
+                            with patch(
+                                "app.api.routes.chatbot.BlobStorage",
+                                return_value=MagicMock(),
+                            ):
+                                with patch(
+                                    "app.api.routes.chatbot.get_llm_for_chat",
+
+                                    new_callable=AsyncMock,
+                                    return_value=(
+                                        MagicMock(),
+                                        {"provider": "openai",
+                                         "isMultimodal": False,
+                                         "contextLength": 4096},
+                                        {},
+
+                                    ),
+                                ):
+                                    with patch(
+                                        "app.api.routes.chatbot._build_llm_user_context_string",
+                                        new_callable=AsyncMock,
+                                        return_value="",
+                                    ):
+                                        async for _chunk in _generate_internal_search_stream(
+                                            req,
+                                            qi,
+                                            retrieval,
+
+                                            gp,
+
+
+                                            cfg,
+                                        ):
+                                            pass
+
+
+
+
+    assert captured["defer_name"] == "search_internal_knowledge"
+
+
+    assert captured["defer_len"] == 2
+
+
+
+
+    assert captured["max_hops"] == 3
+
+
+@pytest.mark.asyncio
+async def test_upload_missing_user_context():
+    import base64
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+    rr = MagicMock()
+    rr.json = AsyncMock(
+        return_value={
+            "attachments": [
+                {
+                    "fileName": "a.png",
+                    "mimeType": "image/png",
+                    "size": 4,
+                    "contentBase64": base64.b64encode(b"abcd").decode(),
+                },
+            ],
+        },
+    )
+    rr.state.user = {"orgId": "org"}
+    rr.app.container.logger.return_value = MagicMock()
+    gp = AsyncMock()
+    gp.get_user_by_user_id = AsyncMock(return_value={"_key": "k"})
+    with pytest.raises(HTTPException) as ex:
+        await upload_chat_attachments(rr, gp, AsyncMock())
+    assert ex.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_upload_user_resolve_failures():
+    import base64
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+    att = {
+        "fileName": "a.png",
+        "mimeType": "image/png",
+        "size": 8,
+        "contentBase64": base64.b64encode(b"12345678").decode(),
+    }
+
+    rr = MagicMock()
+
+    rr.json = AsyncMock(return_value={"attachments": [att]})
+
+
+    rr.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": False}
+
+
+
+
+    rr.app.container.logger.return_value = MagicMock()
+
+
+
+    gp1 = AsyncMock()
+
+
+
+    gp1.get_user_by_user_id = AsyncMock(return_value=None)
+
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await upload_chat_attachments(rr, gp1, AsyncMock())
+
+
+    assert ex.value.status_code == 404
+
+
+
+    gp2 = AsyncMock()
+
+
+    gp2.get_user_by_user_id = AsyncMock(return_value={"noKeys": True})
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await upload_chat_attachments(rr, gp2, AsyncMock())
+
+
+    assert ex.value.status_code == 500
+
+
+
+
+@pytest.mark.asyncio
+async def test_upload_validation_helpers():
+    import base64
+
+
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+
+
+
+    user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+
+
+    rr = MagicMock()
+
+
+    rr.state.user = user
+
+
+    rr.app.container.logger.return_value = MagicMock()
+
+
+
+    rr.json = AsyncMock(
+
+        return_value={
+
+            "attachments": [{"fileName": "x.gif", "mimeType": "image/gif", "size": 8,
+
+                             "contentBase64": base64.b64encode(b"zzzzzzzz").decode()}],
+
+        },
+
+
+
+
+    )
+
+
+    gp = AsyncMock()
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+    assert ex.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    rr.json = AsyncMock(return_value={"attachments": [{"fileName": "n.png",
+
+
+
+
+                                                      "mimeType": "image/png",
+
+                                                      "size": 0,
+
+
+
+
+                                                      "contentBase64": base64.b64encode(b"z").decode(),
+
+
+
+                                                     }]},
+
+
+
+
+                    )
+
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+    assert "positive" in str(ex.value.detail).lower()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    rr.json = AsyncMock(return_value={"attachments": [{"fileName": "n.png",
+
+
+
+
+                                                      "mimeType": "image/png",
+
+
+
+
+                                                      "size": 2,
+
+
+
+
+                                                      "contentBase64": "bad!!!",
+
+                                                      }]},
+
+
+                    )
+
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+    assert "Invalid base64" in str(ex.value.detail)
+
+
+
+
+
+@pytest.mark.asyncio
+
+async def test_upload_image_block_failure():
+
+
+
+
+
+
+    import base64
+
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+
+
+
+
+
+
+
+    rr = MagicMock()
+
+
+    rr.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+    rr.app.container.logger.return_value = MagicMock()
+
+
+    rr.json = AsyncMock(return_value={"attachments": [{"fileName": "i.png",
+
+
+
+
+                                                      "mimeType": "image/png",
+
+                                                      "size": 8,
+
+                                                      "contentBase64":
+
+
+
+
+                                                      base64.b64encode(b"hhhhhhhh").decode(),
+
+
+
+                                                      }]},
+
+
+
+
+                    )
+
+
+    gp = AsyncMock()
+
+
+    gp.batch_upsert_nodes = AsyncMock()
+
+
+    gp.batch_create_edges = AsyncMock()
+
+
+
+
+
+
+    orch = AsyncMock()
+
+
+    orch.apply = AsyncMock()
+
+
+    with patch("app.api.routes.chatbot.BlobStorage") as bscl:
+
+
+        bs = AsyncMock()
+
+
+        bs.save_binary_to_storage = AsyncMock(return_value=("x", None))
+
+
+        bscl.return_value = bs
+
+
+        with patch("app.api.routes.chatbot.GraphDBTransformer", return_value=MagicMock()):
+
+
+            with patch("app.api.routes.chatbot._build_image_blocks", side_effect=RuntimeError("x")):
+
+
+                with pytest.raises(HTTPException) as ex:
+
+
+                    await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+                assert ex.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_upload_pdf_regular_and_scan_cap():
+
+
+
+
+    import base64
+
+
+
+
+    from app.models.blocks import BlocksContainer
+
+
+
+
+    from app.api.routes.chatbot import OCR_IMAGE_PAGE_CAP, upload_chat_attachments
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    pdf_b64 = base64.b64encode(b"%PDF-xx").decode()
+
+
+
+
+
+
+
+
+    pym = MagicMock()
+
+
+    pym.parse_document = AsyncMock(return_value={"chunks": True})
+
+
+    pym.create_blocks = AsyncMock(return_value=BlocksContainer(blocks=[], block_groups=[]))
+
+
+
+
+
+    orch_ok = AsyncMock()
+
+
+    orch_ok.apply = AsyncMock()
+
+
+
+
+
+    fakerec = MagicMock()
+
+
+    fakerec.block_containers = BlocksContainer(blocks=[], block_groups=[])
+
+
+
+
+
+
+    rr_ok = MagicMock()
+
+
+    rr_ok.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+    rr_ok.app.container.logger.return_value = MagicMock()
+
+
+    rr_ok.json = AsyncMock(return_value={"attachments": [{"fileName": "f.pdf",
+
+
+                                                           "mimeType": "application/pdf",
+
+
+                                                           "size": 8,
+
+
+
+
+                                                           "contentBase64": pdf_b64,
+
+
+
+
+                                                           }]},
+
+
+
+
+                    )
+
+
+
+
+
+
+
+
+    gp_ok = AsyncMock()
+
+
+    gp_ok.batch_upsert_nodes = AsyncMock()
+
+
+    gp_ok.batch_create_edges = AsyncMock()
+
+
+
+
+
+
+
+
+
+
+
+
+    with patch("app.api.routes.chatbot.BlobStorage") as bscl:
+
+
+        bins = AsyncMock()
+
+
+        bins.save_binary_to_storage = AsyncMock(return_value=("id", None))
+
+
+        bscl.return_value = bins
+
+
+
+
+        with patch("app.api.routes.chatbot.GraphDBTransformer", return_value=MagicMock()):
+
+
+            with patch("app.api.routes.chatbot.PyMuPDFOpenCVProcessor", return_value=pym):
+
+
+                with patch("app.api.routes.chatbot._pdf_has_any_ocr_page", return_value=False):
+
+
+                    with patch(
+
+
+                        "app.api.routes.chatbot.convert_record_dict_to_record",
+
+
+
+
+
+                        return_value=fakerec,
+
+
+
+
+
+                    ):
+
+
+                        with patch(
+
+
+
+
+                            "app.api.routes.chatbot.TransformContext",
+
+
+
+
+
+                            MagicMock(side_effect=lambda **_: MagicMock()),
+
+
+
+
+
+                        ):
+
+
+                            with patch(
+
+
+
+
+                                "app.api.routes.chatbot.SinkOrchestrator",
+
+
+
+
+
+                                return_value=orch_ok,
+
+
+
+
+
+                            ):
+
+
+                                await upload_chat_attachments(rr_ok, gp_ok, AsyncMock())
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    pym.parse_document.assert_awaited()
+
+
+    orch_ok.apply.assert_awaited()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    orch2 = AsyncMock()
+
+
+
+    orch2.apply = AsyncMock()
+
+
+
+    rr_bad = MagicMock()
+
+
+
+    rr_bad.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+
+    rr_bad.app.container.logger.return_value = rr_ok.app.container.logger.return_value
+
+
+
+    rr_bad.json = rr_ok.json
+
+
+
+
+
+
+    gp_bad = AsyncMock()
+
+
+
+
+
+    gp_bad.batch_upsert_nodes = AsyncMock()
+
+
+
+
+
+    gp_bad.batch_create_edges = AsyncMock()
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    with patch("app.api.routes.chatbot.BlobStorage") as bscl:
+
+
+
+
+
+
+
+
+        bins = AsyncMock()
+
+
+        bins.save_binary_to_storage = AsyncMock(return_value=("id", None))
+
+
+
+
+        bscl.return_value = bins
+
+
+
+
+
+
+
+        with patch("app.api.routes.chatbot.GraphDBTransformer", return_value=MagicMock()):
+
+
+
+            with patch("app.api.routes.chatbot.PyMuPDFOpenCVProcessor", return_value=pym):
+
+
+
+
+                with patch("app.api.routes.chatbot._pdf_has_any_ocr_page", return_value=True):
+
+
+
+
+                    with patch(
+
+                        "app.api.routes.chatbot._pdf_page_count",
+
+                        return_value=OCR_IMAGE_PAGE_CAP + 1,
+
+                    ):
+
+
+                        with pytest.raises(HTTPException) as exc:
+
+
+
+
+
+                            await upload_chat_attachments(rr_bad, gp_bad, AsyncMock())
+
+
+
+
+
+                        assert "Scanned attachment page cap" in str(exc.value.detail)
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_grant_and_revoke_permissions_json_noise():
+
+
+
+
+
+
+    """1408-1466"""
+
+
+    import app.api.routes.chatbot as cr
+
+
+
+
+    from app.api.routes.chatbot import grant_attachment_permissions, revoke_attachment_permissions
+
+
+
+
+
+
+    req_g_json = MagicMock()
+
+
+    req_g_json.json = AsyncMock(side_effect=RuntimeError("boom"))
+
+
+
+
+
+
+    with pytest.raises(HTTPException) as exc:
+
+
+        await grant_attachment_permissions(req_g_json, AsyncMock())
+
+
+
+
+
+
+    assert exc.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    rk = MagicMock()
+
+
+    rk.json = AsyncMock(return_value={})
+
+
+
+
+
+
+
+
+    with pytest.raises(HTTPException) as exc:
+
+
+        await grant_attachment_permissions(rk, AsyncMock())
+
+
+
+
+
+    assert exc.value.status_code == 400
+
+
+
+
+
+
+
+
+    gp_miss = AsyncMock()
+
+
+    gp_miss.get_user_by_user_id = AsyncMock(return_value={"n": True})
+
+
+    rk2 = MagicMock()
+
+
+    rk2.json = AsyncMock(return_value={"userIds": ["u"], "recordIds": ["rid"]})
+
+
+
+
+
+
+
+
+    with patch.object(cr.logger, "warning", MagicMock()):
+
+
+
+
+
+        grant_out = await grant_attachment_permissions(rk2, gp_miss)
+
+
+
+
+
+
+
+    assert grant_out["granted"] == 0
+
+
+
+
+
+
+
+
+
+
+
+    rq = MagicMock()
+
+
+
+
+    rq.json = AsyncMock(side_effect=RuntimeError("boom"))
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    with pytest.raises(HTTPException) as exc:
+
+
+        await revoke_attachment_permissions(rq, AsyncMock())
+
+
+    assert exc.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_delete_chat_attachment_early_and_full():
+
+
+
+
+
+    """1534 and 1540-1545."""
+
+
+
+
+
+    from app.api.routes.chatbot import delete_chat_attachment
+
+
+
+
+
+
+
+
+    rr = MagicMock()
+
+
+
+
+    rr.state.user = {"orgId": "o1"}
+
+
+
+
+    gp = AsyncMock()
+
+
+
+
+    gp.get_document = AsyncMock(return_value=None)
+
+
+
+
+    await delete_chat_attachment("rid", rr, gp)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    gp.get_document.return_value = {"orgId": "o1"}
+
+
+
+
+    gp.delete_nodes_and_edges = AsyncMock()
+
+
+
+
+
+    gp.delete_nodes = AsyncMock()
+
+
+
+
+
+
+
+
+    await delete_chat_attachment("rid", rr, gp)
+
+
+
+
+
+
+    gp.delete_nodes_and_edges.assert_awaited()
+
+    gp.delete_nodes.assert_awaited()
+
+
+def test_collect_effective_attachments_filters_entries():
+    from app.api.routes.chatbot import ChatQuery, _collect_effective_attachments
+
+    q = ChatQuery(
+        query="hi",
+        attachments=[{"oops": True}, {"virtualRecordId": " v1 ", "mimeType": "png"}],
+        previousConversations=[
+            {
+                "role": "bot_response",
+                "attachments": [{"virtualRecordId": "ignored"}],
+            },
+
+            {
+
+
+                "role": "user_query",
+
+
+                "attachments": [{"x": True}, {"recordId": "r2"}],
+
+
+            },
+
+
+        ],
+    )
+
+
+
+    merged = _collect_effective_attachments(q)
+
+
+    def norm_id(att: dict) -> str:
+
+
+        return str(att.get("recordId") or att.get("virtualRecordId") or "").strip()
+
+
+    assert {norm_id(x) for x in merged} == {"v1", "r2"}
+
+
+
+def test_estimate_tokens_non_string_uri_and_non_string_block_data():
+
+
+
+
+
+
+    from app.api.routes.chatbot import _estimate_record_tokens
+
+
+
+
+
+
+
+
+
+    tiny = {
+
+
+        "block_containers": {
+
+
+            "blocks": [
+
+
+                {"data": {"uri": 404}},
+
+
+
+
+
+                {"data": [None, False]},
+
+
+
+
+
+            ]
+
+
+
+
+        }
+
+
+
+    }
+
+
+
+
+
+
+
+    tokens = _estimate_record_tokens(tiny)
+
+
+    assert tokens >= 3
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_append_history_pdf_plain_user_text():
+
+
+
+
+
+
+    """427-428: PDF history merges with plain-string user content."""
+
+
+
+
+
+
+    from app.api.routes.chatbot import CitationRefMapper, _append_conversation_history
+
+
+
+
+
+
+    bs = AsyncMock()
+
+
+
+    bs.get_record_from_storage = AsyncMock(return_value={"record": True})
+
+
+
+
+
+
+
+
+    conv = [{"role": "user_query", "content": "prior text",
+
+
+             "attachments": [{"virtualRecordId": "pv",
+
+
+                                "mimeType": "application/pdf"}]}]
+
+
+    msgs: list = [{"role": "system", "content": "-"}]
+
+
+    cmap: dict[str, object] = {}
+
+
+    fm = MagicMock()
+
+
+    with patch("app.api.routes.chatbot.record_to_message_content") as rtc:
+
+
+        rtc.return_value = ([{"type": "text", "text": "pdf"}], fm)
+
+
+        await _append_conversation_history(
+
+
+            msgs,
+
+            conv,
+
+
+
+
+            blob_store=bs,
+
+
+
+
+            org_id="o",
+
+
+
+
+            ref_mapper=CitationRefMapper(),
+
+            virtual_record_id_to_result=cmap,
+
+            logger=None,
+
+
+
+
+            is_multimodal_llm=False,
+
+
+        )
+
+
+
+
+
+    merged = msgs[1]["content"]
+
+
+    assert isinstance(merged, list)
+
+
+    flat = "".join(
+
+
+        p.get("text", "") if isinstance(p, dict) and p.get("type") == "text" else ""
+
+
+
+
+        for p in merged
+
+
+
+
+    )
+
+
+    assert "prior text" in flat
+
+
+    assert "Attached PDF documents" in flat
+
+
+
+
+
+
+
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_attachment_messages_pdf_warnings():
+
+
+
+
+
+
+    from app.api.routes.chatbot import ChatQuery, _build_attachment_llm_messages
+
+
+
+
+
+
+    log = MagicMock()
+
+
+    bs = AsyncMock()
+
+
+    bs.get_record_from_storage = AsyncMock(return_value=None)
+
+
+
+
+
+
+
+
+    cq = ChatQuery(
+
+
+        query="q",
+
+        attachments=[{"virtualRecordId": "", "mimeType": "application/pdf"}],
+
+
+    )
+
+
+
+
+
+
+
+
+    await _build_attachment_llm_messages(
+
+
+        cq,
+
+
+        {"customSystemPrompt": "CUSTOM"},
+
+
+
+
+        "",
+
+
+        log,
+
+        is_multimodal_llm=False,
+
+        blob_store=bs,
+
+        org_id="o",
+
+
+
+
+        has_attachments=True,
+
+
+        virtual_record_id_to_result={},
+
+
+    )
+
+
+
+
+
+
+
+
+    assert log.debug.called
+
+
+
+
+
+
+    log2 = MagicMock()
+
+
+    bs2 = AsyncMock()
+
+
+    bs2.get_record_from_storage = AsyncMock(side_effect=RuntimeError("db"))
+
+
+
+
+    cq2 = ChatQuery(
+
+
+
+
+        query="q",
+
+
+        attachments=[{"virtualRecordId": "z", "mimeType": "application/pdf"}],
+
+
+
+
+    )
+
+
+    with patch("app.api.routes.chatbot.record_to_message_content"):
+
+
+        await _build_attachment_llm_messages(
+
+
+            cq2,
+
+
+            {},
+
+
+
+
+            "",
+
+
+
+
+            log2,
+
+
+
+
+            is_multimodal_llm=False,
+
+
+
+
+            blob_store=bs2,
+
+
+
+
+            org_id="o",
+
+
+
+
+            has_attachments=True,
+
+
+
+
+            virtual_record_id_to_result={},
+
+
+        )
+
+
+
+
+
+
+
+
+    log2.warning.assert_called()
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_upload_no_attachments_in_body():
+
+
+
+
+
+
+    """1195."""
+
+
+
+
+
+
+
+
+    import base64
+
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+
+
+
+
+
+
+
+
+    rr = MagicMock()
+
+
+    rr.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+
+
+    rr.app.container.logger.return_value = MagicMock()
+
+
+
+
+    rr.json = AsyncMock(return_value={"attachments": []})
+
+
+
+
+
+
+    gp = AsyncMock()
+
+
+
+
+
+
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+    assert ex.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_upload_pdf_ocr_success_small_doc():
+
+
+
+
+
+
+    """1297-1298."""
+
+
+
+
+
+
+
+
+    import base64
+
+
+
+
+
+
+
+
+
+    from app.models.blocks import BlocksContainer
+
+
+
+
+
+
+
+
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+
+
+
+
+
+
+
+
+    pym = MagicMock()
+
+
+    orch = AsyncMock()
+
+
+    orch.apply = AsyncMock()
+
+
+    rr = MagicMock()
+
+
+    rr.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+    rr.app.container.logger.return_value = MagicMock()
+
+
+    pdf_raw = base64.b64encode(b"%PDF-xx").decode()
+
+
+    rr.json = AsyncMock(return_value={"attachments": [{"fileName": "s.pdf",
+
+                                                        "mimeType": "application/pdf",
+
+                                                        "size": 16,
+
+                                                        "contentBase64": pdf_raw}]})
+
+
+    gp = AsyncMock()
+
+
+    gp.batch_upsert_nodes = AsyncMock()
+
+
+    gp.batch_create_edges = AsyncMock()
+
+
+    fakerec = MagicMock()
+
+
+    fakerec.block_containers = BlocksContainer(blocks=[], block_groups=[])
+
+
+
+
+
+
+    with patch("app.api.routes.chatbot.BlobStorage") as bscl:
+
+
+        bs = AsyncMock()
+
+
+        bs.save_binary_to_storage = AsyncMock(return_value=("id", None))
+
+
+        bscl.return_value = bs
+
+
+        with patch("app.api.routes.chatbot.GraphDBTransformer", return_value=MagicMock()):
+
+
+            with patch("app.api.routes.chatbot.PyMuPDFOpenCVProcessor", return_value=pym):
+
+
+                with patch("app.api.routes.chatbot._pdf_has_any_ocr_page", return_value=True):
+
+
+                    with patch("app.api.routes.chatbot._pdf_page_count", return_value=5):
+
+
+                        with patch(
+
+
+                            "app.api.routes.chatbot._build_pdf_image_blocks",
+
+
+
+
+
+
+                            return_value=BlocksContainer(blocks=[], block_groups=[]),
+
+
+
+
+
+                        ):
+
+
+                            with patch("app.api.routes.chatbot.convert_record_dict_to_record",
+
+                                      return_value=fakerec):
+
+
+                                with patch("app.api.routes.chatbot.TransformContext",
+
+
+                                           MagicMock(side_effect=lambda **_: MagicMock())):
+
+
+                                    with patch("app.api.routes.chatbot.SinkOrchestrator",
+
+
+                                               return_value=orch):
+
+
+                                        await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+    orch.apply.assert_awaited()
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_upload_pdf_parse_generic_failure():
+
+
+
+
+
+
+    """1305-1306."""
+
+
+
+
+
+
+
+
+    import base64
+
+
+
+
+
+
+
+
+
+
+    from app.api.routes.chatbot import upload_chat_attachments
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    pym = MagicMock()
+
+
+    pym.parse_document = AsyncMock(side_effect=RuntimeError("parse"))
+
+
+
+
+    rr = MagicMock()
+
+
+    rr.state.user = {"orgId": "o", "userId": "u", "isServiceAccount": True}
+
+
+    rr.app.container.logger.return_value = MagicMock()
+
+
+    pdf_raw = base64.b64encode(b"x" * 8).decode()
+
+
+    rr.json = AsyncMock(return_value={"attachments": [{"fileName": "p.pdf",
+
+                                                        "mimeType": "application/pdf",
+
+                                                        "size": 16,
+
+                                                        "contentBase64": pdf_raw}]})
+
+
+    gp = AsyncMock()
+
+
+    gp.batch_upsert_nodes = AsyncMock()
+
+
+    gp.batch_create_edges = AsyncMock()
+
+
+
+
+
+
+
+
+    with patch("app.api.routes.chatbot.BlobStorage") as bscl:
+
+
+        bs = AsyncMock()
+
+
+        bs.save_binary_to_storage = AsyncMock(return_value=("id", None))
+
+
+        bscl.return_value = bs
+
+
+        with patch("app.api.routes.chatbot.GraphDBTransformer", return_value=MagicMock()):
+
+
+            with patch("app.api.routes.chatbot.PyMuPDFOpenCVProcessor", return_value=pym):
+
+
+                with patch("app.api.routes.chatbot._pdf_has_any_ocr_page", return_value=False):
+
+
+                    with pytest.raises(HTTPException) as ex:
+
+
+                        await upload_chat_attachments(rr, gp, AsyncMock())
+
+
+                    assert ex.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+
+@pytest.mark.asyncio
+
+
+async def test_revoke_invalid_payload_and_bad_user():
+
+
+
+
+
+    import app.api.routes.chatbot as cr
+
+
+    from app.api.routes.chatbot import revoke_attachment_permissions
+
+
+
+
+
+
+
+
+
+    rk = MagicMock()
+
+
+    rk.json = AsyncMock(return_value={})
+
+
+
+
+
+
+
+
+    with pytest.raises(HTTPException) as ex:
+
+
+        await revoke_attachment_permissions(rk, AsyncMock())
+
+
+
+
+
+    assert ex.value.status_code == 400
+
+
+
+
+
+
+
+
+
+
+
+    rp = AsyncMock()
+
+
+
+
+    rp.get_user_by_user_id = AsyncMock(return_value={"n": True})
+
+
+    rk2 = MagicMock()
+
+
+    rk2.json = AsyncMock(return_value={"userIds": ["u"], "recordIds": ["x"]})
+
+
+
+
+
+
+
+
+    with patch.object(cr.logger, "warning", MagicMock()):
+
+
+        out = await revoke_attachment_permissions(rk2, rp)
+
+
+
+
+
+
+
+
+    assert out["revoked"] == 0
+
+@pytest.mark.asyncio
+
+
+async def test_internal_search_standard_path_appends_execute_query_tool_when_sql_configured():
+    # Standard retrieval adds execute_query when SQL is configured.
+    from types import SimpleNamespace
+
+    from app.api.routes.chatbot import _generate_internal_search_stream
+
+
+    tools_passed: list = []
+
+    async def fake_stream_llm(**kwargs):
+        tools_passed.append(list(kwargs.get("tools") or []))
+        yield {"event": "token", "data": {}}
+        yield {"event": "done", "data": {}}
+
+    qi = SimpleNamespace(
+        attachments=[],
+        previousConversations=[],
+        chatMode="internal_search",
+        mode="simple",
+        query="plain",
+        modelKey=None,
+        modelName=None,
+        limit=5,
+        filters=None,
+        conversationId="c1",
+    )
+
+    req = MagicMock()
+    req.state.user = {"orgId": "org", "userId": "user"}
+    req.query_params = {}
+    req.app.container.logger.return_value = MagicMock()
+
+    retrieval = AsyncMock()
+    retrieval.search_with_filters = AsyncMock(
+        return_value={
+            "searchResults": [{}],
+            "virtual_to_record_map": {},
+            "status_code": 200,
+        },
+    )
+
+    gp = AsyncMock()
+    cfg_exec = AsyncMock()
+    eq_tool = MagicMock()
+    fetch_tool = MagicMock()
+
+    with patch("app.api.routes.chatbot.stream_llm_response_with_tools", side_effect=fake_stream_llm):
+        with patch(
+            "app.api.routes.chatbot.has_sql_connector_configured",
+            new_callable=AsyncMock,
+            return_value=True,
+        ):
+            with patch("app.api.routes.chatbot.create_execute_query_tool", return_value=eq_tool):
+                with patch(
+                    "app.api.routes.chatbot.create_fetch_full_record_tool",
+                    return_value=fetch_tool,
+                ):
+                    with patch(
+                        "app.api.routes.chatbot.get_flattened_results",
+                        new_callable=AsyncMock,
+                        return_value=[],
+                    ):
+                        with patch(
+                            "app.api.routes.chatbot.enrich_virtual_record_id_to_result_with_fk_children",
+                            new_callable=AsyncMock,
+                        ):
+                            with patch(
+                                "app.api.routes.chatbot._build_chat_llm_messages",
+                                new_callable=AsyncMock,
+                                return_value=([], MagicMock()),
+                            ):
+                                with patch(
+                                    "app.api.routes.chatbot.get_llm_for_chat",
+                                    new_callable=AsyncMock,
+                                    return_value=(
+                                        MagicMock(),
+                                        {
+                                            "provider": "openai",
+                                            "isMultimodal": False,
+                                            "contextLength": 8000,
+                                        },
+                                        {},
+                                    ),
+                                ):
+                                    with patch(
+                                        "app.api.routes.chatbot.BlobStorage",
+                                        return_value=MagicMock(),
+                                    ):
+                                        with patch(
+                                            "app.api.routes.chatbot._build_llm_user_context_string",
+                                            new_callable=AsyncMock,
+                                            return_value="",
+                                        ):
+                                            async for _ in _generate_internal_search_stream(
+                                                req,
+                                                qi,
+                                                retrieval,
+                                                gp,
+                                                cfg_exec,
+                                            ):
+                                                pass
+
+    assert tools_passed
+    tls = tools_passed[-1]
+    assert eq_tool in tls
+    assert fetch_tool in tls
+    assert tls.index(eq_tool) < tls.index(fetch_tool)

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_coverage_gaps.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_coverage_gaps.py
@@ -1,0 +1,560 @@
+"""Targeted tests to raise coverage for blob_storage.py remaining branches."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from app.config.constants.http_status_code import HttpStatusCode
+from app.config.constants.service import DefaultEndpoints
+from app.modules.transformers.blob_storage import BlobStorage
+
+
+def _make_bs(*, config_service=None, graph_provider=None):
+    return BlobStorage(
+        logger=MagicMock(),
+        config_service=config_service or AsyncMock(),
+        graph_provider=graph_provider,
+    )
+
+
+def _auth_side_effect(storage_type: str):
+    return [
+        {"scopedJwtSecret": "scoped-jwt-secret-32bytes-min"},
+        {"cm": {"endpoint": "http://nodejs:3001"}},
+        {"storageType": storage_type},
+    ]
+
+
+def _resp(status=200, json_value=None, text_value=""):
+    r = AsyncMock()
+    r.status = status
+    r.json = AsyncMock(return_value=json_value if json_value is not None else {})
+    r.text = AsyncMock(return_value=text_value)
+    r.__aenter__ = AsyncMock(return_value=r)
+    r.__aexit__ = AsyncMock(return_value=False)
+    return r
+
+
+def _make_record_mock(org_id="org-1", record_id="rec-1", virtual_record_id="vr-1"):
+    rec = MagicMock()
+    rec.id = record_id
+    rec.org_id = org_id
+    rec.virtual_record_id = virtual_record_id
+    rec.model_dump.return_value = {
+        "id": record_id,
+        "org_id": org_id,
+        "virtual_record_id": virtual_record_id,
+        "block_containers": {"blocks": [], "block_groups": []},
+    }
+    return rec
+
+
+# ---------------------------------------------------------------------------
+# _get_public_download_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestGetPublicDownloadBaseUrl:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "endpoints_payload, expected",
+        [
+            (
+                {"frontend": {"publicEndpoint": "https://app.example"}},
+                "https://app.example",
+            ),
+            (
+                {"frontend": {}, "storage": {"endpoint": "https://storage.example"}},
+                "https://storage.example",
+            ),
+            (
+                {},
+                DefaultEndpoints.FRONTEND_ENDPOINT.value,
+            ),
+        ],
+    )
+    async def test_fallback_chain(self, endpoints_payload, expected):
+        cs = AsyncMock()
+        cs.get_config = AsyncMock(return_value=endpoints_payload)
+        bs = _make_bs(config_service=cs)
+        url = await bs._get_public_download_base_url()
+        assert url == expected
+
+
+# ---------------------------------------------------------------------------
+# save_binary_to_storage
+# ---------------------------------------------------------------------------
+
+
+class TestSaveBinaryToStorage:
+    @pytest.mark.asyncio
+    async def test_local_success(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("local"))
+
+        post_resp = _resp(200, {"_id": "bin-local"})
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=post_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            doc_id, size = await bs.save_binary_to_storage(
+                "org-1",
+                "rec-1",
+                "report.pdf",
+                "pdf",
+                "application/pdf",
+                b"%PDF-1.4\n",
+            )
+        assert doc_id == "bin-local"
+        assert size == len(b"%PDF-1.4\n")
+
+    @pytest.mark.asyncio
+    async def test_local_non_success_returns_none(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("local"))
+
+        post_resp = _resp(500, text_value="error")
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=post_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            doc_id, size = await bs.save_binary_to_storage(
+                "org-1", "rec-1", "f.pdf", "pdf", "application/pdf", b"x",
+            )
+        assert doc_id is None
+        assert size is None
+
+    @pytest.mark.asyncio
+    async def test_s3_success(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("s3"))
+
+        placeholder_r = _resp(200, {"_id": "s3-bin"})
+        signed_post_r = _resp(200, {"signedUrl": "https://bucket/presigned"})
+        put_r = _resp(HttpStatusCode.SUCCESS.value, {})
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=[placeholder_r, signed_post_r])
+        mock_session.put = MagicMock(return_value=put_r)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            doc_id, size = await bs.save_binary_to_storage(
+                "org-1", "rec-1", "x.csv", "csv", "text/csv", b"a,b\n",
+            )
+        assert doc_id == "s3-bin"
+        assert size == len(b"a,b\n")
+
+    @pytest.mark.asyncio
+    async def test_s3_no_placeholder_id_returns_none(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("s3"))
+
+        placeholder_r = _resp(200, {})
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=placeholder_r)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            doc_id, size = await bs.save_binary_to_storage(
+                "org-1", "rec-1", "f.bin", "bin", "application/octet-stream", b"x",
+            )
+        assert doc_id is None
+        assert size is None
+
+    @pytest.mark.asyncio
+    async def test_s3_no_signed_url_returns_none(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("s3"))
+
+        placeholder_r = _resp(200, {"_id": "doc1"})
+        signed_post_r = _resp(200, {})
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=[placeholder_r, signed_post_r])
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            doc_id, size = await bs.save_binary_to_storage(
+                "org-1", "rec-1", "f.bin", "bin", "application/octet-stream", b"x",
+            )
+        assert doc_id is None
+        assert size is None
+
+    @pytest.mark.asyncio
+    async def test_outer_exception_returns_none(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=ValueError("config broken"))
+
+        doc_id, size = await bs.save_binary_to_storage(
+            "org-1", "rec-1", "f.bin", "bin", "application/octet-stream", b"x",
+        )
+        assert doc_id is None
+        assert size is None
+
+
+# ---------------------------------------------------------------------------
+# apply — upload_next_version raises non–versioning errors
+# ---------------------------------------------------------------------------
+
+
+class TestApplyUploadNextVersionErrors:
+    @pytest.mark.asyncio
+    async def test_propagates_when_not_versioning_error(self):
+        gp = AsyncMock()
+        bs = _make_bs(graph_provider=gp)
+        bs.get_document_id_by_virtual_record_id = AsyncMock(
+            return_value={"record_doc_id": "doc-existing"}
+        )
+        bs.upload_next_version = AsyncMock(side_effect=RuntimeError("upstream failure"))
+        bs.save_record_to_storage = AsyncMock()
+
+        ctx = MagicMock()
+        ctx.record = _make_record_mock()
+
+        with pytest.raises(RuntimeError, match="upstream failure"):
+            await bs.apply(ctx)
+
+        bs.save_record_to_storage.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_non_versioned_exception_message_detected(self):
+        """_is_non_versioned_exception is case-insensitive on the phrase."""
+        bs = _make_bs()
+        assert bs._is_non_versioned_exception(Exception("Cannot Be Versioned")) is True
+        assert bs._is_non_versioned_exception(Exception("other")) is False
+
+
+# ---------------------------------------------------------------------------
+# get_document_id_by_virtual_record_id — record_metadata_doc_id
+# ---------------------------------------------------------------------------
+
+
+class TestGetDocumentIdMetadataField:
+    @pytest.mark.asyncio
+    async def test_includes_record_metadata_doc_id_when_present(self):
+        gp = AsyncMock()
+        gp.get_nodes_by_filters = AsyncMock(
+            return_value=[
+                {
+                    "record_doc_id": "rd1",
+                    "fileSizeBytes": 10,
+                    "record_metadata_doc_id": "meta-z",
+                }
+            ]
+        )
+        bs = _make_bs(graph_provider=gp)
+        result = await bs.get_document_id_by_virtual_record_id("vr-99")
+        assert result["record_doc_id"] == "rd1"
+        assert result["record_metadata_doc_id"] == "meta-z"
+
+
+# ---------------------------------------------------------------------------
+# get_record_from_storage — no document id after lookup
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecordFromStorageNoDocId:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_only_size_known(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("s3"))
+        bs.get_document_id_by_virtual_record_id = AsyncMock(
+            return_value={"fileSizeBytes": 100, "record_doc_id": None},
+        )
+
+        out = await bs.get_record_from_storage("vr-x", "org-1")
+        assert out is None
+
+
+# ---------------------------------------------------------------------------
+# get_reconciliation_metadata — signed URL follow-up + raw dict body
+# ---------------------------------------------------------------------------
+
+
+class TestGetReconciliationMetadataDeep:
+    @pytest.mark.asyncio
+    async def test_signed_url_secondary_fetch_returns_plain_dict(self):
+        gp = AsyncMock()
+        gp.get_document = AsyncMock(
+            return_value={"record_metadata_doc_id": "meta-doc"},
+        )
+        bs = _make_bs(graph_provider=gp)
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("s3"))
+
+        dl = _resp(200, {"signedUrl": "https://cdn.example/object"})
+        nested = _resp(200, {"hash": "only-top-level", "no_record_key": True})
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(side_effect=[dl, nested])
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            result = await bs.get_reconciliation_metadata("vr-1", "org-1")
+
+        assert result == {"hash": "only-top-level", "no_record_key": True}
+
+
+# ---------------------------------------------------------------------------
+# save_reconciliation_metadata — no graph provider skips mapping upsert
+# ---------------------------------------------------------------------------
+
+
+class TestSaveReconciliationMetadataNoGraph:
+    @pytest.mark.asyncio
+    async def test_returns_doc_id_without_upsert_when_no_graph(self):
+        bs = BlobStorage(
+            logger=MagicMock(),
+            config_service=AsyncMock(),
+            graph_provider=None,
+        )
+        bs._create_metadata_document = AsyncMock(return_value="meta-standalone")
+
+        out = await bs.save_reconciliation_metadata("o1", "r1", "vr1", {"k": 1})
+
+        assert out == "meta-standalone"
+        bs._create_metadata_document.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _get_signed_url — cannot be versioned warning path
+# ---------------------------------------------------------------------------
+
+
+class TestGetSignedUrlVersionWarning:
+    @pytest.mark.asyncio
+    async def test_logs_when_error_message_contains_cannot_version(self):
+        bs = _make_bs()
+        err_body = {
+            "error": {
+                "message": "This document cannot be versioned in storage",
+            }
+        }
+        mock_resp = AsyncMock()
+        mock_resp.status = 400
+        mock_resp.json = AsyncMock(return_value=err_body)
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with pytest.raises(aiohttp.ClientError):
+            await bs._get_signed_url(mock_session, "http://x/upload", {}, {})
+
+        bs.logger.warning.assert_called()
+        warning_msg = str(bs.logger.warning.call_args)
+        assert "legacy" in warning_msg or "non-versioned" in warning_msg
+
+
+# ---------------------------------------------------------------------------
+# upload_next_version (local) — ContentTypeError on error body
+# ---------------------------------------------------------------------------
+
+
+class TestUploadNextVersionLocalContentTypeError:
+    @pytest.mark.asyncio
+    async def test_non_json_error_body_uses_text_branch(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("local"))
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 502
+        mock_resp.json = AsyncMock(
+            side_effect=aiohttp.ContentTypeError(MagicMock(), MagicMock()),
+        )
+        mock_resp.text = AsyncMock(return_value="bad gateway html")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            with pytest.raises(Exception, match="Failed to upload next version"):
+                await bs.upload_next_version(
+                    "org",
+                    "rec",
+                    "doc-1",
+                    {"data": 1},
+                    "vr",
+                )
+
+
+# ---------------------------------------------------------------------------
+# _create_metadata_document (local) — ContentTypeError on failed create
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMetadataDocumentLocalContentTypeError:
+    @pytest.mark.asyncio
+    async def test_non_json_error_response(self):
+        bs = _make_bs()
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("local"))
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.json = AsyncMock(
+            side_effect=aiohttp.ContentTypeError(MagicMock(), MagicMock()),
+        )
+        mock_resp.text = AsyncMock(return_value="not json")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            with pytest.raises(Exception, match="Failed to create metadata document"):
+                await bs._create_metadata_document("org", "rec", "vr", {"m": 1})
+
+
+# ---------------------------------------------------------------------------
+# save_reconciliation_metadata — propagate non–versioning failures
+# ---------------------------------------------------------------------------
+
+
+class TestSaveReconciliationMetadataPropagates:
+    @pytest.mark.asyncio
+    async def test_upload_next_version_unrelated_error_propagates(self):
+        gp = AsyncMock()
+        gp.get_document = AsyncMock(
+            return_value={"record_metadata_doc_id": "existing-meta"},
+        )
+        bs = _make_bs(graph_provider=gp)
+        bs.upload_next_version = AsyncMock(side_effect=RuntimeError("s3 outage"))
+
+        with pytest.raises(RuntimeError, match="s3 outage"):
+            await bs.save_reconciliation_metadata("o", "r", "vr", {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# get_reconciliation_metadata — signed URL GET returns non-200
+# ---------------------------------------------------------------------------
+
+
+class TestGetReconciliationMetadataSignedUrlNonSuccess:
+    @pytest.mark.asyncio
+    async def test_keeps_outer_payload_when_signed_fetch_fails_status(self):
+        gp = AsyncMock()
+        gp.get_document = AsyncMock(
+            return_value={"record_metadata_doc_id": "meta-doc"},
+        )
+        bs = _make_bs(graph_provider=gp)
+        bs.config_service.get_config = AsyncMock(side_effect=_auth_side_effect("s3"))
+
+        dl = _resp(200, {"signedUrl": "https://cdn.example/object"})
+        nested_fail = AsyncMock()
+        nested_fail.status = 403
+        nested_fail.__aenter__ = AsyncMock(return_value=nested_fail)
+        nested_fail.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.get = MagicMock(side_effect=[dl, nested_fail])
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch(
+            "app.modules.transformers.blob_storage.aiohttp.ClientSession",
+            return_value=mock_session,
+        ):
+            result = await bs.get_reconciliation_metadata("vr-1", "org-1")
+
+        assert result == {"signedUrl": "https://cdn.example/object"}
+
+
+# ---------------------------------------------------------------------------
+# _get_signed_url — non-dict JSON error body
+# ---------------------------------------------------------------------------
+
+
+class TestGetSignedUrlNonDictErrorBody:
+    @pytest.mark.asyncio
+    async def test_list_error_detail(self):
+        bs = _make_bs()
+        mock_resp = AsyncMock()
+        mock_resp.status = 400
+        mock_resp.json = AsyncMock(return_value=["list", "error"])
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with pytest.raises(aiohttp.ClientError, match="Failed with status"):
+            await bs._get_signed_url(mock_session, "http://x", {}, {})
+
+
+class TestGetSignedUrlDictMissingErrorKey:
+    @pytest.mark.asyncio
+    async def test_dict_without_error_key_uses_full_body_string(self):
+        """Covers lines 478–479: fallback ``str(error_response)`` for odd JSON shapes."""
+        bs = _make_bs()
+        mock_resp = AsyncMock()
+        mock_resp.status = 400
+        mock_resp.json = AsyncMock(return_value={"reason": "other"})
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with pytest.raises(aiohttp.ClientError, match="Failed with status"):
+            await bs._get_signed_url(mock_session, "http://x", {}, {})
+
+
+class TestGetSignedUrlBareStatusWhenNoErrorDetail:
+    @pytest.mark.asyncio
+    async def test_non_json_body_empty_text_raises_without_suffix(self):
+        """Covers line 491 when ``error_detail`` is empty after ContentTypeError."""
+        bs = _make_bs()
+        mock_resp = AsyncMock()
+        mock_resp.status = 503
+        mock_resp.json = AsyncMock(
+            side_effect=aiohttp.ContentTypeError(MagicMock(), MagicMock()),
+        )
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+
+        with pytest.raises(aiohttp.ClientError, match="Failed with status 503$"):
+            await bs._get_signed_url(mock_session, "http://x", {}, {})

--- a/backend/python/tests/unit/modules/transformers/test_vectorstore.py
+++ b/backend/python/tests/unit/modules/transformers/test_vectorstore.py
@@ -1725,6 +1725,52 @@ class TestIndexDocumentsAdditional:
         assert result is None
 
     @pytest.mark.asyncio
+    async def test_record_summary_embedded_with_blocks(self):
+        """Semantic record summary is embedded alongside content blocks."""
+        from app.models.blocks import Block, BlocksContainer, SemanticMetadata
+
+        vs = _make_vectorstore()
+        vs.get_embedding_model_instance = AsyncMock(return_value=False)
+        vs.delete_blocks_by_ids = AsyncMock()
+        vs._create_embeddings = AsyncMock()
+        vs.nlp = MagicMock()
+        sent = MagicMock()
+        sent.text = "Hello world"
+        vs.nlp.return_value = MagicMock(sents=[sent])
+
+        block = Block(index=0, type="text", format="txt", data="Hello world", comments=[])
+        container = BlocksContainer(blocks=[block], block_groups=[])
+        record = MagicMock()
+        record.semantic_metadata = SemanticMetadata(
+            summary="Document overview",
+            categories=["General"],
+            departments=["Engineering"],
+            topics=["onboarding"],
+        )
+
+        with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
+            result = await vs.index_documents(
+                container,
+                "org-1",
+                "rec-1",
+                "vr-1",
+                "text/plain",
+                record=record,
+            )
+
+        assert result is True
+        from app.modules.transformers.vectorstore import VectorStore as VS
+
+        vs.delete_blocks_by_ids.assert_any_await(
+            {VS.record_summary_block_id("rec-1")},
+            "vr-1",
+        )
+        vs._create_embeddings.assert_awaited_once()
+        chunks = vs._create_embeddings.await_args.args[0]
+        assert len(chunks) >= 2  # text block chunk(s) + record summary
+
+    @pytest.mark.asyncio
     async def test_embedding_model_instance_failure(self):
         """When get_embedding_model_instance fails, should raise IndexingError."""
         from app.exceptions.indexing_exceptions import IndexingError

--- a/backend/python/tests/unit/modules/transformers/test_vectorstore.py
+++ b/backend/python/tests/unit/modules/transformers/test_vectorstore.py
@@ -159,9 +159,9 @@ class TestVectorStoreApply:
             "org-1",
             "rec-1",
             "vr-1",
-            "application/pdf",
             block_ids_to_delete=None,
             is_reconciliation=False,
+            record=record,
         )
         assert result is True
 
@@ -210,9 +210,9 @@ class TestVectorStoreApply:
             "specific-org-id",
             "specific-rec-id",
             "specific-vr-id",
-            "image/png",
             block_ids_to_delete=None,
             is_reconciliation=False,
+            record=record,
         )
 
 
@@ -724,7 +724,7 @@ class TestIndexDocuments:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
                 BlocksContainer(blocks=[], block_groups=[]),
-                "org-1", "rec-1", "vr-1", "text/plain"
+                "org-1", "rec-1", "vr-1",
             )
 
         assert result is None
@@ -749,7 +749,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         vs._create_embeddings.assert_awaited_once()
@@ -776,7 +776,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         # The documents should include individual sentences + the full block
@@ -796,7 +796,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "image/png")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         chunks = vs._create_embeddings.call_args[0][0]
@@ -819,7 +819,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": True})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "image/png")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         vs.describe_images.assert_awaited_once()
@@ -839,7 +839,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -861,7 +861,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -879,7 +879,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -897,7 +897,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -912,7 +912,7 @@ class TestIndexDocuments:
         with pytest.raises(IndexingError, match="Failed to get embedding model"):
             await vs.index_documents(
                 BlocksContainer(blocks=[], block_groups=[]),
-                "org-1", "rec-1", "vr-1", "text/plain"
+                "org-1", "rec-1", "vr-1",
             )
 
     @pytest.mark.asyncio
@@ -928,7 +928,7 @@ class TestIndexDocuments:
             with pytest.raises(IndexingError, match="Failed to get LLM"):
                 await vs.index_documents(
                     BlocksContainer(blocks=[], block_groups=[]),
-                    "org-1", "rec-1", "vr-1", "text/plain"
+                    "org-1", "rec-1", "vr-1",
                 )
 
     @pytest.mark.asyncio
@@ -947,7 +947,7 @@ class TestIndexDocuments:
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             with pytest.raises(IndexingError, match="Unexpected error during indexing"):
-                await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+                await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
     @pytest.mark.asyncio
     async def test_paragraph_blocks_processed_as_text(self):
@@ -963,7 +963,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -981,7 +981,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -999,7 +999,7 @@ class TestIndexDocuments:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         # table_cell blocks have no summary, so no documents to embed => True
         assert result is True
@@ -1116,9 +1116,9 @@ class TestApply:
             "org-1",
             "rec-1",
             "vr-1",
-            "text/plain",
             block_ids_to_delete=None,
             is_reconciliation=False,
+            record=mock_ctx.record,
         )
 
 
@@ -1651,7 +1651,7 @@ class TestIndexDocumentsAdditional:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "image/png")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         # Should have called _create_embeddings with image dict
@@ -1678,7 +1678,7 @@ class TestIndexDocumentsAdditional:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": True})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "image/png")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         vs.describe_images.assert_awaited_once()
@@ -1704,7 +1704,7 @@ class TestIndexDocumentsAdditional:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -1720,7 +1720,7 @@ class TestIndexDocumentsAdditional:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is None
 
@@ -1755,20 +1755,25 @@ class TestIndexDocumentsAdditional:
                 "org-1",
                 "rec-1",
                 "vr-1",
-                "text/plain",
                 record=record,
             )
 
         assert result is True
         from app.modules.transformers.vectorstore import VectorStore as VS
+        from langchain_core.documents import Document
 
-        vs.delete_blocks_by_ids.assert_any_await(
-            {VS.record_summary_block_id("rec-1")},
-            "vr-1",
-        )
+        vs.delete_blocks_by_ids.assert_not_called()
         vs._create_embeddings.assert_awaited_once()
         chunks = vs._create_embeddings.await_args.args[0]
         assert len(chunks) >= 2  # text block chunk(s) + record summary
+        summary_chunks = [
+            c for c in chunks
+            if isinstance(c, Document)
+            and (c.metadata or {}).get("isRecordSummary")
+        ]
+        assert len(summary_chunks) == 1
+        assert summary_chunks[0].page_content == "Document overview"
+        assert summary_chunks[0].metadata.get("blockId") == VS.record_summary_block_id("vr-1")
 
     @pytest.mark.asyncio
     async def test_embedding_model_instance_failure(self):
@@ -1781,7 +1786,7 @@ class TestIndexDocumentsAdditional:
         container = BlocksContainer(blocks=[], block_groups=[])
 
         with pytest.raises(IndexingError, match="Failed to get embedding model instance"):
-            await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
     @pytest.mark.asyncio
     async def test_get_llm_failure(self):
@@ -1795,7 +1800,7 @@ class TestIndexDocumentsAdditional:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock, side_effect=Exception("LLM failed")):
             with pytest.raises(IndexingError, match="Failed to get LLM"):
-                await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+                await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
     @pytest.mark.asyncio
     async def test_no_documents_to_embed_returns_true(self):
@@ -1811,7 +1816,7 @@ class TestIndexDocumentsAdditional:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "image/png")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
 
@@ -1831,7 +1836,7 @@ class TestIndexDocumentsAdditional:
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             with pytest.raises(IndexingError, match="Unexpected error during indexing"):
-                await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+                await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
 
 # ===================================================================
@@ -2202,7 +2207,7 @@ class TestIndexDocumentsImageDescription:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": True})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "image/png")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         # When all image descriptions fail and no text blocks, returns True (no docs to embed)
         assert result is True
@@ -2222,7 +2227,7 @@ class TestIndexDocumentsImageDescription:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         chunks = vs._create_embeddings.call_args[0][0]
@@ -2242,7 +2247,78 @@ class TestIndexDocumentsImageDescription:
 
         with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
-            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1", "text/plain")
+            result = await vs.index_documents(container, "org-1", "rec-1", "vr-1")
 
         assert result is True
         vs._create_embeddings.assert_awaited_once()
+
+
+class TestRecordSummaryEdgeCases:
+    """Coverage for record-summary embedding edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_blank_semantic_summary_skips_extra_document(self):
+        from langchain_core.documents import Document
+
+        from app.models.blocks import Block, BlocksContainer, SemanticMetadata
+
+        vs = _make_vectorstore()
+        vs.get_embedding_model_instance = AsyncMock(return_value=False)
+        vs._create_embeddings = AsyncMock()
+        vs.nlp = MagicMock()
+        sent = MagicMock()
+        sent.text = "x"
+        vs.nlp.return_value = MagicMock(sents=[sent])
+
+        block = Block(index=0, type="text", format="txt", data="x", comments=[])
+        container = BlocksContainer(blocks=[block], block_groups=[])
+        record = MagicMock()
+        record.semantic_metadata = SemanticMetadata(
+            summary="   \n",
+            categories=[],
+        )
+
+        with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
+            await vs.index_documents(
+                container, "org-1", "rec-1", "vr-1", record=record,
+            )
+
+        chunks = vs._create_embeddings.await_args.args[0]
+        summary_docs = [
+            c for c in chunks
+            if isinstance(c, Document) and (c.metadata or {}).get("isRecordSummary")
+        ]
+        assert summary_docs == []
+
+    @pytest.mark.asyncio
+    async def test_semantic_metadata_none_skips_summary(self):
+        from langchain_core.documents import Document
+
+        from app.models.blocks import Block, BlocksContainer
+
+        vs = _make_vectorstore()
+        vs.get_embedding_model_instance = AsyncMock(return_value=False)
+        vs._create_embeddings = AsyncMock()
+        vs.nlp = MagicMock()
+        sent = MagicMock()
+        sent.text = "y"
+        vs.nlp.return_value = MagicMock(sents=[sent])
+
+        block = Block(index=0, type="text", format="txt", data="y", comments=[])
+        container = BlocksContainer(blocks=[block], block_groups=[])
+        record = MagicMock()
+        record.semantic_metadata = None
+
+        with patch("app.modules.transformers.vectorstore.get_llm", new_callable=AsyncMock) as mock_llm:
+            mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
+            await vs.index_documents(
+                container, "org-1", "rec-1", "vr-1", record=record,
+            )
+
+        chunks = vs._create_embeddings.await_args.args[0]
+        summary_docs = [
+            c for c in chunks
+            if isinstance(c, Document) and (c.metadata or {}).get("isRecordSummary")
+        ]
+        assert summary_docs == []

--- a/backend/python/tests/unit/modules/transformers/test_vectorstore_sql.py
+++ b/backend/python/tests/unit/modules/transformers/test_vectorstore_sql.py
@@ -64,7 +64,7 @@ class TestSqlBlockGroups:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain"
+                container, "org", "rec", "vr"
             )
 
         assert result is True
@@ -96,7 +96,7 @@ class TestSqlBlockGroups:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain"
+                container, "org", "rec", "vr"
             )
         # Nothing to embed -> returns True but no chunks created
         assert result is True
@@ -131,7 +131,7 @@ class TestSqlBlockGroups:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain"
+                container, "org", "rec", "vr"
             )
 
         assert result is True
@@ -164,7 +164,7 @@ class TestSqlBlockGroups:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain"
+                container, "org", "rec", "vr"
             )
         assert result is True
         vs._create_embeddings.assert_not_awaited()
@@ -199,7 +199,7 @@ class TestSqlRowBlocks:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain"
+                container, "org", "rec", "vr"
             )
 
         assert result is True
@@ -232,7 +232,7 @@ class TestRegularTableBlockWithSummary:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain"
+                container, "org", "rec", "vr"
             )
 
         assert result is True
@@ -267,7 +267,7 @@ class TestReconciliationProcessing:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain",
+                container, "org", "rec", "vr",
                 is_reconciliation=True,
             )
 
@@ -293,7 +293,7 @@ class TestReconciliationProcessing:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain",
+                container, "org", "rec", "vr",
                 is_reconciliation=True,
                 block_ids_to_delete={"old-block-1"},
             )
@@ -322,7 +322,7 @@ class TestReconciliationProcessing:
         ) as mock_llm:
             mock_llm.return_value = (MagicMock(), {"isMultimodal": False})
             result = await vs.index_documents(
-                container, "org", "rec", "vr", "text/plain",
+                container, "org", "rec", "vr",
                 block_ids_to_delete={"stale"},
             )
         assert result is True

--- a/backend/python/tests/unit/modules/transformers/test_vectorstore_sql.py
+++ b/backend/python/tests/unit/modules/transformers/test_vectorstore_sql.py
@@ -18,6 +18,8 @@ from app.models.blocks import (
 
 import app.modules.transformers.vectorstore as _vs_mod  # noqa: E402
 
+_LANGCHAIN_DOCUMENT_IS_CLASS = isinstance(_vs_mod.Document, type)
+
 
 def _make_vectorstore():
     with patch.object(_vs_mod, "FastEmbedSparse"), patch.object(
@@ -246,6 +248,10 @@ class TestRegularTableBlockWithSummary:
 
 
 class TestReconciliationProcessing:
+    @pytest.mark.skipif(
+        not _LANGCHAIN_DOCUMENT_IS_CLASS,
+        reason="langchain_core.documents.Document must be a real class (optional dep stubbed)",
+    )
     @pytest.mark.asyncio
     async def test_is_reconciliation_with_text_and_images_routes_correctly(self):
         """When is_reconciliation=True, text goes through _process_document_chunks
@@ -276,6 +282,10 @@ class TestReconciliationProcessing:
         vs._process_image_embeddings.assert_awaited_once()
         vs._store_image_points.assert_awaited_once()
 
+    @pytest.mark.skipif(
+        not _LANGCHAIN_DOCUMENT_IS_CLASS,
+        reason="langchain_core.documents.Document must be a real class (optional dep stubbed)",
+    )
     @pytest.mark.asyncio
     async def test_is_reconciliation_deletes_removed_block_ids(self):
         vs = _make_vectorstore()
@@ -299,14 +309,16 @@ class TestReconciliationProcessing:
             )
 
         assert result is True
-        vs.delete_blocks_by_ids.assert_awaited_once_with(
-            {"old-block-1"}, "vr",
-        )
+        summary_id = _vs_mod.VectorStore.record_summary_block_id("vr")
+        assert vs.delete_blocks_by_ids.await_count == 2
+        calls = vs.delete_blocks_by_ids.await_args_list
+        assert calls[0].args == ({summary_id}, "vr")
+        assert calls[1].args == ({"old-block-1"}, "vr")
 
     @pytest.mark.asyncio
     async def test_block_ids_to_delete_called_when_no_docs_to_embed(self):
         """When every block is filtered out but block_ids_to_delete is set,
-        delete_blocks_by_ids must still run."""
+        delete_blocks_by_ids must still run (record summary first, removed blocks second)."""
         vs = _make_vectorstore()
         vs.get_embedding_model_instance = AsyncMock(return_value=False)
         vs.delete_blocks_by_ids = AsyncMock()
@@ -326,4 +338,8 @@ class TestReconciliationProcessing:
                 block_ids_to_delete={"stale"},
             )
         assert result is True
-        vs.delete_blocks_by_ids.assert_awaited_once_with({"stale"}, "vr")
+        summary_id = _vs_mod.VectorStore.record_summary_block_id("vr")
+        assert vs.delete_blocks_by_ids.await_count == 2
+        calls = vs.delete_blocks_by_ids.await_args_list
+        assert calls[0].args == ({summary_id}, "vr")
+        assert calls[1].args == ({"stale"}, "vr")

--- a/backend/python/tests/unit/utils/test_chat_helpers.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers.py
@@ -25,6 +25,8 @@ from app.utils.chat_helpers import (
     _extract_text_content_recursive,
     _find_first_block_index_recursive,
     build_block_web_url,
+    build_message_content_array,
+    flattened_result_sort_key,
     build_group_blocks as _build_group_blocks,
     get_group_label_n_first_child as _get_group_label_n_first_child,
     count_tokens,
@@ -178,6 +180,25 @@ class TestBuildBlockWebUrl:
     def test_record_id_embedded_in_path(self):
         result = build_block_web_url("https://app.example.com", "my-uuid-abc", 1)
         assert "/record/my-uuid-abc/preview" in result
+
+
+class TestFlattenedResultSortKey:
+    def test_none_block_index_sorts_before_zero(self):
+        results = [
+            {"virtual_record_id": "vr1", "block_index": 2},
+            {"virtual_record_id": "vr1", "block_index": None},
+            {"virtual_record_id": "vr1", "block_index": 0},
+        ]
+        sorted_results = sorted(results, key=flattened_result_sort_key)
+        assert [r["block_index"] for r in sorted_results] == [None, 0, 2]
+
+    def test_mixed_virtual_record_ids(self):
+        results = [
+            {"virtual_record_id": "vr2", "block_index": 0},
+            {"virtual_record_id": "vr1", "block_index": None},
+        ]
+        sorted_results = sorted(results, key=flattened_result_sort_key)
+        assert [r["virtual_record_id"] for r in sorted_results] == ["vr1", "vr2"]
 
 
 # ===================================================================
@@ -1160,6 +1181,64 @@ class TestGetMessageContent:
         combined = " ".join(texts)
         assert "First block" in combined
 
+    def test_summary_citation_only_when_no_record_blocks_in_context(self):
+        record = _make_record_blob(frontend_url="https://app.example.com")
+        vr_map = {"vr-1": record}
+
+        summary_only, _ = build_message_content_array(
+            [
+                _make_flattened_result(
+                    block_index=None,
+                    block_type=BlockType.RECORD_SUMMARY.value,
+                    content="High-level overview",
+                ),
+            ],
+            vr_map,
+        )
+        summary_only_items = [
+            item for group in summary_only for item in group if item.get("type") == "text"
+        ]
+        summary_only_text = " ".join(item["text"] for item in summary_only_items)
+        assert "Citation ID for summary:" in summary_only_text
+        summary_idx = next(
+            i for i, item in enumerate(summary_only_items)
+            if "Citation ID for summary:" in item["text"]
+        )
+        assert summary_idx == 1
+
+        with_blocks, _ = build_message_content_array(
+            [_make_flattened_result(block_index=0, content="Chunk text")],
+            vr_map,
+        )
+        with_blocks_text = " ".join(
+            item["text"] for group in with_blocks for item in group if item.get("type") == "text"
+        )
+        assert "Citation ID for summary:" not in with_blocks_text
+        assert "Chunk text" in with_blocks_text
+
+    def test_json_mode_record_summary_only_includes_record_metadata(self):
+        record = _make_record_blob()
+        record["context_metadata"] = (
+            "Record ID       : rec-1\n"
+            "Name            : Policy Doc\n"
+            "Summary         : High-level overview"
+        )
+        flattened = [
+            _make_flattened_result(
+                block_index=None,
+                block_type=BlockType.RECORD_SUMMARY.value,
+                content="High-level overview",
+            ),
+        ]
+        vr_map = {"vr-1": record}
+        result = get_message_content(flattened, vr_map, "user", "query", mode="json")
+        texts = [item["text"] for item in result if item.get("type") == "text"]
+        combined = " ".join(texts)
+        assert "Record ID       : rec-1" in combined
+        assert "Policy Doc" in combined
+        assert "record_summary" in combined
+        assert "High-level overview" in combined
+
     def test_json_mode_uses_virtual_map_records_when_flattened_empty(self):
         flattened = []
         record = _make_record_blob(
@@ -1401,9 +1480,13 @@ class TestRecordToMessageContent:
         text = _all_text(content)
         assert "Citation ID:" in text
         assert "ref1" in text
-        preview_url = ref_mapper.ref_to_url["ref1"]
+        assert "ref2" in text
+        record_url = ref_mapper.ref_to_url["ref1"]
+        preview_url = ref_mapper.ref_to_url["ref2"]
         assert "rec-xyz" in preview_url
         assert "blockIndex=0" in preview_url
+        assert "/record/rec-xyz" in record_url
+        assert "preview" not in record_url
 
     def test_image_blocks_skipped(self):
         record = _make_record_blob()
@@ -4859,6 +4942,31 @@ class TestGetFlattenedResultsNewBranches:
             result_set, blob_store, "org-1", False, vr_map,
         )
         assert len(results) == 0
+
+    @pytest.mark.asyncio
+    async def test_record_summary_vector_hit_is_flattened(self):
+        record = _make_record_blob()
+        record["context_metadata"] = "Record ID       : rec-1\nSummary         : Doc overview"
+        record["block_containers"]["blocks"] = []
+        blob_store = self._make_blob_store(record)
+        vr_map = {"vr-1": record}
+
+        result_set = [{
+            "content": "Doc overview",
+            "score": 0.95,
+            "metadata": {
+                "virtualRecordId": "vr-1",
+                "isRecordSummary": True,
+                "isBlockGroup": False,
+                "isBlock": False,
+            },
+        }]
+        results = await get_flattened_results(
+            result_set, blob_store, "org-1", False, vr_map,
+        )
+        assert len(results) == 1
+        assert results[0]["block_type"] == BlockType.RECORD_SUMMARY.value
+        assert results[0]["content"] == "Doc overview"
 
     @pytest.mark.asyncio
     async def test_ddl_prepended_to_table_summary(self):

--- a/backend/python/tests/unit/utils/test_chat_helpers.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from types import ModuleType
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 from urllib.parse import quote
 
@@ -1237,7 +1238,6 @@ class TestGetMessageContent:
         combined = " ".join(texts)
         assert "Record ID       : rec-1" in combined
         assert "Policy Doc" in combined
-        assert "record_summary" in combined
         assert "High-level overview" in combined
 
     def test_json_mode_uses_virtual_map_records_when_flattened_empty(self):
@@ -1481,13 +1481,10 @@ class TestRecordToMessageContent:
         text = _all_text(content)
         assert "Citation ID:" in text
         assert "ref1" in text
-        assert "ref2" in text
-        record_url = ref_mapper.ref_to_url["ref1"]
-        preview_url = ref_mapper.ref_to_url["ref2"]
+        preview_url = ref_mapper.ref_to_url["ref1"]
         assert "rec-xyz" in preview_url
         assert "blockIndex=0" in preview_url
-        assert "/record/rec-xyz" in record_url
-        assert "preview" not in record_url
+        assert "/preview" in preview_url
 
     def test_image_blocks_skipped(self):
         record = _make_record_blob()
@@ -5065,6 +5062,74 @@ class TestGetFlattenedResultsNewBranches:
         assert len(children) == 1
         assert children[0]["content"] == "synthetic row content"
         assert children[0]["citationType"] == "vectordb"
+
+    @pytest.mark.asyncio
+    async def test_is_record_summary_skipped_when_duplicate_chunk(self):
+        record = _make_record_blob()
+        blob_store = self._make_blob_store(record)
+        vr_map = {"vr-1": record}
+        meta = {"virtualRecordId": "vr-1", "isRecordSummary": True, "isBlockGroup": False}
+        result_set = [
+            {"content": "summary text", "score": 0.9, "metadata": meta},
+            {"content": "summary text", "score": 0.8, "metadata": meta},
+        ]
+        results = await get_flattened_results(
+            result_set, blob_store, "org-1", False, vr_map,
+        )
+        assert len(results) == 1
+        assert results[0]["block_type"] == BlockType.RECORD_SUMMARY.value
+
+    @pytest.mark.asyncio
+    async def test_is_record_summary_skipped_when_vr_map_missing_record(self):
+        blob_store = self._make_blob_store()
+        vr_map: dict[str, Any] = {}
+        result_set = [{
+            "content": "summary text",
+            "score": 0.9,
+            "metadata": {"virtualRecordId": "vr-missing", "isRecordSummary": True, "isBlockGroup": False},
+        }]
+        with patch("app.utils.chat_helpers.get_record", new_callable=AsyncMock):
+            results = await get_flattened_results(
+                result_set, blob_store, "org-1", False, vr_map,
+            )
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_is_record_summary_skipped_when_content_empty(self):
+        record = _make_record_blob()
+        blob_store = self._make_blob_store(record)
+        vr_map = {"vr-1": record}
+        result_set = [{
+            "content": "",
+            "score": 0.9,
+            "metadata": {"virtualRecordId": "vr-1", "isRecordSummary": True, "isBlockGroup": False},
+        }]
+        results = await get_flattened_results(
+            result_set, blob_store, "org-1", False, vr_map,
+        )
+        assert results == []
+
+
+class TestBuildMessageContentArraySummaryCitation:
+    """insert_summary_citation_if_needed when record has no rendered blocks."""
+
+    def test_inserts_summary_citation_when_only_base64_image_skipped(self):
+        record = _make_record_blob(frontend_url="https://app.example.com")
+        vr_map = {"vr-1": record}
+        flat = [
+            _make_flattened_result(
+                block_index=0,
+                block_type=BlockType.IMAGE.value,
+                content=_VALID_MINIMAL_PNG_DATA_URI,
+            ),
+        ]
+        contents, _ = build_message_content_array(
+            flat, vr_map, is_multimodal_llm=False, from_tool=True
+        )
+        text = " ".join(
+            item["text"] for group in contents for item in group if item.get("type") == "text"
+        )
+        assert "Citation ID for summary:" in text
 
 
 # ===================================================================

--- a/backend/python/tests/unit/utils/test_chat_helpers.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers.py
@@ -1214,6 +1214,7 @@ class TestGetMessageContent:
             item["text"] for group in with_blocks for item in group if item.get("type") == "text"
         )
         assert "Citation ID for summary:" not in with_blocks_text
+        assert "Record blocks (sorted):" in with_blocks_text
         assert "Chunk text" in with_blocks_text
 
     def test_json_mode_record_summary_only_includes_record_metadata(self):

--- a/backend/python/tests/unit/utils/test_chat_helpers_coverage_above_95.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers_coverage_above_95.py
@@ -1,0 +1,829 @@
+"""Targeted tests to raise branch/line coverage of app.utils.chat_helpers above ~95%."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.models.blocks import BlockType, GroupType
+from app.models.entities import DealRecord, MeetingRecord
+from app.utils.chat_helpers import (
+    CitationRefMapper,
+    _extract_text_content_recursive,
+    _find_first_block_index_recursive,
+    build_fk_info,
+    build_group_blocks,
+    build_multimodal_user_content,
+    build_message_content_array,
+    create_record_instance_from_dict,
+    enrich_virtual_record_id_to_result_with_fk_children,
+    extract_bounding_boxes,
+    extract_start_end_text,
+    generate_text_fragment_url,
+    get_message_content,
+    get_flattened_results,
+    is_base64_image,
+    record_to_message_content,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+_VALID_MINIMAL_PNG_DATA_URI = (
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk"
+    "+A8AAQUBAScY42YAAAAASUVORK5CYII="
+)
+
+
+def _base_record_dict(**overrides):
+    defaults = {
+        "id": "rec-1",
+        "org_id": "org-1",
+        "record_name": "Test Record",
+        "external_record_id": "ext-1",
+        "version": 1,
+        "origin": "CONNECTOR",
+        "connector_name": "DRIVE",
+        "connector_id": "conn-1",
+        "mime_type": "text/plain",
+        "source_created_at": None,
+        "source_updated_at": None,
+        "weburl": "https://example.com",
+        "semantic_metadata": {},
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+# ---------------------------------------------------------------------------
+# is_base64_image branches
+# ---------------------------------------------------------------------------
+
+
+class TestIsBase64ImageExtraBranches:
+    def test_blank_string(self):
+        assert is_base64_image("   ") is False
+
+    def test_invalid_padding_length(self):
+        # Length not multiple of 4 after stripping
+        assert is_base64_image("AAA") is False
+
+    def test_decode_raises_returns_false(self, monkeypatch):
+        def boom(_data):
+            raise ValueError("bad decode")
+
+        monkeypatch.setattr(base64, "b64decode", boom)
+        assert is_base64_image("AAAA") is False
+
+    def test_svg_xml_after_decode(self):
+        raw = b"<svg xmlns='http://www.w3.org/2000/svg'><rect/></svg>"
+        b64 = base64.b64encode(raw).decode("ascii")
+        assert is_base64_image(b64) is True
+
+
+class TestBuildMultimodalNonDictBlockDataContinues:
+    def test_skips_block_when_data_neither_dict_nor_string(self):
+        mock_blob = MagicMock()
+        mock_blob.get_record_from_storage = AsyncMock(
+            return_value={
+                "block_containers": {
+                    "blocks": [
+                        {"type": "image", "data": 12345},  # invalid shape
+                        {"type": "image", "data": {"uri": _VALID_MINIMAL_PNG_DATA_URI}},
+                    ],
+                },
+            },
+        )
+        attachments = [{"mimeType": "image/png", "virtualRecordId": "vr1"}]
+        result = _run(
+            build_multimodal_user_content("Hi", attachments, mock_blob, "org1")
+        )
+        assert isinstance(result, list)
+        assert result[0]["text"] == "Hi"
+
+
+# ---------------------------------------------------------------------------
+# CitationRefMapper.url_to_ref returns a copy (line 251)
+# ---------------------------------------------------------------------------
+
+
+class TestCitationRefMapperUrlProperty:
+    def test_url_to_ref_returns_independent_snapshot(self):
+        m = CitationRefMapper()
+        m.get_or_create_ref("http://a.example/block")
+        snap = m.url_to_ref
+        snap["http://b.example/other"] = "ref_fake"
+        assert "http://b.example/other" not in m.url_to_ref
+
+
+# ---------------------------------------------------------------------------
+# create_record_instance_from_dict — Meeting + Deal arms
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRecordMeetingAndDeal:
+    def test_meeting_record_with_graph_doc(self):
+        d = _base_record_dict(record_type="MEETING")
+        gd = {
+            "hostEmail": "h@example.com",
+            "hostId": "h1",
+            "meetingType": 2,
+            "durationMinutes": 30,
+            "startTime": "2020-01-01T00:00:00Z",
+            "endTime": "2020-01-01T00:30:00Z",
+            "timezone": "UTC",
+            "recordingUrl": "https://zoom.example/rec",
+        }
+        r = create_record_instance_from_dict(d, gd)
+        assert isinstance(r, MeetingRecord)
+        assert r.host_email == "h@example.com"
+
+    def test_deal_record_with_graph_doc_float_amount(self):
+        d = _base_record_dict(record_type="DEAL")
+        gd = {"name": "Big", "amount": "99.5", "isWon": False, "isClosed": False}
+        r = create_record_instance_from_dict(d, gd)
+        assert isinstance(r, DealRecord)
+        assert r.amount == 99.5
+
+
+# ---------------------------------------------------------------------------
+# Recursive helpers (_find_first_block_index_recursive /
+# _extract_text_content_recursive)
+# ---------------------------------------------------------------------------
+
+
+class TestRecursiveBlockHelpers:
+    def test_find_first_via_block_group_ranges_nested(self):
+        block_groups = [
+            {
+                "type": GroupType.TEXT_SECTION.value,
+                "children": {"block_ranges": [{"start": 5, "end": 5}]},
+            },
+        ]
+        outer_children: dict[str, Any] = {
+            "block_ranges": [],
+            "block_group_ranges": [{"start": 0, "end": 0}],
+        }
+        idx = _find_first_block_index_recursive(block_groups, outer_children)
+        assert idx == 5
+
+    def test_extract_text_block_ranges_and_group_ranges(self):
+        blocks = [
+            {"type": BlockType.TEXT.value, "data": "a"},
+            {"type": BlockType.TEXT.value, "data": "b"},
+        ]
+        children = {
+            "block_ranges": [{"start": 0, "end": 1}],
+            "block_group_ranges": [],
+        }
+        text = _extract_text_content_recursive(
+            [], blocks, children, virtual_record_id="vr", seen_chunks=set()
+        )
+        assert "a" in text and "b" in text
+
+
+# ---------------------------------------------------------------------------
+# enrich_virtual_record_id_to_result_with_fk_children — deep path
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichFkChildrenDeep:
+    @pytest.mark.asyncio
+    async def test_fetches_related_blob_and_appends_table_ddl(self):
+        graph = MagicMock()
+        graph.get_child_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "rec_child", "childTable": "child_t"}]
+        )
+        graph.get_parent_record_ids_by_relation_type = AsyncMock(return_value=[])
+        graph.get_virtual_record_ids_for_record_ids = AsyncMock(
+            return_value={"rec_child": "vr_child"}
+        )
+        graph.get_document = AsyncMock(
+            return_value={
+                "orgId": "org-1",
+                "recordName": "child",
+                "recordType": "SQL_TABLE",
+                "version": 1,
+                "origin": "CONNECTOR",
+                "connectorName": "SNOWFLAKE",
+                "connectorId": "c1",
+                "mimeType": "application/sql",
+                "webUrl": "https://sql.example",
+                "hideWeburl": False,
+            }
+        )
+
+        blob = MagicMock()
+        blob.get_record_from_storage = AsyncMock(
+            return_value={
+                "id": "rec_child",
+                "record_name": "child",
+                "record_type": "SQL_TABLE",
+                "block_containers": {
+                    "block_groups": [
+                        {
+                            "type": "table",
+                            "data": "raw-ddl-fallback-summary",  # non-dict data branch
+                        },
+                        {
+                            "type": BlockType.TABLE.value,
+                            "data": {
+                                "ddl": "CREATE TABLE child (id INT);",
+                                "table_summary": "Child table",
+                            },
+                        },
+                    ],
+                    "blocks": [
+                        {
+                            "type": "table_row",
+                            "data": {"row_natural_language_text": "row one"},
+                        },
+                    ],
+                },
+            }
+        )
+
+        vmap = {
+            "vr_main": {
+                "id": "rec_main",
+                "record_type": "SQL_TABLE",
+                "record_name": "orders",
+            }
+        }
+        flat: list = []
+
+        await enrich_virtual_record_id_to_result_with_fk_children(
+            vmap,
+            blob,
+            "org-1",
+            graph_provider=graph,
+            flattened_results=flat,
+        )
+
+        assert "vr_child" in vmap
+        fk_blocks = [x for x in flat if (x.get("metadata") or {}).get("source") == "FK_ENRICHMENT"]
+        assert len(fk_blocks) >= 1
+        # Child path: record_id not in initial record_id_to_fk_relations → inline fetch
+        graph.get_child_record_ids_by_relation_type.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_child_and_parent_fetch_exceptions_are_handled(self):
+        graph = MagicMock()
+        graph.get_child_record_ids_by_relation_type = AsyncMock(
+            side_effect=RuntimeError("child boom")
+        )
+        graph.get_parent_record_ids_by_relation_type = AsyncMock(
+            side_effect=RuntimeError("parent boom")
+        )
+        graph.get_virtual_record_ids_for_record_ids = AsyncMock(return_value={})
+
+        vmap = {
+            "vr_main": {
+                "id": "rec_main",
+                "record_type": "SQL_TABLE",
+                "record_name": "t",
+            }
+        }
+        await enrich_virtual_record_id_to_result_with_fk_children(
+            vmap, MagicMock(), "org-1", graph_provider=graph, flattened_results=[]
+        )
+
+
+# ---------------------------------------------------------------------------
+# build_fk_info, get_message_content, build_message_content_array
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFkInfo:
+    def test_parent_and_child_lines(self):
+        s = build_fk_info(
+            {
+                "fk_parent_relations": [
+                    {
+                        "parentTable": "p",
+                        "sourceColumn": "a",
+                        "targetColumn": "b",
+                        "record_id": "r1",
+                    }
+                ],
+                "fk_child_relations": [
+                    {
+                        "childTable": "c",
+                        "sourceColumn": "x",
+                        "targetColumn": "y",
+                        "record_id": "r2",
+                    }
+                ],
+            }
+        )
+        assert "Parent Tables" in s and "Child Tables" in s
+
+
+class TestGetMessageContentBranches:
+    def test_image_blocks_appended_before_context(self):
+        flat = []
+        # Only vr_extra in map triggers record_to_message_content extension path
+        vmap = {
+            "vr_x": {
+                "id": "rid",
+                "frontend_url": "https://app.example.com",
+                "virtual_record_id": "vr_x",
+                "context_metadata": "",
+                "block_containers": {"blocks": [], "block_groups": []},
+            }
+        }
+        ib = [{"type": "text", "text": "[img-placeholder]"}]
+        content, _ = get_message_content(
+            flat,
+            vmap,
+            user_data="u",
+            query="q",
+            mode="json",
+            image_blocks=ib,
+        )
+        texts = [c.get("text", "") for c in content if c.get("type") == "text"]
+        assert any(t.strip() == "Attachments:" for t in texts)
+
+
+class TestBuildMessageContentArrayGrouped:
+    def test_valid_group_label_renders_block_group_prompt(self):
+        flat = [
+            {
+                "virtual_record_id": "vr_g",
+                "block_type": GroupType.TEXT_SECTION.value,
+                "block_index": 0,
+                "block_group_index": 0,
+                "content": (
+                    "",
+                    [
+                        {
+                            "content": "cell",
+                            "block_index": 0,
+                            "block_type": BlockType.TEXT.value,
+                        },
+                    ],
+                ),
+                "metadata": {},
+            }
+        ]
+        vmap = {
+            "vr_g": {
+                "id": "gr",
+                "frontend_url": "https://fe.example",
+                "context_metadata": "ctx",
+            }
+        }
+        parts, mapper = build_message_content_array(
+            flat, vmap, is_multimodal_llm=False, from_tool=True
+        )
+        flattened_text = "".join(
+            chunk.get("text", "")
+            for sub in parts
+            for chunk in sub
+            if chunk.get("type") == "text"
+        )
+        assert "cell" in flattened_text
+        assert isinstance(mapper, CitationRefMapper)
+
+
+# ---------------------------------------------------------------------------
+# record_to_message_content — multimodal image + FK footer
+# ---------------------------------------------------------------------------
+
+
+class TestRecordToMessageMultimodalAndFk:
+    def test_multimodal_image_block_appends_image_url(self):
+        rec = {
+            "id": "r1",
+            "frontend_url": "https://fe.example",
+            "virtual_record_id": "vrz",
+            "context_metadata": "meta",
+            "block_containers": {
+                "blocks": [
+                    {
+                        "index": 1,
+                        "type": BlockType.IMAGE.value,
+                        "data": {"uri": _VALID_MINIMAL_PNG_DATA_URI},
+                    },
+                ],
+                "block_groups": [],
+            },
+        }
+        content, _ = record_to_message_content(rec, ref_mapper=None, is_multimodal_llm=True)
+        assert any(c.get("type") == "image_url" for c in content)
+
+    def test_foreign_key_related_tables_footer(self):
+        rec = {
+            "id": "r1",
+            "frontend_url": "",
+            "virtual_record_id": "vrz",
+            "context_metadata": "",
+            "fk_parent_record_ids": [
+                {
+                    "parentTable": "p",
+                    "sourceColumn": "a",
+                    "targetColumn": "b",
+                    "record_id": "rp",
+                }
+            ],
+            "fk_child_record_ids": [
+                {
+                    "childTable": "c",
+                    "sourceColumn": "x",
+                    "targetColumn": "y",
+                    "record_id": "rc",
+                }
+            ],
+            "block_containers": {"blocks": [], "block_groups": []},
+        }
+        content, _ = record_to_message_content(rec)
+        joined = "".join(x.get("text", "") for x in content if x.get("type") == "text")
+        assert "Foreign Key Related Tables" in joined
+
+
+# ---------------------------------------------------------------------------
+# extract_start_end_text / generate_text_fragment_url
+# ---------------------------------------------------------------------------
+
+
+class TestExtractStartEndAndFragmentUrl:
+    def test_end_text_fallback_when_no_second_match_but_long_first(self):
+        # One long alphabetic run; FRAGMENT_WORD_COUNT is 4 — forces elif branch on end_text
+        s = "one two three four five six seven eight"
+        start, end = extract_start_end_text(s)
+        assert start
+        assert end  # last four words subset
+
+    def test_generate_fragment_url_exception_falls_back(self, monkeypatch):
+        def boom(_snippet):
+            raise RuntimeError("fail")
+
+        monkeypatch.setattr("app.utils.chat_helpers.extract_start_end_text", boom)
+        url = generate_text_fragment_url("https://ex.com/page", "one two three four")
+        assert url == "https://ex.com/page"
+
+
+# ---------------------------------------------------------------------------
+# count_tokens_in_messages — skipped unknown + string list items
+# ---------------------------------------------------------------------------
+
+
+class TestCountTokensInMessagesBranches:
+    def test_unknown_message_skipped_and_string_chunks_counted(self):
+        from app.utils.chat_helpers import count_tokens_in_messages
+        import tiktoken
+
+        enc = tiktoken.get_encoding("cl100k_base")
+
+        class NoContent:
+            pass
+
+        messages = [
+            NoContent(),
+            {"content": [{"type": "text", "text": "a"}, "raw string slice"]},
+        ]
+        total = count_tokens_in_messages(messages, enc)
+        assert total > 0
+
+
+# ---------------------------------------------------------------------------
+# get_flattened_results — prefetch recon warning + multimodal retrieval image
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_flattened_results_prefetch_recon_resolves_block_id():
+    """blockIndex=None + blockId uses reconciliation prefetch + adjacent chunk sweep."""
+    vrid = "vr_pref"
+    blob = MagicMock()
+    blob.config_service.get_config = AsyncMock(return_value={"frontend": {"publicEndpoint": None}})
+    blob.get_record_from_storage = AsyncMock(
+        return_value={
+            "id": "rid_doc",
+            "record_type": "FILE",
+            "mime_type": "text/plain",
+            "block_containers": {
+                "blocks": [
+                    {"type": BlockType.TEXT.value, "parent_index": None, "data": "hello"},
+                    {"type": BlockType.TEXT.value, "parent_index": None, "data": "world"},
+                    {"type": BlockType.TEXT.value, "parent_index": None, "data": "after"},
+                ],
+                "block_groups": [],
+            },
+        }
+    )
+    blob.get_reconciliation_metadata = AsyncMock(
+        return_value={"block_id_to_index": {"bid-1": 1}}
+    )
+
+    result_set = [
+        {
+            "metadata": {
+                "virtualRecordId": vrid,
+                "blockIndex": None,
+                "blockId": "bid-1",
+                "isBlockGroup": False,
+            },
+            "content": "",
+            "score": 1.0,
+        }
+    ]
+    out = await get_flattened_results(
+        result_set,
+        blob,
+        "org-1",
+        is_multimodal_llm=False,
+        virtual_record_id_to_result={},
+        from_tool=False,
+        from_retrieval_service=False,
+        graph_provider=None,
+    )
+    texts = [
+        x.get("content")
+        for x in out
+        if x.get("block_type") == BlockType.TEXT.value
+    ]
+    assert "world" in texts
+
+
+@pytest.mark.asyncio
+async def test_get_flattened_results_prefetch_recon_logs_warning_on_failure():
+    vrid = "vr_pref_bad"
+    blob = MagicMock()
+    blob.config_service.get_config = AsyncMock(return_value={})
+    blob.get_record_from_storage = AsyncMock(
+        return_value={
+            "id": "rid_doc",
+            "record_type": "FILE",
+            "block_containers": {
+                "blocks": [{"type": BlockType.TEXT.value, "parent_index": None, "data": "x"}],
+                "block_groups": [],
+            },
+        }
+    )
+    blob.get_reconciliation_metadata = AsyncMock(side_effect=RuntimeError("boom"))
+    result_set = [
+        {
+            "metadata": {
+                "virtualRecordId": vrid,
+                "blockIndex": None,
+                "blockId": "bid-z",
+                "isBlockGroup": False,
+            },
+            "content": "",
+            "score": 1.0,
+        }
+    ]
+    out = await get_flattened_results(
+        result_set,
+        blob,
+        "org-1",
+        is_multimodal_llm=False,
+        virtual_record_id_to_result={},
+        graph_provider=None,
+    )
+    assert out == []
+
+
+@pytest.mark.asyncio
+async def test_get_flattened_results_image_from_retrieval_service():
+    blob = MagicMock()
+    blob.config_service.get_config = AsyncMock(return_value={})
+    blob.get_record_from_storage = AsyncMock(
+        return_value={
+            "id": "rimg",
+            "record_type": "FILE",
+            "block_containers": {
+                "blocks": [
+                    {
+                        "type": BlockType.IMAGE.value,
+                        "data": {"uri": _VALID_MINIMAL_PNG_DATA_URI},
+                    },
+                ],
+                "block_groups": [],
+            },
+        }
+    )
+
+    rs = [
+        {
+            "metadata": {
+                "virtualRecordId": "vr_img",
+                "blockIndex": 0,
+                "isBlockGroup": False,
+            },
+            "content": "ignored_for_image",
+            "score": 0.5,
+        }
+    ]
+    out = await get_flattened_results(
+        rs,
+        blob,
+        "org",
+        is_multimodal_llm=False,
+        virtual_record_id_to_result={},
+        from_tool=False,
+        from_retrieval_service=True,
+    )
+    imgs = [x for x in out if x.get("block_type") == BlockType.IMAGE.value]
+    assert imgs and imgs[0].get("content", "").startswith("image_")
+
+
+class TestExtractBoundingBoxesPartialFailure:
+    def test_returns_none_when_later_point_invalid(self):
+        assert (
+            extract_bounding_boxes({"bounding_boxes": [{"x": 1, "y": 2}, {}]}) is None
+        )
+
+
+class TestBuildGroupBlocksSkipsImages:
+    def test_filtered_child_blocks_exclude_images(self):
+        block_groups = [
+            {"type": GroupType.LIST.value, "children": [{"block_index": 0}]},
+        ]
+        blocks = [
+            {
+                "type": BlockType.IMAGE.value,
+                "index": 0,
+                "data": {"uri": "x"},
+                "comments": [],
+            },
+            {"type": BlockType.TEXT.value, "index": 1, "data": "ok", "comments": []},
+        ]
+        out = build_group_blocks(
+            block_groups,
+            blocks,
+            0,
+            virtual_record_id="vr",
+            record={"id": "r", "mime_type": "plain"},
+            result={"score": 1.0, "metadata": {}},
+        )
+        assert isinstance(out, list)
+
+
+class TestExtractStartEndEmptyEndText:
+    def test_two_word_fragment_yields_blank_end_segment(self):
+        start, end = extract_start_end_text("Alpha Beta")
+        assert start == "Alpha Beta"
+        assert end == ""
+
+
+class TestBuildFkInfoOnlyChild:
+    def test_child_relation_without_parents(self):
+        s = build_fk_info(
+            {
+                "fk_parent_relations": [],
+                "fk_child_relations": [
+                    {
+                        "childTable": "kid",
+                        "sourceColumn": "a",
+                        "targetColumn": "b",
+                        "record_id": "kid1",
+                    }
+                ],
+            }
+        )
+        assert "Child Tables" in s
+        assert "Parent Tables" not in s
+
+
+class TestEnrichFkChildrenEdgeBranches:
+    @pytest.mark.asyncio
+    async def test_related_vrid_skipped_when_already_flattened(self):
+        graph = MagicMock()
+        graph.get_child_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "rec_known"}],
+        )
+        graph.get_parent_record_ids_by_relation_type = AsyncMock(return_value=[])
+        graph.get_virtual_record_ids_for_record_ids = AsyncMock(
+            return_value={"rec_known": "vr_known"}
+        )
+
+        blob = MagicMock()
+
+        flat = [{"virtual_record_id": "vr_known", "score": 0.1}]
+        vmap = {
+            "vr_main": {
+                "id": "rec_main",
+                "record_type": "SQL_TABLE",
+                "record_name": "main",
+            },
+            "vr_known": {"id": "rec_known"},
+        }
+
+        await enrich_virtual_record_id_to_result_with_fk_children(
+            vmap,
+            blob,
+            "org",
+            graph_provider=graph,
+            flattened_results=flat,
+        )
+        blob.get_record_from_storage.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_related_blob_missing_sets_none_placeholder(self):
+        graph = MagicMock()
+        graph.get_child_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "rec_x"}],
+        )
+        graph.get_parent_record_ids_by_relation_type = AsyncMock(return_value=[])
+        graph.get_virtual_record_ids_for_record_ids = AsyncMock(
+            return_value={"rec_x": "vr_x"}
+        )
+        graph.get_document = AsyncMock(return_value={"recordName": "n"})
+
+        blob = MagicMock()
+        blob.get_record_from_storage = AsyncMock(return_value=None)
+
+        vmap = {
+            "vr_main": {
+                "id": "rec_main",
+                "record_type": "SQL_TABLE",
+                "record_name": "orders",
+            }
+        }
+
+        await enrich_virtual_record_id_to_result_with_fk_children(
+            vmap,
+            blob,
+            "org",
+            graph_provider=graph,
+            flattened_results=[],
+        )
+        assert vmap["vr_x"] is None
+
+    @pytest.mark.asyncio
+    async def test_graph_metadata_merge_failure_is_soft(self):
+        graph = MagicMock()
+        graph.get_child_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "rec_y"}],
+        )
+        graph.get_parent_record_ids_by_relation_type = AsyncMock(return_value=[])
+        graph.get_virtual_record_ids_for_record_ids = AsyncMock(
+            return_value={"rec_y": "vr_y"}
+        )
+        graph.get_document = AsyncMock(side_effect=RuntimeError("arangodb unavailable"))
+
+        blob = MagicMock()
+        blob.get_record_from_storage = AsyncMock(
+            return_value={
+                "id": "rec_y",
+                "record_name": "y",
+                "record_type": "SQL_TABLE",
+                "block_containers": {"block_groups": [], "blocks": []},
+            }
+        )
+
+        vmap = {
+            "vr_main": {
+                "id": "rec_main",
+                "record_type": "SQL_TABLE",
+                "record_name": "orders",
+            }
+        }
+        await enrich_virtual_record_id_to_result_with_fk_children(
+            vmap,
+            blob,
+            "org",
+            graph_provider=graph,
+            flattened_results=[],
+        )
+        assert vmap["vr_y"]["record_name"] == "y"
+
+    @pytest.mark.asyncio
+    async def test_blob_fetch_exception_sets_none_placeholder(self):
+        graph = MagicMock()
+        graph.get_child_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "rec_z"}],
+        )
+        graph.get_parent_record_ids_by_relation_type = AsyncMock(return_value=[])
+        graph.get_virtual_record_ids_for_record_ids = AsyncMock(
+            return_value={"rec_z": "vr_z"}
+        )
+
+        blob = MagicMock()
+        blob.get_record_from_storage = AsyncMock(side_effect=OSError("network"))
+
+        vmap = {
+            "vr_main": {
+                "id": "rec_main",
+                "record_type": "SQL_TABLE",
+                "record_name": "orders",
+            }
+        }
+
+        await enrich_virtual_record_id_to_result_with_fk_children(
+            vmap,
+            blob,
+            "org",
+            graph_provider=graph,
+            flattened_results=[],
+        )
+        assert vmap["vr_z"] is None

--- a/backend/python/tests/unit/utils/test_citations.py
+++ b/backend/python/tests/unit/utils/test_citations.py
@@ -201,6 +201,10 @@ class TestExtractRecordIdFromUrl:
         url = f"{BASE}/record/rec_1.2/preview#blockIndex=0"
         assert _extract_record_id_from_url(url) == "rec_1.2"
 
+    def test_extracts_record_landing_url_without_preview(self):
+        url = f"{BASE}/record/{REC1}"
+        assert _extract_record_id_from_url(url) == REC1
+
 
 # ---------------------------------------------------------------------------
 # _renumber_citation_links

--- a/backend/python/tests/unit/utils/test_citations.py
+++ b/backend/python/tests/unit/utils/test_citations.py
@@ -1400,6 +1400,80 @@ class TestNormalizeMalformedCitations:
         assert citations[1]["content"] == "agent chunk 2"
 
 
+class TestRecordLandingPageCitations:
+    """Record /header URLs (/record/{id}) map to record-level citation chunks."""
+
+    def test_chat_finds_record_via_records_list(self):
+        landing = f"{BASE}/record/{REC1}"
+        record = {
+            "id": REC1,
+            "record_name": "Named Record",
+            "semantic_metadata": {"summary": "Summary line"},
+            "block_containers": {"blocks": [], "block_groups": []},
+        }
+        answer = f"Overview [doc]({landing})."
+        _, citations = normalize_citations_and_chunks(answer, [], records=[record])
+        assert len(citations) == 1
+        assert citations[0]["content"] == "Summary line"
+
+    def test_chat_record_page_non_string_summary_is_stringified(self):
+        landing = f"{BASE}/record/{REC1}"
+        record = {
+            "id": REC1,
+            "record_name": "Named Record",
+            "semantic_metadata": {"summary": 42},
+            "block_containers": {"blocks": [], "block_groups": []},
+        }
+        answer = f"Overview [doc]({landing})."
+        _, citations = normalize_citations_and_chunks(answer, [], records=[record])
+        assert len(citations) == 1
+        assert citations[0]["content"] == "42"
+
+    def test_chat_finds_record_via_virtual_record_id_map(self):
+        landing = f"{BASE}/record/{REC1}"
+        rec = {
+            "id": REC1,
+            "record_name": "VR Map Record",
+            "block_containers": {"blocks": [], "block_groups": []},
+        }
+        answer = f"See [r]({landing})."
+        _, citations = normalize_citations_and_chunks(
+            answer, [], records=[], virtual_record_id_to_result={"vr-x": rec},
+        )
+        assert len(citations) == 1
+        assert "VR Map Record" in citations[0]["content"]
+
+    def test_chat_warns_when_record_missing(self):
+        landing = f"{BASE}/record/{REC1}"
+        answer = f"x [d]({landing})."
+        with patch("app.utils.citations.logger") as log:
+            _, citations = normalize_citations_and_chunks(answer, [], records=[])
+        assert citations == []
+        log.warning.assert_called()
+
+    def test_agent_record_landing_page(self):
+        landing = f"{BASE}/record/{REC1}"
+        record = {
+            "id": REC1,
+            "record_name": "Agent Landing",
+            "block_containers": {"blocks": [], "block_groups": []},
+        }
+        answer = f"y [t]({landing})."
+        _, citations = normalize_citations_and_chunks_for_agent(
+            answer, [], records=[record],
+        )
+        assert len(citations) == 1
+        assert "Agent Landing" in citations[0]["content"]
+
+    def test_agent_warns_when_record_missing(self):
+        landing = f"{BASE}/record/{REC1}"
+        answer = f"z [t]({landing})."
+        with patch("app.utils.citations.logger") as log:
+            _, citations = normalize_citations_and_chunks_for_agent(answer, [], records=[])
+        assert citations == []
+        log.warning.assert_called()
+
+
 class _TruthyButEmptyStr:
     """Test double whose bool is True but str() returns empty."""
 

--- a/backend/python/tests/unit/utils/test_citations.py
+++ b/backend/python/tests/unit/utils/test_citations.py
@@ -1,14 +1,22 @@
 """Unit tests for app.utils.citations (new markdown-link citation format)."""
 
 import re
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from app.models.blocks import BlockType, GroupType
+import app.utils.citations as citations_mod
+
 from app.utils.citations import (
+    ChatDocCitation,
+    _clean_duplicate_citation_links,
     _extract_block_index_from_url,
     _extract_record_id_from_url,
+    _find_web_record_by_url,
     _renumber_citation_links,
+    build_tiny_web_ref_url,
     detect_hallucinated_citation_urls,
+    display_url_for_llm,
+    extract_tiny_ref,
     fix_json_string,
     normalize_citations_and_chunks,
     normalize_citations_and_chunks_for_agent,
@@ -929,15 +937,311 @@ class TestNormalizeBracketRefs:
 
 class TestResolveRef:
     def test_ref_resolved_via_mapping(self):
-        """Cover line 72 — tiny ref present in mapping returns the full URL."""
+        """Tiny ref present in mapping returns the full URL."""
         mapping = {"ref1": "http://full/url#blockIndex=0"}
         assert _resolve_ref("ref1", mapping) == "http://full/url#blockIndex=0"
+
+    def test_tiny_web_url_maps_through_inner_ref(self):
+        assert _resolve_ref("https://ref1.xyz/", {"ref1": "http://canonical/page"}) == (
+            "http://canonical/page"
+        )
 
     def test_ref_not_in_mapping_returns_target(self):
         assert _resolve_ref("ref99", {"ref1": "x"}) == "ref99"
 
     def test_none_mapping_returns_target(self):
         assert _resolve_ref("ref1", None) == "ref1"
+
+
+class TestTinyRefHelpers:
+    def test_extract_tiny_ref_empty(self):
+        assert extract_tiny_ref("") is None
+
+    def test_extract_tiny_ref_non_match(self):
+        assert extract_tiny_ref("http://regular.example") is None
+
+    def test_extract_tiny_ref_strips_https_form(self):
+        assert extract_tiny_ref("http://ref9.xyz") == "ref9"
+
+    def test_build_tiny_web_ref_url(self):
+        assert build_tiny_web_ref_url("ref2") == "https://ref2.xyz"
+
+
+class TestDisplayUrlForLlm:
+    def test_empty_url(self):
+        mapper = MagicMock()
+        assert display_url_for_llm("", mapper) == ""
+
+    def test_none_mapper_returns_verbatim(self):
+        u = "https://corp.example/long/path?q=1"
+        assert display_url_for_llm(u, None) is u
+
+    def test_mapper_replaces_with_tiny_web_ref_url(self):
+        mapper = MagicMock()
+        mapper.get_or_create_ref.return_value = "ref55"
+        u = "https://docs.example/guide#section"
+        assert display_url_for_llm(u, mapper) == "https://ref55.xyz"
+        mapper.get_or_create_ref.assert_called_once_with(u)
+
+
+class TestCleanDuplicateCitationLinks:
+    def test_trailing_paren_same_as_link_target_removed(self):
+        t = "[source](https://example.com/article) (https://example.com/article)"
+        assert _clean_duplicate_citation_links(t) == "[source](https://example.com/article)"
+
+    def test_trailing_https_ref_xyz_always_stripped_keep_first_link_only(self):
+        t = "[s](https://example.com/long) (https://ref901.xyz)"
+        assert _clean_duplicate_citation_links(t) == "[s](https://example.com/long)"
+
+    def test_kept_when_paren_target_differs_from_resolved_link(self):
+        t = "[s](https://example.com/a) (https://other.com/b)"
+        assert _clean_duplicate_citation_links(t) == t
+
+    def test_ref_mapped_same_as_paren_url(self):
+        full = "https://resolved-target.example/path"
+        t = "[q](ref1) (https://resolved-target.example/path)"
+        assert _clean_duplicate_citation_links(t, {"ref1": full}) == "[q](ref1)"
+
+    def test_consecutive_md_links_same_url_collapsed(self):
+        u = "https://ref707.xyz"
+        combo = f"[Site title]({u}) [more]({u})"
+        assert _clean_duplicate_citation_links(combo) == f"[Site title]({u})"
+
+    def test_consecutive_without_space_between(self):
+        u = "https://dup.example/page"
+        combo = f"[A]({u})[cite]({u})"
+        assert _clean_duplicate_citation_links(combo) == f"[A]({u})"
+
+    def test_consecutive_different_urls_kept(self):
+        t = "[A](https://one.example/a) [B](https://two.example/b)"
+        assert _clean_duplicate_citation_links(t) == t
+
+
+class TestRenumberCitationLinksMarkdownPattern:
+    def test_blank_link_label_still_renumbered(self):
+        """Whitespace-only / empty brackets → ``_is_citation_label`` early ``True`` path."""
+        page = "https://edge.example/about"
+        text = f"Odd []({page})."
+        matches = list(re.finditer(citations_mod._MD_LINK_PATTERN, text))
+        out = _renumber_citation_links(text, matches, {page: 9})
+        assert "[9]" in out
+
+    def test_descriptive_link_text_kept_not_numeric_badge(self):
+        page = "https://readable.example/guide"
+        text = f"Details in [Installation guide]({page}) please."
+        matches = list(re.finditer(citations_mod._MD_LINK_PATTERN, text))
+        out = _renumber_citation_links(text, matches, {page: 4})
+        assert "[Installation guide]" in out
+        assert "[4]" not in out
+        assert page in out
+
+
+class TestChatDocCitation:
+    def test_dataclass_roundtrip_fields(self):
+        c = ChatDocCitation(content="body", metadata={"m": True}, chunkindex=2)
+        assert c.content == "body" and c.metadata == {"m": True} and c.chunkindex == 2
+
+
+class TestFindWebRecordByUrl:
+    def test_empty_url_returns_none_without_iterating(self):
+        assert _find_web_record_by_url("", [{"url": "x"}]) is None
+
+
+class TestDetectHallucinatedExtras:
+    def test_duplicate_tiny_refs_count_once(self):
+        r = detect_hallucinated_citation_urls("[1](ref5) duplicate [z](ref5)")
+        assert r == ["ref5"]
+
+
+class TestWebRecordsCitationsPath:
+    """Cover web search citation assembly in normalize_citations_*"""
+
+    WEB = "https://search.example/snippet?q=1#page"
+
+    def test_normalize_chat_builds_web_citation(self):
+        answer = f"Found [article]({self.WEB})."
+        rows = [{"url": self.WEB, "content": "HTML snippet ok", "org_id": "o-9"}]
+        _, cites = normalize_citations_and_chunks(
+            answer,
+            [],
+            records=[],
+            web_records=rows,
+        )
+        assert len(cites) == 1
+        assert cites[0]["citationType"] == "web|url"
+        assert cites[0]["content"] == "HTML snippet ok"
+        assert cites[0]["metadata"]["connector"] == "WEB"
+
+    def test_empty_web_record_content_skips(self):
+        answer = f"See [site]({self.WEB})."
+        rows = [{"url": self.WEB, "content": "", "org_id": ""}]
+        _, cites = normalize_citations_and_chunks(
+            answer, [], records=[], web_records=rows
+        )
+        assert cites == []
+
+    def test_normalize_agent_web_records(self):
+        answer = f"Web [cite]({self.WEB})."
+        rows = [{"url": self.WEB, "content": "agent web text", "org_id": ""}]
+        _, cites = normalize_citations_and_chunks_for_agent(
+            answer, [], records=[], web_records=rows
+        )
+        assert len(cites) == 1 and cites[0]["content"] == "agent web text"
+
+    def test_normalize_agent_skips_when_web_record_content_empty(self):
+        answer = f"Web [cite]({self.WEB})."
+        rows = [{"url": self.WEB, "content": "", "org_id": ""}]
+        _, cites = normalize_citations_and_chunks_for_agent(
+            answer, [], records=[], web_records=rows,
+        )
+        assert cites == []
+
+    def test_web_records_list_but_no_hit_falls_through_to_vectordb(self):
+        url = _url(REC1, 0)
+        docs = [_make_doc(REC1, 0, "from vector", block_web_url=url)]
+        answer = f"Use [doc]({url})."
+        decoy = [{"url": "http://different", "content": "noise", "org_id": ""}]
+        _, cites = normalize_citations_and_chunks(
+            answer, docs, web_records=decoy
+        )
+        assert len(cites) == 1 and cites[0]["content"] == "from vector"
+
+
+class TestFlattenListGroupDocs:
+    def test_list_child_url_indexed_like_table(self):
+        child_url = _url(REC1, 41)
+        list_doc = {
+            "virtual_record_id": REC1,
+            "block_index": 40,
+            "block_type": GroupType.LIST.value,
+            "block_web_url": None,
+            "content": (
+                "",
+                [
+                    {
+                        "block_web_url": child_url,
+                        "content": "item one",
+                        "metadata": {"origin": "O", "recordName": "N", "recordId": REC1, "mimeType": "M", "orgId": "Org"},
+                    }
+                ],
+            ),
+            "metadata": {},
+        }
+        answer = f"Bullet [1]({child_url})."
+        _, cites = normalize_citations_and_chunks(answer, [list_doc])
+        assert len(cites) == 1 and cites[0]["content"] == "item one"
+
+
+class TestAppendCitationEmptyDataBranches:
+    def test_chat_record_block_without_data_logged(self):
+        url = _url(REC1, 0)
+        record = {
+            "id": REC1,
+            "block_containers": {"blocks": [
+                {"type": BlockType.TEXT.value, "data": None, "index": 0},
+            ]},
+        }
+        answer = f"See [src]({url})."
+        with patch("app.utils.citations.logger") as log:
+            _, cites = normalize_citations_and_chunks(answer, [], records=[record])
+        assert cites == []
+        log.warning.assert_called()
+
+    def test_agent_virtual_block_data_none_logs(self):
+        url = _url(REC1, 0)
+        vrid = {
+            "vr1": {
+                "id": REC1,
+                "block_containers": {"blocks": [
+                    {"type": BlockType.TEXT.value, "data": None, "index": 0},
+                ]},
+            }
+        }
+        answer = f"See [agent]({url})."
+        with patch("app.utils.citations.logger") as log:
+            _, cites = normalize_citations_and_chunks_for_agent(
+                answer, [], records=[], virtual_record_id_to_result=vrid,
+            )
+        assert cites == []
+        log.warning.assert_called()
+
+
+class TestAgentMetadataMergeFromVirtualMap:
+    def test_virtual_record_id_only_in_metadata_payload(self):
+        url = _url(REC1, 0)
+        docs = [{
+            "virtual_record_id": None,
+            "block_index": 0,
+            "block_type": "text",
+            "block_web_url": url,
+            "content": "chunk",
+            "metadata": {"virtualRecordId": "vr-meta"},
+        }]
+        vmap = {"vr-meta": {"origin": "CONFL", "record_name": "Rn", "id": "rid-1", "mime_type": "text/plain"}}
+        _, cites = normalize_citations_and_chunks_for_agent(
+            f"[1]({url})", docs, virtual_record_id_to_result=vmap,
+        )
+        meta = cites[0]["metadata"]
+        assert meta["origin"] == "CONFL" and meta["recordName"] == "Rn"
+
+
+class TestExpandMultiRefLinksEdge:
+    def test_replacer_returns_original_when_split_yields_single(self):
+        class _DummyMatch:
+            def group(self, n: int) -> str:
+                if n == 0:
+                    return "[lbl](solo_only)"
+                if n == 1:
+                    return "lbl"
+                if n == 2:
+                    return "solo_only"
+                raise AssertionError(n)
+
+        mock_pat = MagicMock()
+
+        def fake_sub(fn, _text):
+            return fn(_DummyMatch())
+
+        mock_pat.sub = fake_sub
+        with patch.object(citations_mod, "_MULTI_REF_IN_LINK_RE", mock_pat):
+            assert citations_mod._expand_multi_ref_links("ignore") == "[lbl](solo_only)"
+
+    def test_wrap_bare_refs_unknown_match_returns_group_zero(self):
+        class _BareMatch:
+            def group(self, n: int) -> object:
+                if n == 0:
+                    return "keepme"
+                return None
+
+        mock_pat = MagicMock()
+
+        def fake_sub(fn, _text):
+            return fn(_BareMatch())
+
+        mock_pat.sub = fake_sub
+        with patch.object(citations_mod, "_BARE_CITATION_NORMALIZE_RE", mock_pat):
+            assert citations_mod._wrap_bare_refs("x") == "keepme"
+
+
+class TestFindRecordByVirtualMapWithNoneEntries:
+    def test_skips_none_values_in_virtual_map(self):
+        """``_find_record_by_id`` must ignore ``None`` map entries."""
+
+        landing = f"{BASE}/record/{REC1}"
+        real_rec = {
+            "id": REC1,
+            "record_name": "SkipNoneWorks",
+            "block_containers": {"blocks": []},
+        }
+        vmap = {"nulled_entry": None, "real_record": real_rec}
+        _, cites = normalize_citations_and_chunks(
+            f"See [h]({landing}).",
+            [],
+            records=[],
+            virtual_record_id_to_result=vmap,
+        )
+        assert len(cites) == 1
+        assert "SkipNoneWorks" in cites[0]["content"]
 
 
 class TestSafeStringifyContent:

--- a/backend/python/tests/unit/utils/test_streaming.py
+++ b/backend/python/tests/unit/utils/test_streaming.py
@@ -376,6 +376,19 @@ class TestAppendTaskMarkers:
         result = _append_task_markers("Answer text", [])
         assert result == "Answer text"
 
+    def test_empty_answer_with_none_tasks(self):
+        """Cover _strip_llm_authored_markers early return when answer is falsy."""
+        assert _append_task_markers("", None) == ""
+
+    def test_artifacts_missing_url_are_skipped(self):
+        tasks = [
+            {
+                "type": "artifacts",
+                "artifacts": [{"fileName": "skip.bin", "mimeType": "application/octet-stream"}],
+            }
+        ]
+        assert _append_task_markers("Out", tasks) == "Out"
+
     def test_tasks_without_urls_are_skipped(self):
         # Tasks without signedUrl or downloadUrl produce no marker text,
         # so the answer is returned unchanged (no stray trailing "\n\n").

--- a/backend/python/tests/unit/utils/test_streaming_extra.py
+++ b/backend/python/tests/unit/utils/test_streaming_extra.py
@@ -1,10 +1,11 @@
 """Additional unit tests for app.utils.streaming targeting uncovered branches."""
 
 import logging
+import types
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from pydantic import ValidationError
 
 from app.utils.streaming import (
@@ -1498,6 +1499,458 @@ class TestStreamContentEmptyErrorBody:
         async def fake_coroutine():
             return "https://example.com"
 
+        # Use a non-awaitable object; a coroutine would emit RuntimeWarning when garbage-collected.
         with pytest.raises(TypeError, match="Expected signed_url to be a string"):
-            async for _ in stream_content(fake_coroutine()):
+            async for _ in stream_content(object()):
                 pass
+
+
+# ---------------------------------------------------------------------------
+# execute_tool_calls — web records, deferred tools, threshold empty results,
+# ContentHandler tool instructions
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteToolCallsWebAndDeferred:
+    """Cover lines 499, 622, 637–646, 726→734 (empty search), 749, 766–777."""
+
+    @pytest.mark.asyncio
+    async def test_web_search_tool_appends_web_records(self):
+        from app.utils.streaming import execute_tool_calls
+
+        mock_tool = MagicMock()
+        mock_tool.name = "web_search"
+        mock_tool.arun = AsyncMock(
+            return_value={
+                "ok": True,
+                "web_results": [{"title": "T", "link": "https://ex.com", "snippet": "snip"}],
+                "query": "q",
+            }
+        )
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[{"name": "web_search", "args": {}, "id": "c1"}],
+        )
+
+        async def mock_call_aiter(*args, **kwargs):
+            yield {"event": "tool_calls", "data": {"ai": ai_msg}}
+
+        with patch("app.utils.streaming.call_aiter_llm_stream", side_effect=mock_call_aiter), patch(
+            "app.utils.streaming.bind_tools_for_llm", return_value=MagicMock()
+        ):
+            complete = None
+            async for event in execute_tool_calls(
+                llm=MagicMock(),
+                messages=[HumanMessage(content="hi")],
+                tools=[mock_tool],
+                tool_runtime_kwargs={"config_service": AsyncMock()},
+                final_results=[],
+                virtual_record_id_to_result={},
+                blob_store=MagicMock(),
+                all_queries=["q"],
+                retrieval_service=AsyncMock(),
+                user_id="u1",
+                org_id="o1",
+                context_length=128000,
+            ):
+                if event.get("event") == "tool_execution_complete":
+                    complete = event
+
+        assert complete is not None
+        web = complete["data"].get("web_records", [])
+        assert any(r.get("source_type") == "web" for r in web)
+
+    @pytest.mark.asyncio
+    async def test_deferred_tool_as_list_attached_after_trigger(self):
+        from app.utils.streaming import execute_tool_calls
+
+        trigger_tool = MagicMock()
+        trigger_tool.name = "trigger_tool"
+        trigger_tool.arun = AsyncMock(
+            return_value={"ok": True, "result_type": "content", "content": "t"}
+        )
+
+        extra_tool = MagicMock()
+        extra_tool.name = "extra_tool"
+        extra_tool.arun = AsyncMock(
+            return_value={"ok": True, "result_type": "content", "content": "x"}
+        )
+
+        class SimpleChunk:
+            def __init__(self, content, tool_calls=None):
+                self.content = content
+                self.tool_calls = tool_calls or []
+
+            def __add__(self, other):
+                tc = (self.tool_calls or []) + (getattr(other, "tool_calls", None) or [])
+                return SimpleChunk(self.content + getattr(other, "content", ""), tc)
+
+        hop = {"n": 0}
+
+        async def mock_astream(messages, config=None):
+            hop["n"] += 1
+            if hop["n"] == 1:
+                yield SimpleChunk(
+                    "",
+                    tool_calls=[
+                        {"name": "trigger_tool", "args": {}, "id": "t1"},
+                    ],
+                )
+            else:
+                yield SimpleChunk("", tool_calls=[])
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools = MagicMock(side_effect=RuntimeError("no bind"))
+        mock_llm.astream = mock_astream
+
+        async for _ in execute_tool_calls(
+            llm=mock_llm,
+            messages=[HumanMessage(content="hi")],
+            tools=[trigger_tool],
+            tool_runtime_kwargs={"has_sql_connector": False},
+            final_results=[],
+            virtual_record_id_to_result={},
+            blob_store=MagicMock(),
+            all_queries=["q"],
+            retrieval_service=AsyncMock(),
+            user_id="u1",
+            org_id="o1",
+            context_length=100000,
+            defer_tool_until_called_name="trigger_tool",
+            deferred_tool=[extra_tool],
+        ):
+            pass
+
+        assert mock_llm.bind_tools.call_count >= 2
+        bound_tools = mock_llm.bind_tools.call_args_list[1][0][0]
+        assert {t.name for t in bound_tools} == {"trigger_tool", "extra_tool"}
+
+    @pytest.mark.asyncio
+    async def test_token_threshold_empty_search_results_skips_flatten(self):
+        from app.utils.streaming import execute_tool_calls
+
+        mock_tool = MagicMock()
+        mock_tool.name = "search"
+        mock_tool.arun = AsyncMock(
+            return_value={
+                "ok": True,
+                "records": [{"virtual_record_id": "vr1", "content": "test"}],
+                "record_count": 1,
+            }
+        )
+
+        ai_msg = AIMessage(
+            content="",
+            tool_calls=[{"name": "search", "args": {}, "id": "c1"}],
+        )
+
+        async def mock_call_aiter(*args, **kwargs):
+            yield {"event": "tool_calls", "data": {"ai": ai_msg}}
+
+        with patch("app.utils.streaming.call_aiter_llm_stream", side_effect=mock_call_aiter), patch(
+            "app.utils.streaming.bind_tools_for_llm", return_value=MagicMock()
+        ), patch(
+            "app.utils.streaming.record_to_message_content",
+            return_value=([{"type": "text", "text": "content"}], MagicMock()),
+        ), patch("app.utils.streaming.count_tokens", return_value=(100000, 50000)), patch(
+            "app.utils.streaming.get_vectorDb_limit", return_value=100
+        ):
+            mock_retrieval = AsyncMock()
+            mock_retrieval.search_with_filters = AsyncMock(
+                return_value={"searchResults": [], "status_code": 200}
+            )
+            flat = AsyncMock()
+            with patch("app.utils.streaming.get_flattened_results", new=flat):
+                events = []
+                async for event in execute_tool_calls(
+                    llm=MagicMock(),
+                    messages=[],
+                    tools=[mock_tool],
+                    tool_runtime_kwargs={},
+                    final_results=[],
+                    virtual_record_id_to_result={},
+                    blob_store=MagicMock(),
+                    all_queries=["q"],
+                    retrieval_service=mock_retrieval,
+                    user_id="u1",
+                    org_id="o1",
+                    context_length=128000,
+                ):
+                    events.append(event)
+            flat.assert_not_called()
+            assert any(e.get("event") == "tool_success" for e in events)
+
+    @pytest.mark.asyncio
+    async def test_content_handler_appends_tool_instructions_to_human_message(self):
+        from app.utils.streaming import execute_tool_calls
+
+        mock_tool = MagicMock()
+        mock_tool.name = "execute_sql_query"
+        mock_tool.arun = AsyncMock(
+            return_value={
+                "ok": True,
+                "result_type": "content",
+                "content": "rows: 1",
+            }
+        )
+
+        class SimpleChunk:
+            def __init__(self, content, tool_calls=None):
+                self.content = content
+                self.tool_calls = tool_calls or []
+
+            def __add__(self, other):
+                tc = (self.tool_calls or []) + (getattr(other, "tool_calls", None) or [])
+                return SimpleChunk(self.content + getattr(other, "content", ""), tc)
+
+        hop = {"n": 0}
+
+        async def mock_astream(messages, config=None):
+            hop["n"] += 1
+            if hop["n"] == 1:
+                yield SimpleChunk(
+                    "",
+                    tool_calls=[
+                        {"name": "execute_sql_query", "args": {}, "id": "c1"},
+                    ],
+                )
+            else:
+                yield SimpleChunk("", tool_calls=[])
+
+        mock_llm = MagicMock()
+        mock_llm.bind_tools = MagicMock(side_effect=RuntimeError("no bind"))
+        mock_llm.astream = mock_astream
+
+        human = HumanMessage(content="Run a query")
+        messages = [human]
+        async for _ in execute_tool_calls(
+            llm=mock_llm,
+            messages=messages,
+            tools=[mock_tool],
+            tool_runtime_kwargs={"has_sql_connector": True},
+            final_results=[],
+            virtual_record_id_to_result={},
+            blob_store=MagicMock(),
+            all_queries=["q"],
+            retrieval_service=AsyncMock(),
+            user_id="u1",
+            org_id="o1",
+            context_length=100000,
+        ):
+            pass
+
+        hm_contents = [
+            m.content for m in messages if isinstance(m, HumanMessage) and isinstance(m.content, str)
+        ]
+        assert any("<tools>" in c for c in hm_contents)
+        assert any("execute_sql_query" in c for c in hm_contents)
+
+
+# ---------------------------------------------------------------------------
+# stream_llm_response_with_tools — early complete + conversation task markers
+# ---------------------------------------------------------------------------
+
+
+class TestStreamLlmResponseWithToolsEarlyComplete:
+    """Cover lines 1326–1329 (_append_task_markers on early complete)."""
+
+    @pytest.mark.asyncio
+    async def test_conversation_tasks_appended_on_early_complete(self):
+        from app.utils.streaming import stream_llm_response_with_tools
+
+        async def mock_execute(*args, **kwargs):
+            yield {
+                "event": "complete",
+                "data": {"answer": "done", "citations": [], "reason": None, "confidence": None},
+            }
+
+        task_row = {"fileName": "out.csv", "signedUrl": "https://bucket/out.csv"}
+
+        with patch("app.utils.streaming.execute_tool_calls", side_effect=mock_execute), patch(
+            "app.utils.conversation_tasks.await_and_collect_results",
+            new_callable=AsyncMock,
+            return_value=[task_row],
+        ):
+            events = []
+            async for event in stream_llm_response_with_tools(
+                llm=MagicMock(),
+                messages=[HumanMessage(content="hi")],
+                final_results=[],
+                all_queries=["q"],
+                retrieval_service=MagicMock(),
+                user_id="u1",
+                org_id="o1",
+                virtual_record_id_to_result={},
+                blob_store=MagicMock(),
+                is_multimodal_llm=False,
+                context_length=10000,
+                tools=[MagicMock()],
+                tool_runtime_kwargs={"config_service": MagicMock()},
+                conversation_id="conv-1",
+                mode="json",
+            ):
+                events.append(event)
+
+        done = next(e for e in events if e.get("event") == "complete")
+        assert "download_conversation_task[out.csv]" in (done["data"].get("answer") or "")
+
+
+# ---------------------------------------------------------------------------
+# call_aiter_llm_stream — dict token metadata emission (lines 1632–1636)
+# ---------------------------------------------------------------------------
+
+
+class TestCallAiterLlmStreamDictMetadata:
+    """When repeated dict snapshots add no safe answer progress, emit metadata."""
+
+    @pytest.mark.asyncio
+    async def test_duplicate_dict_answer_yields_metadata(self):
+        from app.utils.streaming import call_aiter_llm_stream
+
+        snap = {"answer": "Hi"}
+
+        async def mock_aiter(llm, messages, parts=None):
+            yield snap
+            yield snap
+
+        with patch("app.utils.streaming.aiter_llm_stream", side_effect=mock_aiter), patch(
+            "app.utils.streaming.normalize_citations_and_chunks", return_value=("Hi", [])
+        ):
+            events = []
+            async for event in call_aiter_llm_stream(
+                llm=MagicMock(),
+                messages=[],
+                final_results=[],
+                records=[],
+                target_words_per_chunk=10,
+                original_llm=MagicMock(),
+            ):
+                events.append(event)
+
+        assert any(e.get("event") == "metadata" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# call_aiter_function — both mode branches
+# ---------------------------------------------------------------------------
+
+
+class TestCallAiterFunctionModeDispatch:
+    @pytest.mark.asyncio
+    async def test_json_mode_delegates_to_call_aiter_llm_stream(self):
+        from app.utils.streaming import call_aiter_function
+
+        async def fake_json_stream(*a, **k):
+            yield {"event": "complete", "data": {}}
+
+        with patch("app.utils.streaming.call_aiter_llm_stream", side_effect=fake_json_stream):
+            out = []
+            async for e in call_aiter_function(
+                MagicMock(),
+                [],
+                [],
+                mode="json",
+            ):
+                out.append(e)
+        assert out and out[0]["event"] == "complete"
+
+    @pytest.mark.asyncio
+    async def test_simple_mode_delegates_to_call_aiter_llm_stream_simple(self):
+        from app.utils.streaming import call_aiter_function
+
+        async def fake_simple_stream(*a, **k):
+            yield {"event": "complete", "data": {}}
+
+        with patch(
+            "app.utils.streaming.call_aiter_llm_stream_simple",
+            side_effect=fake_simple_stream,
+        ):
+            out = []
+            async for e in call_aiter_function(
+                MagicMock(),
+                [],
+                [],
+                mode="simple",
+            ):
+                out.append(e)
+        assert out and out[0]["event"] == "complete"
+
+
+# ---------------------------------------------------------------------------
+# call_aiter_llm_stream_simple — skip citation reflection when web_search
+# ---------------------------------------------------------------------------
+
+
+class TestCallAiterLlmStreamSimpleWebSearchSkipsReflection:
+    @pytest.mark.asyncio
+    async def test_no_reflection_when_chat_mode_web_search(self):
+        from app.utils.streaming import call_aiter_llm_stream_simple
+
+        async def mock_aiter(llm, messages, parts=None):
+            yield "bad [1](http://evil/x#blockIndex=0)"
+
+        with patch("app.utils.streaming.aiter_llm_stream", side_effect=mock_aiter), patch(
+            "app.utils.streaming.detect_hallucinated_citation_urls",
+            return_value=["http://evil/x#blockIndex=0"],
+        ), patch(
+            "app.utils.streaming.normalize_citations_and_chunks",
+            return_value=("normalized", []),
+        ):
+            events = []
+            async for event in call_aiter_llm_stream_simple(
+                llm=MagicMock(),
+                messages=[HumanMessage(content="q")],
+                final_results=[],
+                records=[],
+                target_words_per_chunk=10,
+                original_llm=MagicMock(),
+                chat_mode="web_search",
+            ):
+                events.append(event)
+
+        assert not any(e.get("event") == "restreaming" for e in events)
+        assert any(e.get("event") == "complete" for e in events)
+
+
+# ---------------------------------------------------------------------------
+# Opik configure failure at import time (lines 68–71) via module reload
+# ---------------------------------------------------------------------------
+
+
+class TestOpikConfigureImportFailure:
+    def test_configure_exception_sets_tracer_none(self, monkeypatch):
+        import importlib
+        import sys
+
+        monkeypatch.setenv("OPIK_API_KEY", "test-key")
+        monkeypatch.setenv("OPIK_WORKSPACE", "test-ws")
+
+        opik_mod = types.ModuleType("opik")
+
+        def configure(**kwargs):
+            raise RuntimeError("opik unavailable")
+
+        opik_mod.configure = configure
+        integrations = types.ModuleType("opik.integrations")
+        langchain_int = types.ModuleType("opik.integrations.langchain")
+        langchain_int.OpikTracer = MagicMock()
+
+        sys.modules["opik"] = opik_mod
+        sys.modules["opik.integrations"] = integrations
+        sys.modules["opik.integrations.langchain"] = langchain_int
+
+        import app.utils.streaming as sm
+
+        importlib.reload(sm)
+        assert sm.opik_tracer is None
+
+        monkeypatch.delenv("OPIK_API_KEY", raising=False)
+        monkeypatch.delenv("OPIK_WORKSPACE", raising=False)
+        for key in (
+            "opik",
+            "opik.integrations",
+            "opik.integrations.langchain",
+        ):
+            sys.modules.pop(key, None)
+        importlib.reload(sm)


### PR DESCRIPTION
New summary embedding after Reconcilation on Reindexing: 
<img width="1596" height="517" alt="image" src="https://github.com/user-attachments/assets/8fd047ca-5335-43d9-80c5-fcf4b752941b" />

Opik trace for conversation having only summary for some records & having both summary & blocks for other records: https://www.comet.com/opik/me-only/projects/019e2b0c-f569-7090-b2fa-2dbaacdc6ba7/logs?traces_filters=%5B%5D&time_range=past30days&size=100&height=small&trace=019e4558-a7f9-7e08-8b91-d03a6b585880&span=019e4558-a7fa-7676-9bdd-bd0a7908b27a&trace_panel_filters=%5B%5D&thread=
