### PR TITLE
Removed base64 encoding for pdfs client-to-docling_service sending

### DIFF
--- a/backend/python/app/services/docling/client.py
+++ b/backend/python/app/services/docling/client.py
@@ -1,5 +1,4 @@
 import asyncio
-import base64
 import json
 import os
 from typing import Optional
@@ -22,154 +21,6 @@ class DoclingClient:
         self.logger = create_logger(__name__)
         self.max_retries = 3
         self.retry_delay = 1.0  # seconds
-
-    async def process_pdf(self, record_name: str, pdf_binary: bytes, org_id: Optional[str] = None) -> Optional[BlocksContainer]:
-        """
-        Process PDF using the external Docling service with retry logic
-
-        Args:
-            record_name: Name of the record/document
-            pdf_binary: Binary PDF data
-            org_id: Optional organization ID
-
-        Returns:
-            BlocksContainer if successful, None if failed
-        """
-
-        # Validate pdf_binary type
-        if not isinstance(pdf_binary, bytes):
-            self.logger.error(f"❌ Invalid pdf_binary type: expected bytes, got {type(pdf_binary).__name__}")
-            return None
-
-
-        # Validate payload size
-        if len(pdf_binary) > 100 * 1024 * 1024:  # 100MB limit
-            self.logger.error(f"❌ PDF too large for processing: {len(pdf_binary)} bytes (max: 100MB)")
-            return None
-
-        # Configure httpx with proper connection settings
-        timeout_config = httpx.Timeout(
-            connect=30.0,  # Connection timeout
-            read=self.timeout,  # Read timeout
-            write=30.0,  # Write timeout
-            pool=30.0  # Pool timeout
-        )
-
-        # Use connection pooling and keep-alive
-        limits = httpx.Limits(
-            max_keepalive_connections=5,
-            max_connections=10,
-            keepalive_expiry=30.0
-        )
-
-        # Create client once and reuse for all retry attempts
-        async with httpx.AsyncClient(
-            timeout=timeout_config,
-            limits=limits,
-            http2=True  # Enable HTTP/2 for better performance
-        ) as client:
-            for attempt in range(self.max_retries):
-                try:
-                    # Encode PDF binary to base64
-                    pdf_base64 = base64.b64encode(pdf_binary).decode('utf-8')
-
-                    # Prepare request payload
-                    payload = {
-                        "record_name": record_name,
-                        "pdf_binary": pdf_base64,
-                        "org_id": org_id
-                    }
-
-                    self.logger.info(f"🚀 Sending PDF processing request for: {record_name} (attempt {attempt + 1}/{self.max_retries})")
-
-                    response = await client.post(
-                        f"{self.service_url}/process-pdf",
-                        json=payload,
-                        headers=inject_request_headers({
-                            "Content-Type": "application/json",
-                            "Connection": "keep-alive",
-                            "Keep-Alive": "timeout=30"
-                        })
-                    )
-
-                    if response.status_code == HttpStatusCode.SUCCESS.value:
-                        # Parse JSON response in thread pool to avoid blocking
-                        result = await asyncio.to_thread(response.json)
-                        if result.get("success"):
-                            # Run heavy JSON parsing and object creation in thread pool
-                            block_containers = await asyncio.to_thread(
-                                self._parse_blocks_container,
-                                result["block_containers"]
-                            )
-                            return block_containers
-                        else:
-                            error_msg = result.get("error", "Unknown error")
-                            self.logger.error(f"❌ Docling service returned error for {record_name}: {error_msg}")
-                            return None
-                    else:
-                        self.logger.error(f"❌ Docling service HTTP error {response.status_code}: {response.text}")
-
-                        # Check if it's a service unavailable error
-                        if response.status_code in [502, 503, 504]:
-                            self.logger.warning(f"⚠️ Service temporarily unavailable (HTTP {response.status_code})")
-
-                        if attempt < self.max_retries - 1:
-                            delay = self.retry_delay * (2 ** attempt)
-                            self.logger.info(f"🔄 Retrying in {delay} seconds...")
-                            await asyncio.sleep(delay)
-                            continue
-                        return None
-
-                except httpx.TimeoutException as e:
-                    self.logger.error(f"❌ Timeout processing PDF {record_name} (attempt {attempt + 1}): {str(e)}")
-                    if attempt < self.max_retries - 1:
-                        delay = self.retry_delay * (2 ** attempt)
-                        self.logger.info(f"🔄 Retrying in {delay} seconds...")
-                        await asyncio.sleep(delay)
-                        continue
-                    return None
-                except httpx.ConnectError as e:
-                    self.logger.error(f"❌ Connection error processing PDF {record_name} (attempt {attempt + 1}): {str(e)}")
-                    self.logger.warning("⚠️ Service appears to be down (connection refused)")
-
-                    if attempt < self.max_retries - 1:
-                        delay = self.retry_delay * (2 ** attempt)
-                        self.logger.info(f"🔄 Service may be starting up. Retrying in {delay} seconds...")
-                        await asyncio.sleep(delay)
-                        continue
-                    return None
-                except httpx.WriteError as e:
-                    # Handle the specific "write could not complete without blocking" error
-                    self.logger.error(f"❌ Write error processing PDF {record_name} (attempt {attempt + 1}): {str(e)}")
-                    if "write could not complete without blocking" in str(e):
-                        self.logger.warning("⚠️ Network buffer issue detected, retrying with exponential backoff...")
-                        if attempt < self.max_retries - 1:
-                            # Exponential backoff for write errors
-                            delay = self.retry_delay * (2 ** attempt)
-                            self.logger.info(f"🔄 Retrying in {delay} seconds...")
-                            await asyncio.sleep(delay)
-                            continue
-                    return None
-                except httpx.RequestError as e:
-                    self.logger.error(f"❌ Request error processing PDF {record_name} (attempt {attempt + 1}): {str(e)}")
-                    if attempt < self.max_retries - 1:
-                        delay = self.retry_delay * (2 ** attempt)
-                        self.logger.info(f"🔄 Retrying in {delay} seconds...")
-                        await asyncio.sleep(delay)
-                        continue
-                    return None
-                except Exception as e:
-                    self.logger.error(f"❌ Unexpected error processing PDF {record_name} (attempt {attempt + 1}): {str(e)}")
-                    self.logger.exception(e)  # Log full traceback for debugging
-                    if attempt < self.max_retries - 1:
-                        delay = self.retry_delay * (2 ** attempt)
-                        self.logger.info(f"🔄 Retrying in {delay} seconds...")
-                        await asyncio.sleep(delay)
-                        continue
-                    return None
-
-            self.logger.error(f"❌ Failed to process PDF {record_name} after {self.max_retries} attempts")
-            return None
 
     def _parse_blocks_container(self, block_containers_data) -> BlocksContainer:
         """
@@ -199,21 +50,18 @@ class DoclingClient:
         Returns:
             Serialized parse result (JSON-encoded document) if successful, None if failed
         """
-        # Validate pdf_binary type
         if not isinstance(pdf_binary, bytes):
             self.logger.error(f"❌ Invalid pdf_binary type: expected bytes, got {type(pdf_binary).__name__}")
             return None
 
-        # Validate payload size
         if len(pdf_binary) > 100 * 1024 * 1024:  # 100MB limit
             self.logger.error(f"❌ PDF too large for processing: {len(pdf_binary)} bytes (max: 100MB)")
             return None
 
-        # Configure httpx with proper connection settings (shorter timeout for parsing)
         timeout_config = httpx.Timeout(
             connect=30.0,
-            read=self.timeout,  # 40 minutes for parsing
-            write=30.0,
+            read=self.timeout,
+            write=60.0,
             pool=30.0
         )
 
@@ -230,19 +78,13 @@ class DoclingClient:
         ) as client:
             for attempt in range(self.max_retries):
                 try:
-                    pdf_base64 = base64.b64encode(pdf_binary).decode('utf-8')
-                    payload = {
-                        "record_name": record_name,
-                        "pdf_binary": pdf_base64
-                    }
-
                     self.logger.info(f"🚀 Sending PDF parse request for: {record_name} (attempt {attempt + 1}/{self.max_retries})")
 
                     response = await client.post(
                         f"{self.service_url}/parse-pdf",
-                        json=payload,
+                        data={"record_name": record_name},
+                        files={"file": (record_name, pdf_binary, "application/pdf")},
                         headers=inject_request_headers({
-                            "Content-Type": "application/json",
                             "Connection": "keep-alive",
                             "Keep-Alive": "timeout=30"
                         })

--- a/backend/python/app/services/docling/docling_service.py
+++ b/backend/python/app/services/docling/docling_service.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from docling_core.types.doc.document import DoclingDocument
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 
 from app.config.constants.http_status_code import HttpStatusCode
@@ -26,11 +26,6 @@ class ProcessResponse(BaseModel):
     success: bool
     block_containers: dict[str, Any] | None = None
     error: str | None = None
-
-
-class ParseRequest(BaseModel):
-    record_name: str
-    pdf_binary: str  # base64 encoded PDF binary data
 
 
 class ParseResponse(BaseModel):
@@ -268,32 +263,22 @@ def deserialize_docling_doc(serialized: str) -> DoclingDocument:
 
 
 @app.post("/parse-pdf", response_model=ParseResponse)
-async def parse_pdf_endpoint(request: ParseRequest) -> ParseResponse:
+async def parse_pdf_endpoint(
+    file: UploadFile = File(...),
+    record_name: str = Form(...),
+) -> ParseResponse:
     """Parse PDF document (phase 1 - no block creation, no LLM calls)"""
     try:
-        # Decode base64 PDF binary data
-        try:
-            pdf_binary = base64.b64decode(request.pdf_binary)
-        except Exception as e:
-            raise HTTPException(
-                status_code=HttpStatusCode.BAD_REQUEST.value,
-                detail=f"Invalid base64 PDF data: {str(e)}"
-            ) from e
+        pdf_binary = await file.read()
 
-        # Ensure service is wired
         if docling_service is None:
             raise HTTPException(status_code=500, detail="Docling service not available")
 
-        # Parse the PDF with timeout
         doc = await asyncio.wait_for(
-            docling_service.parse_pdf_only(
-                request.record_name,
-                pdf_binary
-            ),
+            docling_service.parse_pdf_only(record_name, pdf_binary),
             timeout=PDF_PARSING_TIMEOUT_SECONDS
         )
 
-        # Serialize ConversionResult document to JSON
         serialized_result = await asyncio.to_thread(serialize_docling_doc, doc)
 
         return ParseResponse(
@@ -348,7 +333,6 @@ async def create_blocks_endpoint(request: CreateBlocksRequest) -> CreateBlocksRe
             success=True,
             block_containers=block_containers_dict
         )
-
     except asyncio.TimeoutError:
         return CreateBlocksResponse(
             success=False,

--- a/backend/python/tests/unit/services/docling/test_docling_client.py
+++ b/backend/python/tests/unit/services/docling/test_docling_client.py
@@ -1,19 +1,13 @@
 """
 Tests for DoclingClient:
   - __init__ (URL, timeout, retry config)
-  - process_pdf (base64 encoding, HTTP POST, response parsing, retry, size validation)
   - _parse_blocks_container (dict and string input)
-  - parse_pdf (similar to process_pdf but returns parse_result string)
+  - parse_pdf (multipart POST /parse-pdf, response parsing, retry, size validation)
   - create_blocks (POST /create-blocks)
   - health_check (GET /health)
   - _check_service_health (internal health check with existing client)
 """
 
-import asyncio
-import base64
-import json
-import logging
-from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -46,12 +40,6 @@ def _make_response(status_code=200, json_data=None, text=""):
     if json_data is not None:
         resp.json = lambda: json_data
     return resp
-
-
-@asynccontextmanager
-async def _mock_async_client(mock_client_instance):
-    """Helper context manager that yields the mock client instance."""
-    yield mock_client_instance
 
 
 # ===========================================================================
@@ -92,243 +80,6 @@ class TestInit:
     def test_default_url_fallback(self):
         c = DoclingClient()
         assert c.service_url == "http://localhost:8081"
-
-
-# ===========================================================================
-# process_pdf
-# ===========================================================================
-
-
-class TestProcessPdf:
-    """Test process_pdf method."""
-
-    @pytest.mark.asyncio
-    async def test_invalid_pdf_type_returns_none(self, client):
-        result = await client.process_pdf("doc.pdf", "not bytes")  # type: ignore
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_pdf_too_large_returns_none(self, client):
-        huge = b"x" * (101 * 1024 * 1024)  # 101 MB
-        result = await client.process_pdf("doc.pdf", huge)
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_successful_processing(self, client, small_pdf):
-        """Successful POST returns a parsed BlocksContainer."""
-        blocks_data = {"blocks": [], "block_groups": []}
-        response_json = {"success": True, "block_containers": blocks_data}
-        mock_blocks = MagicMock()
-
-        mock_response = _make_response(status_code=200, json_data=response_json)
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        async def fake_to_thread(fn, *args, **kwargs):
-            return fn(*args, **kwargs)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            with patch("asyncio.to_thread", side_effect=fake_to_thread):
-                with patch.object(client, "_parse_blocks_container", return_value=mock_blocks):
-                    result = await client.process_pdf("doc.pdf", small_pdf, org_id="org-1")
-
-        assert result is mock_blocks
-        mock_http.post.assert_awaited_once()
-        call_args = mock_http.post.call_args
-        assert "/process-pdf" in call_args[0][0]
-
-    @pytest.mark.asyncio
-    async def test_service_returns_error(self, client, small_pdf):
-        """When service returns success=False, should return None."""
-        response_json = {"success": False, "error": "parse failure"}
-        mock_response = _make_response(status_code=200, json_data=response_json)
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        async def fake_to_thread(fn, *args, **kwargs):
-            return fn(*args, **kwargs)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            with patch("asyncio.to_thread", side_effect=fake_to_thread):
-                result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_http_error_retries_and_fails(self, client, small_pdf):
-        """Non-200 response should retry and eventually return None."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_response = _make_response(status_code=503, text="Service Unavailable")
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_timeout_retries(self, client, small_pdf):
-        """TimeoutException should trigger retries."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(side_effect=httpx.TimeoutException("timed out"))
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_connect_error_retries(self, client, small_pdf):
-        """ConnectError should trigger retries."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_write_error_blocking_retries(self, client, small_pdf):
-        """WriteError with 'write could not complete without blocking' should retry."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(
-            side_effect=httpx.WriteError("write could not complete without blocking")
-        )
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_write_error_non_blocking_no_retry(self, client, small_pdf):
-        """WriteError without 'blocking' message should not retry."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(side_effect=httpx.WriteError("other error"))
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_request_error_retries(self, client, small_pdf):
-        """Generic RequestError should retry."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(
-            side_effect=httpx.RequestError("request failed", request=MagicMock())
-        )
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_unexpected_error_retries(self, client, small_pdf):
-        """Unexpected exceptions should also retry."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(side_effect=RuntimeError("unexpected"))
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_base64_encoding_in_payload(self, client, small_pdf):
-        """Verify that pdf_binary is base64-encoded in the request payload."""
-        response_json = {"success": False, "error": "test"}
-        mock_response = _make_response(status_code=200, json_data=response_json)
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        async def fake_to_thread(fn, *args, **kwargs):
-            return fn(*args, **kwargs)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            with patch("asyncio.to_thread", side_effect=fake_to_thread):
-                await client.process_pdf("doc.pdf", small_pdf, org_id="org-1")
-
-        # Check the payload sent
-        call_kwargs = mock_http.post.call_args.kwargs
-        payload = call_kwargs["json"]
-        assert payload["record_name"] == "doc.pdf"
-        assert payload["org_id"] == "org-1"
-        # Verify it's valid base64
-        decoded = base64.b64decode(payload["pdf_binary"])
-        assert decoded == small_pdf
-
-    @pytest.mark.asyncio
-    async def test_non_retryable_http_error(self, client, small_pdf):
-        """HTTP 400 should not match 502/503/504 branch but still retries."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_response = _make_response(status_code=400, text="Bad Request")
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
 
 
 # ===========================================================================
@@ -406,6 +157,13 @@ class TestParsePdf:
                 result = await client.parse_pdf("doc.pdf", small_pdf)
 
         assert result == "serialized-doc"
+        mock_http.post.assert_awaited_once()
+        call_args = mock_http.post.call_args
+        assert "/parse-pdf" in call_args[0][0]
+        assert call_args.kwargs["data"] == {"record_name": "doc.pdf"}
+        assert call_args.kwargs["files"] == {
+            "file": ("doc.pdf", small_pdf, "application/pdf")
+        }
 
     @pytest.mark.asyncio
     async def test_parse_error_response(self, client, small_pdf):
@@ -431,7 +189,7 @@ class TestParsePdf:
         client.max_retries = 2
         client.retry_delay = 0.001
 
-        mock_response = _make_response(status_code=502, text="Bad Gateway")
+        mock_response = _make_response(status_code=503, text="Service Unavailable")
         mock_http = MagicMock()
         mock_http.post = AsyncMock(return_value=mock_response)
 
@@ -476,12 +234,66 @@ class TestParsePdf:
         assert mock_http.post.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_parse_write_error_retries(self, client, small_pdf):
+        client.max_retries = 2
+        client.retry_delay = 0.001
+
+        mock_http = MagicMock()
+        mock_http.post = AsyncMock(
+            side_effect=httpx.WriteError("write could not complete without blocking")
+        )
+
+        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.parse_pdf("doc.pdf", small_pdf)
+
+        assert result is None
+        assert mock_http.post.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_parse_request_error_retries(self, client, small_pdf):
+        client.max_retries = 2
+        client.retry_delay = 0.001
+
+        mock_http = MagicMock()
+        mock_http.post = AsyncMock(
+            side_effect=httpx.RequestError("request failed", request=MagicMock())
+        )
+
+        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.parse_pdf("doc.pdf", small_pdf)
+
+        assert result is None
+        assert mock_http.post.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_parse_unexpected_error_retries(self, client, small_pdf):
         client.max_retries = 2
         client.retry_delay = 0.001
 
         mock_http = MagicMock()
         mock_http.post = AsyncMock(side_effect=RuntimeError("unexpected"))
+
+        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.parse_pdf("doc.pdf", small_pdf)
+
+        assert result is None
+        assert mock_http.post.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_non_retryable_http_error(self, client, small_pdf):
+        """HTTP 400 should not match 502/503/504 branch but still retries."""
+        client.max_retries = 2
+        client.retry_delay = 0.001
+
+        mock_response = _make_response(status_code=400, text="Bad Request")
+        mock_http = MagicMock()
+        mock_http.post = AsyncMock(return_value=mock_response)
 
         with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
             MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)

--- a/backend/python/tests/unit/services/docling/test_docling_client_coverage.py
+++ b/backend/python/tests/unit/services/docling/test_docling_client_coverage.py
@@ -1,14 +1,13 @@
 """Additional unit tests for DoclingClient to push coverage above 97%.
 
 Targets missing lines/branches:
-- Lines 170-171: process_pdf loop fallthrough (all retries exhausted via loop exit)
-- Line 260->262: parse_pdf non-503 HTTP error (non-retryable status codes)
-- Lines 287-288: parse_pdf loop fallthrough (all retries exhausted)
-- Lines 353->355: create_blocks non-503 HTTP error
-- Lines 380-381: create_blocks loop fallthrough (all retries exhausted)
+- parse_pdf non-503 HTTP error (non-retryable status codes)
+- parse_pdf loop fallthrough (all retries exhausted)
+- parse_pdf retryable HTTP 502/504 status
+- create_blocks non-503 HTTP error
+- create_blocks loop fallthrough (all retries exhausted)
 """
 
-import base64
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -42,56 +41,12 @@ def _make_response(status_code=200, json_data=None, text=""):
 
 
 # ===========================================================================
-# process_pdf - loop fallthrough (all retries exhausted without exception)
-# ===========================================================================
-
-
-class TestProcessPdfLoopFallthrough:
-    """Cover lines 170-171: after all retries, the loop exits and returns None."""
-
-    @pytest.mark.asyncio
-    async def test_all_retries_exhausted_loop_exit(self, client, small_pdf):
-        """When all retries are used up via HTTP errors, the loop ends and returns None.
-
-        The key is to get max_retries=1 so there's only attempt 0.
-        On attempt 0, it's the last attempt (attempt < max_retries - 1 is False),
-        so it returns None inside the loop. We need max_retries=3 (default) and
-        every attempt to succeed in entering retry branch but the last to also return None.
-        Actually, the fallthrough on line 170 can only be reached if the loop exits normally
-        (i.e., all iterations complete without any return/break/continue). This happens
-        when every iteration enters a continue branch - which means HTTP errors with retries.
-        But on the last attempt, the code returns None.
-
-        Actually, for process_pdf, every error path either returns None or continues.
-        The fallthrough on line 170 is actually unreachable in practice because the last
-        attempt always hits a return None. But it's there as a safety net.
-        Let's check: for an HTTP error on the last attempt, attempt < self.max_retries - 1
-        is False, so it returns None (line 120). So line 170 should not be reachable.
-
-        But wait - there IS a scenario: if max_retries = 0, the loop body never runs at all.
-        """
-        client.max_retries = 0
-        client.retry_delay = 0.001
-
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=_make_response(status_code=500, text="Error"))
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        mock_http.post.assert_not_awaited()
-
-
-# ===========================================================================
 # parse_pdf - non-503 HTTP error + loop fallthrough
 # ===========================================================================
 
 
 class TestParsePdfNon503Error:
-    """Cover line 260->262: parse_pdf HTTP error not in [502, 503, 504]."""
+    """Cover parse_pdf HTTP error not in [502, 503, 504]."""
 
     @pytest.mark.asyncio
     async def test_non_retryable_http_error(self, client, small_pdf):
@@ -132,7 +87,7 @@ class TestParsePdfNon503Error:
 
 
 class TestParsePdfLoopFallthrough:
-    """Cover lines 287-288: parse_pdf loop fallthrough."""
+    """Cover parse_pdf loop fallthrough."""
 
     @pytest.mark.asyncio
     async def test_parse_pdf_zero_retries(self, client, small_pdf):
@@ -150,6 +105,68 @@ class TestParsePdfLoopFallthrough:
         assert result is None
         mock_http.post.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    async def test_all_retries_exhausted_loop_exit(self, client, small_pdf):
+        """When max_retries=0, the loop body never runs and fallthrough returns None."""
+        client.max_retries = 0
+        client.retry_delay = 0.001
+
+        mock_http = MagicMock()
+        mock_http.post = AsyncMock(return_value=_make_response(status_code=500, text="Error"))
+
+        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.parse_pdf("doc.pdf", small_pdf)
+
+        assert result is None
+        mock_http.post.assert_not_awaited()
+
+
+# ===========================================================================
+# parse_pdf - retryable HTTP 502/504 status
+# ===========================================================================
+
+
+class TestParsePdf502:
+    """Cover the 502/504 status code paths for parse_pdf."""
+
+    @pytest.mark.asyncio
+    async def test_http_502_retries_and_logs_warning(self, client, small_pdf):
+        """HTTP 502 triggers both the warning and the retry."""
+        client.max_retries = 2
+        client.retry_delay = 0.001
+
+        mock_response = _make_response(status_code=502, text="Bad Gateway")
+        mock_http = MagicMock()
+        mock_http.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.parse_pdf("doc.pdf", small_pdf)
+
+        assert result is None
+        assert mock_http.post.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_http_504_retries_and_logs_warning(self, client, small_pdf):
+        """HTTP 504 triggers both the warning and the retry."""
+        client.max_retries = 2
+        client.retry_delay = 0.001
+
+        mock_response = _make_response(status_code=504, text="Gateway Timeout")
+        mock_http = MagicMock()
+        mock_http.post = AsyncMock(return_value=mock_response)
+
+        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
+            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
+            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
+            result = await client.parse_pdf("doc.pdf", small_pdf)
+
+        assert result is None
+        assert mock_http.post.await_count == 2
+
 
 # ===========================================================================
 # create_blocks - non-503 HTTP error + loop fallthrough
@@ -157,7 +174,7 @@ class TestParsePdfLoopFallthrough:
 
 
 class TestCreateBlocksNon503Error:
-    """Cover line 353->355: create_blocks HTTP error not in [502, 503, 504]."""
+    """Cover create_blocks HTTP error not in [502, 503, 504]."""
 
     @pytest.mark.asyncio
     async def test_non_retryable_http_error(self, client):
@@ -198,7 +215,7 @@ class TestCreateBlocksNon503Error:
 
 
 class TestCreateBlocksLoopFallthrough:
-    """Cover lines 380-381: create_blocks loop fallthrough."""
+    """Cover create_blocks loop fallthrough."""
 
     @pytest.mark.asyncio
     async def test_create_blocks_zero_retries(self, client):
@@ -215,48 +232,3 @@ class TestCreateBlocksLoopFallthrough:
 
         assert result is None
         mock_http.post.assert_not_awaited()
-
-
-# ===========================================================================
-# process_pdf - retryable HTTP 502 status
-# ===========================================================================
-
-
-class TestProcessPdf502:
-    """Cover the 502 status code path for process_pdf."""
-
-    @pytest.mark.asyncio
-    async def test_http_502_retries_and_logs_warning(self, client, small_pdf):
-        """HTTP 502 triggers both the warning and the retry."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_response = _make_response(status_code=502, text="Bad Gateway")
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2
-
-    @pytest.mark.asyncio
-    async def test_http_504_retries_and_logs_warning(self, client, small_pdf):
-        """HTTP 504 triggers both the warning and the retry."""
-        client.max_retries = 2
-        client.retry_delay = 0.001
-
-        mock_response = _make_response(status_code=504, text="Gateway Timeout")
-        mock_http = MagicMock()
-        mock_http.post = AsyncMock(return_value=mock_response)
-
-        with patch("app.services.docling.client.httpx.AsyncClient") as MockClient:
-            MockClient.return_value.__aenter__ = AsyncMock(return_value=mock_http)
-            MockClient.return_value.__aexit__ = AsyncMock(return_value=False)
-            result = await client.process_pdf("doc.pdf", small_pdf)
-
-        assert result is None
-        assert mock_http.post.await_count == 2

--- a/backend/python/tests/unit/services/docling/test_docling_service.py
+++ b/backend/python/tests/unit/services/docling/test_docling_service.py
@@ -66,7 +66,6 @@ try:
     from app.services.docling.docling_service import (
         CreateBlocksRequest,
         CreateBlocksResponse,
-        ParseRequest,
         ParseResponse,
         ProcessRequest,
         ProcessResponse,
@@ -74,6 +73,13 @@ try:
     HAS_PYDANTIC_MODELS = True
 except Exception:
     HAS_PYDANTIC_MODELS = False
+
+
+def _make_upload_file(content: bytes = b"data"):
+    """Create a mock UploadFile with async read()."""
+    mock_file = MagicMock()
+    mock_file.read = AsyncMock(return_value=content)
+    return mock_file
 
 
 # ---------------------------------------------------------------------------
@@ -354,10 +360,6 @@ class TestRequestResponseModels:
         assert resp.success is False
         assert resp.error == "failed"
 
-    def test_parse_request(self):
-        req = ParseRequest(record_name="doc.pdf", pdf_binary="abc")
-        assert req.record_name == "doc.pdf"
-
     def test_parse_response(self):
         resp = ParseResponse(success=True, parse_result='{"doc": true}')
         assert resp.parse_result == '{"doc": true}'
@@ -506,41 +508,27 @@ class TestProcessPdfEndpoint:
 
 
 class TestParsePdfEndpoint:
-    """Tests for the /parse-pdf endpoint."""
-
-    @pytest.mark.asyncio
-    async def test_parse_pdf_endpoint_invalid_base64(self):
-        import app.services.docling.docling_service as mod
-        original = mod.docling_service
-        mod.docling_service = DoclingService()
-        try:
-            from app.services.docling.docling_service import parse_pdf_endpoint
-            req = ParseRequest(record_name="test.pdf", pdf_binary="!!invalid!!")
-            from fastapi import HTTPException
-            with pytest.raises(HTTPException):
-                await parse_pdf_endpoint(req)
-        finally:
-            mod.docling_service = original
+    """Tests for the /parse-pdf endpoint (multipart file upload)."""
 
     @pytest.mark.asyncio
     async def test_parse_pdf_endpoint_service_not_available(self):
         import app.services.docling.docling_service as mod
-        import base64
         original = mod.docling_service
         mod.docling_service = None
         try:
             from app.services.docling.docling_service import parse_pdf_endpoint
-            req = ParseRequest(record_name="test.pdf", pdf_binary=base64.b64encode(b"data").decode())
             from fastapi import HTTPException
             with pytest.raises(HTTPException):
-                await parse_pdf_endpoint(req)
+                await parse_pdf_endpoint(
+                    file=_make_upload_file(b"data"),
+                    record_name="test.pdf",
+                )
         finally:
             mod.docling_service = original
 
     @pytest.mark.asyncio
     async def test_parse_pdf_endpoint_success(self):
         import app.services.docling.docling_service as mod
-        import base64
         original = mod.docling_service
         svc = DoclingService()
         mock_doc = MagicMock()
@@ -549,24 +537,28 @@ class TestParsePdfEndpoint:
         mod.docling_service = svc
         try:
             from app.services.docling.docling_service import parse_pdf_endpoint
-            req = ParseRequest(record_name="test.pdf", pdf_binary=base64.b64encode(b"data").decode())
-            resp = await parse_pdf_endpoint(req)
+            resp = await parse_pdf_endpoint(
+                file=_make_upload_file(b"data"),
+                record_name="test.pdf",
+            )
             assert resp.success is True
+            svc.parse_pdf_only.assert_awaited_once_with("test.pdf", b"data")
         finally:
             mod.docling_service = original
 
     @pytest.mark.asyncio
     async def test_parse_pdf_endpoint_error(self):
         import app.services.docling.docling_service as mod
-        import base64
         original = mod.docling_service
         svc = DoclingService()
         svc.parse_pdf_only = AsyncMock(side_effect=RuntimeError("parse fail"))
         mod.docling_service = svc
         try:
             from app.services.docling.docling_service import parse_pdf_endpoint
-            req = ParseRequest(record_name="test.pdf", pdf_binary=base64.b64encode(b"data").decode())
-            resp = await parse_pdf_endpoint(req)
+            resp = await parse_pdf_endpoint(
+                file=_make_upload_file(b"data"),
+                record_name="test.pdf",
+            )
             assert resp.success is False
             assert "parse fail" in resp.error
         finally:


### PR DESCRIPTION
<img width="1385" height="720" alt="image" src="https://github.com/user-attachments/assets/58e890bc-bac2-45f0-9f76-d01d3f1a95b3" />


Indexed after this change