### PR TITLE
ci: parallelize enterprise-search integration tests with pytest-xdist

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,7 +67,7 @@ on:
           - kafka
           - redis
       pytest_workers:
-        description: 'pytest-xdist workers. One is reserved for the serial (connector) group; the rest run enterprise-search. 1 disables parallelism.'
+        description: 'pytest-xdist worker count. Connector suites are grouped onto a single worker to keep their ordering; enterprise-search tests spread across all workers. 1 disables parallelism.'
         required: false
         default: '5'
 
@@ -85,9 +85,13 @@ concurrency:
 env:
   PIPESHUB_BASE_URL: http://localhost:3000
   MESSAGE_BROKER: ${{ github.event.inputs.message_broker || 'redis' }}
-  # xdist workers. `--dist loadgroup` pins every non-enterprise-search test to a
-  # single worker (connectors keep their --order-scope=module ordering), so the
-  # remaining PYTEST_WORKERS-1 spread enterprise-search per test.
+  # xdist workers. `--dist loadgroup` keeps every non-enterprise-search test on
+  # one worker so connectors retain their --order-scope=module ordering, while
+  # enterprise-search is distributed test-by-test. That worker is not exclusive
+  # -- it takes enterprise-search work too, it just rarely has spare capacity
+  # while the ~30m connector group is running.
+  # The `|| '5'` is what schedule and pull_request_target runs use; `inputs` only
+  # exists on workflow_dispatch. The input's own default just prefills the form.
   PYTEST_WORKERS: ${{ github.event.inputs.pytest_workers || '5' }}
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -95,13 +95,6 @@ concurrency:
 env:
   PIPESHUB_BASE_URL: http://localhost:3000
   MESSAGE_BROKER: ${{ github.event.inputs.message_broker || 'redis' }}
-  # xdist workers. `--dist loadgroup` keeps every non-enterprise-search test on
-  # one worker so connectors retain their --order-scope=module ordering, while
-  # enterprise-search is distributed test-by-test. That worker is not exclusive
-  # -- it takes enterprise-search work too, it just rarely has spare capacity
-  # while the ~30m connector group is running.
-  # The `|| '5'` is what schedule and pull_request_target runs use; `inputs` only
-  # exists on workflow_dispatch. The input's own default just prefills the form.
   PYTEST_WORKERS: ${{ github.event.inputs.pytest_workers || '5' }}
 
 jobs:
@@ -320,8 +313,12 @@ jobs:
         run: |
           source .venv/bin/activate
           MARKERS="${{ github.event.inputs.connectors || 'integration' }}"
+          # -n 1 still forks a worker, so shared_session_resource treats the run as
+          # distributed and skips teardown. -n 0 runs in-process and restores it.
+          WORKERS="$PYTEST_WORKERS"
+          if [ "$WORKERS" = "1" ]; then WORKERS=0; fi
           pytest -m "$MARKERS" -v --tb=short \
-            -n "$PYTEST_WORKERS" --dist loadgroup \
+            -n "$WORKERS" --dist loadgroup \
             --junitxml=reports/neo4j-results.xml 2>&1
 
       - name: 'Neo4j: Run Playwright e2e tests'
@@ -442,8 +439,12 @@ jobs:
         run: |
           source .venv/bin/activate
           MARKERS="${{ github.event.inputs.connectors || 'integration' }}"
+          # -n 1 still forks a worker, so shared_session_resource treats the run as
+          # distributed and skips teardown. -n 0 runs in-process and restores it.
+          WORKERS="$PYTEST_WORKERS"
+          if [ "$WORKERS" = "1" ]; then WORKERS=0; fi
           pytest -m "$MARKERS" -v --tb=short \
-            -n "$PYTEST_WORKERS" --dist loadgroup \
+            -n "$WORKERS" --dist loadgroup \
             --junitxml=reports/arango-results.xml 2>&1
 
       - name: 'ArangoDB: Run Playwright e2e tests'

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,6 +66,10 @@ on:
         options:
           - kafka
           - redis
+      pytest_workers:
+        description: 'pytest-xdist workers. One is reserved for the serial (connector) group; the rest run enterprise-search. 1 disables parallelism.'
+        required: false
+        default: '5'
 
 permissions:
   contents: read
@@ -81,6 +85,10 @@ concurrency:
 env:
   PIPESHUB_BASE_URL: http://localhost:3000
   MESSAGE_BROKER: ${{ github.event.inputs.message_broker || 'redis' }}
+  # xdist workers. `--dist loadgroup` pins every non-enterprise-search test to a
+  # single worker (connectors keep their --order-scope=module ordering), so the
+  # remaining PYTEST_WORKERS-1 spread enterprise-search per test.
+  PYTEST_WORKERS: ${{ github.event.inputs.pytest_workers || '5' }}
 
 jobs:
   integration-tests:
@@ -298,7 +306,9 @@ jobs:
         run: |
           source .venv/bin/activate
           MARKERS="${{ github.event.inputs.connectors || 'integration' }}"
-          pytest -m "$MARKERS" -v --tb=short --junitxml=reports/neo4j-results.xml 2>&1
+          pytest -m "$MARKERS" -v --tb=short \
+            -n "$PYTEST_WORKERS" --dist loadgroup \
+            --junitxml=reports/neo4j-results.xml 2>&1
 
       - name: 'Neo4j: Run Playwright e2e tests'
         if: ${{ !cancelled() && (matrix.graph_db == 'neo4j' || matrix.graph_db == 'both') }}
@@ -418,7 +428,9 @@ jobs:
         run: |
           source .venv/bin/activate
           MARKERS="${{ github.event.inputs.connectors || 'integration' }}"
-          pytest -m "$MARKERS" -v --tb=short --junitxml=reports/arango-results.xml 2>&1
+          pytest -m "$MARKERS" -v --tb=short \
+            -n "$PYTEST_WORKERS" --dist loadgroup \
+            --junitxml=reports/arango-results.xml 2>&1
 
       - name: 'ArangoDB: Run Playwright e2e tests'
         if: ${{ !cancelled() && matrix.graph_db == 'arango' && env.RUN_PLAYWRIGHT == 'true' }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,8 +68,16 @@ on:
           - redis
       pytest_workers:
         description: 'pytest-xdist worker count. Connector suites are grouped onto a single worker to keep their ordering; enterprise-search tests spread across all workers. 1 disables parallelism.'
-        required: false
+        required: true
         default: '5'
+        type: choice
+        options:
+          - '1'
+          - '3'
+          - '4'
+          - '5'
+          - '6'
+          - '8'
 
 permissions:
   contents: read

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,10 +73,12 @@ on:
         type: choice
         options:
           - '1'
+          - '2'
           - '3'
           - '4'
           - '5'
           - '6'
+          - '7'
           - '8'
 
 permissions:

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -5,6 +5,7 @@ import os
 import sys
 import time
 import warnings
+from dataclasses import asdict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, TYPE_CHECKING, AsyncGenerator, List, Generator
@@ -111,11 +112,13 @@ _init_global_test_env()
 
 from ai_models_setup import (  # noqa: E402
     SeededAIModel,
+    SeededIndexingModels,
     setup_test_indexing_models,
     setup_test_llm_model,
     teardown_test_indexing_models,
     teardown_test_llm_model,
 )
+from xdist_shared import shared_session_resource  # noqa: E402
 from integration_report import TestReportEntry, write_html_report  # noqa: E402
 from local_auth import obtain_local_oauth_credentials  # noqa: E402
 from pipeshub_client import PipeshubClient  # noqa: E402
@@ -139,6 +142,10 @@ from sample_data import ensure_sample_data_files_root  # noqa: E402
 # Module-level refs so pytest_runtest_logreport can merge even when report.config is missing
 _integration_test_reports_by_nodeid: Dict[str, TestReportEntry] = {}
 _integration_test_report_order: List[str] = []
+
+# Set in pytest_configure. pytest_runtest_logreport gets no config argument, and
+# only the xdist controller may rewrite node ids (see that hook's docstring).
+_IS_XDIST_WORKER = False
 
 
 def _longrepr_and_streams(report: pytest.TestReport) -> tuple[str, str | None, str | None, str | None]:
@@ -403,6 +410,8 @@ def sample_data_root() -> Path:
 
 @pytest.fixture(scope="session")
 def ai_models_configured(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
     pipeshub_client: PipeshubClient,
 ) -> Generator[SeededAIModel, None, None]:
     """Seed OpenAI LLM + cloud embedding models and tear them down at session end.
@@ -428,12 +437,26 @@ def ai_models_configured(
 
     On teardown, both models are DELETEd via the providers endpoint so no test
     residue is left on the backend.
+
+    These models are org-wide singletons, so under ``-n`` they are seeded once
+    per run and shared by every worker rather than once per worker session.
     """
-    models = setup_test_indexing_models(pipeshub_client)
-    try:
+    with shared_session_resource(
+        "ai_models_configured",
+        config=request.config,
+        tmp_path_factory=tmp_path_factory,
+        create=lambda: setup_test_indexing_models(pipeshub_client),
+        destroy=lambda models: teardown_test_indexing_models(pipeshub_client, models),
+        dump=lambda models: {
+            "llm": asdict(models.llm),
+            "embedding": asdict(models.embedding),
+        },
+        load=lambda raw: SeededIndexingModels(
+            llm=SeededAIModel(**raw["llm"]),
+            embedding=SeededAIModel(**raw["embedding"]),
+        ),
+    ) as models:
         yield models.llm
-    finally:
-        teardown_test_indexing_models(pipeshub_client, models)
 
 
 @pytest_asyncio.fixture(scope="session", loop_scope="session")
@@ -488,6 +511,58 @@ async def graph_provider(config_service) -> AsyncGenerator["GraphProviderProtoco
         yield provider
     finally:
         await provider.disconnect()
+
+
+# Suites that may be spread across xdist workers, as rootdir-relative prefixes.
+# Everything else is pinned to one worker by pytest_collection_modifyitems below.
+_PARALLEL_SAFE_PATHS = ("response-validation/enterprise-search",)
+
+# Group name is arbitrary; what matters is that every pinned test shares it, so
+# ``--dist loadgroup`` routes them all to the same worker.
+_SERIAL_XDIST_GROUP = "serial"
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(
+    config: pytest.Config,
+    items: List[pytest.Item],
+) -> None:
+    """Pin every non-enterprise-search test to one xdist worker.
+
+    The connector suites depend on ``--order-scope=module`` ordering and on
+    module-scoped fixtures that drive a whole connector sync, both of which
+    assume a single process. Enterprise-search tests hold no shared state --
+    each builds its own conversation and the autouse setup only wires clients
+    onto ``self`` -- so they are safe to distribute per test.
+
+    Under ``--dist loadgroup`` all tests carrying the same ``xdist_group`` mark
+    run on one worker, so this keeps the connectors serial and in order while
+    enterprise-search fans out across the remaining workers. No-op on a serial
+    run, which leaves ordering identical to today.
+
+    Two xdist details this depends on, both verified against xdist 3.8:
+
+    * ``tryfirst`` is required. xdist's own ``pytest_collection_modifyitems`` in
+      ``remote.py`` is what turns the mark into the ``nodeid@group`` suffix the
+      scheduler reads, and it otherwise runs before this hook -- marks added
+      afterwards are silently ignored and every test spreads.
+    * Workers cannot be detected via ``--dist``. ``remote.setup_config`` resets
+      ``config.option.dist`` to ``"no"`` on each worker, so a ``dist``-only guard
+      no-ops in precisely the processes that matter. ``workerinput`` is the
+      reliable signal.
+    """
+    is_worker = hasattr(config, "workerinput")
+    if not is_worker and config.getoption("dist", "no") == "no":
+        return
+
+    rootdir = config.rootpath
+    for item in items:
+        try:
+            rel = item.path.relative_to(rootdir).as_posix()
+        except ValueError:
+            rel = str(item.path)
+        if not rel.startswith(_PARALLEL_SAFE_PATHS):
+            item.add_marker(pytest.mark.xdist_group(_SERIAL_XDIST_GROUP))
 
 
 def pytest_sessionstart(session) -> None:  # type: ignore[override]
@@ -558,6 +633,8 @@ def pytest_sessionstart(session) -> None:  # type: ignore[override]
 def pytest_configure(config: pytest.Config) -> None:
     """Initialize report collection for the HTML integration report."""
     global _integration_test_reports_by_nodeid, _integration_test_report_order
+    global _IS_XDIST_WORKER
+    _IS_XDIST_WORKER = hasattr(config, "workerinput")
     _integration_test_reports_by_nodeid = {}
     _integration_test_report_order = []
     config._integration_test_reports_by_nodeid = _integration_test_reports_by_nodeid  # type: ignore[attr-defined]
@@ -565,8 +642,24 @@ def pytest_configure(config: pytest.Config) -> None:
     config._integration_session_start = time.monotonic()  # type: ignore[attr-defined]
 
 
+@pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report: pytest.TestReport) -> None:
-    """Collect pass/fail/skip + failure text for HTML report (setup, call, teardown)."""
+    """Collect pass/fail/skip + failure text for HTML report (setup, call, teardown).
+
+    Also drops the ``@<group>`` suffix that xdist appends to node ids under
+    ``--dist loadgroup``. That suffix is how its scheduler routes a test to the
+    pinned worker, but it is an implementation detail that would otherwise land
+    in the JUnit XML, this HTML report, and the failed-test list posted to
+    Slack. Only the controller may rewrite it: workers report back by node id,
+    so stripping there desynchronises them from the scheduler and tests silently
+    go unreported. Scheduling is already settled by the time the controller
+    dispatches reports, so this is presentation-only.
+    """
+    if not _IS_XDIST_WORKER:
+        suffix = f"@{_SERIAL_XDIST_GROUP}"
+        if report.nodeid.endswith(suffix):
+            report.nodeid = report.nodeid[: -len(suffix)]
+
     if report.when not in ("setup", "call", "teardown"):
         return
     config = getattr(report, "config", None)

--- a/integration-tests/helper/xdist_shared.py
+++ b/integration-tests/helper/xdist_shared.py
@@ -1,0 +1,92 @@
+"""Cross-worker sharing of expensive session-scoped resources under pytest-xdist.
+
+Run serially, a ``scope="session"`` fixture is built exactly once -- which is what
+the org-level fixtures here assume. Under ``-n N`` every xdist worker is its own
+process with its own session, so a fixture that seeds an *org-wide singleton*
+(the default LLM / embedding written to Configuration Manager) would be seeded
+and torn down N times concurrently, and one worker's teardown would delete the
+model another worker is mid-stream on.
+
+``shared_session_resource`` elects exactly one worker to build the resource,
+writes its serialized form into the directory shared by every worker in the run,
+and hands the rest a rehydrated copy.
+
+Teardown is deliberately **skipped** under xdist. The only safe moment to delete
+an org-wide singleton is once every worker is done with it, and pytest offers no
+cross-worker barrier at session end -- a refcount race would let the first worker
+to finish delete a KB that a slower worker is still querying. CI tears the whole
+docker stack down immediately after the pytest step, so the residue is collected
+there. Running without ``-n`` keeps the original create/destroy behaviour intact,
+which is what local runs against a long-lived server rely on.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import Any, TypeVar
+
+import pytest
+from filelock import FileLock
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+def get_worker_id(config: pytest.Config) -> str:
+    """Return the xdist worker id (``gw0``, ``gw1``, ...) or ``master`` if serial."""
+    return getattr(config, "workerinput", {}).get("workerid", "master")
+
+
+def is_distributed(config: pytest.Config) -> bool:
+    """True when this process is an xdist worker rather than a plain pytest run."""
+    return get_worker_id(config) != "master"
+
+
+@contextmanager
+def shared_session_resource(
+    name: str,
+    *,
+    config: pytest.Config,
+    tmp_path_factory: pytest.TempPathFactory,
+    create: Callable[[], T],
+    destroy: Callable[[T], None],
+    dump: Callable[[T], Any],
+    load: Callable[[Any], T],
+) -> Iterator[T]:
+    """Build ``name`` once per run and share it across all xdist workers.
+
+    ``create``/``destroy`` are the original fixture body and teardown. ``dump``
+    and ``load`` convert the resource to and from JSON so non-electing workers
+    can rehydrate it without touching the backend -- they must round-trip
+    everything ``destroy`` and the tests need (ids, keys), not live objects.
+    """
+    worker_id = get_worker_id(config)
+
+    # Serial run: no sharing needed, preserve the original create/destroy pair.
+    if not is_distributed(config):
+        resource = create()
+        try:
+            yield resource
+        finally:
+            destroy(resource)
+        return
+
+    # Each worker's basetemp is <root>/popen-gwN; the parent is common to the run.
+    root = tmp_path_factory.getbasetemp().parent
+    state_file = root / f"{name}.json"
+
+    with FileLock(str(root / f"{name}.lock")):
+        if state_file.is_file():
+            resource = load(json.loads(state_file.read_text()))
+            logger.info("[%s] reusing shared %r built by another worker", worker_id, name)
+        else:
+            resource = create()
+            state_file.write_text(json.dumps(dump(resource)))
+            logger.info("[%s] built shared %r for this run", worker_id, name)
+
+    # Intentionally no teardown -- see module docstring.
+    yield resource

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
   "pytest-asyncio>=0.21.0",
   "pytest-order>=1.1.0",
   "pytest-timeout>=2.2.0",
+  "pytest-xdist>=3.5.0",
+  "filelock>=3.13.0",
   "aioboto3>=12.0.0",
   "aiohttp==3.14.1",
   "aiokafka==0.12.0",

--- a/integration-tests/response-validation/enterprise-search/conftest.py
+++ b/integration-tests/response-validation/enterprise-search/conftest.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import mimetypes
+from dataclasses import asdict
 from typing import Any, TypedDict
 from urllib.parse import unquote, urlparse
 from uuid import uuid4
@@ -34,6 +35,7 @@ from ai_models_setup import (
     teardown_test_llm_model,
 )
 from pipeshub_client import PipeshubClient
+from xdist_shared import shared_session_resource
 
 logger = logging.getLogger("enterprise-search-conftest")
 
@@ -114,6 +116,8 @@ def asana_pdf_blob() -> AsanaPdfBlob:
 
 @pytest.fixture(scope="session")
 def session_kb(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
     pipeshub_client: PipeshubClient,
     ai_models_configured,
     reasoning_multimodal_llm_model: SeededAIModel,
@@ -122,18 +126,22 @@ def session_kb(
     """Session-scoped KB with the Asana DR PDF uploaded and indexed.
 
     Yields ``{"kb_id": str, "record_id": str}``. Deletes the KB on teardown.
+
+    Uploading and indexing the PDF is the single most expensive piece of setup in
+    this suite, so under ``-n`` it runs once per run and every worker queries the
+    same KB rather than each building its own.
     """
     del ai_models_configured  # fixture ordering only
     del reasoning_multimodal_llm_model  # ensure OCR fallback has a multimodal LLM
 
     kb_client = KBClient(pipeshub_client)
 
-    kb_resp = kb_client.create_kb(name="enterprise-search-it-kb")
-    kb_id = _extract_kb_id(kb_resp)
-    assert kb_id, f"KB create returned no id: {kb_resp}"
-    logger.info("Created KB %s for enterprise search IT", kb_id)
+    def _build() -> dict[str, str]:
+        kb_resp = kb_client.create_kb(name="enterprise-search-it-kb")
+        kb_id = _extract_kb_id(kb_resp)
+        assert kb_id, f"KB create returned no id: {kb_resp}"
+        logger.info("Created KB %s for enterprise search IT", kb_id)
 
-    try:
         buffer = asana_pdf_blob["buffer"]
         originalname = asana_pdf_blob["originalname"]
         mimetype = asana_pdf_blob["mimetype"]
@@ -167,13 +175,25 @@ def session_kb(
             f"Search/conversation tests will not have any data to query."
         )
 
-        yield {"kb_id": kb_id, "record_id": record_id}
-    finally:
+        return {"kb_id": kb_id, "record_id": record_id}
+
+    def _teardown(kb: dict[str, str]) -> None:
         try:
-            kb_client.delete_kb(kb_id)
-            logger.info("Deleted KB %s", kb_id)
+            kb_client.delete_kb(kb["kb_id"])
+            logger.info("Deleted KB %s", kb["kb_id"])
         except Exception as e:
-            logger.warning("Failed to delete KB %s: %s", kb_id, e)
+            logger.warning("Failed to delete KB %s: %s", kb["kb_id"], e)
+
+    with shared_session_resource(
+        "session_kb",
+        config=request.config,
+        tmp_path_factory=tmp_path_factory,
+        create=_build,
+        destroy=_teardown,
+        dump=lambda kb: kb,
+        load=lambda raw: raw,
+    ) as kb:
+        yield kb
 
 
 def _agent_create_payload(
@@ -235,6 +255,8 @@ def _delete_agent(agents: AgentsClient, agent_key: str) -> None:
 
 @pytest.fixture(scope="session")
 def reasoning_multimodal_llm_model(
+    request: pytest.FixtureRequest,
+    tmp_path_factory: pytest.TempPathFactory,
     pipeshub_client: PipeshubClient,
     ai_models_configured,
 ) -> SeededAIModel:
@@ -248,9 +270,8 @@ def reasoning_multimodal_llm_model(
     """
     del ai_models_configured  # fixture ordering only
 
-    seeded_by_fixture: SeededAIModel | None = None
-    try:
-        seeded_by_fixture = setup_test_llm_model(
+    def _seed() -> SeededAIModel:
+        seeded = setup_test_llm_model(
             pipeshub_client,
             is_reasoning=True,
             is_multimodal=True,
@@ -258,10 +279,22 @@ def reasoning_multimodal_llm_model(
         )
         logger.info(
             "Seeded reasoning multimodal LLM for agent ITs: modelKey=%s model=%s",
-            seeded_by_fixture.model_key,
-            seeded_by_fixture.model_name,
+            seeded.model_key,
+            seeded.model_name,
         )
-        yield seeded_by_fixture
+        return seeded
+
+    try:
+        with shared_session_resource(
+            "reasoning_multimodal_llm_model",
+            config=request.config,
+            tmp_path_factory=tmp_path_factory,
+            create=_seed,
+            destroy=lambda seeded: teardown_test_llm_model(pipeshub_client, seeded),
+            dump=asdict,
+            load=lambda raw: SeededAIModel(**raw),
+        ) as seeded_by_fixture:
+            yield seeded_by_fixture
     except RuntimeError as e:
         pytest.fail(
             f"Failed to seed reasoning multimodal LLM for enterprise-search ITs: {e}. "
@@ -270,9 +303,6 @@ def reasoning_multimodal_llm_model(
             "Set TEST_AI_MODEL_PROVIDER=azureOpenAI to prefer Azure when multiple "
             "providers are configured."
         )
-    finally:
-        if seeded_by_fixture is not None:
-            teardown_test_llm_model(pipeshub_client, seeded_by_fixture)
 
 
 @pytest.fixture(scope="session")

--- a/integration-tests/response-validation/enterprise-search/conftest.py
+++ b/integration-tests/response-validation/enterprise-search/conftest.py
@@ -271,12 +271,21 @@ def reasoning_multimodal_llm_model(
     del ai_models_configured  # fixture ordering only
 
     def _seed() -> SeededAIModel:
-        seeded = setup_test_llm_model(
-            pipeshub_client,
-            is_reasoning=True,
-            is_multimodal=True,
-            is_default=False,
-        )
+        try:
+            seeded = setup_test_llm_model(
+                pipeshub_client,
+                is_reasoning=True,
+                is_multimodal=True,
+                is_default=False,
+            )
+        except RuntimeError as e:
+            pytest.fail(
+                f"Failed to seed reasoning multimodal LLM for enterprise-search ITs: {e}. "
+                "Configure TEST_OPENAI_API_KEY, TEST_AZURE_OPENAI_API_KEY (+ endpoint "
+                "and deployment), TEST_GEMINI_API_KEY, or TEST_GROQ_API_KEY. "
+                "Set TEST_AI_MODEL_PROVIDER=azureOpenAI to prefer Azure when multiple "
+                "providers are configured."
+            )
         logger.info(
             "Seeded reasoning multimodal LLM for agent ITs: modelKey=%s model=%s",
             seeded.model_key,
@@ -284,25 +293,16 @@ def reasoning_multimodal_llm_model(
         )
         return seeded
 
-    try:
-        with shared_session_resource(
-            "reasoning_multimodal_llm_model",
-            config=request.config,
-            tmp_path_factory=tmp_path_factory,
-            create=_seed,
-            destroy=lambda seeded: teardown_test_llm_model(pipeshub_client, seeded),
-            dump=asdict,
-            load=lambda raw: SeededAIModel(**raw),
-        ) as seeded_by_fixture:
-            yield seeded_by_fixture
-    except RuntimeError as e:
-        pytest.fail(
-            f"Failed to seed reasoning multimodal LLM for enterprise-search ITs: {e}. "
-            "Configure TEST_OPENAI_API_KEY, TEST_AZURE_OPENAI_API_KEY (+ endpoint "
-            "and deployment), TEST_GEMINI_API_KEY, or TEST_GROQ_API_KEY. "
-            "Set TEST_AI_MODEL_PROVIDER=azureOpenAI to prefer Azure when multiple "
-            "providers are configured."
-        )
+    with shared_session_resource(
+        "reasoning_multimodal_llm_model",
+        config=request.config,
+        tmp_path_factory=tmp_path_factory,
+        create=_seed,
+        destroy=lambda seeded: teardown_test_llm_model(pipeshub_client, seeded),
+        dump=asdict,
+        load=lambda raw: SeededAIModel(**raw),
+    ) as seeded_by_fixture:
+        yield seeded_by_fixture
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Description
The integration job has hit its 180m timeout twice (runs 30713418317 and 30739572956), losing the Slack report both times because the reporting steps are gated on `!cancelled()`. Per-file JUnit timings show the neo4j suite went 43.1m -> 70.3m between Jul 31 and Aug 2: +9.6m from the Drive folder-filter tests that started running once #2861 supplied the second workspace user, and +17.7m spread across every LLM-driven enterprise-search file.

Enterprise-search is 37.2m of that 70.3m and is almost entirely stream wait, so it parallelizes well. Its tests are already independent -- no order markers, no class-level state, and each builds its own conversation. What blocked `-n` was the shared setup:

* `ai_models_configured` seeds the org-wide default LLM + embedding and deletes them at session end. Every xdist worker gets its own session, so N workers meant N concurrent seed/teardown cycles against one singleton, with one worker's teardown deleting a model another was mid-stream on.
* `session_kb` uploads a PDF and blocks on indexing -- the most expensive setup in the suite, and naively it would run per worker.

`helper/xdist_shared.py` elects one worker to build each of these and shares the serialized handle with the rest. Teardown is skipped under xdist: there is no cross-worker barrier at session end, so a refcount would race, and CI drops the whole docker stack immediately after. Serial runs keep the original create/destroy path.

Connectors stay serial. `pytest_collection_modifyitems` marks everything outside enterprise-search with a shared `xdist_group`, so `--dist loadgroup` pins it to a single worker and preserves the `--order-scope=module` ordering its module-scoped fixtures rely on.

Two xdist behaviours the hook has to work around, both verified against xdist 3.8 in a standalone harness:

* the hook must be `tryfirst` -- xdist's own collection hook is what encodes the mark into the nodeid, and it otherwise runs first, so the marks are ignored and every test spreads.
* workers can't be detected via `--dist`; `remote.setup_config` resets it to "no" on each worker, so a dist-only guard no-ops exactly where it matters. `workerinput` is the reliable signal.

The `@group` suffix xdist appends is stripped from reports on the controller so it stays out of the JUnit XML, the HTML report and the Slack failed-test list. Stripping on workers desynchronises them from the scheduler and silently drops tests.

Worker count is `PYTEST_WORKERS` (default 5, dispatch input); 1 restores serial behaviour.

[Provide a brief description of the changes in this PR]

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes. Provide instructions so we can reproduce.]

### Test Configuration

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [ ] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [ ] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Integration tests now run in parallel for faster execution across supported database environments.
  * Manual test runs support configurable worker counts from 1 to 8.
  * Improved scheduling isolates serial scenarios while distributing eligible enterprise-search tests.
  * Shared test resources are reused safely across parallel workers, with centralized cleanup and consistent reporting.

* **Chores**
  * Improved reliability and consistency of distributed integration-test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->