### PR TITLE
fix(file-preview): add CJK fonts for PPT and PPTX conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,13 @@ RUN --mount=type=cache,target=/root/.cache/uv,sharing=locked \
 
 FROM ${RUNTIME_BASE_IMAGE} AS runtime-base
 
+# Install CJK fallback fonts until they are available in the published runtime
+# base image. LibreOffice uses these when documents reference unavailable fonts.
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+    fonts-noto-cjk \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # -----------------------------------------------------------------------------
 # Stage 1: Node.js Backend Build
 # -----------------------------------------------------------------------------

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -203,6 +203,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     # Comment out if not needed - this is still ~300-400MB
     libreoffice-writer-nogui \
     libreoffice-calc-nogui \
+    # CJK fallback fonts used by LibreOffice when documents reference fonts
+    # that are unavailable in the Linux runtime (e.g. Microsoft JhengHei).
+    fonts-noto-cjk \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Node.js runtime only (not full dev environment)

--- a/deployment/docker-compose/hot-reload/Dockerfile.dev
+++ b/deployment/docker-compose/hot-reload/Dockerfile.dev
@@ -120,6 +120,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libreoffice-writer-nogui \
     libreoffice-calc-nogui \
     libreoffice-impress-nogui \
+    fonts-noto-cjk \
     procps \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Description

Adds Noto CJK fallback fonts to the production, runtime-base, and development Docker images. This fixes unreadable glyphs in converted document previews when presentations reference Chinese fonts unavailable in the Linux runtime, such as Microsoft JhengHei.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #2712
- Closes #2712
- Related to #2710 #2712

Related PR #2711 

## How Has This Been Tested?

The Docker image was rebuilt with `fonts-noto-cjk` installed. A temporary PPTX containing Traditional Chinese text and using Microsoft JhengHei was converted to PDF with LibreOffice.

Fontconfig correctly resolved Microsoft JhengHei to Noto Sans CJK TC, and the converted PDF retained the original readable Chinese text.


### Test Configuration

- [ ] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [x] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [x] Edge cases considered and tested
- [x] Performance impact assessed
- [x] Security implications reviewed

### Test Results

- Docker image built successfully with `fonts-noto-cjk`.
- The rebuilt PipesHub container started successfully and reported healthy.
- Fontconfig resolved `Microsoft JhengHei` to `Noto Sans CJK TC`.
- A PPTX containing Chinese text was converted successfully.
- Text extracted from the generated PDF exactly matched the original Chinese text.

## Screenshots/Videos

**Before:**
<img width="980" height="990" alt="image" src="https://github.com/user-attachments/assets/d547a4c3-a161-4a8b-a9a3-5ba382280196" />


**After:**
<img width="988" height="993" alt="image" src="https://github.com/user-attachments/assets/1494a162-a6b0-42f5-834c-b03e5c6e2ef6" />

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [x] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [x] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [x] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [x] New dependencies are necessary and approved
- [x] Dependencies updated and tested

List any new dependencies:

- `fonts-noto-cjk` — Debian system font package providing Simplified Chinese, Traditional Chinese, Japanese, and Korean fallback fonts.

## Deployment Notes

Rebuild and recreate the PipesHub application container so the new system font package is installed.
Existing containers will not receive the fonts until they are rebuilt or replaced with an image containing this change.

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [x] Core functionality verified
- [x] Security review completed (if applicable)
- [x] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

This PR contains only the CJK font fallback change.
The fallback allows LibreOffice to render Chinese characters when the original Microsoft or proprietary presentation font is unavailable in the Linux container.

Related PR #2711 

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Chinese text rendering in converted document previews
- Docker image-size impact from the CJK font package
- Before-and-after preview screenshots
