### PR TITLE
Using an individual VLMOCR instance for each ocr parse call

### DIFF
--- a/backend/python/app/modules/parsers/pdf/ocr_handler.py
+++ b/backend/python/app/modules/parsers/pdf/ocr_handler.py
@@ -59,7 +59,12 @@ class OCRStrategy(ABC):
 
 
 class OCRHandler:
-    """Factory and facade for OCR processing"""
+    """Factory and facade for OCR processing.
+
+    Strategies hold mutable per-document state (page images, temp PDF path),
+    so each ``process_document`` call creates a fresh strategy instance.
+    The handler itself is safe to share across concurrent requests.
+    """
 
     def __init__(self, logger, strategy_type: str, **kwargs) -> None:
         """
@@ -71,33 +76,37 @@ class OCRHandler:
         """
         self.logger = logger
         self.provider = strategy_type
+        self._strategy_kwargs = kwargs
         self.logger.info("🛠️ Initializing OCR handler with strategy: %s", strategy_type)
-        self.strategy = self._create_strategy(strategy_type, **kwargs)
+        self._ensure_supported(strategy_type)
+
+    def _ensure_supported(self, strategy_type: str) -> None:
+        if strategy_type == OCRProvider.VLM_OCR.value:
+            return
+        self.logger.error(f"❌ Unsupported OCR strategy: {strategy_type}")
+        raise DocumentProcessingError(
+            f"Unsupported OCR strategy: {strategy_type}",
+            details={"strategy": strategy_type},
+        )
 
     def _create_strategy(self, strategy_type: str, **kwargs) -> OCRStrategy:
         """Factory method to create appropriate OCR strategy"""
         self.logger.debug(f"🏭 Creating OCR strategy: {strategy_type}")
+        self._ensure_supported(strategy_type)
 
-        if strategy_type == OCRProvider.VLM_OCR.value:
-            self.logger.debug("🤖 Creating VLM OCR strategy")
-            from app.modules.parsers.pdf.vlm_ocr_strategy import (
-                VLMOCRStrategy,
-            )
+        self.logger.debug("🤖 Creating VLM OCR strategy")
+        from app.modules.parsers.pdf.vlm_ocr_strategy import (
+            VLMOCRStrategy,
+        )
 
-            return VLMOCRStrategy(
-                logger=self.logger,
-                config=kwargs.get("config"),
-            )
-        else:
-            self.logger.error(f"❌ Unsupported OCR strategy: {strategy_type}")
-            raise DocumentProcessingError(
-                f"Unsupported OCR strategy: {strategy_type}",
-                details={"strategy": strategy_type},
-            )
+        return VLMOCRStrategy(
+            logger=self.logger,
+            config=kwargs.get("config"),
+        )
 
     async def process_document(self, content: bytes) -> Dict[str, Any]:
         """
-        Process document using the configured OCR strategy
+        Process document using a fresh OCR strategy instance.
 
         Args:
             content: PDF document content as bytes
@@ -106,10 +115,11 @@ class OCRHandler:
             Dict containing extracted text and layout information
         """
         self.logger.info("🚀 Starting document processing")
+        strategy = self._create_strategy(self.provider, **self._strategy_kwargs)
         try:
             self.logger.debug("📥 Loading document")
-            await self.strategy.load_document(content)
-            return self.strategy.document_analysis_result
+            await strategy.load_document(content)
+            return strategy.document_analysis_result
         except Exception as e:
             self.logger.error(f"❌ Error processing document: {str(e)}")
             raise

--- a/backend/python/tests/unit/modules/parsers/test_ocr_handler.py
+++ b/backend/python/tests/unit/modules/parsers/test_ocr_handler.py
@@ -1,7 +1,7 @@
 """Tests for OCRHandler and OCRStrategy."""
 
 import logging
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -153,33 +153,18 @@ class TestOCRHandlerInit:
     def logger(self):
         return logging.getLogger("test_ocr_handler")
 
-    @patch("app.modules.parsers.pdf.ocr_handler.OCRProvider", OCRProvider)
     def test_init_vlm_ocr_strategy(self, logger):
-        """OCRHandler with VLM OCR strategy."""
-        with patch(
-            "app.modules.parsers.pdf.vlm_ocr_strategy.VLMOCRStrategy"
-        ) as mock_cls:
-            mock_strategy = MagicMock()
-            mock_cls.return_value = mock_strategy
+        """OCRHandler with VLM OCR strategy validates and stores config."""
+        handler = OCRHandler(logger, OCRProvider.VLM_OCR.value, config={"key": "val"})
 
-            handler = OCRHandler(logger, OCRProvider.VLM_OCR.value, config={"key": "val"})
-
-            assert handler.provider == OCRProvider.VLM_OCR.value
-            assert handler.strategy is mock_strategy
-            mock_cls.assert_called_once_with(logger=logger, config={"key": "val"})
+        assert handler.provider == OCRProvider.VLM_OCR.value
+        assert handler._strategy_kwargs == {"config": {"key": "val"}}
 
     def test_init_unsupported_strategy_raises(self, logger):
         """Unsupported strategy type raises ValueError."""
         with pytest.raises(DocumentProcessingError, match="Unsupported OCR strategy"):
             OCRHandler(logger, "unknown_strategy")
 
-
-class TestOCRHandlerCreateStrategy:
-    """Tests for OCRHandler._create_strategy selection logic."""
-
-    @pytest.fixture
-    def logger(self):
-        return logging.getLogger("test_strategy")
 
 class TestOCRHandlerProcessDocument:
     """Tests for OCRHandler.process_document."""
@@ -190,36 +175,60 @@ class TestOCRHandlerProcessDocument:
 
     @pytest.mark.asyncio
     async def test_process_document_success(self, logger):
-        """process_document calls strategy.load_document and returns result."""
+        """process_document creates a strategy, loads the document, returns result."""
         mock_strategy = MagicMock()
         mock_strategy.load_document = AsyncMock(return_value=None)
         mock_strategy.document_analysis_result = {"pages": [{"text": "Hello"}]}
 
-        # Bypass __init__ strategy creation
-        with patch.object(OCRHandler, "__init__", lambda self, *a, **kw: None):
-            handler = OCRHandler.__new__(OCRHandler)
-            handler.logger = logger
-            handler.strategy = mock_strategy
-            mock_strategy.load_document = AsyncMock()
+        handler = OCRHandler.__new__(OCRHandler)
+        handler.logger = logger
+        handler.provider = OCRProvider.VLM_OCR.value
+        handler._strategy_kwargs = {"config": {"key": "val"}}
 
+        with patch.object(handler, "_create_strategy", return_value=mock_strategy) as create:
             result = await handler.process_document(b"pdf-bytes")
 
-            mock_strategy.load_document.assert_awaited_once_with(b"pdf-bytes")
-            assert result == {"pages": [{"text": "Hello"}]}
+        create.assert_called_once_with(OCRProvider.VLM_OCR.value, config={"key": "val"})
+        mock_strategy.load_document.assert_awaited_once_with(b"pdf-bytes")
+        assert result == {"pages": [{"text": "Hello"}]}
 
     @pytest.mark.asyncio
     async def test_process_document_raises_on_error(self, logger):
         """process_document re-raises exceptions from strategy."""
-        with patch.object(OCRHandler, "__init__", lambda self, *a, **kw: None):
-            handler = OCRHandler.__new__(OCRHandler)
-            handler.logger = logger
-            handler.strategy = MagicMock()
-            handler.strategy.load_document = AsyncMock(side_effect=RuntimeError("parse error"))
+        mock_strategy = MagicMock()
+        mock_strategy.load_document = AsyncMock(side_effect=RuntimeError("parse error"))
 
+        handler = OCRHandler.__new__(OCRHandler)
+        handler.logger = logger
+        handler.provider = OCRProvider.VLM_OCR.value
+        handler._strategy_kwargs = {}
+
+        with patch.object(handler, "_create_strategy", return_value=mock_strategy):
             with pytest.raises(RuntimeError, match="parse error"):
                 await handler.process_document(b"bad-pdf")
 
+    @pytest.mark.asyncio
+    async def test_process_document_uses_fresh_strategy_per_call(self, logger):
+        """Concurrent-safe: each process_document call gets its own strategy."""
+        strategies = []
 
-# Need this import for AsyncMock in process_document tests
-from unittest.mock import AsyncMock
-import asyncio
+        def make_strategy(*_args, **_kwargs):
+            strategy = MagicMock()
+            strategy.load_document = AsyncMock()
+            strategy.document_analysis_result = {"id": len(strategies)}
+            strategies.append(strategy)
+            return strategy
+
+        handler = OCRHandler(logger, OCRProvider.VLM_OCR.value, config={})
+        with patch(
+            "app.modules.parsers.pdf.vlm_ocr_strategy.VLMOCRStrategy",
+            side_effect=make_strategy,
+        ):
+            result_a = await handler.process_document(b"doc-a")
+            result_b = await handler.process_document(b"doc-b")
+
+        assert result_a == {"id": 0}
+        assert result_b == {"id": 1}
+        assert strategies[0] is not strategies[1]
+        strategies[0].load_document.assert_awaited_once_with(b"doc-a")
+        strategies[1].load_document.assert_awaited_once_with(b"doc-b")


### PR DESCRIPTION
<img width="840" height="332" alt="image" src="https://github.com/user-attachments/assets/4b37feb4-7829-4c5e-a476-ef0e9ba5a633" />
