### PR TITLE
fix(deployment): stabilize MongoDB failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,3 +151,34 @@ jobs:
           else
             echo "No Python files changed in backend/python, skipping pyright."
           fi
+
+  validate-docker-compose:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check changed deployment files
+        id: changes
+        run: |
+          git fetch origin main
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+          CHANGED_FILES=$(git diff --diff-filter=d --name-only "$MERGE_BASE" -- \
+            'deployment/docker-compose/**' \
+            '.github/workflows/main.yml' || true)
+
+          if [ -n "$CHANGED_FILES" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Docker Compose validation will run for:"
+            echo "$CHANGED_FILES"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No Docker Compose deployment files changed, skipping validation."
+          fi
+
+      - name: Validate MongoDB compose stability settings
+        if: steps.changes.outputs.changed == 'true'
+        run: bash deployment/docker-compose/tests/mongodb_stability_test.sh

--- a/deployment/docker-compose/docker-compose.build.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.build.neo4j.yml
@@ -186,11 +186,14 @@ services:
       start_period: 300s
 
   mongodb:
-    image: mongo:8.0.17
+    image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     restart: always
+    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.build.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.build.neo4j.yml
@@ -193,7 +193,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
-      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=0}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.build.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.build.neo4j.yml
@@ -188,7 +188,8 @@ services:
   mongodb:
     image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     restart: always
-    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    # Shared 16 GB-class quickstart hosts need MongoDB bounded: 1 GB cache
+    # leaves room for the app, graph DB, vector DB, Redis, and broker services.
     command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -171,7 +171,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
-      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=0}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -162,13 +162,16 @@ services:
       - "host.docker.internal:host-gateway"
 
   mongodb:
-    image: mongo:8.0.17
+    image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     restart: always
+    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     ports:
       - "27017:27017"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -164,7 +164,8 @@ services:
   mongodb:
     image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     restart: always
-    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    # Shared 16 GB-class quickstart hosts need MongoDB bounded: 1 GB cache
+    # leaves room for the app, graph DB, vector DB, Redis, and broker services.
     command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     ports:
       - "27017:27017"

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -156,13 +156,16 @@ services:
       - "host.docker.internal:host-gateway"
 
   mongodb:
-    image: mongo:8.0.17
+    image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     restart: always
+    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     ports:
       - "27017:27017"
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -158,7 +158,8 @@ services:
   mongodb:
     image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     restart: always
-    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    # Shared 16 GB-class quickstart hosts need MongoDB bounded: 1 GB cache
+    # leaves room for the app, graph DB, vector DB, Redis, and broker services.
     command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     ports:
       - "27017:27017"

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -165,7 +165,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
-      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=0}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.prod.yml
+++ b/deployment/docker-compose/docker-compose.prod.yml
@@ -170,7 +170,8 @@ services:
     image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     container_name: mongodb
     restart: always
-    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    # Shared 16 GB-class quickstart hosts need MongoDB bounded: 1 GB cache
+    # leaves room for the app, graph DB, vector DB, Redis, and broker services.
     command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}

--- a/deployment/docker-compose/docker-compose.prod.yml
+++ b/deployment/docker-compose/docker-compose.prod.yml
@@ -167,12 +167,15 @@ services:
       start_period: 300s
 
   mongodb:
-    image: mongo:8.0.17
+    image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     container_name: mongodb
     restart: always
+    # Keep MongoDB from reserving half the host RAM and allow the rseq workaround.
+    command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.prod.yml
+++ b/deployment/docker-compose/docker-compose.prod.yml
@@ -175,7 +175,7 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-password}
-      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=0}
     volumes:
       - mongodb_data:/data/db
     healthcheck:

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -237,8 +237,10 @@ services:
     image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     container_name: mongodb
     restart: always
-    # WiredTiger otherwise reserves roughly half of host RAM, which can OOM-loop
-    # small Docker hosts running the full stack.
+    # Quickstart targets a 16 GB-class shared Docker host running MongoDB beside
+    # the app, Qdrant, graph DB, Redis, and optional broker services. WiredTiger
+    # otherwise reserves roughly half of host RAM; cap cache at 1 GB by default
+    # and keep the container limit at 2 GB to leave room for process overhead.
     command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -233,16 +233,29 @@ services:
   # ---------------------------------------------------------------------------
 
   mongodb:
-    image: mongo:8.0.17
+    # Pin via MONGO_IMAGE_TAG to recover from host-specific MongoDB 8.x crashes.
+    image: mongo:${MONGO_IMAGE_TAG:-8.0.17}
     container_name: mongodb
     restart: always
+    # WiredTiger otherwise reserves roughly half of host RAM, which can OOM-loop
+    # small Docker hosts running the full stack.
+    command: ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", "${MONGO_CACHE_GB:-1}"]
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-}
+      # Empty by default overrides the official image's rseq=0 setting; set
+      # MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 if MongoDB exits 139 on newer kernels.
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
     volumes:
       - mongodb_data:/data/db
     networks:
       - pipeshub
+    deploy:
+      resources:
+        limits:
+          memory: ${MONGO_MEMORY_LIMIT:-2G}
+        reservations:
+          memory: 512M
     healthcheck:
       test: ["CMD", "mongosh", "--eval", "db.adminCommand('ping')"]
       interval: 5s

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -243,9 +243,9 @@ services:
     environment:
       - MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME:-admin}
       - MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD:-}
-      # Empty by default overrides the official image's rseq=0 setting; set
+      # Keep the official image's rseq=0 default for TCMalloc performance; set
       # MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 if MongoDB exits 139 on newer kernels.
-      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-}
+      - GLIBC_TUNABLES=${MONGO_GLIBC_TUNABLES:-glibc.pthread.rseq=0}
     volumes:
       - mongodb_data:/data/db
     networks:

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -27,6 +27,11 @@ MONGO_PASSWORD=your_mongodb_password
 # Fallback only: pin an older image. MongoDB 8.x data is not readable by 7.x,
 # so wipe the mongo volume before downgrading.
 # MONGO_IMAGE_TAG=8.0.17
+#
+# MongoDB resource limits. Increase these on larger dedicated hosts if MongoDB
+# needs more cache for your workload.
+# MONGO_CACHE_GB=1
+# MONGO_MEMORY_LIMIT=2G
 
 QDRANT_API_KEY=your_qdrant_api_key
 

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -28,8 +28,12 @@ MONGO_PASSWORD=your_mongodb_password
 # so wipe the mongo volume before downgrading.
 # MONGO_IMAGE_TAG=8.0.17
 #
-# MongoDB resource limits. Increase these on larger dedicated hosts if MongoDB
-# needs more cache for your workload.
+# MongoDB resource limits. Defaults target the quickstart minimum: a 16 GB-class
+# shared Docker host running MongoDB alongside the app, Qdrant, graph DB, Redis,
+# and optional broker services. WiredTiger's upstream default can reserve several
+# GB on such hosts, so the default cache is capped at 1 GB and the container gets
+# 2 GB to leave room for process overhead. Increase both on larger/dedicated
+# hosts; avoid decreasing below 1 GB unless this is a very small dev workload.
 # MONGO_CACHE_GB=1
 # MONGO_MEMORY_LIMIT=2G
 

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -21,6 +21,12 @@ REDIS_PASSWORD=
 
 MONGO_USERNAME=admin
 MONGO_PASSWORD=your_mongodb_password
+# If MongoDB crash-loops with a segfault (exit 139) on a newer host kernel,
+# try the rseq tunable first so the supported MongoDB version can stay pinned.
+# MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1
+# Fallback only: pin an older image. MongoDB 8.x data is not readable by 7.x,
+# so wipe the mongo volume before downgrading.
+# MONGO_IMAGE_TAG=8.0.17
 
 QDRANT_API_KEY=your_qdrant_api_key
 

--- a/deployment/docker-compose/tests/mongodb_stability_test.sh
+++ b/deployment/docker-compose/tests/mongodb_stability_test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+COMPOSE_DIR="$ROOT_DIR/deployment/docker-compose"
+ENV_FILE="$COMPOSE_DIR/env.template"
+
+COMPOSE_FILES=(
+  docker-compose.yml
+  docker-compose.build.neo4j.yml
+  docker-compose.integration.arango.yml
+  docker-compose.integration.neo4j.yml
+  docker-compose.prod.yml
+)
+
+render_compose() {
+  local compose_file="$1"
+  local output_file="$2"
+
+  docker compose \
+    -f "$COMPOSE_DIR/$compose_file" \
+    --env-file "$ENV_FILE" \
+    config --format json > "$output_file"
+}
+
+assert_mongo_config() {
+  local rendered_file="$1"
+  local compose_file="$2"
+  local expected_image="$3"
+  local expected_cache_gb="$4"
+  local expected_tunables="$5"
+  local expected_memory_bytes="${6:-}"
+
+  python3 - "$rendered_file" "$compose_file" "$expected_image" "$expected_cache_gb" "$expected_tunables" "$expected_memory_bytes" <<'PY'
+import json
+import sys
+
+rendered_file, compose_file, expected_image, expected_cache_gb, expected_tunables, expected_memory_bytes = sys.argv[1:]
+
+with open(rendered_file, "r", encoding="utf-8") as fh:
+    data = json.load(fh)
+
+mongo = data["services"]["mongodb"]
+command = mongo.get("command") or []
+environment = mongo.get("environment") or {}
+
+checks = [
+    (mongo.get("image") == expected_image, f"{compose_file}: expected image {expected_image}, got {mongo.get('image')!r}"),
+    (command == ["mongod", "--bind_ip_all", "--wiredTigerCacheSizeGB", expected_cache_gb], f"{compose_file}: unexpected MongoDB command {command!r}"),
+    (environment.get("GLIBC_TUNABLES", "") == expected_tunables, f"{compose_file}: expected GLIBC_TUNABLES={expected_tunables!r}, got {environment.get('GLIBC_TUNABLES')!r}"),
+]
+
+if expected_memory_bytes:
+    memory = str(mongo.get("deploy", {}).get("resources", {}).get("limits", {}).get("memory", ""))
+    checks.append((memory == expected_memory_bytes, f"{compose_file}: expected memory limit {expected_memory_bytes}, got {memory!r}"))
+
+for passed, message in checks:
+    if not passed:
+        raise SystemExit(f"FAIL: {message}")
+PY
+}
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+for compose_file in "${COMPOSE_FILES[@]}"; do
+  rendered="$tmp_dir/${compose_file}.default.json"
+  render_compose "$compose_file" "$rendered"
+  assert_mongo_config "$rendered" "$compose_file" "mongo:8.0.17" "1" ""
+done
+
+override_rendered="$tmp_dir/docker-compose.override.json"
+MONGO_IMAGE_TAG=7.0 \
+MONGO_CACHE_GB=2 \
+MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 \
+MONGO_MEMORY_LIMIT=3G \
+  render_compose docker-compose.yml "$override_rendered"
+
+assert_mongo_config "$override_rendered" "docker-compose.yml" "mongo:7.0" "2" "glibc.pthread.rseq=1" "3221225472"
+
+printf 'MongoDB compose stability tests passed.\n'

--- a/deployment/docker-compose/tests/mongodb_stability_test.sh
+++ b/deployment/docker-compose/tests/mongodb_stability_test.sh
@@ -66,7 +66,7 @@ trap 'rm -rf "$tmp_dir"' EXIT
 for compose_file in "${COMPOSE_FILES[@]}"; do
   rendered="$tmp_dir/${compose_file}.default.json"
   render_compose "$compose_file" "$rendered"
-  assert_mongo_config "$rendered" "$compose_file" "mongo:8.0.17" "1" ""
+  assert_mongo_config "$rendered" "$compose_file" "mongo:8.0.17" "1" "glibc.pthread.rseq=0"
 done
 
 override_rendered="$tmp_dir/docker-compose.override.json"


### PR DESCRIPTION
## Summary

This is a focused MongoDB deployment stability bugfix.

On smaller Docker hosts, MongoDB's WiredTiger engine can reserve a large share of available memory by default. In the full PipesHub compose stack, that can push MongoDB into an OOM crash loop and then the services depending on MongoDB never become healthy.

There is also a separate host-specific failure mode where MongoDB 8.x can exit with `139` on newer kernels because of a glibc rseq/tcmalloc interaction.

## What Changed

- Cap MongoDB's WiredTiger cache with `MONGO_CACHE_GB` defaulting to `1` GB.
- Add a default MongoDB memory limit of `2G` in the main compose file so MongoDB cannot consume the whole Docker host.
- Keep the MongoDB image tag overridable through `MONGO_IMAGE_TAG` for recovery cases.
- Preserve the official MongoDB image default `glibc.pthread.rseq=0` for normal hosts, while allowing affected hosts to set `MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1` without editing compose files.
- Apply the same MongoDB runtime settings to the default, build-from-source, production, and integration compose entrypoints.
- Document the recovery and resource knobs in `env.template`.
- Wire the MongoDB compose regression test into PR validations when Docker Compose deployment files change.

## Why These Defaults

The defaults are based on the quickstart/self-hosted target: a 16 GB-class shared Docker host running MongoDB alongside the PipesHub app, Qdrant, graph DB, Redis, and optional broker services.

MongoDB WiredTiger's upstream default can reserve several GB on that kind of host because it sizes cache from available memory. That behavior is good for a dedicated MongoDB box, but risky for this compose stack because the other services need the same RAM. The `1` GB cache cap prevents MongoDB from taking a disproportionate share of memory, and the `2G` container limit leaves extra room for MongoDB process overhead, connections, journaling, and spikes above the cache.

These are stability-first defaults, not maximum-performance MongoDB tuning. On larger or dedicated hosts, raise `MONGO_CACHE_GB` and `MONGO_MEMORY_LIMIT` together. Avoid decreasing below `1` GB cache unless this is a very small dev workload.

## Performance Notes

The new defaults intentionally favor small-host stability. On larger dedicated hosts, the `1` GB WiredTiger cache cap can reduce MongoDB cache hit rate for very large or Mongo-heavy workloads. The setting is overridable with `MONGO_CACHE_GB`, and the main compose memory limit is overridable with `MONGO_MEMORY_LIMIT`.

For the expected quickstart/self-hosted profile, this is a reasonable tradeoff because PipesHub also runs the app, vector DB, graph DB, Redis, and optional broker services on the same machine. Capable hosts can raise the limits without editing compose.

## Automated Tests

- [x] CI: `.github/workflows/main.yml` now has a `validate-docker-compose` job in `PR Validations`.
  - It runs automatically on PRs when `deployment/docker-compose/**` or `.github/workflows/main.yml` changes.
  - It executes `bash deployment/docker-compose/tests/mongodb_stability_test.sh`.
  - It skips unrelated PRs so normal backend/frontend changes do not pay for compose validation.
- [x] Unit-style config test: `bash deployment/docker-compose/tests/mongodb_stability_test.sh`
  - Renders all affected compose files as JSON.
  - Asserts MongoDB defaults to `mongo:8.0.17`.
  - Asserts the WiredTiger cache cap is present and defaults to `1` GB.
  - Asserts `GLIBC_TUNABLES` defaults to `glibc.pthread.rseq=0` and remains overridable.
  - Asserts `MONGO_IMAGE_TAG`, `MONGO_CACHE_GB`, `MONGO_GLIBC_TUNABLES`, and `MONGO_MEMORY_LIMIT` overrides render correctly.
- [x] Integration/config validation:
  - `docker compose -f deployment/docker-compose/docker-compose.yml --env-file deployment/docker-compose/env.template config --quiet`
  - `docker compose -f deployment/docker-compose/docker-compose.build.neo4j.yml --env-file deployment/docker-compose/env.template config --quiet`
  - `docker compose -f deployment/docker-compose/docker-compose.integration.arango.yml --env-file deployment/docker-compose/env.template config --quiet`
  - `docker compose -f deployment/docker-compose/docker-compose.integration.neo4j.yml --env-file deployment/docker-compose/env.template config --quiet`
  - `docker compose -f deployment/docker-compose/docker-compose.prod.yml --env-file deployment/docker-compose/env.template config --quiet`

## Manual Tests Recommended

- [ ] On a smaller host or Docker Desktop VM, start the default compose stack and confirm MongoDB remains healthy instead of entering an OOM restart loop.
- [ ] On a host that reproduces MongoDB `exit 139`, set `MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1` in `.env`, restart MongoDB, and confirm it stays healthy.
- [ ] On a larger host, optionally raise `MONGO_CACHE_GB` and `MONGO_MEMORY_LIMIT`, then run `docker compose config` before restarting to verify the intended values render.
- [ ] If using the fallback image pin, set `MONGO_IMAGE_TAG` intentionally and verify the rendered compose config uses that tag before starting. Do not downgrade an existing MongoDB 8.x data volume to 7.x without wiping the volume.