### PR TITLE
ci: use Mailpit for SMTP integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -151,11 +151,9 @@ jobs:
       GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
       GOOGLE_DRIVE_TEST_USER_EMAIL: ${{ secrets.GOOGLE_DRIVE_TEST_USER_EMAIL }}
       GOOGLE_DRIVE_REFRESH_TOKEN: ${{ secrets.GOOGLE_DRIVE_REFRESH_TOKEN }}
-      SMTP_HOST: ${{ secrets.SMTP_HOST }}
-      SMTP_PORT: ${{ secrets.SMTP_PORT }}
-      SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
-      SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
-      SMTP_FROM_EMAIL: ${{ secrets.SMTP_FROM_EMAIL || secrets.SMTP_USERNAME }}
+      SMTP_HOST: 127.0.0.1
+      SMTP_PORT: '1025'
+      SMTP_FROM_EMAIL: no-reply@example.com
       # Playwright runs once: on the neo4j/both leg, or the arango leg only when
       # arango is the sole backend (arango dispatch input, or it-arango alone).
       RUN_PLAYWRIGHT: ${{ (matrix.graph_db == 'neo4j' || matrix.graph_db == 'both' || (matrix.graph_db == 'arango' && (github.event.inputs.graph_db == 'arango' || (contains(github.event.pull_request.labels.*.name, 'it-arango') && !contains(github.event.pull_request.labels.*.name, 'it-neo4j') && !contains(github.event.pull_request.labels.*.name, 'it-parallel'))))) && 'true' || 'false' }}

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -157,6 +157,8 @@ services:
         condition: service_started
       arango:
         condition: service_healthy
+      mailpit:
+        condition: service_healthy
     volumes:
       - pipeshub_data:/data/pipeshub
       - pipeshub_root_local:/root/.local
@@ -200,6 +202,19 @@ services:
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}"
     volumes:
       - redis_data:/data
+
+  # Local SMTP sink for mail-dependent integration tests: CI runners cannot
+  mailpit:
+    image: axllent/mailpit:v1.30.6
+    restart: always
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    healthcheck:
+      test: ["CMD", "/mailpit", "readyz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   arango:
     image: arangodb:3.12.4

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -158,6 +158,8 @@ services:
         condition: service_started
       neo4j:
         condition: service_healthy
+      mailpit:
+        condition: service_healthy
     volumes:
       - pipeshub_data:/data/pipeshub
       - pipeshub_root_local:/root/.local
@@ -201,6 +203,19 @@ services:
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}"
     volumes:
       - redis_data:/data
+
+  # Local SMTP sink for mail-dependent integration tests: CI runners cannot
+  mailpit:
+    image: axllent/mailpit:v1.30.6
+    restart: always
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    healthcheck:
+      test: ["CMD", "/mailpit", "readyz"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   neo4j:
     image: neo4j:5.26.0


### PR DESCRIPTION
## Problem

The bulk invite integration tests depend on an external SMTP server. In CI, the
application is unable to establish a reliable connection to that server, causing
mail-dependent integration tests to fail even when the application logic is
correct.

Using an external SMTP service in CI also introduces unnecessary dependencies on
network connectivity, third-party availability, rate limits, and production SMTP
credentials.

## Changes

Replace the external SMTP dependency with a local Mailpit instance for the
integration test environment.

### Docker Compose

Updated both integration compose stacks because CI executes tests against both
Neo4j and ArangoDB.

- `deployment/docker-compose/docker-compose.integration.neo4j.yml`
- `deployment/docker-compose/docker-compose.integration.arango.yml`

Changes:
- Added `axllent/mailpit:v1.30.6`
- Added a Mailpit health check
- Added `depends_on: condition: service_healthy` so the application starts only
  after Mailpit is ready

### Integration Workflow

Updated `.github/workflows/integration-tests.yml` to use Mailpit for SMTP during
integration tests.

- SMTP host points to the Mailpit service
- SMTP port set to `1025`
- `SMTP_FROM_EMAIL` uses a test sender address
- Removed SMTP username/password since Mailpit accepts unauthenticated SMTP

## Verification

Verified locally:

- Docker Compose configuration is valid for both integration stacks
- Mailpit starts successfully and reports healthy
- The application resolves the `mailpit` service over the Compose network
- SMTP handshake succeeds
- Test emails are successfully delivered and visible in the Mailpit inbox

## Scope

This PR only updates the integration test infrastructure.

It does **not** modify the production mail implementation or timeout handling.
Those changes are covered in a separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Integration tests now use a local SMTP server, improving reliability and removing reliance on SMTP secrets.
  * Added readiness checks to ensure email services are available before tests run.

* **New Features**
  * Added a local Mailpit email sink with SMTP support and a web interface for viewing test emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->