### PR TITLE
feat(indexing): add JSON document parser

### DIFF
--- a/backend/python/app/config/constants/arangodb.py
+++ b/backend/python/app/config/constants/arangodb.py
@@ -258,6 +258,7 @@ class ExtensionTypes(Enum):
     TXT = "txt"
     MD = "md"
     MDX = "mdx"
+    JSON = "json"
     HTML = "html"
     PNG = "png"
     JPG = "jpg"

--- a/backend/python/app/config/constants/arangodb.py
+++ b/backend/python/app/config/constants/arangodb.py
@@ -324,6 +324,7 @@ RECONCILIATION_ENABLED_MIME_TYPES = {
     MimeTypes.DOC.value,
     MimeTypes.PLAIN_TEXT.value,
     MimeTypes.HTML.value,
+    MimeTypes.JSON.value,
 }
 
 RECONCILIATION_ENABLED_EXTENSIONS = {
@@ -335,7 +336,8 @@ RECONCILIATION_ENABLED_EXTENSIONS = {
     ExtensionTypes.TXT.value,
     ExtensionTypes.MD.value,
     ExtensionTypes.MDX.value,
-    ExtensionTypes.HTML.value
+    ExtensionTypes.HTML.value,
+    ExtensionTypes.JSON.value,
 }
 
 

--- a/backend/python/app/containers/utils/utils.py
+++ b/backend/python/app/containers/utils/utils.py
@@ -12,6 +12,7 @@ from app.modules.parsers.excel.excel_parser import ExcelParser
 from app.modules.parsers.excel.xls_parser import XLSParser
 from app.modules.parsers.html_parser.html_parser import HTMLParser
 from app.modules.parsers.image_parser.image_parser import ImageParser
+from app.modules.parsers.json.json_parser import JSONParser
 from app.modules.parsers.markdown.markdown_parser import MarkdownParser
 from app.modules.parsers.markdown.mdx_parser import MDXParser
 from app.modules.parsers.pptx.ppt_parser import PPTParser
@@ -121,6 +122,7 @@ class ContainerUtils:
             ExtensionTypes.MDX.value: MDXParser(),
             ExtensionTypes.CSV.value: CSVParser(),
             ExtensionTypes.TSV.value: CSVParser(delimiter="\t"),
+            ExtensionTypes.JSON.value: JSONParser(),
             ExtensionTypes.XLSX.value: ExcelParser(logger),
             ExtensionTypes.XLS.value: XLSParser(),
             ExtensionTypes.PNG.value: image_parser,

--- a/backend/python/app/events/events.py
+++ b/backend/python/app/events/events.py
@@ -750,6 +750,17 @@ class EventProcessor:
                 ):
                     yield event
 
+            elif extension == ExtensionTypes.JSON.value or mime_type == MimeTypes.JSON.value:
+                async for event in self.processor.process_json_document(
+                    recordName=record_name,
+                    recordId=record_id,
+                    json_binary=file_content,
+                    virtual_record_id=virtual_record_id,
+                    event_type=event_type,
+                    prev_virtual_record_id=prev_virtual_record_id,
+                ):
+                    yield event
+
             elif extension == ExtensionTypes.MDX.value or mime_type == MimeTypes.MDX.value:
                 async for event in self.processor.process_mdx_document(
                     recordName=record_name,

--- a/backend/python/app/events/processor.py
+++ b/backend/python/app/events/processor.py
@@ -1775,6 +1775,61 @@ class Processor:
             self.logger.error(f"❌ Error processing Markdown document: {str(e)}")
             raise
 
+    async def process_json_document(
+        self, recordName, recordId, json_binary, virtual_record_id, event_type: Optional[str] = None, prev_virtual_record_id: Optional[str] = None
+    ) -> AsyncGenerator[Dict[str, Any], None]:
+        """Process JSON document, yielding phase completion events.
+
+        Flattens the JSON into readable text blocks via JSONParser, then runs
+        the standard indexing pipeline (no Docling/LLM needed).
+        """
+        self.logger.info(
+            f"🚀 Starting JSON document processing for record: {recordName}"
+        )
+
+        try:
+            if isinstance(json_binary, bytes):
+                json_content = json_binary.decode("utf-8")
+            else:
+                json_content = json_binary
+
+            if not json_content or json_content.strip() == "":
+                await self._mark_record(recordId, ProgressStatus.EMPTY)
+                self.logger.info("✅ JSON processing completed (empty document).")
+                yield PipelineEvent(event=IndexingEvent.PARSING_COMPLETE, data=PipelineEventData(record_id=recordId))
+                yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=recordId))
+                return
+
+            parser = self.parsers[ExtensionTypes.JSON.value]
+            block_containers = parser.parse(json_content)
+
+            # Phase 1: Parsing complete (pure, no LLM)
+            yield PipelineEvent(event=IndexingEvent.PARSING_COMPLETE, data=PipelineEventData(record_id=recordId))
+
+            record = await self.graph_provider.get_document(
+                recordId, CollectionNames.RECORDS.value
+            )
+            if record is None:
+                self.logger.error(f"❌ Record {recordId} not found in database")
+                yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=recordId))
+                return
+            record = convert_record_dict_to_record(record)
+            record.block_containers = block_containers
+            record.virtual_record_id = virtual_record_id
+
+            # Phase 2: Index
+            ctx = self._create_transform_context(record, event_type, prev_virtual_record_id)
+            pipeline = IndexingPipeline(document_extraction=self.document_extraction, sink_orchestrator=self.sink_orchestrator)
+            await pipeline.apply(ctx)
+
+            yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=recordId))
+
+            self.logger.info("✅ JSON processing completed successfully")
+            return
+        except Exception as e:
+            self.logger.error(f"❌ Error processing JSON document: {str(e)}")
+            raise
+
     async def process_txt_document(
         self, recordName, recordId, version, source, orgId, txt_binary, virtual_record_id, recordType, connectorName, origin, event_type: Optional[str] = None, prev_virtual_record_id: Optional[str] = None
     ) -> AsyncGenerator[Dict[str, Any], None]:

--- a/backend/python/app/events/processor.py
+++ b/backend/python/app/events/processor.py
@@ -1776,7 +1776,13 @@ class Processor:
             raise
 
     async def process_json_document(
-        self, recordName, recordId, json_binary, virtual_record_id, event_type: Optional[str] = None, prev_virtual_record_id: Optional[str] = None
+        self,
+        recordName: str,
+        recordId: str,
+        json_binary: bytes | str,
+        virtual_record_id: str,
+        event_type: Optional[str] = None,
+        prev_virtual_record_id: Optional[str] = None,
     ) -> AsyncGenerator[Dict[str, Any], None]:
         """Process JSON document, yielding phase completion events.
 

--- a/backend/python/app/modules/parsers/json/json_parser.py
+++ b/backend/python/app/modules/parsers/json/json_parser.py
@@ -1,0 +1,88 @@
+"""Parser for JSON documents.
+
+JSON is structured text rather than a spreadsheet or a rich document, so this
+parser flattens arbitrary JSON into readable ``key.path: value`` TEXT blocks
+(the same block shape the markdown parser emits). This keeps JSON records
+searchable/indexable without depending on Docling or an LLM.
+"""
+
+import json
+from typing import Any, List, Tuple, Union
+from uuid import uuid4
+
+from app.models.blocks import (
+    Block,
+    BlocksContainer,
+    BlockSubType,
+    BlockType,
+    DataFormat,
+)
+
+
+class JSONParser:
+    """Flatten arbitrary JSON into readable TEXT blocks (key path + value)."""
+
+    def parse(self, content: Union[str, bytes]) -> BlocksContainer:
+        """Parse JSON text/bytes into a BlocksContainer of TEXT blocks.
+
+        Raises:
+            json.JSONDecodeError: if the content is not valid JSON.
+        """
+        if isinstance(content, bytes):
+            content = content.decode("utf-8")
+
+        data = json.loads(content)
+
+        blocks: List[Block] = []
+        for path, value in self._flatten(data):
+            text = f"{path}: {self._render(value)}" if path else self._render(value)
+            blocks.append(
+                Block(
+                    id=str(uuid4()),
+                    index=len(blocks),
+                    type=BlockType.TEXT,
+                    sub_type=BlockSubType.PARAGRAPH,
+                    format=DataFormat.TXT,
+                    data=text,
+                    parent_index=None,
+                )
+            )
+
+        return BlocksContainer(blocks=blocks, block_groups=[])
+
+    @staticmethod
+    def _render(value: Any) -> str:
+        """Render a JSON leaf value as a human-readable string."""
+        if value is None:
+            return "null"
+        if isinstance(value, bool):
+            return "true" if value else "false"
+        return str(value)
+
+    def _flatten(self, obj: Any, prefix: str = "") -> List[Tuple[str, Any]]:
+        """Flatten nested JSON into (dotted_path, leaf_value) pairs.
+
+        - dict  -> ``prefix.key``
+        - list  -> ``prefix[i]``
+        - empty containers keep a leaf so their presence is still indexed.
+        """
+        out: List[Tuple[str, Any]] = []
+
+        if isinstance(obj, dict):
+            if not obj:
+                out.append((prefix, "{}"))
+                return out
+            for key, value in obj.items():
+                child = f"{prefix}.{key}" if prefix else str(key)
+                out.extend(self._flatten(value, child))
+        elif isinstance(obj, list):
+            if not obj:
+                out.append((prefix, "[]"))
+                return out
+            for i, value in enumerate(obj):
+                child = f"{prefix}[{i}]"
+                out.extend(self._flatten(value, child))
+        else:
+            out.append((prefix, obj))
+
+        return out

--- a/backend/python/tests/unit/modules/parsers/test_json_parser.py
+++ b/backend/python/tests/unit/modules/parsers/test_json_parser.py
@@ -1,0 +1,73 @@
+"""Unit tests for app.modules.parsers.json.json_parser.JSONParser."""
+
+import json
+
+import pytest
+
+from app.models.blocks import BlocksContainer, BlockSubType, BlockType, DataFormat
+from app.modules.parsers.json.json_parser import JSONParser
+
+
+@pytest.fixture
+def parser():
+    return JSONParser()
+
+
+class TestParse:
+    def test_returns_blocks_container(self, parser):
+        result = parser.parse('{"a": 1}')
+        assert isinstance(result, BlocksContainer)
+
+    def test_flat_object(self, parser):
+        result = parser.parse('{"name": "Alice", "age": 30}')
+        texts = [b.data for b in result.blocks]
+        assert "name: Alice" in texts
+        assert "age: 30" in texts
+
+    def test_nested_object_dotted_path(self, parser):
+        result = parser.parse('{"user": {"address": {"city": "NYC"}}}')
+        assert "user.address.city: NYC" in [b.data for b in result.blocks]
+
+    def test_array_indexed_path(self, parser):
+        result = parser.parse('{"items": [{"name": "foo"}, {"name": "bar"}]}')
+        texts = [b.data for b in result.blocks]
+        assert "items[0].name: foo" in texts
+        assert "items[1].name: bar" in texts
+
+    def test_top_level_array(self, parser):
+        result = parser.parse('["a", "b"]')
+        texts = [b.data for b in result.blocks]
+        assert "[0]: a" in texts
+        assert "[1]: b" in texts
+
+    def test_accepts_bytes(self, parser):
+        result = parser.parse(b'{"k": "v"}')
+        assert "k: v" in [b.data for b in result.blocks]
+
+    def test_primitive_rendering(self, parser):
+        result = parser.parse('{"b": true, "n": null, "f": 1.5}')
+        texts = [b.data for b in result.blocks]
+        assert "b: true" in texts
+        assert "n: null" in texts
+        assert "f: 1.5" in texts
+
+    def test_empty_containers_keep_a_leaf(self, parser):
+        result = parser.parse('{"obj": {}, "arr": []}')
+        texts = [b.data for b in result.blocks]
+        assert "obj: {}" in texts
+        assert "arr: []" in texts
+
+    def test_block_type_and_format(self, parser):
+        result = parser.parse('{"k": "v"}')
+        block = result.blocks[0]
+        assert block.type == BlockType.TEXT
+        assert block.sub_type == BlockSubType.PARAGRAPH
+        assert block.format == DataFormat.TXT
+
+    def test_block_indices_sequential(self, parser):
+        result = parser.parse('{"a": 1, "b": 2, "c": 3}')
+        assert [b.index for b in result.blocks] == list(range(len(result.blocks)))
+
+    def test_invalid_json_raises(self, parser):
+        with pytest.raises(json.JSONDecodeError):
+            parser.parse("{not valid json}")


### PR DESCRIPTION
## What

Adds support for indexing **`.json`** documents.

Closes #587

## Why

JSON files couldn't be indexed. The extension-routing chain in `events.py` had no JSON branch, so a `.json` record fell through to:

```python
raise Exception(f"Unsupported file extension: {extension}")
```

…even though `MimeTypes.JSON` (`application/json`) and `DataFormat.JSON` already existed in the codebase — the routing/parser was simply never wired up.

## Approach

JSON is structured text rather than a spreadsheet or a rich document, so the parser flattens arbitrary JSON into readable `key.path: value` **TEXT** blocks (the same block shape the markdown parser emits). This keeps it **pure** — no Docling, no LLM calls — so JSON indexes like other text content.

- nested objects → dotted paths (`user.address.city: NYC`)
- arrays → indexed paths (`items[0].name: foo`)
- primitives rendered readably (`null`, `true`/`false`)
- empty `{}`/`[]` kept as leaves so their presence is still indexed

## Changes (follows the existing parser pattern)

- **`app/modules/parsers/json/json_parser.py`** (new) — `JSONParser.parse(str|bytes) -> BlocksContainer`.
- **`arangodb.py`** — add `ExtensionTypes.JSON = "json"` (`MimeTypes.JSON` already exists).
- **`containers/utils/utils.py`** — register `JSONParser()` in `create_parsers()`.
- **`events/processor.py`** — `process_json_document()` handler: decode → parse → `PARSING_COMPLETE` → indexing pipeline → `INDEXING_COMPLETE`, with an empty-document short-circuit (mirrors `process_md_document`).
- **`events/events.py`** — a `.json` branch in the routing chain.

## Testing

```
pytest backend/python/tests/unit/modules/parsers/test_json_parser.py
11 passed
```

Unit tests cover flat/nested/array JSON, top-level arrays, primitives, bytes input, empty containers, block type/format, sequential indices, and invalid-JSON raising.

> **Verification note:** I unit-tested the parser in isolation and syntax-checked all the wired files, but I was not able to run the full indexing pipeline locally (it needs ArangoDB/Kafka/Qdrant + an LLM). The wiring mirrors the existing CSV/MD/TXT parsers exactly — please give the `processor.py`/`events.py` hookup a review. The issue was a stub, so if maintainers prefer a different JSON representation (e.g. preserving structure as key-value groups rather than flattened text), I'm happy to adjust.