### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/backend/nodejs/apps/tests/modules/configuration_manager/validator/validators.test.ts
+++ b/backend/nodejs/apps/tests/modules/configuration_manager/validator/validators.test.ts
@@ -135,7 +135,7 @@ describe('configuration_manager/validator/validators', () => {
           modelType: 'llm',
           provider: 'minimax',
           configuration: {
-            model: 'MiniMax-M2.7',
+            model: 'MiniMax-M3',
             apiKey: 'test-minimax-key',
           },
           isMultimodal: true,
@@ -153,7 +153,7 @@ describe('configuration_manager/validator/validators', () => {
           modelType: 'llm',
           provider: 'minimax',
           configuration: {
-            model: 'MiniMax-M2.7, MiniMax-M2.7-highspeed',
+            model: 'MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed',
             apiKey: 'test-minimax-key',
           },
           isMultimodal: true,
@@ -171,7 +171,7 @@ describe('configuration_manager/validator/validators', () => {
           modelType: 'invalid',
           provider: 'minimax',
           configuration: {
-            model: 'MiniMax-M2.7',
+            model: 'MiniMax-M3',
             apiKey: 'test-key',
           },
           isMultimodal: false,

--- a/backend/python/app/config/ai_models/providers/llm_only.py
+++ b/backend/python/app/config/ai_models/providers/llm_only.py
@@ -51,12 +51,12 @@ class GroqProvider:
 # ---------------------------------------------------------------------------
 
 @AIModelProviderBuilder("MiniMax", "minimax") \
-    .with_description("MiniMax M2.7 models with 1M context") \
+    .with_description("MiniMax M3 and M2.7 models with 1M context") \
     .with_capabilities([ModelCapability.TEXT_GENERATION]) \
     .with_icon("/icons/ai-models/minimax.svg") \
     .with_color("#1A1A2E") \
     .add_field(API_KEY) \
-    .add_field(model_field("e.g., MiniMax-M2.7, MiniMax-M2.7-highspeed")) \
+    .add_field(model_field("e.g., MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed")) \
     .add_field(LLM_COMMON_TAIL[0]) \
     .add_field(LLM_COMMON_TAIL[1]) \
     .add_field(LLM_COMMON_TAIL[2]) \

--- a/backend/python/tests/unit/utils/test_aimodels.py
+++ b/backend/python/tests/unit/utils/test_aimodels.py
@@ -499,11 +499,11 @@ class TestGetGeneratorModel:
     @patch("langchain_openai.ChatOpenAI")
     def test_minimax(self, mock_cls):
         mock_cls.return_value = MagicMock()
-        config = self._base_config("MiniMax-M2.7")
+        config = self._base_config("MiniMax-M3")
         result = get_generator_model(LLMProvider.MINIMAX.value, config)
         mock_cls.assert_called_once()
         call_kwargs = mock_cls.call_args.kwargs
-        assert call_kwargs["model"] == "MiniMax-M2.7"
+        assert call_kwargs["model"] == "MiniMax-M3"
         assert call_kwargs["base_url"] == "https://api.minimax.io/v1"
         assert call_kwargs["stream_usage"] is True
         assert result is mock_cls.return_value
@@ -511,7 +511,7 @@ class TestGetGeneratorModel:
     @patch("langchain_openai.ChatOpenAI")
     def test_minimax_temperature_clamping(self, mock_cls):
         mock_cls.return_value = MagicMock()
-        config = self._base_config("MiniMax-M2.7")
+        config = self._base_config("MiniMax-M3")
         config["configuration"]["temperature"] = 0.0
         result = get_generator_model(LLMProvider.MINIMAX.value, config)
         call_kwargs = mock_cls.call_args.kwargs
@@ -521,7 +521,7 @@ class TestGetGeneratorModel:
     @patch("langchain_openai.ChatOpenAI")
     def test_minimax_temperature_upper_bound(self, mock_cls):
         mock_cls.return_value = MagicMock()
-        config = self._base_config("MiniMax-M2.7")
+        config = self._base_config("MiniMax-M3")
         config["configuration"]["temperature"] = 2.0
         result = get_generator_model(LLMProvider.MINIMAX.value, config)
         call_kwargs = mock_cls.call_args.kwargs

--- a/backend/python/tests/unit/utils/test_minimax_integration.py
+++ b/backend/python/tests/unit/utils/test_minimax_integration.py
@@ -16,7 +16,7 @@ from app.utils.aimodels import LLMProvider, get_generator_model
 class TestMiniMaxIntegration:
     """Integration tests for MiniMax LLM provider."""
 
-    def _minimax_config(self, model="MiniMax-M2.7", temperature=None):
+    def _minimax_config(self, model="MiniMax-M3", temperature=None):
         config = {
             "configuration": {
                 "model": model,
@@ -37,6 +37,24 @@ class TestMiniMaxIntegration:
         mock_cls.assert_called_once()
         call_kwargs = mock_cls.call_args.kwargs
         assert call_kwargs["base_url"] == "https://api.minimax.io/v1"
+        assert call_kwargs["model"] == "MiniMax-M3"
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_m3_model(self, mock_cls):
+        """MiniMax-M3 model should be accepted as the new default."""
+        mock_cls.return_value = MagicMock()
+        config = self._minimax_config("MiniMax-M3")
+        result = get_generator_model(LLMProvider.MINIMAX.value, config)
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["model"] == "MiniMax-M3"
+
+    @patch("langchain_openai.ChatOpenAI")
+    def test_minimax_m27_model(self, mock_cls):
+        """MiniMax-M2.7 should still work for backward compatibility."""
+        mock_cls.return_value = MagicMock()
+        config = self._minimax_config("MiniMax-M2.7")
+        result = get_generator_model(LLMProvider.MINIMAX.value, config)
+        call_kwargs = mock_cls.call_args.kwargs
         assert call_kwargs["model"] == "MiniMax-M2.7"
 
     @patch("langchain_openai.ChatOpenAI")


### PR DESCRIPTION
## Summary
Upgrade the MiniMax LLM provider's default model hint to the new M3 release while keeping the existing M2.7 and M2.7-highspeed entries available.

## Changes
- `backend/python/app/config/ai_models/providers/llm_only.py` — provider description and `model_field` example updated to put `MiniMax-M3` first, with `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` retained.
- `backend/python/tests/unit/utils/test_minimax_integration.py` — default test config now exercises `MiniMax-M3`; explicit M3 test added; M2.7 backward-compat test added; existing M2.7-highspeed and temperature-clamping tests preserved.
- `backend/python/tests/unit/utils/test_aimodels.py` — generator-model tests updated from `MiniMax-M2.7` to `MiniMax-M3` (temperature-clamping behaviour unchanged).
- `backend/nodejs/apps/tests/modules/configuration_manager/validator/validators.test.ts` — validator examples updated; the multi-model test now lists `MiniMax-M3, MiniMax-M2.7, MiniMax-M2.7-highspeed` together to confirm all three pass schema validation.

## Why
MiniMax-M3 is the new flagship model with 512K context, 128K max output, and image input support across both OpenAI-compatible and Anthropic-compatible interfaces. M2.7 / M2.7-highspeed remain available as alternatives. No API base URL, temperature handling, or LangChain wiring is changed — only the user-facing model identifier.

## Testing
- The MiniMax branch in `get_generator_model` was exercised end-to-end against the mocked `langchain_openai.ChatOpenAI` (M3 default, M2.7 backward compat, M2.7-highspeed, temperature clamping at 0.0 → 0.01 and >1.0 → 1.0). All assertions pass.
- TypeScript validator unit tests still cover the rejection path for invalid `modelType`.