### PR TITLE
fix(frontend): point NEXT_PUBLIC_API_BASE_URL at the backend (:3000)

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -54,7 +54,7 @@ frontend/
 2. **Configure Environment Variables**
    Create a `.env.local` file (or copy `env.template`):
    ```env
-   NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
+   NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
    ```
 
 3. **Run Development Server**

--- a/frontend/env.template
+++ b/frontend/env.template
@@ -1,1 +1,3 @@
-NEXT_PUBLIC_API_BASE_URL=http://localhost:3001
+# URL of the Node.js backend API. The frontend dev server runs on :3001,
+# the backend on :3000 (see backend/env.template PORT and ALLOWED_ORIGINS).
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000


### PR DESCRIPTION
## What

Corrects `NEXT_PUBLIC_API_BASE_URL` in the two frontend onboarding files so it points at the **backend (`:3000`)** instead of the **frontend itself (`:3001`)**.

Closes #2502
Closes #2503

## Why

The frontend dev server runs on `:3001` (`CONTRIBUTING.md` → `PORT=3001 npm run dev`) and the Node.js backend on `:3000` (`backend/env.template` → `PORT=3000`). But:

- `frontend/env.template` → `NEXT_PUBLIC_API_BASE_URL=http://localhost:3001`
- `frontend/README.md` → same

That value is used as the axios `baseURL` (`frontend/lib/api/public-auth-client.ts`, `frontend/lib/api/axios-instance.ts`). So a fresh contributor who copies the template sends every API call to the frontend's own port. `GET /api/v1/org/exists` (a real backend route — mounted at `app.ts:424`, defined in `org.routes.ts:96`) hits Next.js, which has no such route and returns its 404 HTML page.

That's the reported behavior:
- **#2502** — "Requests are not rerouted to the backend" (the 404 HTML / RSC payload).
- **#2503** — the login page calls `/org/exists` on mount and spins forever waiting on the failed call.

## Why `:3000` is correct (and this is the minimal fix)

Every *other* config in the repo already uses `:3000`:
- `deployment/docker-compose/hot-reload/docker-compose.dev.{arango,neo4j}.yml` → `NEXT_PUBLIC_API_BASE_URL=http://localhost:3000`
- `frontend/tests/e2e/fixtures/api-context.fixture.ts` defaults to `http://localhost:3000`
- `CONTRIBUTING.md` / `frontend/tests/e2e/README.md` document `:3000` as the backend URL

Only the two files a new contributor copies were wrong. The backend already permits the cross-origin `:3001 → :3000` model: CORS allows the `:3001` origin with `credentials: true` (`app.ts`, `backend/env.template ALLOWED_ORIGINS=http://localhost:3001`). So just correcting the port is enough — no proxy/rewrite needed.

## Changes
- `frontend/env.template`: `3001` → `3000`, with a short comment explaining the split-port setup.
- `frontend/README.md`: matching value.

No code changes; this is a config/docs correction verified by statically tracing the `/org/exists` call to the backend route on `:3000`.