### PR TITLE
fix: increase file descriptor limits to prevent EMFILE errors during …

### DIFF
--- a/deployment/docker-compose/beta/docker-compose.build.neo4j.slim.yml
+++ b/deployment/docker-compose/beta/docker-compose.build.neo4j.slim.yml
@@ -21,6 +21,12 @@ services:
         limits:
           memory: 12G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/beta/docker-compose.build.opensearch.neo4j.yml
+++ b/deployment/docker-compose/beta/docker-compose.build.opensearch.neo4j.yml
@@ -21,6 +21,12 @@ services:
         limits:
           memory: 12G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/docker-compose.build.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.build.neo4j.yml
@@ -21,6 +21,12 @@ services:
         limits:
           memory: 10G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -26,6 +26,12 @@ services:
         limits:
           memory: 10G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -26,6 +26,12 @@ services:
         limits:
           memory: 10G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/docker-compose.prod-legacy.yml
+++ b/deployment/docker-compose/docker-compose.prod-legacy.yml
@@ -10,6 +10,12 @@ services:
         limits:
           memory: 10G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -47,6 +47,12 @@ services:
         limits:
           memory: ${APP_MEMORY_LIMIT:-10G}
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/hot-reload/docker-compose.dev.arango.yml
+++ b/deployment/docker-compose/hot-reload/docker-compose.dev.arango.yml
@@ -27,6 +27,12 @@ services:
         limits:
           memory: 12G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/hot-reload/docker-compose.dev.neo4j.yml
+++ b/deployment/docker-compose/hot-reload/docker-compose.dev.neo4j.yml
@@ -27,6 +27,12 @@ services:
         limits:
           memory: 12G
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local

--- a/deployment/docker-compose/legacy/docker-compose.build.arango.yml
+++ b/deployment/docker-compose/legacy/docker-compose.build.arango.yml
@@ -47,6 +47,12 @@ services:
         limits:
           memory: ${APP_MEMORY_LIMIT:-10G}
     shm_size: 2gb
+    # 7 services (node, frontend, 5 python) share one container's fd budget;
+    # docker's 1024 default hits EMFILE on accept() during startup.
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
     init: true
     logging:
       driver: local


### PR DESCRIPTION
## Summary

This PR increases the `nofile` (`ulimits`) limit for the `pipeshub-ai` service to **65536** across all Docker Compose files.

## Problem

The `pipeshub-ai` container runs multiple services (Node.js, Next.js, and several Python FastAPI services) inside a single container. During startup, these services open many sockets, database connections, log files, and other file descriptors.

With Docker's default `nofile` limit of **1024**, the container can hit the **EMFILE (Too many open files)** error, causing services to fail health checks and preventing the stack from starting correctly.

## Solution

Added the following runtime configuration to the `pipeshub-ai` service in every Docker Compose file:

```yaml
ulimits:
  nofile:
    soft: 65536
    hard: 65536
```

This provides a consistent file descriptor limit regardless of which Compose file is used.

## Changes

* Added `ulimits.nofile: 65536` to the `pipeshub-ai` service in all Docker Compose files.
* Kept the configuration consistent across every Compose variant.

## Result

* Prevents `EMFILE (Too many open files)` errors during startup.
* Ensures all Compose configurations use the same runtime limits.
* Removes the need for developers to configure `default-ulimits` in their local Docker daemon for this project.

<img width="921" height="535" alt="screenshot-2026-07-19_00-38-15" src="https://github.com/user-attachments/assets/039ed6ff-fa23-4d96-bea4-b0d8e9a65cae" />
<img width="1050" height="967" alt="screenshot-2026-07-30_15-51-37" src="https://github.com/user-attachments/assets/31dc8b84-28f9-48fb-9a10-68ac9dd759a9" />
