### PR TITLE
skipping authentication for expired refresh token

### DIFF
--- a/backend/python/app/connectors/core/base/token_service/oauth_service.py
+++ b/backend/python/app/connectors/core/base/token_service/oauth_service.py
@@ -29,6 +29,26 @@ class TokenType(Enum):
     MAC = "MAC"
 
 
+class RefreshTokenInvalidError(Exception):
+    """The OAuth provider permanently rejected the refresh token (expired or
+    revoked). Retrying cannot succeed — the user must re-authenticate."""
+
+
+_PERMANENT_REFRESH_ERROR_MARKERS = (
+    "invalid_grant",
+    "refresh_token is invalid",
+    "refresh token is invalid",
+    "refresh token has expired",
+    "invalid_refresh_token",
+    "bad_refresh_token",
+)
+
+
+def _is_permanent_refresh_rejection(error_str: str) -> bool:
+    lowered = error_str.lower()
+    return any(marker in lowered for marker in _PERMANENT_REFRESH_ERROR_MARKERS)
+
+
 @dataclass
 class OAuthConfig:
     """OAuth Configuration"""
@@ -312,12 +332,13 @@ class OAuthProvider:
         try:
             token_data = await self._make_token_request(data)
         except Exception as e:
-            # Enhance error message for 403 errors (common with expired/invalid refresh tokens)
             error_str = str(e)
-            # Extract status code from error message using regex for more reliable matching
+            if _is_permanent_refresh_rejection(error_str):
+                raise RefreshTokenInvalidError(f"Refresh token rejected by provider — expired or revoked; re-authentication is required. {error_str}") from e
             status_match = re.search(r"status (\d+)", error_str)
+            # Bare 403 stays transient — may be a WAF block, not a dead token
             if status_match and int(status_match.group(1)) == HttpStatusCode.FORBIDDEN.value:
-                raise Exception(f"Token refresh failed with 403 Forbidden. This usually means the refresh token has expired or is invalid. {error_str}")
+                raise Exception(f"Token refresh failed with 403 Forbidden. This usually means the refresh token has expired or is invalid. {error_str}") from e
             raise
 
         # Normalize only if configured (backward compatible)

--- a/backend/python/app/connectors/core/base/token_service/oauth_service.py
+++ b/backend/python/app/connectors/core/base/token_service/oauth_service.py
@@ -36,7 +36,6 @@ class RefreshTokenInvalidError(Exception):
 
 _PERMANENT_REFRESH_ERROR_MARKERS = (
     "invalid_grant",
-    "refresh_token is invalid",
     "refresh token is invalid",
     "refresh token has expired",
     "invalid_refresh_token",

--- a/backend/python/app/connectors/core/base/token_service/oauth_service.py
+++ b/backend/python/app/connectors/core/base/token_service/oauth_service.py
@@ -36,6 +36,7 @@ class RefreshTokenInvalidError(Exception):
 
 _PERMANENT_REFRESH_ERROR_MARKERS = (
     "invalid_grant",
+    "refresh_token is invalid",
     "refresh token is invalid",
     "refresh token has expired",
     "invalid_refresh_token",

--- a/backend/python/app/connectors/core/base/token_service/oauth_service.py
+++ b/backend/python/app/connectors/core/base/token_service/oauth_service.py
@@ -49,6 +49,20 @@ def _is_permanent_refresh_rejection(error_str: str) -> bool:
     return any(marker in lowered for marker in _PERMANENT_REFRESH_ERROR_MARKERS)
 
 
+_SERVICENOW_TOKEN_ENDPOINT = "oauth_token.do"
+
+# servicenow specific check for refresh token rejection
+def _is_servicenow_refresh_rejection(error_str: str, token_url: str) -> bool:
+    """ServiceNow reports a dead refresh token as 401 server_error/access_denied"""
+    if _SERVICENOW_TOKEN_ENDPOINT not in token_url.lower():
+        return False
+    status_match = re.search(r"status (\d+)", error_str)
+    if not status_match or int(status_match.group(1)) != HttpStatusCode.UNAUTHORIZED.value:
+        return False
+    lowered = error_str.lower()
+    return "server_error" in lowered and "access_denied" in lowered
+
+
 @dataclass
 class OAuthConfig:
     """OAuth Configuration"""
@@ -333,7 +347,7 @@ class OAuthProvider:
             token_data = await self._make_token_request(data)
         except Exception as e:
             error_str = str(e)
-            if _is_permanent_refresh_rejection(error_str):
+            if _is_permanent_refresh_rejection(error_str) or _is_servicenow_refresh_rejection(error_str, self.config.token_url):
                 raise RefreshTokenInvalidError(f"Refresh token rejected by provider — expired or revoked; re-authentication is required. {error_str}") from e
             status_match = re.search(r"status (\d+)", error_str)
             # Bare 403 stays transient — may be a WAF block, not a dead token

--- a/backend/python/app/connectors/core/base/token_service/startup_service.py
+++ b/backend/python/app/connectors/core/base/token_service/startup_service.py
@@ -16,6 +16,7 @@ from app.connectors.core.base.token_service.toolset_token_refresh_service import
     ToolsetTokenRefreshService,
 )
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
+from app.services.messaging.interface.producer import IMessagingProducer
 
 
 class StartupService:
@@ -29,7 +30,16 @@ class StartupService:
         self._initialized = False
 
 
-    async def initialize(self, configuration_service: ConfigurationService, graph_provider: IGraphDBProvider) -> None:
+    def set_messaging_producer(self, producer: IMessagingProducer) -> None:
+        """Attach the messaging producer once it starts (after initialize)."""
+        if self._token_refresh_service:
+            self._token_refresh_service.set_messaging_producer(producer)
+
+    async def initialize(
+        self,
+        configuration_service: ConfigurationService,
+        graph_provider: IGraphDBProvider,
+    ) -> None:
         """Initialize startup services"""
         async with self._initialize_lock:
             if self._initialized:

--- a/backend/python/app/connectors/core/base/token_service/token_refresh_service.py
+++ b/backend/python/app/connectors/core/base/token_service/token_refresh_service.py
@@ -6,34 +6,56 @@ Handles automatic token refresh for OAuth connectors
 import asyncio
 import logging
 from datetime import datetime, timedelta
+from typing import Optional
 
 from app.config.configuration_service import ConfigurationService
+from app.config.constants.arangodb import CollectionNames
 from app.connectors.core.constants import (
     AuthFieldKeys,
     ConnectorRequestKeys,
+    ConnectorStateKeys,
     OAuthConfigKeys,
 )
-from app.connectors.core.base.token_service.oauth_service import OAuthToken
+from app.connectors.core.base.token_service.oauth_service import (
+    OAuthToken,
+    RefreshTokenInvalidError,
+)
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
+from app.services.messaging.interface.producer import IMessagingProducer
 from app.utils.oauth_config import get_oauth_config
 from app.utils.request_context import (
     new_system_root,
     reset_context,
     set_context,
 )
+from app.utils.time_conversion import get_epoch_timestamp_in_ms
+
+# Consecutive rejections before deactivating; guards against provider blips
+MAX_REFRESH_TOKEN_INVALID_FAILURES = 3
 
 
 class TokenRefreshService:
     """Service for managing token refresh across all connectors"""
 
-    def __init__(self, configuration_service: ConfigurationService, graph_provider: IGraphDBProvider) -> None:
+    def __init__(
+        self,
+        configuration_service: ConfigurationService,
+        graph_provider: IGraphDBProvider,
+        messaging_producer: Optional[IMessagingProducer] = None,
+    ) -> None:
         self.configuration_service = configuration_service
         self.graph_provider = graph_provider
+        self._messaging_producer = messaging_producer
         self.logger = logging.getLogger("connector_service")
         self._refresh_tasks: dict[str, asyncio.Task] = {}
         self._running = False
         self._refresh_lock = asyncio.Lock()  # Prevent concurrent refresh operations
         self._processing_connectors: set = set()  # Track connectors currently being processed to prevent recursion
+        self._invalid_refresh_failures: dict[str, int] = {}  # Consecutive refresh-token rejections per connector
+
+    def set_messaging_producer(self, producer: IMessagingProducer) -> None:
+        """Attach the messaging producer; it starts after this service at app startup."""
+        self._messaging_producer = producer
 
     async def start(self, wait_for_initial_refresh: bool = True) -> None:
         """Start the token refresh service.
@@ -129,6 +151,10 @@ class TokenRefreshService:
         for conn in connectors:
             # Only process OAuth connectors
             if not self._is_oauth_connector(conn):
+                continue
+
+            # Explicit False only — legacy docs may lack the flag
+            if conn.get(ConnectorStateKeys.IS_AUTHENTICATED) is False:
                 continue
 
             connector_id = conn.get('_key')
@@ -499,9 +525,112 @@ class TokenRefreshService:
         refresh_token: str,
     ) -> OAuthToken:
         """Public entry point for an on-demand OAuth token refresh."""
-        return await self._perform_token_refresh(
-            connector_id, connector_type, refresh_token
+        try:
+            return await self._perform_token_refresh(
+                connector_id, connector_type, refresh_token
+            )
+        except RefreshTokenInvalidError as e:
+            await self._handle_refresh_token_invalid(connector_id, e)
+            raise
+
+    async def _handle_refresh_token_invalid(self, connector_id: str, error: Exception) -> None:
+        """Deactivate the connector after MAX_REFRESH_TOKEN_INVALID_FAILURES consecutive rejections."""
+        failures = self._invalid_refresh_failures.get(connector_id, 0) + 1
+        self._invalid_refresh_failures[connector_id] = failures
+
+        if failures < MAX_REFRESH_TOKEN_INVALID_FAILURES:
+            self.logger.error(
+                f"Refresh token rejected for connector {connector_id} "
+                f"(failure {failures}/{MAX_REFRESH_TOKEN_INVALID_FAILURES}): {error}",
+                exc_info=False,
+            )
+            return
+
+        self.logger.error(
+            f"Refresh token rejected for connector {connector_id} "
+            f"{failures} consecutive times, deactivating: {error}",
+            exc_info=False,
         )
+        self._invalid_refresh_failures.pop(connector_id, None)
+        await self._mark_connector_unauthenticated(connector_id)
+
+    async def _mark_connector_unauthenticated(self, connector_id: str) -> None:
+        """Flip the connector to unauthenticated so refresh scans stop until re-auth."""
+        # Cancelling our own task here would abort the state update below.
+        existing_task = self._refresh_tasks.get(connector_id)
+        if existing_task is not None and existing_task is not asyncio.current_task():
+            self._cancel_existing_refresh_task(connector_id)
+
+        updates = {
+            ConnectorStateKeys.IS_AUTHENTICATED: False,
+            ConnectorStateKeys.UPDATED_AT_TIMESTAMP: get_epoch_timestamp_in_ms(),
+        }
+
+        # The appDisabled consumer owns isActive and sync-stop; write directly if it can't be reached
+        if not await self._send_app_disabled_event(connector_id):
+            updates[ConnectorStateKeys.IS_ACTIVE] = False
+
+        try:
+            updated = await self.graph_provider.update_node(
+                connector_id,
+                CollectionNames.APPS.value,
+                updates,
+            )
+            if updated:
+                self.logger.warning(
+                    f"Marked connector {connector_id} as unauthenticated — "
+                    f"refresh token is invalid, re-authentication required"
+                )
+            else:
+                self.logger.error(f"Failed to mark connector {connector_id} as unauthenticated")
+        except Exception as e:
+            self.logger.error(
+                f"Error marking connector {connector_id} as unauthenticated: {e}", exc_info=False
+            )
+
+    async def _send_app_disabled_event(self, connector_id: str) -> bool:
+        """Publish the platform appDisabled event for this connector instance."""
+        producer = self._messaging_producer
+        if producer is None:
+            return False
+
+        try:
+            app_doc = await self.graph_provider.get_document(connector_id, CollectionNames.APPS.value)
+            if not app_doc:
+                return False
+
+            org_id = None
+            edges = await self.graph_provider.get_edges_to_node(
+                f"{CollectionNames.APPS.value}/{connector_id}",
+                CollectionNames.ORG_APP_RELATION.value,
+            )
+            if edges:
+                org_id = edges[0].get("_from", "").split("/")[-1]
+            if not org_id:
+                # The appDisabled consumer rejects payloads without orgId
+                return False
+
+            message = {
+                "eventType": "appDisabled",
+                "payload": {
+                    "orgId": org_id,
+                    "appGroup": app_doc.get("appGroup"),
+                    "apps": [str(app_doc.get("type", "")).replace(" ", "").lower()],
+                    "connectorId": connector_id,
+                    "scope": app_doc.get("scope"),
+                },
+                "timestamp": get_epoch_timestamp_in_ms(),
+            }
+            await producer.send_message(topic="entity-events", message=message)
+            self.logger.info(
+                f"Sent appDisabled event for connector {connector_id} (refresh token invalid)"
+            )
+            return True
+        except Exception as e:
+            self.logger.error(
+                f"Failed to send appDisabled event for connector {connector_id}: {e}", exc_info=False
+            )
+            return False
 
     async def _perform_token_refresh(
         self,
@@ -561,6 +690,8 @@ class TokenRefreshService:
             config['credentials'] = new_token.to_dict()
             await self.configuration_service.set_config(config_key, config)
             self.logger.info(f"💾 Updated stored credentials for connector {connector_id}")
+
+            self._invalid_refresh_failures.pop(connector_id, None)
 
             return new_token
         finally:
@@ -670,6 +801,8 @@ class TokenRefreshService:
         except RecursionError as e:
             # Special handling for recursion errors
             self.logger.error(f"❌ Recursion error refreshing token for connector {connector_id}: {e}", exc_info=False)
+        except RefreshTokenInvalidError as e:
+            await self._handle_refresh_token_invalid(connector_id, e)
         except Exception as e:
             # Use exc_info=False to avoid potential recursion in traceback formatting
             self.logger.error(f"❌ Error refreshing token for connector {connector_id}: {e}", exc_info=False)
@@ -723,6 +856,9 @@ class TokenRefreshService:
             new_token = await self._perform_token_refresh(connector_id, connector_type, token.refresh_token)
             self.logger.info(f"🔄 Immediate refresh completed for connector {connector_id}")
             return new_token, True
+        except RefreshTokenInvalidError as e:
+            await self._handle_refresh_token_invalid(connector_id, e)
+            return None, False
         except Exception as e:
             self.logger.error(f"❌ Failed to perform immediate refresh for connector {connector_id}: {e}", exc_info=False)
             return None, False

--- a/backend/python/app/connectors/core/base/token_service/token_refresh_service.py
+++ b/backend/python/app/connectors/core/base/token_service/token_refresh_service.py
@@ -599,16 +599,17 @@ class TokenRefreshService:
             if not app_doc:
                 return False
 
-            org_id = None
-            edges = await self.graph_provider.get_edges_to_node(
-                f"{CollectionNames.APPS.value}/{connector_id}",
-                CollectionNames.ORG_APP_RELATION.value,
-            )
-            if edges:
-                org_id = edges[0].get("_from", "").split("/")[-1]
+            org_id = app_doc.get("orgId")
             if not org_id:
-                # The appDisabled consumer rejects payloads without orgId
-                return False
+                edges = await self.graph_provider.get_edges_to_node(
+                    f"{CollectionNames.APPS.value}/{connector_id}",
+                    CollectionNames.ORG_APP_RELATION.value,
+                )
+                if edges:
+                    from_val = edges[0].get("_from")
+                    if from_val: 
+                        org_id = from_val.split("/")[-1]
+
 
             message = {
                 "eventType": "appDisabled",

--- a/backend/python/app/connectors/core/base/token_service/toolset_token_refresh_service.py
+++ b/backend/python/app/connectors/core/base/token_service/toolset_token_refresh_service.py
@@ -882,7 +882,7 @@ class ToolsetTokenRefreshService:
                 f"refresh token is invalid, re-authentication required"
             )
         except Exception as e:
-            self.logger.error(f"Error marking toolset {config_path} as unauthenticated: {e}", exc_info=True)
+            self.logger.error(f"Error marking toolset {config_path} as unauthenticated: {e}", exc_info=False)
 
         # Cancelling our own task here would raise CancelledError on the caller's next await.
         existing_task = self._refresh_tasks.get(config_path)

--- a/backend/python/app/connectors/core/base/token_service/toolset_token_refresh_service.py
+++ b/backend/python/app/connectors/core/base/token_service/toolset_token_refresh_service.py
@@ -14,13 +14,17 @@ if TYPE_CHECKING:
     from app.connectors.core.base.token_service.oauth_service import OAuthConfig
 
 from app.config.configuration_service import ConfigurationService
-from app.connectors.core.base.token_service.oauth_service import OAuthToken
+from app.connectors.core.base.token_service.oauth_service import (
+    OAuthToken,
+    RefreshTokenInvalidError,
+)
 from app.utils.oauth_config import get_oauth_config
 from app.utils.request_context import (
     new_system_root,
     reset_context,
     set_context,
 )
+from app.utils.time_conversion import get_epoch_timestamp_in_ms
 
 # Constants
 MIN_PATH_PARTS_COUNT = 4  # Minimum path parts: services, toolsets, instance_id, user_id
@@ -32,6 +36,8 @@ MIN_IMMEDIATE_RECHECK_DELAY = 1  # Seconds; used when an already-expired token n
 PROACTIVE_REFRESH_WINDOW_SECONDS = 600  # Refresh 10 minutes before expiry for normal tokens
 MIN_SHORT_LIVED_REFRESH_WINDOW_SECONDS = 60  # Minimum proactive window for short-lived tokens
 SHORT_LIVED_TOKEN_BUFFER_RATIO = 0.2  # For short-lived tokens, refresh ~20% before expiry
+# Consecutive rejections before deactivating; guards against provider blips
+MAX_REFRESH_TOKEN_INVALID_FAILURES = 3
 
 
 class ToolsetTokenRefreshService:
@@ -47,6 +53,7 @@ class ToolsetTokenRefreshService:
         self._toolset_locks: Dict[str, asyncio.Lock] = {}  # Per-toolset locks to prevent concurrent refreshes
         self._schedule_locks: Dict[str, asyncio.Lock] = {}  # Per-toolset locks for atomic task scheduling
         self._last_refresh_time: Dict[str, float] = {}  # Track last successful refresh time (prevents duplicates)
+        self._invalid_refresh_failures: Dict[str, int] = {}  # Consecutive refresh-token rejections per toolset
 
     def _get_toolset_lock(self, config_path: str) -> asyncio.Lock:
         """
@@ -152,6 +159,10 @@ class ToolsetTokenRefreshService:
                 for path in list(self._last_refresh_time.keys()):
                     if path not in current_paths:
                         del self._last_refresh_time[path]
+
+                for path in list(self._invalid_refresh_failures.keys()):
+                    if path not in current_paths:
+                        del self._invalid_refresh_failures[path]
 
             except asyncio.CancelledError:
                 break
@@ -824,10 +835,59 @@ class ToolsetTokenRefreshService:
             self._last_refresh_time[config_path] = time.time()
             self.logger.debug(f"📝 Updated last refresh time for {config_path}")
 
+            self._invalid_refresh_failures.pop(config_path, None)
+
             return new_token
         finally:
             # Always clean up OAuth provider
             await oauth_provider.close()
+
+    async def _handle_refresh_token_invalid(self, config_path: str, error: Exception) -> None:
+        """Deactivate the toolset after MAX_REFRESH_TOKEN_INVALID_FAILURES consecutive rejections."""
+        failures = self._invalid_refresh_failures.get(config_path, 0) + 1
+        self._invalid_refresh_failures[config_path] = failures
+
+        if failures < MAX_REFRESH_TOKEN_INVALID_FAILURES:
+            self.logger.error(
+                f"Refresh token rejected for toolset {config_path} "
+                f"(failure {failures}/{MAX_REFRESH_TOKEN_INVALID_FAILURES}): {error}",
+                exc_info=False,
+            )
+            return
+
+        self.logger.error(
+            f"Refresh token rejected for toolset {config_path} "
+            f"{failures} consecutive times, deactivating: {error}",
+            exc_info=False,
+        )
+        self._invalid_refresh_failures.pop(config_path, None)
+        await self._mark_toolset_unauthenticated(config_path)
+
+    async def _mark_toolset_unauthenticated(self, config_path: str) -> None:
+        """Flip the toolset to unauthenticated so refresh scans stop until re-auth."""
+        try:
+            config = await self.configuration_service.get_config(config_path, default=None, use_cache=False)
+            if not config or not isinstance(config, dict):
+                return
+
+            now_ms = get_epoch_timestamp_in_ms()
+            config["isAuthenticated"] = False
+            config["deauthReason"] = "refresh_token_invalid"
+            config["deauthAt"] = now_ms
+            config["updatedAt"] = now_ms
+            await self.configuration_service.set_config(config_path, config)
+
+            self.logger.warning(
+                f"Marked toolset {config_path} as unauthenticated — "
+                f"refresh token is invalid, re-authentication required"
+            )
+        except Exception as e:
+            self.logger.error(f"Error marking toolset {config_path} as unauthenticated: {e}", exc_info=True)
+
+        # Cancelling our own task here would raise CancelledError on the caller's next await.
+        existing_task = self._refresh_tasks.get(config_path)
+        if existing_task is not None and existing_task is not asyncio.current_task():
+            self._cancel_existing_refresh_task(config_path)
 
     def _is_toolset_being_processed(self, config_path: str) -> bool:
         """Check if toolset is currently being processed."""
@@ -970,6 +1030,8 @@ class ToolsetTokenRefreshService:
 
             except RecursionError as e:
                 self.logger.error(f"RECURSION ERROR in toolset token refresh for {config_path}: {str(e)[:100]}")
+            except RefreshTokenInvalidError as e:
+                await self._handle_refresh_token_invalid(config_path, e)
             except Exception as e:
                 import traceback
                 error_details = traceback.format_exc()
@@ -1050,6 +1112,9 @@ class ToolsetTokenRefreshService:
             new_token = await self._perform_token_refresh(config_path, toolset_type, token.refresh_token)
             self.logger.info(f"🔄 Immediate refresh completed for toolset {config_path}")
             return new_token, True
+        except RefreshTokenInvalidError as e:
+            await self._handle_refresh_token_invalid(config_path, e)
+            return None, False
         except Exception as e:
             self.logger.error(f"❌ Failed to perform immediate refresh for toolset {config_path}: {e}", exc_info=False)
             return None, False

--- a/backend/python/app/connectors/services/event_service.py
+++ b/backend/python/app/connectors/services/event_service.py
@@ -251,8 +251,7 @@ class EventService:
             document_key=connector_id,
             collection=CollectionNames.APPS.value,
         )
-        # Scheduled BullMQ crawls keep firing after auto-deactivation (e.g. dead
-        # refresh token); skip before attempting a connector init that cannot succeed.
+
         if connector_doc and (
             connector_doc.get(ConnectorStateKeys.IS_ACTIVE) is False
             or connector_doc.get(ConnectorStateKeys.IS_AUTHENTICATED) is False

--- a/backend/python/app/connectors/services/event_service.py
+++ b/backend/python/app/connectors/services/event_service.py
@@ -247,6 +247,21 @@ class EventService:
             self.logger.error("orgId is required in start sync payload")
             return False
 
+        connector_doc = await self.graph_provider.get_document(
+            document_key=connector_id,
+            collection=CollectionNames.APPS.value,
+        )
+        # Scheduled BullMQ crawls keep firing after auto-deactivation (e.g. dead
+        # refresh token); skip before attempting a connector init that cannot succeed.
+        if connector_doc and (
+            connector_doc.get(ConnectorStateKeys.IS_ACTIVE) is False
+            or connector_doc.get(ConnectorStateKeys.IS_AUTHENTICATED) is False
+        ):
+            self.logger.warning(
+                f"Skipping {connector_name} sync for {connector_id}: connector is disabled or requires re-authentication"
+            )
+            return False
+
         connector = await self._ensure_connector(connector_name, connector_id)
         if not connector:
             self.logger.error(f"{connector_name.capitalize()} {connector_id} connector could not be initialized")
@@ -256,11 +271,6 @@ class EventService:
             self.logger.error(f"{connector_name.capitalize()} {connector_id} connector not initialized")
             return False
 
-        # Load apps document only after connector is valid (avoids extra I/O on init failure).
-        connector_doc = await self.graph_provider.get_document(
-            document_key=connector_id,
-            collection=CollectionNames.APPS.value,
-        )
         pending_full_sync = False
         if connector_doc:
             pending_full_sync = bool(connector_doc.get(ConnectorStateKeys.PENDING_FULL_SYNC, False))

--- a/backend/python/app/connectors_main.py
+++ b/backend/python/app/connectors_main.py
@@ -458,6 +458,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     # Start messaging producer first
     try:
         await start_messaging_producer(app_container)
+        startup_service.set_messaging_producer(app_container.messaging_producer)
         logger.info("✅ Messaging producer started successfully")
     except Exception as e:
         logger.error(f"❌ Failed to start messaging producer: {str(e)}")

--- a/backend/python/app/services/messaging/kafka/handlers/entity.py
+++ b/backend/python/app/services/messaging/kafka/handlers/entity.py
@@ -476,6 +476,18 @@ class EntityEventService(BaseEventService):
             except Exception as cancel_err:
                 self.logger.error(f"❌ Failed to cancel sync for connector {connector_id}: {cancel_err}")
 
+            if (
+                hasattr(self.app_container, "connectors_map")
+                and connector_id in self.app_container.connectors_map
+            ):
+                existing_connector = self.app_container.connectors_map.pop(connector_id)
+                try:
+                    if hasattr(existing_connector, "cleanup"):
+                        await existing_connector.cleanup()
+                    self.logger.info(f"Cleaned up connector instance {connector_id}")
+                except Exception as cleanup_err:
+                    self.logger.error(f"Error cleaning up connector {connector_id}: {cleanup_err}")
+
             self.logger.info(f"✅ Successfully disabled apps for org: {org_id}")
             return True
 

--- a/backend/python/tests/unit/connectors/services/test_event_service_connector.py
+++ b/backend/python/tests/unit/connectors/services/test_event_service_connector.py
@@ -373,11 +373,47 @@ class TestHandleStartSync:
 
     @pytest.mark.asyncio
     async def test_connector_not_found(self, service):
+        # Apps doc is now fetched before init so disabled connectors can be skipped
         with patch.object(service, "_ensure_connector", new_callable=AsyncMock, return_value=None), \
              patch.object(service, "_get_connector", return_value=None):
             result = await service._handle_start_sync("gmail", {"orgId": "org1", "connectorId": "c1"})
             assert result is False
-            service.graph_provider.get_document.assert_not_awaited()
+            service.graph_provider.get_document.assert_awaited_once_with(
+                document_key="c1",
+                collection=CollectionNames.APPS.value,
+            )
+
+    @pytest.mark.asyncio
+    async def test_start_sync_skips_inactive_connector(self, service):
+        service.graph_provider.get_document = AsyncMock(
+            return_value={"_key": "c1", ConnectorStateKeys.IS_ACTIVE: False, ConnectorStateKeys.IS_AUTHENTICATED: False}
+        )
+        with patch.object(service, "_ensure_connector", new_callable=AsyncMock) as mock_ensure:
+            result = await service._handle_start_sync("gmail", {"orgId": "org1", "connectorId": "c1"})
+            assert result is False
+            mock_ensure.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_sync_skips_unauthenticated_connector(self, service):
+        """isAuthenticated=False alone (e.g. dead refresh token) must also skip."""
+        service.graph_provider.get_document = AsyncMock(
+            return_value={"_key": "c1", ConnectorStateKeys.IS_ACTIVE: True, ConnectorStateKeys.IS_AUTHENTICATED: False}
+        )
+        with patch.object(service, "_ensure_connector", new_callable=AsyncMock) as mock_ensure:
+            result = await service._handle_start_sync("gmail", {"orgId": "org1", "connectorId": "c1"})
+            assert result is False
+            mock_ensure.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_start_sync_proceeds_for_active_connector(self, service):
+        service.graph_provider.get_document = AsyncMock(
+            return_value={"_key": "c1", ConnectorStateKeys.IS_ACTIVE: True, ConnectorStateKeys.IS_AUTHENTICATED: True}
+        )
+        with patch.object(service, "_ensure_connector", new_callable=AsyncMock, return_value=None) as mock_ensure, \
+             patch.object(service, "_get_connector", return_value=None):
+            result = await service._handle_start_sync("gmail", {"orgId": "org1", "connectorId": "c1"})
+            mock_ensure.assert_awaited_once()
+            assert result is False
 
     @pytest.mark.asyncio
     async def test_pending_full_sync_triggers_full_sync(self, service):

--- a/backend/python/tests/unit/connectors/test_oauth_service.py
+++ b/backend/python/tests/unit/connectors/test_oauth_service.py
@@ -995,6 +995,40 @@ class TestRefreshAccessToken:
             await provider.refresh_access_token("expired-refresh")
 
     @pytest.mark.asyncio
+    async def test_refresh_servicenow_401_raises_refresh_token_invalid_error(self, mock_config_service):
+        """ServiceNow signals a dead refresh token as 401 server_error/access_denied."""
+        config = _make_oauth_config(token_url="https://dev293310.service-now.com/oauth_token.do")
+        provider = OAuthProvider(config, mock_config_service, "/path")
+
+        provider._make_token_request = AsyncMock(
+            side_effect=Exception(
+                'OAuth token request failed with status 401. '
+                'Token URL: https://dev293310.service-now.com/oauth_token.do, '
+                'Response: {"error_description":"access_denied","error":"server_error"}'
+            )
+        )
+
+        with pytest.raises(RefreshTokenInvalidError):
+            await provider.refresh_access_token("expired-refresh")
+
+    @pytest.mark.asyncio
+    async def test_refresh_servicenow_body_on_other_provider_is_not_permanent(self, mock_config_service):
+        """server_error/access_denied is ambiguous outside ServiceNow and must stay transient."""
+        config = _make_oauth_config()
+        provider = OAuthProvider(config, mock_config_service, "/path")
+
+        provider._make_token_request = AsyncMock(
+            side_effect=Exception(
+                'OAuth token request failed with status 401. '
+                'Response: {"error_description":"access_denied","error":"server_error"}'
+            )
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            await provider.refresh_access_token("expired-refresh")
+        assert not isinstance(exc_info.value, RefreshTokenInvalidError)
+
+    @pytest.mark.asyncio
     async def test_refresh_non_403_error_reraises(self, mock_config_service):
         """Non-403 errors are re-raised without modification."""
         config = _make_oauth_config()

--- a/backend/python/tests/unit/connectors/test_oauth_service.py
+++ b/backend/python/tests/unit/connectors/test_oauth_service.py
@@ -11,6 +11,7 @@ from app.connectors.core.base.token_service.oauth_service import (
     OAuthConfig,
     OAuthProvider,
     OAuthToken,
+    RefreshTokenInvalidError,
 )
 
 # ---------------------------------------------------------------------------
@@ -949,6 +950,49 @@ class TestRefreshAccessToken:
 
         with pytest.raises(Exception, match="Token refresh failed with 403 Forbidden"):
             await provider.refresh_access_token("bad-refresh")
+
+    @pytest.mark.asyncio
+    async def test_refresh_atlassian_403_raises_refresh_token_invalid_error(self, mock_config_service):
+        """Atlassian-style 403 with refresh_token marker raises the typed error."""
+        config = _make_oauth_config()
+        provider = OAuthProvider(config, mock_config_service, "/path")
+
+        provider._make_token_request = AsyncMock(
+            side_effect=Exception(
+                'OAuth token request failed with status 403. '
+                'Response: {"error":"unauthorized_client","error_description":"refresh_token is invalid"}'
+            )
+        )
+
+        with pytest.raises(RefreshTokenInvalidError):
+            await provider.refresh_access_token("bad-refresh")
+
+    @pytest.mark.asyncio
+    async def test_refresh_bare_403_is_not_permanent(self, mock_config_service):
+        """403 without a token-specific marker (WAF block, misconfig) must not deactivate."""
+        config = _make_oauth_config()
+        provider = OAuthProvider(config, mock_config_service, "/path")
+
+        provider._make_token_request = AsyncMock(
+            side_effect=Exception("OAuth token request failed with status 403. Response: forbidden")
+        )
+
+        with pytest.raises(Exception, match="403 Forbidden") as exc_info:
+            await provider.refresh_access_token("bad-refresh")
+        assert not isinstance(exc_info.value, RefreshTokenInvalidError)
+
+    @pytest.mark.asyncio
+    async def test_refresh_invalid_grant_raises_refresh_token_invalid_error(self, mock_config_service):
+        """invalid_grant (Google/Microsoft style, status 400) raises the typed error."""
+        config = _make_oauth_config()
+        provider = OAuthProvider(config, mock_config_service, "/path")
+
+        provider._make_token_request = AsyncMock(
+            side_effect=Exception('OAuth token request failed with status 400. Response: {"error":"invalid_grant"}')
+        )
+
+        with pytest.raises(RefreshTokenInvalidError, match="invalid_grant"):
+            await provider.refresh_access_token("expired-refresh")
 
     @pytest.mark.asyncio
     async def test_refresh_non_403_error_reraises(self, mock_config_service):

--- a/backend/python/tests/unit/connectors/test_token_refresh_service.py
+++ b/backend/python/tests/unit/connectors/test_token_refresh_service.py
@@ -1,0 +1,183 @@
+"""Tests for app.connectors.core.base.token_service.token_refresh_service"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.connectors.core.base.token_service.oauth_service import (
+    OAuthProvider,
+    OAuthToken,
+    RefreshTokenInvalidError,
+)
+from app.connectors.core.base.token_service.token_refresh_service import (
+    MAX_REFRESH_TOKEN_INVALID_FAILURES,
+    TokenRefreshService,
+)
+
+CONNECTOR_ID = "conn-123"
+
+
+@pytest.fixture
+def mock_config_service() -> MagicMock:
+    """Mock ConfigurationService with async get_config/set_config."""
+    svc = MagicMock()
+    svc.get_config = AsyncMock(return_value={})
+    svc.set_config = AsyncMock()
+    return svc
+
+
+@pytest.fixture
+def mock_graph_provider() -> MagicMock:
+    """Mock IGraphDBProvider with async update_node."""
+    provider = MagicMock()
+    provider.update_node = AsyncMock(return_value=True)
+    return provider
+
+
+@pytest.fixture
+def service(mock_config_service: MagicMock, mock_graph_provider: MagicMock) -> TokenRefreshService:
+    return TokenRefreshService(mock_config_service, mock_graph_provider)
+
+
+def _connector_config() -> dict:
+    """Connector config using the auth-config credential fallback path."""
+    return {
+        "auth": {
+            "clientId": "test-client-id",
+            "clientSecret": "test-client-secret",
+            "authorizeUrl": "https://auth.example.com/authorize",
+            "tokenUrl": "https://auth.example.com/token",
+            "redirectUri": "http://localhost/callback",
+        },
+        "credentials": {"access_token": "old-access", "refresh_token": "old-refresh"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Refresh-token-invalid threshold behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshTokenInvalidThreshold:
+    """Tests for _handle_refresh_token_invalid() deactivation threshold."""
+
+    @pytest.mark.asyncio
+    async def test_deactivates_only_on_threshold_rejection(self, service: TokenRefreshService, mock_graph_provider: MagicMock) -> None:
+        """First N-1 rejections leave the connector untouched; the Nth deactivates it."""
+        error = RefreshTokenInvalidError("refresh_token is invalid")
+
+        for _ in range(MAX_REFRESH_TOKEN_INVALID_FAILURES - 1):
+            await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+
+        mock_graph_provider.update_node.assert_not_awaited()
+        assert service._invalid_refresh_failures[CONNECTOR_ID] == MAX_REFRESH_TOKEN_INVALID_FAILURES - 1
+
+        await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+
+        mock_graph_provider.update_node.assert_awaited_once()
+        key, collection, updates = mock_graph_provider.update_node.await_args.args
+        assert key == CONNECTOR_ID
+        assert collection == "apps"
+        assert updates["isAuthenticated"] is False
+        assert updates["isActive"] is False
+        assert CONNECTOR_ID not in service._invalid_refresh_failures
+
+    @pytest.mark.asyncio
+    async def test_deactivation_publishes_app_disabled_event(
+        self, mock_config_service: MagicMock, mock_graph_provider: MagicMock
+    ) -> None:
+        """With a producer available, deactivation reuses the appDisabled event
+        and leaves isActive to its consumer."""
+        producer = MagicMock()
+        producer.send_message = AsyncMock()
+        service = TokenRefreshService(mock_config_service, mock_graph_provider, producer)
+
+        mock_graph_provider.get_document = AsyncMock(
+            return_value={"_key": CONNECTOR_ID, "type": "Confluence", "appGroup": "Atlassian", "scope": "team"}
+        )
+        mock_graph_provider.get_edges_to_node = AsyncMock(return_value=[{"_from": "orgs/org-1"}])
+
+        error = RefreshTokenInvalidError("refresh_token is invalid")
+        for _ in range(MAX_REFRESH_TOKEN_INVALID_FAILURES):
+            await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+
+        producer.send_message.assert_awaited_once()
+        kwargs = producer.send_message.await_args.kwargs
+        assert kwargs["topic"] == "entity-events"
+        assert kwargs["message"]["eventType"] == "appDisabled"
+        payload = kwargs["message"]["payload"]
+        assert payload["connectorId"] == CONNECTOR_ID
+        assert payload["orgId"] == "org-1"
+        assert payload["apps"] == ["confluence"]
+
+        _, _, updates = mock_graph_provider.update_node.await_args.args
+        assert updates["isAuthenticated"] is False
+        assert "isActive" not in updates
+
+    @pytest.mark.asyncio
+    async def test_event_send_failure_falls_back_to_direct_disable(
+        self, mock_config_service: MagicMock, mock_graph_provider: MagicMock
+    ) -> None:
+        """If the appDisabled publish fails, isActive is written directly instead."""
+        producer = MagicMock()
+        producer.send_message = AsyncMock(side_effect=Exception("kafka down"))
+        service = TokenRefreshService(mock_config_service, mock_graph_provider, producer)
+
+        mock_graph_provider.get_document = AsyncMock(
+            return_value={"_key": CONNECTOR_ID, "type": "Confluence", "appGroup": "Atlassian", "scope": "team"}
+        )
+        mock_graph_provider.get_edges_to_node = AsyncMock(return_value=[{"_from": "orgs/org-1"}])
+
+        error = RefreshTokenInvalidError("refresh_token is invalid")
+        for _ in range(MAX_REFRESH_TOKEN_INVALID_FAILURES):
+            await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+
+        _, _, updates = mock_graph_provider.update_node.await_args.args
+        assert updates["isAuthenticated"] is False
+        assert updates["isActive"] is False
+
+    @pytest.mark.asyncio
+    async def test_scan_skips_explicitly_unauthenticated_connectors(
+        self, service: TokenRefreshService, mock_config_service: MagicMock
+    ) -> None:
+        """Explicit isAuthenticated=False is skipped; missing flag (legacy) is kept."""
+        mock_config_service.get_config = AsyncMock(
+            return_value={"credentials": {"refresh_token": "tok"}}
+        )
+        connectors = [
+            {"_key": "dead", "authType": "OAUTH", "isAuthenticated": False},
+            {"_key": "legacy", "authType": "OAUTH"},
+            {"_key": "live", "authType": "OAUTH", "isAuthenticated": True},
+            {"_key": "api", "authType": "API_TOKEN", "isAuthenticated": False},
+        ]
+
+        result = await service._filter_authenticated_oauth_connectors(connectors)
+
+        assert [c["_key"] for c in result] == ["legacy", "live"]
+
+    @pytest.mark.asyncio
+    async def test_successful_refresh_resets_failure_count(
+        self, service: TokenRefreshService, mock_config_service: MagicMock, mock_graph_provider: MagicMock
+    ) -> None:
+        """A successful refresh clears the streak; deactivation needs N new consecutive failures."""
+        error = RefreshTokenInvalidError("refresh_token is invalid")
+
+        for _ in range(MAX_REFRESH_TOKEN_INVALID_FAILURES - 2):
+            await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+
+        mock_config_service.get_config = AsyncMock(return_value=_connector_config())
+        new_token = OAuthToken(access_token="new-access", refresh_token="new-refresh", expires_in=3600)
+        with (
+            patch.object(OAuthProvider, "refresh_access_token", AsyncMock(return_value=new_token)),
+            patch.object(OAuthProvider, "close", AsyncMock()),
+        ):
+            await service.refresh_now(CONNECTOR_ID, "confluence", "old-refresh")
+
+        assert CONNECTOR_ID not in service._invalid_refresh_failures
+
+        for _ in range(MAX_REFRESH_TOKEN_INVALID_FAILURES - 1):
+            await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+        mock_graph_provider.update_node.assert_not_awaited()
+
+        await service._handle_refresh_token_invalid(CONNECTOR_ID, error)
+        mock_graph_provider.update_node.assert_awaited_once()

--- a/backend/python/tests/unit/connectors/test_toolset_token_refresh_service.py
+++ b/backend/python/tests/unit/connectors/test_toolset_token_refresh_service.py
@@ -1,0 +1,66 @@
+"""Tests for app.connectors.core.base.token_service.toolset_token_refresh_service"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.connectors.core.base.token_service.oauth_service import (
+    RefreshTokenInvalidError,
+)
+from app.connectors.core.base.token_service.toolset_token_refresh_service import (
+    MAX_REFRESH_TOKEN_INVALID_FAILURES,
+    ToolsetTokenRefreshService,
+)
+
+CONFIG_PATH = "/services/toolsets/inst-1/user-1"
+
+
+@pytest.fixture
+def mock_config_service() -> MagicMock:
+    """Mock ConfigurationService with async get_config/set_config."""
+    svc = MagicMock()
+    svc.get_config = AsyncMock(return_value={"isAuthenticated": True, "toolsetType": "confluence"})
+    svc.set_config = AsyncMock(return_value=True)
+    return svc
+
+
+@pytest.fixture
+def service(mock_config_service: MagicMock) -> ToolsetTokenRefreshService:
+    return ToolsetTokenRefreshService(mock_config_service)
+
+
+class TestToolsetRefreshTokenInvalidThreshold:
+    """Tests for _handle_refresh_token_invalid() deactivation threshold."""
+
+    @pytest.mark.asyncio
+    async def test_deactivates_only_on_threshold_rejection(
+        self, service: ToolsetTokenRefreshService, mock_config_service: MagicMock
+    ) -> None:
+        """First N-1 rejections leave the toolset untouched; the Nth deauthenticates it."""
+        error = RefreshTokenInvalidError("refresh_token is invalid")
+
+        for _ in range(MAX_REFRESH_TOKEN_INVALID_FAILURES - 1):
+            await service._handle_refresh_token_invalid(CONFIG_PATH, error)
+
+        mock_config_service.set_config.assert_not_awaited()
+        assert service._invalid_refresh_failures[CONFIG_PATH] == MAX_REFRESH_TOKEN_INVALID_FAILURES - 1
+
+        await service._handle_refresh_token_invalid(CONFIG_PATH, error)
+
+        mock_config_service.set_config.assert_awaited_once()
+        path, config = mock_config_service.set_config.await_args.args
+        assert path == CONFIG_PATH
+        assert config["isAuthenticated"] is False
+        assert config["deauthReason"] == "refresh_token_invalid"
+        assert CONFIG_PATH not in service._invalid_refresh_failures
+
+    @pytest.mark.asyncio
+    async def test_mark_unauthenticated_tolerates_missing_config(
+        self, service: ToolsetTokenRefreshService, mock_config_service: MagicMock
+    ) -> None:
+        """A deleted toolset config aborts the write without raising."""
+        mock_config_service.get_config = AsyncMock(return_value=None)
+
+        await service._mark_toolset_unauthenticated(CONFIG_PATH)
+
+        mock_config_service.set_config.assert_not_awaited()

--- a/backend/python/tests/unit/events/test_entity_event_service.py
+++ b/backend/python/tests/unit/events/test_entity_event_service.py
@@ -475,6 +475,52 @@ class TestHandleAppDisabled:
         assert result is False
 
     @pytest.mark.asyncio
+    async def test_app_disabled_removes_live_connector_instance(self):
+        svc, logger, gp, container = _make_service()
+        gp.get_document = AsyncMock(return_value={
+            "name": "Drive", "type": "FILE", "appGroup": "Google",
+            "createdAtTimestamp": 1000000,
+        })
+        gp.batch_upsert_nodes = AsyncMock()
+        live_connector = MagicMock()
+        live_connector.cleanup = AsyncMock()
+        container.connectors_map = {"conn-1": live_connector}
+
+        with patch("app.services.messaging.kafka.handlers.entity.sync_task_manager") as mock_stm:
+            mock_stm.cancel_sync = AsyncMock()
+            result = await svc.process_event("appDisabled", {
+                "orgId": "org-1",
+                "apps": ["Drive"],
+                "connectorId": "conn-1",
+            })
+        assert result is True
+        assert "conn-1" not in container.connectors_map
+        live_connector.cleanup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_app_disabled_connector_cleanup_error_tolerated(self):
+        svc, logger, gp, container = _make_service()
+        gp.get_document = AsyncMock(return_value={
+            "name": "Drive", "type": "FILE", "appGroup": "Google",
+            "createdAtTimestamp": 1000000,
+        })
+        gp.batch_upsert_nodes = AsyncMock()
+        live_connector = MagicMock()
+        live_connector.cleanup = AsyncMock(side_effect=Exception("cleanup failed"))
+        container.connectors_map = {"conn-1": live_connector}
+
+        with patch("app.services.messaging.kafka.handlers.entity.sync_task_manager") as mock_stm:
+            mock_stm.cancel_sync = AsyncMock()
+            result = await svc.process_event("appDisabled", {
+                "orgId": "org-1",
+                "apps": ["Drive"],
+                "connectorId": "conn-1",
+            })
+        assert result is True
+        # Popped before cleanup, so the map entry is gone even on cleanup failure
+        assert "conn-1" not in container.connectors_map
+
+    @pytest.mark.asyncio
     async def test_cancel_sync_error_handled(self):
         svc, logger, gp, _ = _make_service()
         gp.get_document = AsyncMock(return_value={


### PR DESCRIPTION
## Description

An expired or revoked OAuth refresh token cannot be recovered programmatically — only user re-authentication fixes it. Both token refresh services treated this as retryable: every dead integration was retried on every 5-minute scan indefinitely. Production log driving this change (Confluence toolset, Atlassian returning 403 unauthorized_client / "refresh_token is invalid"):


## Design
OAuthProvider.refresh_access_token()
  └─ response contains a permanent-rejection marker → raise RefreshTokenInvalidError (typed)
        │
        ├─ TokenRefreshService (connectors)
        │    count consecutive rejections per connector (in-memory)
        │    on the 3rd: write isAuthenticated=False (Arango apps doc)
        │                publish existing `appDisabled` event → entity-events topic
        │                    consumer: isActive=False, cancel running sync,
        │                              remove + cleanup live instance from connectors_map
        │                fallback (producer unavailable/send fails): write isActive=False directly
        │
        └─ ToolsetTokenRefreshService (toolsets, per-user etcd records)
             same 3-strike counter
             on the 3rd: isAuthenticated=False + deauthReason="refresh_token_invalid" + deauthAt

Any successful refresh resets the streak — "consecutive" is enforced, so provider blips can't accumulate into a deactivation. Recovery is the existing re-auth flow (connector OAuth callback / toolset auth completion both restore isAuthenticated: True); re-enabling sync is the existing toggle endpoint.


## Changes
What to review, file by file. Detailed changes for review

1. oauth_service.py — typed, marker-based rejection detection

- New RefreshTokenInvalidError(Exception). Subclasses Exception, so every existing except Exception caller keeps working — backward compat is proven by the untouched pre-existing test that matches the 403 message text.
- refresh_access_token() classifies a failure as permanent only when the response body contains a token-specific marker (_PERMANENT_REFRESH_ERROR_MARKERS): invalid_grant (RFC 6749 §5.2 — Google, Microsoft, Dropbox, Zoom, Salesforce, ServiceNow, GitLab), refresh_token is invalid / variants (Atlassian's 403 error_description), invalid_refresh_token (Slack rotation), bad_refresh_token (GitHub expiring tokens).
- Reviewer attention: there is deliberately no status-code rule. Providers disagree on status (400 majority, Atlassian 403, Zoom 401, GitHub/Slack even use 200-with-error-body), and a bare 403 can be a WAF block, IP restriction, or app misconfiguration — those must never deactivate. A markerless 403 keeps its old enhanced message as a plain Exception and stays retryable.
- Known gap, dormant: GitHub/Slack return rejection in an HTTP 200 body, which _make_token_request never raises on — unreachable by this detection. Both are non-issues in this platform today (GitHub tokens non-expiring by default; Slack configured as bot API_TOKEN).

2. token_refresh_service.py (connectors) — counting, deactivation, event publishing

- MAX_REFRESH_TOKEN_INVALID_FAILURES = 3 module constant; per-connector counter in _invalid_refresh_failures, logging failure N/3 before deactivation. Counter cleared on refresh success inside _perform_token_refresh — the single success point all paths flow through.
- All three failure paths are wired and mutually exclusive per failure event (worth tracing in review): the periodic-scan/scheduled path (_refresh_connector_token except-clause), the immediate-refresh path (_refresh_token_immediately, which swallows errors by contract so it must count first), and the public on-demand refresh_now() (used by gitlab/runtime.py; counts then re-raises so its caller still sees the failure).
- _mark_connector_unauthenticated(): writes isAuthenticated: False + updatedAtTimestamp via the injected IGraphDBProvider.update_node against apps. The registry's update_connector_instance was deliberately not reused — it enforces per-user access control a system background service has no identity for.
- _send_app_disabled_event(): reuses the platform's existing appDisabled event (topic entity-events) — same producer-side payload shape as the sync-toggle endpoint. orgId (required by the consumer, not stored on app docs) is resolved via the orgAppRelation edge (orgs/{orgId} → apps/{connectorId}). If the producer is unset or the send fails, isActive: False goes into the same direct update_node write, so a Kafka outage cannot leave a dead connector scheduled for sync.
- Subtle guard: when the failure surfaces inside the scheduled _delayed_refresh task itself, cancelling "the tracked task" would cancel ourselves and abort the state write at the next await. _mark_connector_unauthenticated compares against asyncio.current_task() before cancelling.
- Scan filter: _filter_authenticated_oauth_connectors skips docs with explicit isAuthenticated is False (identity check, not falsy) — legacy docs missing the flag keep refreshing. This is the line that actually stops the fan-out: the scan previously checked only etcd credential presence, and a revoked token still exists in etcd.
- Producer dependency is typed against the messaging abstraction: messaging_producer: Optional[IMessagingProducer] (Kafka and Redis Streams both implement it). Because the lifespan starts the producer after the refresh service, connectors_main attaches it via startup_service.set_messaging_producer() immediately after start_messaging_producer() succeeds.

3. entity.py — appDisabled consumer completes the disable

- After the existing isActive: False upsert and sync_task_manager.cancel_sync, the handler now removes the live connector from app_container.connectors_map and awaits its cleanup() — so re-enable does a full re-init instead of reusing a client holding dead credentials. Guarded, so the toggle path (which already pops the map before publishing) no-ops through it; the delete flow gains map cleanup it was previously missing.
- Verified merge semantics (the assumption this design rests on): the consumer's batch_upsert_nodes → batch_insert_documents defaults to overwrite_mode="update" — partial docs merge, so the consumer's write and the refresh service's isAuthenticated write cannot clobber each other in either processing order.

4. toolset_token_refresh_service.py — per-user deactivation, no event

- Same 3-strike counter; deactivation writes isAuthenticated: False, deauthReason: "refresh_token_invalid", deauthAt — the exact shape the admin deauth flow in toolsets.py already writes. Toolset scans already gate on isAuthenticated, so no scan change.
- Deliberate asymmetry — no isActive, no event: toolset auth records are per-user (/services/toolsets/{instanceId}/{userId}) and the instance is shared; one user's dead token must not disable the toolset for everyone. The agent runtime's only usability gate is isAuthenticated (agent.py), toolsets have no sync pipeline to stop, and nothing consumes a toolset-disable event — the etcd flip is the complete disable.
- Counter entries pruned for deleted toolsets in the existing hourly cleanup sweep.

Known limitations (accepted, documented)

1. Failure counters are in-memory: a restart resets streaks (~15 min to re-trip at the 5-min cadence); multi-replica deployments count per instance.
2. In the no-producer fallback, a currently running sync isn't cancelled (only the consumer does that) — it dies on the dead token; future syncs are blocked by isActive: False.
3. Salesforce overloads invalid_grant for IP restrictions/deactivated users — those also deactivate after 3 strikes, which still requires admin action either way.
4. Recovery is two-step for connectors: re-auth restores isAuthenticated; sync re-enable is the existing toggle (which also flips isActive back).



### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes. Provide instructions so we can reproduce.]

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [ ] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [ ] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness
