### PR TITLE
ACK Redis messages after terminal indexing failures

### DIFF
--- a/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
+++ b/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
@@ -522,6 +522,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
     ) -> bool:
         parsing_held = False
         indexing_held = False
+        handler_invoked = False
 
         if not self.parsing_semaphore or not self.indexing_semaphore:
             self.logger.error("Semaphores not initialized for %s", message_id)
@@ -548,6 +549,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                 return False
 
             if self.message_handler:
+                handler_invoked = True
                 # Carry the producer's trace id into indexing logs.
                 ctx = context_from_envelope({"requestId": parsed_message.requestId})
                 token = set_context(ctx.root_id)
@@ -569,8 +571,6 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                             indexing_held = False
                 finally:
                     reset_context(token)
-
-                await self._ack_message(stream_name, message_id)
             else:
                 self.logger.error("No message handler available for %s", message_id)
                 return False
@@ -587,3 +587,8 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                 self.parsing_semaphore.release()
             if indexing_held and self.indexing_semaphore:
                 self.indexing_semaphore.release()
+            # Terminal indexing failures re-raise after persisting FAILED status.
+            # ACK anyway so the message leaves the PEL and is not redelivered on
+            # every indexing restart (Redis PEL zombie retry).
+            if handler_invoked:
+                await self._ack_message(stream_name, message_id)

--- a/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
+++ b/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
@@ -591,4 +591,11 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
             # ACK anyway so the message leaves the PEL and is not redelivered on
             # every indexing restart (Redis PEL zombie retry).
             if handler_invoked:
-                await self._ack_message(stream_name, message_id)
+                try:
+                    await self._ack_message(stream_name, message_id)
+                except Exception as e:
+                    self.logger.error(
+                        "Failed to ACK message %s in finally block: %s",
+                        message_id,
+                        e,
+                    )

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -825,22 +825,66 @@ class TestProcessMessageWrapper:
     async def test_handler_exception_releases_semaphores(self, consumer):
         consumer.parsing_semaphore = asyncio.Semaphore(1)
         consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        mock_main_loop = MagicMock()
+        mock_main_loop.is_running.return_value = True
+        consumer.main_loop = mock_main_loop
 
         async def handler(msg):
             raise RuntimeError("handler exploded")
             yield  # noqa: unreachable
 
         consumer.message_handler = handler
-        result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
+        ack_future = Future()
+        ack_future.set_result(1)
+        with patch("asyncio.run_coroutine_threadsafe", return_value=ack_future):
+            result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
         assert result is False
         assert consumer.parsing_semaphore._value == 1
         assert consumer.indexing_semaphore._value == 1
+        consumer.redis.xack.assert_called_once_with(
+            "s", consumer.config.group_id, "1-0"
+        )
+
+    @pytest.mark.asyncio
+    async def test_handler_terminal_failure_is_acked(self, consumer):
+        """Regression: handler exceptions must XACK so failed jobs leave the PEL."""
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        mock_main_loop = MagicMock()
+        mock_main_loop.is_running.return_value = True
+        consumer.main_loop = mock_main_loop
+
+        async def handler(msg):
+            raise RuntimeError("indexing failed after status update")
+            yield  # noqa: unreachable
+
+        consumer.message_handler = handler
+
+        ack_future = Future()
+        ack_future.set_result(1)
+        with patch("asyncio.run_coroutine_threadsafe", return_value=ack_future):
+            result = await consumer._process_message_wrapper(
+                "record-events", "99-1", _valid_fields()
+            )
+
+        assert result is False
+        consumer.redis.xack.assert_called_once_with(
+            "record-events", consumer.config.group_id, "99-1"
+        )
 
     @pytest.mark.asyncio
     async def test_handler_exception_after_parsing_released(self, consumer):
         """Handler raises after yielding PARSING_COMPLETE. Only indexing released in finally."""
         consumer.parsing_semaphore = asyncio.Semaphore(1)
         consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        mock_main_loop = MagicMock()
+        mock_main_loop.is_running.return_value = True
+        consumer.main_loop = mock_main_loop
 
         async def handler(msg):
             yield PipelineEvent(
@@ -850,10 +894,18 @@ class TestProcessMessageWrapper:
             raise RuntimeError("late boom")
 
         consumer.message_handler = handler
-        result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
+        ack_future = Future()
+        ack_future.set_result(1)
+        with patch("asyncio.run_coroutine_threadsafe", return_value=ack_future):
+            result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
         assert result is False
         assert consumer.parsing_semaphore._value == 1
         assert consumer.indexing_semaphore._value == 1
+        consumer.redis.xack.assert_called_once_with(
+            "s", consumer.config.group_id, "1-0"
+        )
 
     @pytest.mark.asyncio
     async def test_xack_timeout_logged(self, consumer):

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -13,7 +13,8 @@ Covers:
 - _parse_message(): valid JSON, double-encoded, missing value field, invalid JSON
 - _start_processing_task(): no worker loop, not running, future tracking/callback
 - _process_message_wrapper(): semaphore acquire/release, handler iteration with
-  PipelineEvent, xack via main_loop, parse failure, no handler, exception
+  PipelineEvent, xack via main_loop, parse failure, no handler, exception,
+  terminal-failure PEL ACK regression suite
 - cleanup(): stops worker, closes redis, handles errors
 - is_running()
 - _get_active_task_count()
@@ -700,20 +701,35 @@ class TestProcessMessageWrapper:
     async def test_no_semaphores_returns_false(self, consumer):
         consumer.parsing_semaphore = None
         consumer.indexing_semaphore = None
+        consumer.redis = AsyncMock()
         result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
         assert result is False
+        consumer.redis.xack.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_parse_failure_returns_false(self, consumer):
         consumer.parsing_semaphore = asyncio.Semaphore(1)
         consumer.indexing_semaphore = asyncio.Semaphore(1)
-        result = await consumer._process_message_wrapper(
-            "s", "1-0", {"value": "not-json"}
-        )
+        consumer.redis = AsyncMock()
+        mock_main_loop = MagicMock()
+        mock_main_loop.is_running.return_value = True
+        consumer.main_loop = mock_main_loop
+
+        ack_future = Future()
+        ack_future.set_result(1)
+        with patch("asyncio.run_coroutine_threadsafe", return_value=ack_future):
+            result = await consumer._process_message_wrapper(
+                "s", "1-0", {"value": "not-json"}
+            )
+
         assert result is False
         # Semaphores released in finally
         assert consumer.parsing_semaphore._value == 1
         assert consumer.indexing_semaphore._value == 1
+        # Poison path ACKs once; handler_invoked stays False so no second ACK.
+        consumer.redis.xack.assert_called_once_with(
+            "s", consumer.config.group_id, "1-0"
+        )
 
     @pytest.mark.asyncio
     async def test_no_handler_returns_false(self, consumer):
@@ -762,6 +778,9 @@ class TestProcessMessageWrapper:
         assert result is True
         assert consumer.parsing_semaphore._value == 1
         assert consumer.indexing_semaphore._value == 1
+        consumer.redis.xack.assert_called_once_with(
+            "stream-a", consumer.config.group_id, "1-0"
+        )
 
     @pytest.mark.asyncio
     async def test_only_parsing_complete_released(self, consumer):
@@ -899,6 +918,57 @@ class TestProcessMessageWrapper:
             result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
 
         assert result is False
+        consumer._ack_message.assert_awaited_once_with("s", "1-0")
+
+    @pytest.mark.asyncio
+    async def test_ack_failure_in_finally_logs_error(self, consumer, caplog):
+        """ACK failure in finally is logged and does not raise."""
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+
+        async def handler(msg):
+            raise RuntimeError("indexing failed")
+            yield  # noqa: unreachable
+
+        consumer.message_handler = handler
+
+        with patch.object(
+            consumer,
+            "_ack_message",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("redis down"),
+        ):
+            with caplog.at_level(logging.ERROR):
+                result = await consumer._process_message_wrapper(
+                    "s", "1-0", _valid_fields()
+                )
+
+        assert result is False
+        assert "Failed to ACK message 1-0 in finally block" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_ack_failure_on_success_still_returns_true(self, consumer):
+        """Successful handler outcome must not be lost when ACK fails."""
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+
+        async def handler(msg):
+            yield PipelineEvent(
+                event=IndexingEvent.INDEXING_COMPLETE,
+                data=PipelineEventData(record_id="r1"),
+            )
+
+        consumer.message_handler = handler
+
+        with patch.object(
+            consumer,
+            "_ack_message",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("redis down"),
+        ):
+            result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
+        assert result is True
         consumer._ack_message.assert_awaited_once_with("s", "1-0")
 
     @pytest.mark.asyncio
@@ -1052,6 +1122,71 @@ class TestProcessMessageWrapper:
         # Semaphores still released in finally despite the early return.
         assert consumer.parsing_semaphore._value == 1
         assert consumer.indexing_semaphore._value == 1
+
+
+class TestPelZombieRetryRegression:
+    """Regression suite for FAILED-in-UI / Redis-still-pending (bug #4)."""
+
+    @pytest.mark.asyncio
+    async def test_handler_completes_without_events_still_acks(self, consumer):
+        """Early handler return (no exception) still removes message from PEL."""
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        mock_main_loop = MagicMock()
+        mock_main_loop.is_running.return_value = True
+        consumer.main_loop = mock_main_loop
+
+        async def handler(msg):
+            if False:
+                yield PipelineEvent(
+                    event=IndexingEvent.INDEXING_COMPLETE,
+                    data=PipelineEventData(record_id="r1"),
+                )
+
+        consumer.message_handler = handler
+
+        ack_future = Future()
+        ack_future.set_result(1)
+        with patch("asyncio.run_coroutine_threadsafe", return_value=ack_future):
+            result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
+        assert result is True
+        consumer.redis.xack.assert_called_once_with(
+            "s", consumer.config.group_id, "1-0"
+        )
+
+    @pytest.mark.asyncio
+    async def test_redelivered_pel_message_acked_after_terminal_failure(
+        self, consumer
+    ):
+        """PEL redelivery on restart: terminal failure must ACK so no zombie retry."""
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        mock_main_loop = MagicMock()
+        mock_main_loop.is_running.return_value = True
+        consumer.main_loop = mock_main_loop
+
+        async def handler(msg):
+            raise RuntimeError("rate limit 429")
+            yield  # noqa: unreachable
+
+        consumer.message_handler = handler
+
+        ack_future = Future()
+        ack_future.set_result(1)
+        with patch("asyncio.run_coroutine_threadsafe", return_value=ack_future):
+            result = await consumer._process_message_wrapper(
+                "record-events",
+                "pel-redelivery-1",
+                _valid_fields("newRecord", {"recordId": "deadbeef"}),
+            )
+
+        assert result is False
+        consumer.redis.xack.assert_called_once_with(
+            "record-events", consumer.config.group_id, "pel-redelivery-1"
+        )
 
 
 # ===================================================================

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -879,6 +879,29 @@ class TestProcessMessageWrapper:
         )
 
     @pytest.mark.asyncio
+    async def test_ack_failure_in_finally_does_not_mask_handler_error(self, consumer):
+        """Redis ACK errors in finally must be logged without masking handler failure."""
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+
+        async def handler(msg):
+            raise RuntimeError("indexing failed")
+            yield  # noqa: unreachable
+
+        consumer.message_handler = handler
+
+        with patch.object(
+            consumer,
+            "_ack_message",
+            new_callable=AsyncMock,
+            side_effect=ConnectionError("redis down"),
+        ):
+            result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
+
+        assert result is False
+        consumer._ack_message.assert_awaited_once_with("s", "1-0")
+
+    @pytest.mark.asyncio
     async def test_handler_exception_after_parsing_released(self, consumer):
         """Handler raises after yielding PARSING_COMPLETE. Only indexing released in finally."""
         consumer.parsing_semaphore = asyncio.Semaphore(1)

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -720,10 +720,12 @@ class TestProcessMessageWrapper:
         consumer.parsing_semaphore = asyncio.Semaphore(1)
         consumer.indexing_semaphore = asyncio.Semaphore(1)
         consumer.message_handler = None
+        consumer.redis = AsyncMock()
         result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
         assert result is False
         assert consumer.parsing_semaphore._value == 1
         assert consumer.indexing_semaphore._value == 1
+        consumer.redis.xack.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_successful_processing_with_xack(self, consumer):

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -914,11 +914,11 @@ class TestProcessMessageWrapper:
             "_ack_message",
             new_callable=AsyncMock,
             side_effect=ConnectionError("redis down"),
-        ):
+        ) as mock_ack:
             result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
 
         assert result is False
-        consumer._ack_message.assert_awaited_once_with("s", "1-0")
+        mock_ack.assert_awaited_once_with("s", "1-0")
 
     @pytest.mark.asyncio
     async def test_ack_failure_in_finally_logs_error(self, consumer, caplog):
@@ -965,11 +965,11 @@ class TestProcessMessageWrapper:
             "_ack_message",
             new_callable=AsyncMock,
             side_effect=ConnectionError("redis down"),
-        ):
+        ) as mock_ack:
             result = await consumer._process_message_wrapper("s", "1-0", _valid_fields())
 
         assert result is True
-        consumer._ack_message.assert_awaited_once_with("s", "1-0")
+        mock_ack.assert_awaited_once_with("s", "1-0")
 
     @pytest.mark.asyncio
     async def test_handler_exception_after_parsing_released(self, consumer):


### PR DESCRIPTION
## Problem in plain terms

When you upload a file, PipesHub uses **two separate systems** to track progress:

| System | Role | Analogy |
|--------|------|---------|
| **Neo4j + UI** | Stores the record’s indexing status (`IN_PROGRESS`, `COMPLETED`, `FAILED`) | The **status board** on the wall |
| **Redis Streams** | Queues the indexing job and tracks whether the worker has finished handling it | The **to-do slip** handed to the worker |

On a normal success, both agree: UI shows `COMPLETED`, and Redis marks the job as done.

On failure, they could disagree:

| System | What happened (before this PR) |
|--------|--------------------------------|
| **Neo4j / UI** | Record marked `FAILED` with an error reason |
| **Redis** | Job still listed as **not finished** → kept for retry |

So you could see **FAILED** in the UI while Redis quietly kept the same job on its queue. After an indexing restart, the worker picked it up again — causing duplicate OCR runs, extra API calls, and log noise — even though the file was already terminal.

---

## Glossary (short forms expanded)

- **Redis Streams** — Redis’s message queue. New indexing jobs are appended here (stream name: `record-events`).
- **Consumer group** — A set of indexing workers that share work from the stream (group name: `indexing-group`).
- **PEL (Pending Entries List)** — Redis’s “still waiting for confirmation” list. When a worker receives a message, Redis moves it here until the worker explicitly confirms it is done.
- **XACK / ACK (acknowledge)** — The Redis command that tells the queue: *“I am done with this message; remove it from the pending list.”* Without an ACK, Redis assumes the worker crashed mid-job and will **redeliver** the message later.

---

## Why did the Redis entry remain after the record had already failed?

Indexing failure is **not one atomic step**. The code does two separate things:

1. **Update the record status** (Neo4j) → UI shows `FAILED`
2. **Confirm the queue message is handled** (Redis XACK) → remove from pending list

Before this PR, step 1 always ran on failure, but step 2 only ran on **success**.

### What the code did on failure

1. Indexing runs and hits a terminal error (e.g. OpenAI rate limit 429, OCR page failure).
2. The record handler saves `indexingStatus: FAILED` and a `reason` in Neo4j (in its `finally` block).
3. The handler then **re-raises the exception** to signal failure upstream.
4. The Redis consumer catches that exception and returns without sending **XACK**.
5. Redis still thinks: *“This message was delivered but never confirmed — maybe the worker crashed. I should retry.”*

The UI is correct (`FAILED`). Redis is out of date (still pending). That mismatch is the bug.

### When does the stuck Redis entry actually cause trouble?

| Scenario | What you see |
|----------|--------------|
| **Indexing service restart** (most common) | On startup, the consumer drains the pending list and **redelivers** un-ACK’d messages. A record already `FAILED` in the UI gets OCR’d again. This is what we observed at 09:40 during a hot-patch restart. |
| **Worker crash / kill mid-job** | Same: message stays pending → redelivered on next start. *This retry behavior is correct for true crashes.* The bug is that **handled failures** were treated the same way. |
| **Long-running failure with no restart** | Message sits in the pending list in the background. UI shows `FAILED`; Redis still holds the entry until something redelivers it. |
| **Repeated restarts** | Each restart can re-trigger the same failed job until `MAX_DELIVERY_ATTEMPTS` dead-letters it (~10 tries) — wasting API quota each time. |

### What this is **not**

- **Not** the same as same-folder “already exists” upload blocking (that happens at upload time, different code path).
- **Not** MD5 duplicate queuing (that’s a separate indexing design).
- **Not** a user clicking “reindex” — that intentionally enqueues a **new** job.

---

## Root cause (code-level)

`IndexingRedisStreamsConsumer` only called **XACK** when the handler completed without throwing. Terminal indexing failures *do* throw after persisting `FAILED`, so the message was left in the **PEL**.

Poison/unparseable messages were already XACK’d (to stop infinite recovery loops). Handled indexing failures should have been treated the same way — this was an oversight, not intentional product behavior.

---

## Fix

**XACK the Redis message whenever the indexing handler was invoked** — whether it succeeded or failed with a persisted terminal outcome. That removes the message from the **pending list** so it is not redelivered on restart.

Messages where the handler **never ran** (e.g. no handler configured, semaphores not initialized) are still left un-ACK’d so they can retry — that preserves correct behavior for true startup/crash cases.

---

## Test coverage

All tests live in `test_redis_streams_indexing_consumer.py`.

### Core fix (terminal failure → ACK)

| Test | Verifies |
|------|----------|
| `test_handler_terminal_failure_is_acked` | Handler exception → XACK sent (main regression) |
| `test_handler_exception_releases_semaphores` | Exception path releases semaphores and still XACKs |
| `test_handler_exception_after_parsing_released` | Partial progress then failure → still XACKs |
| `test_redelivered_pel_message_acked_after_terminal_failure` | Simulates PEL redelivery on restart → ACK after failure |
| `test_handler_completes_without_events_still_acks` | Early handler return (no exception) → still ACKs |

### Paths that must **not** ACK (retry preserved)

| Test | Verifies |
|------|----------|
| `test_no_handler_does_not_ack` | Handler never configured → no XACK |
| `test_no_semaphores_returns_false` | Consumer not ready → no XACK |

### Success + poison paths (unchanged behavior)

| Test | Verifies |
|------|----------|
| `test_successful_processing_with_xack` | Success path ACKs exactly once in `finally` |
| `test_unparseable_message_is_acked` | Poison messages ACK once (no double-ACK via `handler_invoked`) |
| `test_parse_failure_returns_false` | Parse failure ACKs once on poison path only |

### ACK failure resilience (review feedback)

| Test | Verifies |
|------|----------|
| `test_ack_failure_in_finally_does_not_mask_handler_error` | Handler failure still returns `False` when ACK fails |
| `test_ack_failure_in_finally_logs_error` | ACK failure logged, not raised |
| `test_ack_failure_on_success_still_returns_true` | Handler success still returns `True` when ACK fails |

---

## Manual test plan

### Setup
- Single `pipeshub-ai` container with Redis Streams (default local compose)
- A PDF that will fail indexing (large scanned PDF + low OpenAI TPM, or temporarily invalid indexing LLM key)

### Test 1 — Failed job does not stay in Redis pending list
1. Upload a PDF that will fail indexing.
2. Wait until UI shows **`FAILED`**.
3. Check Redis pending list **before** restart:
   ```bash
   docker exec redis redis-cli XPENDING record-events indexing-group - + 10
   ```
   **Before this PR:** the failed message may still appear here.
4. Restart indexing only (not the whole container):
   ```bash
   docker exec pipeshub-ai bash -c 'kill $(pgrep -f "python -m app.indexing_main")'
   ```
   Wait ~30s for the process monitor to restart indexing.
5. Check logs — **after this PR:** no `Recovering own pending message` and no second `Processing N pages with VLM OCR` for the same failed record.
6. Re-check pending list:
   ```bash
   docker exec redis redis-cli XPENDING record-events indexing-group - + 10
   ```
   **Expected:** the failed job’s message is gone (or count unchanged if already drained).

### Test 2 — Success path unchanged
1. Upload a small PDF that indexes successfully.
2. Confirm `COMPLETED` in UI.
3. Restart indexing (same kill command).
4. **Expected:** no re-indexing / no duplicate OCR in logs.

### Test 3 — UI semantics unchanged
1. Re-use the failed record from Test 1 (or fail a new upload).
2. **Expected:** UI still shows `FAILED` with the original error reason. This PR only stops Redis from retrying; it does not change how failures are displayed.

---

## Out of scope
- Kafka auto-commit path (separate message broker)
- User-initiated manual reindex (expected to enqueue a new job)
