### PR TITLE
fix: persist application logs across container recreates

### DIFF
--- a/backend/nodejs/apps/src/libs/services/logger.service.ts
+++ b/backend/nodejs/apps/src/libs/services/logger.service.ts
@@ -119,12 +119,12 @@ export class Logger {
       defaultMeta: this.defaultMeta,
       transports: [
         new winston.transports.File({
-          filename: 'error.log',
+          filename: path.join(process.env.LOG_DIR || '', 'error.log'),
           level: LogLevel.Error,
           format: winston.format.combine(logFormat, winston.format.json())
         }),
         new winston.transports.File({
-          filename: 'combined.log',
+          filename: path.join(process.env.LOG_DIR || '', 'combined.log'),
           format: winston.format.combine(logFormat, winston.format.json())
         }),
         new winston.transports.Console({

--- a/backend/nodejs/apps/src/libs/services/logger.service.ts
+++ b/backend/nodejs/apps/src/libs/services/logger.service.ts
@@ -1,6 +1,7 @@
 import winston from 'winston';
 import { Request } from 'express';
 import { injectable } from 'inversify';
+import fs from 'fs';
 import path from 'path';
 import { threadId } from 'worker_threads';
 import { currentDisplayId, getRequestContext } from '../context/request-context';
@@ -37,6 +38,28 @@ export function getLogLevel(): LogLevel {
   }
   return LogLevel.Info;
 }
+
+function resolveLogDir(): string | null {
+  const configured = process.env.LOG_DIR;
+  const candidates = configured ? [configured, ''] : [''];
+  for (const candidate of candidates) {
+    try {
+      if (candidate) {
+        fs.mkdirSync(candidate, { recursive: true });
+      }
+      fs.accessSync(candidate || '.', fs.constants.W_OK);
+      return candidate;
+    } catch (error) {
+      console.warn(
+        `WARNING: log directory '${candidate || process.cwd()}' is unusable (${error})`,
+      );
+    }
+  }
+  console.warn('WARNING: file logging disabled; using console only');
+  return null;
+}
+
+const logDir = resolveLogDir();
 
 
 export interface LoggerConfig {
@@ -118,15 +141,19 @@ export class Logger {
       format: logFormat,
       defaultMeta: this.defaultMeta,
       transports: [
-        new winston.transports.File({
-          filename: path.join(process.env.LOG_DIR || '', 'error.log'),
-          level: LogLevel.Error,
-          format: winston.format.combine(logFormat, winston.format.json())
-        }),
-        new winston.transports.File({
-          filename: path.join(process.env.LOG_DIR || '', 'combined.log'),
-          format: winston.format.combine(logFormat, winston.format.json())
-        }),
+        ...(logDir === null
+          ? []
+          : [
+              new winston.transports.File({
+                filename: path.join(logDir, 'error.log'),
+                level: LogLevel.Error,
+                format: winston.format.combine(logFormat, winston.format.json())
+              }),
+              new winston.transports.File({
+                filename: path.join(logDir, 'combined.log'),
+                format: winston.format.combine(logFormat, winston.format.json())
+              }),
+            ]),
         new winston.transports.Console({
           format: logFormat,
         }),

--- a/backend/python/app/utils/logger.py
+++ b/backend/python/app/utils/logger.py
@@ -104,7 +104,7 @@ class HealthCheckFilter(logging.Filter):
 
 
 # Ensure log directory exists
-log_dir = "logs"
+log_dir = os.getenv("LOG_DIR", "logs")
 os.makedirs(log_dir, exist_ok=True)
 
 # Force UTF-8 for stdout/stderr in Windows

--- a/backend/python/app/utils/logger.py
+++ b/backend/python/app/utils/logger.py
@@ -103,9 +103,34 @@ class HealthCheckFilter(logging.Filter):
         return not ("/health" in msg and '" 2' in msg)
 
 
-# Ensure log directory exists
-log_dir = os.getenv("LOG_DIR", "logs")
-os.makedirs(log_dir, exist_ok=True)
+_DEFAULT_LOG_DIR = "logs"
+
+
+def _resolve_log_dir() -> str:
+    """Return a writable log directory, or "" to log to console only.
+
+    This runs at import time, so an unwritable LOG_DIR (bad mount, read-only
+    volume) would otherwise raise here and take down every service that imports
+    the logger. File logging must never stop a service from starting.
+    """
+    configured = os.getenv("LOG_DIR", _DEFAULT_LOG_DIR)
+    candidates = [configured]
+    if configured != _DEFAULT_LOG_DIR:
+        candidates.append(_DEFAULT_LOG_DIR)
+    for candidate in candidates:
+        try:
+            os.makedirs(candidate, exist_ok=True)
+            return candidate
+        except OSError as exc:
+            print(
+                f"WARNING: log directory {candidate!r} is unusable ({exc})",
+                file=sys.stderr,
+            )
+    print("WARNING: file logging disabled; using console only", file=sys.stderr)
+    return ""
+
+
+log_dir = _resolve_log_dir()
 
 # Force UTF-8 for stdout/stderr in Windows
 if sys.platform == "win32":
@@ -154,19 +179,20 @@ def create_logger(service_name: str) -> logging.Logger:
         # Enhanced format: request id + thread/task + filename and line number
         log_format = LOG_FORMAT
 
-        # File handler with enhanced format
-        file_handler = logging.FileHandler(
-            os.path.join(log_dir, f"{service_name}.log"),
-            encoding="utf-8",  # Explicitly set encoding here too
-        )
-        file_handler.setFormatter(logging.Formatter(log_format))
+        # File handler with enhanced format; skipped when no log dir is usable
+        if log_dir:
+            file_handler = logging.FileHandler(
+                os.path.join(log_dir, f"{service_name}.log"),
+                encoding="utf-8",  # Explicitly set encoding here too
+            )
+            file_handler.setFormatter(logging.Formatter(log_format))
+            logger.addHandler(file_handler)
 
         # Console handler with colored format
         console_handler = logging.StreamHandler(sys.stdout)
         console_handler.setFormatter(ColoredFormatter(log_format))
 
         # Add handlers
-        logger.addHandler(file_handler)
         logger.addHandler(console_handler)
         logger.propagate = False
 

--- a/backend/python/app/utils/logger.py
+++ b/backend/python/app/utils/logger.py
@@ -113,7 +113,7 @@ def _resolve_log_dir() -> str:
     volume) would otherwise raise here and take down every service that imports
     the logger. File logging must never stop a service from starting.
     """
-    configured = os.getenv("LOG_DIR", _DEFAULT_LOG_DIR)
+    configured = os.getenv("LOG_DIR") or _DEFAULT_LOG_DIR
     candidates = [configured]
     if configured != _DEFAULT_LOG_DIR:
         candidates.append(_DEFAULT_LOG_DIR)

--- a/deployment/docker-compose/docker-compose.build.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.build.neo4j.yml
@@ -33,6 +33,7 @@ services:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-production}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_DIR=${LOG_DIR:-/data/pipeshub/logs}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:3001}
       - STRICT_MODE=${STRICT_MODE:-false}
       - SKIP_DOMAIN_CHECK=${SKIP_DOMAIN_CHECK:-false}

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -37,6 +37,7 @@ services:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-development}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_DIR=${LOG_DIR:-/data/pipeshub/logs}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-}
       - STRICT_MODE=${STRICT_MODE:-false}
       - SKIP_DOMAIN_CHECK=${SKIP_DOMAIN_CHECK:-false}

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -37,6 +37,7 @@ services:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-development}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_DIR=${LOG_DIR:-/data/pipeshub/logs}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-}
       - STRICT_MODE=${STRICT_MODE:-false}
       - SKIP_DOMAIN_CHECK=${SKIP_DOMAIN_CHECK:-false}

--- a/deployment/docker-compose/docker-compose.prod.yml
+++ b/deployment/docker-compose/docker-compose.prod.yml
@@ -21,6 +21,7 @@ services:
       # Core environment settings
       - NODE_ENV=${NODE_ENV:-production}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_DIR=${LOG_DIR:-/data/pipeshub/logs}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-}
       - STRICT_MODE=${STRICT_MODE:-false}
       - SKIP_DOMAIN_CHECK=${SKIP_DOMAIN_CHECK:-false}

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       # Core
       - NODE_ENV=${NODE_ENV:-production}
       - LOG_LEVEL=${LOG_LEVEL:-info}
+      - LOG_DIR=${LOG_DIR:-/data/pipeshub/logs}
       - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-}
       - STRICT_MODE=${STRICT_MODE:-false}
       - SKIP_DOMAIN_CHECK=${SKIP_DOMAIN_CHECK:-false}


### PR DESCRIPTION
# Persist Docker application logs across container recreation

## Summary

Application logs were being written to relative paths inside the container, causing them to be stored in Docker's ephemeral writable layer instead of a persistent volume.

As a result:

- ✅ Logs survived `docker restart`
- ❌ Logs were lost after container recreation or image updates
- ❌ Logs did not persist until the Docker volume was removed

This PR routes all application logs to the existing `pipeshub_data` volume so they persist across restarts and container recreations, and are only removed when the volume is deleted (`docker compose down -v`).

---

## Root Cause

Previously, logs were written to:

| Component | Previous Location | Persistent |
| ---------- | ----------------- | :--------: |
| Node API (Winston) | `/app/backend/error.log`<br>`/app/backend/combined.log` | ❌ |
| Python services | `/app/python/logs/*.log` | ❌ |

These paths are part of Docker's writable container layer rather than a mounted volume.

Although the writable layer survives a simple `docker restart`, it is discarded whenever the container is recreated or the image is updated.

---

## Changes

Application logs are now written to the existing mounted volume:

```text
/data/pipeshub/logs
```

using the `LOG_DIR` environment variable.

### Updated components

- **Node logger**
  - `backend/nodejs/apps/src/libs/services/logger.service.ts`
- **Python logger**
  - `backend/python/app/utils/logger.py`
- **Docker Compose**
  - `docker-compose.yml`
  - `docker-compose.prod.yml`
  - `docker-compose.build.neo4j.yml`
  - `docker-compose.integration.neo4j.yml`
  - `docker-compose.integration.arango.yml`

Each compose file now sets:

```bash
LOG_DIR=${LOG_DIR:-/data/pipeshub/logs}
```

---

## Why use `LOG_DIR`?

Using an environment variable instead of a hardcoded path keeps local development unchanged.

- Inside Docker:
  - Logs are written to the mounted `pipeshub_data` volume.

- Outside Docker:
  - Existing relative log paths continue to work without any configuration changes.

No additional volumes or dependencies were introduced.

---

## Validation

Verified end-to-end using the development Docker stack.

### Before the fix

- Logs were written under `/app/...`
- `docker restart` preserved logs
- Container recreation removed all logs

### After the fix

- Node and Python logs are written to:

```text
/data/pipeshub/logs
```

- `/app/backend/*.log` is no longer used
- Logs persist after container recreation
- New log entries continue appending correctly
- Logs are removed only after:

```bash
docker compose down -v
```

---

## Result

✅ Logs survive container restarts

✅ Logs survive container recreation and image updates

✅ Logs are stored in the existing persistent Docker volume

✅ Logs are removed only when the Docker volume is deleted

---

## Notes

- No new Docker volumes were added.
- No runtime behavior changed outside Docker.
- This change was originally part of the bulk user invite PR and has been separated since it is an independent improvement.