### PR TITLE
ci: add Mailpit as the SMTP sink for integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -151,7 +151,8 @@ jobs:
       GOOGLE_DRIVE_CLIENT_SECRET: ${{ secrets.GOOGLE_DRIVE_CLIENT_SECRET }}
       GOOGLE_DRIVE_TEST_USER_EMAIL: ${{ secrets.GOOGLE_DRIVE_TEST_USER_EMAIL }}
       GOOGLE_DRIVE_REFRESH_TOKEN: ${{ secrets.GOOGLE_DRIVE_REFRESH_TOKEN }}
-      SMTP_HOST: 127.0.0.1
+
+      SMTP_HOST: mailpit
       SMTP_PORT: '1025'
       SMTP_FROM_EMAIL: no-reply@example.com
       # Playwright runs once: on the neo4j/both leg, or the arango leg only when


### PR DESCRIPTION
## Problem

PR #2855 introduced Mailpit for integration tests but configured:

```yaml
SMTP_HOST: 127.0.0.1
```

The SMTP client runs inside the `pipeshub-ai` container, where `127.0.0.1`
refers to the container itself rather than the Mailpit container. As a result,
SMTP connections are refused.

## Change

Update the integration test workflow to use the Docker Compose service name:

```diff
- SMTP_HOST: 127.0.0.1
+ SMTP_HOST: mailpit
```

Docker Compose provides built-in service discovery, so `mailpit` resolves
correctly from the application container over the default Compose network.

## Verification

Verified locally:

- `mailpit` resolves correctly from the application container.
- SMTP handshake succeeds (`EHLO 250`).
- Test emails are successfully delivered to Mailpit.
- `127.0.0.1` fails with `ConnectionRefusedError` because it points to the
  application container's loopback rather than the Mailpit container.

## Scope

This is a follow-up to **#2855**.

It only corrects the SMTP hostname used by the integration tests and does not
change any application or mail delivery logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test email configuration to use the Mailpit service hostname, improving test environment connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->