### PR TITLE
fix: install LibreOffice and CJK fonts in Docker for PPTX conversion

### DIFF
--- a/backend/python/Dockerfile
+++ b/backend/python/Dockerfile
@@ -51,12 +51,20 @@ COPY --from=builder /build/dist/query_main ./
 ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
 
 # Install necessary runtime libraries
+# libreoffice: required for PPT/PPTX to PDF conversion (fixes #2710)
+# fonts-noto-cjk, fonts-wqy-zenhei, fonts-wqy-microhei: CJK font support for
+# correct rendering of Chinese/Japanese/Korean text in converted PDFs (fixes #2712)
 RUN apt-get update && apt-get install -y \
     librocksdb-dev libgflags-dev libsnappy-dev zlib1g-dev \
     libbz2-dev liblz4-dev libzstd-dev libssl-dev ca-certificates libspatialindex-dev libpq5 \
     ffmpeg \
+    libreoffice \
+    fonts-noto-cjk \
+    fonts-wqy-zenhei \
+    fonts-wqy-microhei \
  && rm -rf /var/lib/apt/lists/*
- # Ensure executable permission
+
+# Ensure executable permission
 RUN chmod +x /app/indexing_main
 RUN chmod +x /app/connectors_main
 RUN chmod +x /app/query_main

--- a/backend/python/Dockerfile
+++ b/backend/python/Dockerfile
@@ -51,14 +51,15 @@ COPY --from=builder /build/dist/query_main ./
 ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
 
 # Install necessary runtime libraries
-# libreoffice: required for PPT/PPTX to PDF conversion (fixes #2710)
+# libreoffice-nogui: headless LibreOffice for PPT/PPTX to PDF conversion without
+#   GUI/X11 dependencies, significantly reducing image size (fixes #2710)
 # fonts-noto-cjk, fonts-wqy-zenhei, fonts-wqy-microhei: CJK font support for
-# correct rendering of Chinese/Japanese/Korean text in converted PDFs (fixes #2712)
-RUN apt-get update && apt-get install -y \
+#   correct rendering of Chinese/Japanese/Korean text in converted PDFs (fixes #2712)
+RUN apt-get update && apt-get install -y --no-install-recommends \
     librocksdb-dev libgflags-dev libsnappy-dev zlib1g-dev \
     libbz2-dev liblz4-dev libzstd-dev libssl-dev ca-certificates libspatialindex-dev libpq5 \
     ffmpeg \
-    libreoffice \
+    libreoffice-nogui \
     fonts-noto-cjk \
     fonts-wqy-zenhei \
     fonts-wqy-microhei \


### PR DESCRIPTION
## Description

This PR fixes two related bugs with PPT/PPTX file handling in the Docker container.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Fixes

### Fix #1 — PPTX to PDF conversion fails entirely (fixes #2710)

**Root cause:** `libreoffice` was never installed in the final Docker stage. The `ppt_parser.py` calls `libreoffice --headless --convert-to` but the binary did not exist in the container, causing an immediate `CalledProcessError` on every PPTX upload.

**Fix:** Added `libreoffice` to the `apt-get install` block in the final stage of `backend/python/Dockerfile`.

---

### Fix #2 — Chinese/CJK text renders as glyphs after conversion (fixes #2712)

**Root cause:** Even with LibreOffice installed, the Docker container had no CJK (Chinese/Japanese/Korean) fonts. When LibreOffice converted a PPTX containing Chinese text, it had no fonts to substitute and rendered empty glyph boxes instead.

**Fix:** Added three CJK font packages to the Docker install:
- `fonts-noto-cjk` — Google Noto CJK fonts (comprehensive CJK coverage)
- `fonts-wqy-zenhei` — WenQuanYi Zen Hei (common Chinese fallback)
- `fonts-wqy-microhei` — WenQuanYi Micro Hei (lightweight CJK fallback)

---

## Changes

- `backend/python/Dockerfile` — Added `libreoffice`, `fonts-noto-cjk`, `fonts-wqy-zenhei`, `fonts-wqy-microhei` to the final stage `apt-get install` block with explanatory comments.

## Testing

- Upload a standard `.pptx` file → should now convert and preview correctly (fixes #2710)
- Upload a `.pptx` containing Chinese/Japanese/Korean text → text should render correctly in the PDF preview (fixes #2712)