### PR TITLE
perf:query service cpu usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,8 @@ backend/python/.claude/settings.local.json
 .commandcode
 # Subagent-driven-development progress ledger (scratch, not committed)
 .superpowers/
+
+# Load-test output and credentials (see loadtest/.gitignore)
+loadtest/results/
+# Host + bearer token for a load-test target environment.
+.env.play

--- a/backend/python/app/agents/actions/knowledge_graph/ops/fetch.py
+++ b/backend/python/app/agents/actions/knowledge_graph/ops/fetch.py
@@ -1,11 +1,10 @@
 """Knowledge graph fetch_record operation.
 
-Extracted from hooks/citations.py ``_FetchFullRecordTool`` so the execution
-logic lives in one place and both the new ``knowledgegraph__fetch_record``
-tool and the legacy dynamic tool name can call it.
-
-The dynamic-grant gating mechanism in ``citations.py`` is preserved
-unchanged; only the *name* of the registered tool changes.
+The execution body for ``knowledgegraph__fetch_record``. The tool itself is
+``_FetchFullRecordTool`` in ``hooks/citations.py``, which owns registration,
+the dynamic grant, and where the returned ref mapper gets stashed; this module
+owns what a fetch actually does. Keeping the two apart is what lets the tool be
+built fresh per call from live ``tool_state`` without duplicating the body.
 """
 from __future__ import annotations
 
@@ -14,7 +13,7 @@ import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from app.agent_loop_lib.agent.spec import AgentSpec
+    from app.agent_loop_lib.tools.base import ToolOutput
     from app.agents.agent_loop.context import AgentContext
 
 logger = logging.getLogger(__name__)
@@ -23,9 +22,15 @@ _DEFAULT_FULL_RECORD_MAX_BLOCKS = 200
 
 FETCH_RECORD_TOOL_NAME = "knowledgegraph__fetch_record"
 
+DEFAULT_FETCH_REASON = "Fetching full record content for comprehensive answer"
+
 
 def resolve_block_cap(model_name: str, requested_max: int | None) -> int:
-    """Resolve the effective block cap for a fetch."""
+    """Resolve the effective block cap for a fetch.
+
+    Deliberately not widened from the model's context window: that reports 128k
+    for unknown/local models, far too optimistic for a small LLM.
+    """
     env_raw = os.getenv("PIPESHUB_FULL_RECORD_MAX_BLOCKS", "")
     try:
         env_cap = int(env_raw) if env_raw.strip() else _DEFAULT_FULL_RECORD_MAX_BLOCKS
@@ -48,18 +53,18 @@ async def execute_fetch_record(
     virtual_records: dict[str, Any],
     citation_ref_mapper: Any,
     record_ids: list[str] | str,
-    reason: str = "Fetching full record content for comprehensive answer",
+    reason: str = DEFAULT_FETCH_REASON,
     start_block: int = 0,
     max_blocks: int | None = None,
-) -> dict[str, Any]:
+) -> tuple["ToolOutput", Any]:
     """Fetch one or more records end-to-end.
 
-    Returns a dict with keys:
-    - ``success``: bool
-    - ``text``: formatted text for the LLM (when success=True)
-    - ``error``: error string (when success=False)
-    - ``updated_ref_mapper``: updated CitationRefMapper (caller must stash)
+    Returns ``(output, ref_mapper)``. The mapper comes back rather than being
+    stashed here, and is the SAME object passed in unless a record was actually
+    rendered -- that identity is how the caller tells an update from a no-op.
     """
+    from app.agent_loop_lib.tools.base import ToolOutput
+    from app.agents.agent_loop.tool_adapter import _to_tool_output
     from app.utils.chat_helpers import record_to_message_content
     from app.utils.fetch_full_record import create_fetch_full_record_tool
 
@@ -80,6 +85,11 @@ async def execute_fetch_record(
     if record_id_shortener is not None:
         record_ids = [record_id_shortener.resolve(rid) for rid in record_ids]
 
+    # Intra-call only. Do NOT extend this to skip records fetched by an earlier
+    # call: `shape_tool_result_clearing` drops stale fetch results and tells the
+    # model to re-call with the same arguments, which such a guard would refuse.
+    # After resolve so a short label and its full id collapse to one entry.
+    record_ids = list(dict.fromkeys(record_ids))
     block_cap = resolve_block_cap(context.model_name, max_blocks)
 
     structured_tool = create_fetch_full_record_tool(
@@ -91,7 +101,7 @@ async def execute_fetch_record(
     try:
         result = await structured_tool.coroutine(record_ids=record_ids, reason=reason)
     except Exception as exc:
-        return {"success": False, "error": str(exc), "updated_ref_mapper": citation_ref_mapper}
+        return ToolOutput(success=False, error=str(exc)), citation_ref_mapper
 
     if isinstance(result, dict) and result.get("ok") and result.get("records"):
         parts: list[str] = []
@@ -121,8 +131,9 @@ async def execute_fetch_record(
         not_available = result.get("not_available_ids", [])
         if not_available:
             if record_id_shortener is not None:
+                # shorten_if_known: do not mint labels for ids the model never saw.
                 not_available = [
-                    record_id_shortener.get_or_create_short_id(rid) for rid in not_available
+                    record_id_shortener.shorten_if_known(rid) for rid in not_available
                 ]
             ids_str = ", ".join(f"'{rid}'" for rid in not_available)
             text += f"\n\nNote: The following record(s) are not available: {ids_str}"
@@ -133,13 +144,6 @@ async def execute_fetch_record(
                 context.full_records_fetched.add(rid)
                 context.tool_state.setdefault("full_records_fetched", set()).add(rid)
 
-        return {"success": True, "text": text, "updated_ref_mapper": ref_mapper}
+        return ToolOutput(success=True, data=text), ref_mapper
 
-    from app.agents.agent_loop.tool_adapter import _to_tool_output
-    out = _to_tool_output(result)
-    return {
-        "success": out.success,
-        "text": out.data if out.success else None,
-        "error": out.error if not out.success else None,
-        "updated_ref_mapper": citation_ref_mapper,
-    }
+    return _to_tool_output(result), citation_ref_mapper

--- a/backend/python/app/agents/agent_loop/answer_streamer.py
+++ b/backend/python/app/agents/agent_loop/answer_streamer.py
@@ -25,10 +25,13 @@ The one turn that ends via `AGENT_COMPLETE` instead of a tool call is, by
 whatever is in the buffer at that point IS the streamed answer.
 
 Citation refs (`[source](refN)`) are resolved progressively via
-`normalize_citations_and_chunks` on every delta, using the `ref_to_url`
-mapping from `CitationCollector` — the same function `AnswerFinalizer`
-uses for the authoritative `complete` event, so numbered citations appear
-live as the answer streams in. The citation state (`ref_to_url`,
+`normalize_citations_and_chunks`, using the `ref_to_url` mapping from
+`CitationCollector` — the same function `AnswerFinalizer` uses for the
+authoritative `complete` event, so numbered citations appear live as the
+answer streams in. That resolution re-runs over the whole accumulated answer,
+so it is rate-limited (`PIPESHUB_ANSWER_DELTA_INTERVAL_MS`, default 100 ms)
+rather than run per token, and forced once more at `AGENT_COMPLETE`; raw text
+still streams per token on its own channel. The citation state (`ref_to_url`,
 `final_results`, `web_records`) is snapshotted once per turn at
 `TEXT_MESSAGE_START` — stable within a turn since no tools execute between
 the model call's first token and its completion.
@@ -41,11 +44,30 @@ passes through token by token — so it never reaches the screen.
 
 from __future__ import annotations
 
+import logging
+import os
+import time
 from typing import TYPE_CHECKING, Any
 
 from app.agent_loop_lib.events.base import EventType
 from app.utils.citations import normalize_citations_and_chunks
-from app.utils.streaming import parse_confidence_from_answer, strip_partial_confidence_trailer
+from app.utils.streaming import (
+    parse_confidence_from_answer,
+    strip_partial_confidence_trailer,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def answer_delta_min_interval() -> float:
+    """Seconds between live citation refreshes; 0 restores per-token emits."""
+    raw = os.getenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", "100")
+    try:
+        value = float(raw)
+    except ValueError:
+        logger.warning("Invalid PIPESHUB_ANSWER_DELTA_INTERVAL_MS=%r, falling back to 100", raw)
+        return 0.1
+    return max(value, 0.0) / 1000.0
 
 if TYPE_CHECKING:
     from app.agent_loop_lib.events.base import AgentEvent
@@ -75,6 +97,9 @@ class TerminalAnswerStreamer:
         self._web_records: list[dict[str, Any]] = []
         self._ref_to_url: dict[str, str] | None = None
         self.streamed_answer = ""
+        self._emit_interval = answer_delta_min_interval()
+        self._last_emit = 0.0
+        self._withheld = False
 
         # Reasoning/thinking accumulation (Phase 1f) — one entry per model
         # turn that actually reasoned. Populated from the SAME `AgentEvent`
@@ -100,6 +125,10 @@ class TerminalAnswerStreamer:
                 await self._clear_preamble()
         elif event.event_type == EventType.AGENT_COMPLETE:
             self.streamed_answer = self._buffer
+            # Flush only what the limiter actually withheld, so a turn it
+            # never throttled does not pay for a second full-size frame.
+            if self._withheld and self._buffer:
+                await self._emit_state_delta()
         elif event.event_type == EventType.REASONING_MESSAGE_START:
             self._reasoning_buffer = ""
         elif event.event_type == EventType.REASONING_MESSAGE_CONTENT:
@@ -118,16 +147,22 @@ class TerminalAnswerStreamer:
         TEXT_MESSAGE_CONTENT deltas extracted from tool call arguments.
         Clearing the preamble buffer for these tools would erase the live
         answer mid-flight."""
-        from app.agent_loop_lib.tools.builtin.planning.final_answer import final_answer_enabled
+        from app.agent_loop_lib.tools.builtin.planning.final_answer import (
+            final_answer_enabled,
+        )
         if not final_answer_enabled():
             return False
-        from app.agent_loop_lib.tools.builtin.planning.final_answer import FinalAnswerTool
+        from app.agent_loop_lib.tools.builtin.planning.final_answer import (
+            FinalAnswerTool,
+        )
         return tool_name == FinalAnswerTool().name
 
     def _start_turn(self) -> None:
         """Snapshot the citation state for this turn's normalization calls.
         Stable within a turn since no tools execute mid-model-call."""
         self._buffer = ""
+        self._last_emit = 0.0
+        self._withheld = False
         self._web_records = self._collector.web_records
         ref_mapper = self._collector.citation_ref_mapper
         self._ref_to_url = ref_mapper.ref_to_url if ref_mapper is not None else None
@@ -136,7 +171,26 @@ class TerminalAnswerStreamer:
         if not delta:
             return
         self._buffer += delta
-        await self._emit_state_delta(delta)
+        if self._due_for_emit():
+            await self._emit_state_delta(delta)
+
+    def _due_for_emit(self) -> bool:
+        """Rate-limit the live-citation refresh.
+
+        `_emit_state_delta` re-normalizes the WHOLE accumulated answer, so
+        per-token calls made it quadratic in answer length (22% of
+        query-service CPU). Raw text still streams per token on its own
+        channel; only the citation overlay refreshes less often.
+        """
+        if self._emit_interval <= 0:
+            return True
+        now = time.monotonic()
+        if (now - self._last_emit) < self._emit_interval:
+            self._withheld = True
+            return False
+        self._last_emit = now
+        self._withheld = False
+        return True
 
     async def _emit_state_delta(self, chunk: str = "") -> None:
         answer_text, confidence = parse_confidence_from_answer(self._buffer)

--- a/backend/python/app/agents/agent_loop/hooks/citations.py
+++ b/backend/python/app/agents/agent_loop/hooks/citations.py
@@ -40,7 +40,6 @@ from typing import TYPE_CHECKING, Any
 
 from app.agent_loop_lib.tools.base import ParameterType, Tool, ToolOutput, ToolParameter
 from app.agents.agent_loop.hooks._tool_naming import INTERNAL_SEARCH_TOOL_NAMES
-from app.agents.agent_loop.tool_adapter import _to_tool_output
 
 if TYPE_CHECKING:
     from app.agent_loop_lib.agent.spec import AgentSpec
@@ -48,6 +47,7 @@ if TYPE_CHECKING:
     from app.agent_loop_lib.hooks.middleware.pipeline import Middleware, Next
     from app.agents.agent_loop.context import AgentContext
 
+from app.agents.actions.knowledge_graph.ops.fetch import DEFAULT_FETCH_REASON as _DEFAULT_FETCH_REASON
 from app.agents.actions.knowledge_graph.ops.fetch import FETCH_RECORD_TOOL_NAME as _FETCH_FULL_RECORD_TOOL_NAME
 
 # ---------------------------------------------------------------------------
@@ -100,43 +100,6 @@ _FETCH_FULL_RECORD_DESCRIPTION = (
     "IDs. Large records return a continuation hint giving the start_block for "
     "the next slice."
 )
-
-# Conservative default: enough for most models but safe for small/local ones.
-# Only reduced (never raised) by the known context window.
-# Override with PIPESHUB_FULL_RECORD_MAX_BLOCKS (int > 0) for deployment tuning.
-_DEFAULT_FULL_RECORD_MAX_BLOCKS = 200
-
-
-def _resolve_block_cap(model_name: str, requested_max: int | None) -> int:
-    """
-    Resolve the effective block cap for a fetch.
-
-    The cap is the minimum of the configured default and the caller's explicit
-    request. Never exceeds _DEFAULT_FULL_RECORD_MAX_BLOCKS unless the env var
-    is set higher (which is the operator's choice, not ours).
-
-    `get_context_window()` returns 128k for unknown/local models — too optimistic
-    for a small LLM — so we do NOT blindly raise the cap from the context window.
-    """
-    import os
-
-    env_raw = os.getenv("PIPESHUB_FULL_RECORD_MAX_BLOCKS", "")
-    try:
-        env_cap = int(env_raw) if env_raw.strip() else _DEFAULT_FULL_RECORD_MAX_BLOCKS
-        if env_cap <= 0:
-            env_cap = _DEFAULT_FULL_RECORD_MAX_BLOCKS
-    except ValueError:
-        import logging
-        logging.getLogger(__name__).warning(
-            "Invalid PIPESHUB_FULL_RECORD_MAX_BLOCKS=%r, using %d",
-            env_raw, _DEFAULT_FULL_RECORD_MAX_BLOCKS,
-        )
-        env_cap = _DEFAULT_FULL_RECORD_MAX_BLOCKS
-
-    if requested_max is not None and requested_max > 0:
-        return min(env_cap, requested_max)
-    return env_cap
-
 
 class CitationCollector:
     """Read-only view over the citation-related fields of `AgentContext.tool_state`."""
@@ -191,6 +154,8 @@ class _FetchFullRecordTool(Tool):
     tool instance built once from the first snapshot.
     """
 
+    _ACCEPTED_ARGS = ("record_ids", "reason", "start_block", "max_blocks")
+
     def __init__(self, collector: CitationCollector, context: AgentContext) -> None:
         self._collector = collector
         self._context = context
@@ -234,7 +199,7 @@ class _FetchFullRecordTool(Tool):
                 type=ParameterType.STRING,
                 description="Brief explanation of why the full records are needed",
                 required=False,
-                default="Fetching full record content for comprehensive answer",
+                default=_DEFAULT_FETCH_REASON,
             ),
             ToolParameter(
                 name="start_block",
@@ -260,97 +225,51 @@ class _FetchFullRecordTool(Tool):
     def validate(self, kwargs: dict[str, Any]) -> None:
         return
 
+    def _live_virtual_records(self) -> dict[str, Any]:
+        """The mapping `_fetch_multiple_records_impl` writes downloaded records
+        back into, so it must be the object in `tool_state` and NOT
+        `CitationCollector.virtual_records`, whose `or {}` returns a throwaway
+        dict while the map is empty — losing the write-back and re-downloading
+        on every repeat fetch.
+
+        Records persisting here skip the ACL re-check a fresh id gets; safe
+        because `tool_state` is per HTTP request, hence per user.
+        """
+        state = self._context.tool_state
+        records = state.get("virtual_record_id_to_result")
+        if not isinstance(records, dict):
+            records = {}
+            state["virtual_record_id_to_result"] = records
+        return records
+
     async def execute(self, **kwargs: Any) -> ToolOutput:  # noqa: ANN401
-        from app.utils.chat_helpers import record_to_message_content
-        from app.utils.fetch_full_record import create_fetch_full_record_tool
+        from app.agents.actions.knowledge_graph.ops.fetch import execute_fetch_record
 
-        start_block: int = int(kwargs.pop("start_block", 0) or 0)
-        requested_max: int | None = kwargs.pop("max_blocks", None)
-        block_cap = _resolve_block_cap(self._context.model_name, requested_max)
-
-        # TEMPORARY token-savings experiment (opt-in, disabled by default —
-        # see `ChatQuery.enableRecordIdShortening`): an earlier retrieval/
-        # search/navigate/lookup_record/list_files call may have handed the
-        # model a short "R<n>" label instead of the full Record ID (see
-        # `RecordIdShortener` in `utils/chat_helpers.py`). Resolve it back
-        # before matching against `virtual_records`. Full ids the model
-        # copied verbatim pass through `.resolve()` unchanged. Created here
-        # (not just read) so a fetch that happens to be the first knowledge
-        # call this request still shortens the ids it prints below. `None`
-        # when the flag is off — record_ids pass through untouched.
-        from app.utils.chat_helpers import get_record_id_shortener_if_enabled
-        record_id_shortener = get_record_id_shortener_if_enabled(self._context.tool_state)
-        raw_record_ids = kwargs.get("record_ids")
-        if raw_record_ids and record_id_shortener is not None:
-            kwargs["record_ids"] = [
-                record_id_shortener.resolve(rid) for rid in raw_record_ids
-            ]
-
-        structured_tool = create_fetch_full_record_tool(
-            self._collector.virtual_records,
-            org_id=self._context.org_id,
-            graph_provider=self._context.graph_provider,
-            # Required for IDs the model got from navigate/lookup_record
-            # rather than from retrieval — those are not in the map, so the
-            # fetch has to re-check access itself.
-            user_id=self._context.user_id,
-        )
-        try:
-            result = await structured_tool.coroutine(**kwargs)
-        except Exception as exc:
-            return ToolOutput(success=False, error=str(exc))
-
-        # Mirror the chatbot path's formatting (`RecordsHandler` +
-        # `record_to_message_content()` in streaming.py) instead of handing
-        # the LLM a raw JSON dict of block_containers/context_metadata — the
-        # same records, rendered as the `<record>` text blocks the model
-        # already knows how to read from `retrieval_search_internal_knowledge`.
-        if isinstance(result, dict) and result.get("ok") and result.get("records"):
-            ref_mapper = self._collector.citation_ref_mapper
-            parts: list[str] = []
-            for record in result["records"]:
-                # Reads start at block 0 unless the caller asked otherwise.
-                # Starting at the first block retrieval matched instead drops
-                # everything before it — for a match near the end that returns
-                # a short tail as if it were the document. Oversized records are
-                # bounded by `block_cap`, which appends a continuation hint.
-                content_list, ref_mapper = record_to_message_content(
-                    record,
-                    ref_mapper=ref_mapper,
-                    start_block=start_block,
-                    max_blocks=block_cap,
-                )
-                parts.append("".join(
-                    item["text"] for item in content_list if item.get("type") == "text"
-                ))
-            self._context.tool_state["citation_ref_mapper"] = ref_mapper
-            text = "\n".join(parts)
-            # TEMPORARY token-savings experiment: shorten every "Record ID:"
-            # this fetch prints (record headers, FK table rows) back down to
-            # the same "R<n>" label the model already saw from retrieval/
-            # navigate/lookup_record — see `RecordIdShortener`.
-            if record_id_shortener is not None:
-                text = record_id_shortener.shorten_record_ids_in_text(text)
-            text += (
-                "\n\nCite facts from the above using each block's `[refN]` id "
-                "as a markdown link, e.g. [source](ref2). Do NOT use external URLs as citations."
+        # Not forwarded as `**kwargs`: a model sending `record_id=` (singular)
+        # must get a correctable error, not a silent empty fetch.
+        unexpected = sorted(set(kwargs) - set(self._ACCEPTED_ARGS))
+        if unexpected:
+            return ToolOutput(
+                success=False,
+                error=(
+                    f"Unexpected argument(s): {', '.join(unexpected)}. "
+                    f"Accepted: {', '.join(self._ACCEPTED_ARGS)}."
+                ),
             )
-            not_available = result.get("not_available_ids", [])
-            if not_available:
-                if record_id_shortener is not None:
-                    not_available = [
-                        record_id_shortener.shorten_if_known(rid) for rid in not_available
-                    ]
-                ids_str = ", ".join(f"'{rid}'" for rid in not_available)
-                text += f"\n\nNote: The following record(s) are not available: {ids_str}"
-            # Track fetched record IDs for the gate.
-            for record in result["records"]:
-                rid = record.get("id")
-                if rid:
-                    self._context.full_records_fetched.add(rid)
-                    self._context.tool_state.setdefault("full_records_fetched", set()).add(rid)
-            return ToolOutput(success=True, data=text)
-        return _to_tool_output(result)
+
+        ref_mapper_in = self._collector.citation_ref_mapper
+        output, ref_mapper = await execute_fetch_record(
+            context=self._context,
+            virtual_records=self._live_virtual_records(),
+            citation_ref_mapper=ref_mapper_in,
+            record_ids=kwargs.get("record_ids") or [],
+            reason=kwargs.get("reason") or _DEFAULT_FETCH_REASON,
+            start_block=int(kwargs.get("start_block") or 0),
+            max_blocks=kwargs.get("max_blocks"),
+        )
+        if ref_mapper is not ref_mapper_in:
+            self._context.tool_state["citation_ref_mapper"] = ref_mapper
+        return output
 
 
 def _grant(spec: "AgentSpec | None", *, require_internal_search_reference: bool) -> None:

--- a/backend/python/app/agents/agent_loop/langchain_transport.py
+++ b/backend/python/app/agents/agent_loop/langchain_transport.py
@@ -250,10 +250,16 @@ class LangChainTransport(LLMTransport):
         # query-service CPU) for output identical whenever the tool set is. Names
         # key it safely: one name resolves to one registry entry per request, and
         # `fetch_tools` granting more tools changes the names, forcing a rebind.
+        # Only bindings onto `self._llm` are cached. An `llm` override is the
+        # API-shape fallback retrying on a differently-configured model, and
+        # handing it the cached original made the retry re-raise the very error
+        # it was retrying.
+        cacheable = llm is self._llm
         cache_key = tuple(tool_names)
-        cached = self._bound_by_tools.get(cache_key)
-        if cached is not None:
-            return cached
+        if cacheable:
+            cached = self._bound_by_tools.get(cache_key)
+            if cached is not None:
+                return cached
 
         lc_tools = convert_tool_schemas_to_langchain(tools)
         try:
@@ -272,7 +278,8 @@ class LangChainTransport(LLMTransport):
             "LangChainTransport: bound %d tool(s) to LLM call: %s",
             len(tool_names), tool_names,
         )
-        self._bound_by_tools[cache_key] = bound
+        if cacheable:
+            self._bound_by_tools[cache_key] = bound
         return bound
 
     def _wrap_error(self, exc: Exception, context: str) -> TransportError:
@@ -471,6 +478,9 @@ class LangChainTransport(LLMTransport):
             # follow) and persisted so the NEXT request for this model
             # skips straight to the working shape.
             self._llm = fallback_llm
+            # Entries were bound onto the old model; keeping them would serve
+            # the shape that just failed for the rest of the run.
+            self._bound_by_tools.clear()
             await self._record_api_mode(mode)
             logger.info(
                 "LangChainTransport.complete: retry succeeded — pinned api_mode=%s for "
@@ -697,6 +707,7 @@ class LangChainTransport(LLMTransport):
             # follow) and persisted so the NEXT request for this model
             # skips straight to the working shape.
             self._llm = fallback_llm
+            self._bound_by_tools.clear()
             await self._record_api_mode(fallback_mode)
             logger.info(
                 "LangChainTransport.stream: retry succeeded — pinned api_mode=%s for "

--- a/backend/python/app/agents/agent_loop/langchain_transport.py
+++ b/backend/python/app/agents/agent_loop/langchain_transport.py
@@ -196,6 +196,9 @@ class LangChainTransport(LLMTransport):
         # runtime fallback below still applies either way).
         self._model_key = model_key
         self._opik_callbacks = build_langchain_opik_callbacks(opik_project_name)
+        # Keyed on the turn's tool names; see `_bind_tools`. A transport is
+        # built per request, so this can never be shared across users.
+        self._bound_by_tools: dict[tuple[str, ...], BaseChatModel] = {}
 
     def _langchain_config(self) -> dict[str, Any]:
         """`config=` kwarg for every `ainvoke`/`astream` call below — see
@@ -242,6 +245,16 @@ class LangChainTransport(LLMTransport):
             logger.debug("LangChainTransport: no tools offered for this turn")
             return llm
         tool_names = [t.name for t in tools]
+
+        # Binding re-derives a pydantic JSON schema per tool every turn (5.5% of
+        # query-service CPU) for output identical whenever the tool set is. Names
+        # key it safely: one name resolves to one registry entry per request, and
+        # `fetch_tools` granting more tools changes the names, forcing a rebind.
+        cache_key = tuple(tool_names)
+        cached = self._bound_by_tools.get(cache_key)
+        if cached is not None:
+            return cached
+
         lc_tools = convert_tool_schemas_to_langchain(tools)
         try:
             bound = llm.bind_tools(lc_tools)
@@ -259,6 +272,7 @@ class LangChainTransport(LLMTransport):
             "LangChainTransport: bound %d tool(s) to LLM call: %s",
             len(tool_names), tool_names,
         )
+        self._bound_by_tools[cache_key] = bound
         return bound
 
     def _wrap_error(self, exc: Exception, context: str) -> TransportError:

--- a/backend/python/app/agents/agent_loop/stream_bridge.py
+++ b/backend/python/app/agents/agent_loop/stream_bridge.py
@@ -174,15 +174,21 @@ class QueueEventSink:
     there), but token-level text/thinking deltas arrive far faster than any
     SSE consumer needs to render them at, so a burst that fills the queue
     would otherwise stall the whole run on I/O nobody is waiting on. Instead,
-    consecutive coalescable events (see `_coalesce_key`) are held in a single
-    one-event `_pending` slot and merged as they arrive; the slot is flushed
-    to the real queue as soon as `write()` sees room, or immediately ahead of
-    any non-coalescable event (which must never be reordered or dropped).
+    coalescable events (see `_coalesce_key`) are held in a per-key `_pending`
+    slot and merged as they arrive; a slot is flushed to the real queue as soon
+    as `write()` sees room, or — for every slot, in arrival order — immediately
+    ahead of any non-coalescable event (which must never be reordered or
+    dropped).
+
+    Slots are per-key rather than one shared slot because the answer stream
+    interleaves two coalescable kinds: a `TEXT_MESSAGE_CONTENT` delta and an
+    `answer_delta` `STATE_DELTA` snapshot per token. With one slot, each write
+    evicted the other kind, so neither ever actually coalesced.
     """
 
     def __init__(self, queue: "asyncio.Queue[Any]") -> None:
         self._queue = queue
-        self._pending: tuple[tuple[str, str], dict[str, Any]] | None = None
+        self._pending: dict[tuple[str, str], dict[str, Any]] = {}
 
     async def write(self, event: dict[str, Any]) -> bool:
         key = _coalesce_key(event)
@@ -191,13 +197,10 @@ class QueueEventSink:
             await self._queue.put(event)
             return True
 
-        if self._pending is not None and self._pending[0] == key:
-            event = _merge_coalesced(self._pending[1], event)
-        else:
-            await self._flush_pending()
-        self._pending = (key, event)
+        held = self._pending.get(key)
+        self._pending[key] = _merge_coalesced(held, event) if held is not None else event
         if not self._queue.full():
-            await self._flush_pending()
+            await self._flush_key(key)
         return True
 
     async def flush(self) -> None:
@@ -207,12 +210,15 @@ class QueueEventSink:
         flush above) would never reach the client at all."""
         await self._flush_pending()
 
-    async def _flush_pending(self) -> None:
-        if self._pending is None:
+    async def _flush_key(self, key: tuple[str, str]) -> None:
+        event = self._pending.pop(key, None)
+        if event is None:
             return
-        _, event = self._pending
-        self._pending = None
         await self._queue.put(event)
+
+    async def _flush_pending(self) -> None:
+        for key in list(self._pending):
+            await self._flush_key(key)
 
 
 async def _heartbeat(queue: "asyncio.Queue[Any]", interval: float = 15.0) -> None:

--- a/backend/python/app/models/entities.py
+++ b/backend/python/app/models/entities.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Optional,Dict, List, Literal, TypeVar
 from uuid import uuid4
-from jinja2 import Template
 from app.modules.qna.prompt_templates import (
     agent_block_group_prompt,
 )
@@ -24,6 +23,7 @@ from app.models.blocks import (
     BlocksContainer,
     SemanticMetadata,
 )
+from app.utils.jinja_templates import compiled_template
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
 
 # Type variable for enum classes (must be after Enum import)
@@ -525,7 +525,7 @@ class FileRecord(Record):
                                     })
 
                             if child_results:
-                                template = Template(agent_block_group_prompt)
+                                template = compiled_template(agent_block_group_prompt)
                                 rendered_form = template.render(
                                     block_group_index=block_group_index,
                                     label=GroupType.TABLE.value,
@@ -540,7 +540,7 @@ class FileRecord(Record):
                     block_group_id = f"{self.virtual_record_id or ''}-{parent_index}"
                     if block_group_id in seen_block_groups:
                         continue
-                    template = Template(agent_block_group_prompt)
+                    template = compiled_template(agent_block_group_prompt)
                     if parent_index >= len(block_groups):
                         continue
                     block_group = block_groups[parent_index]

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -8,8 +8,6 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 from uuid import uuid4
 
-from jinja2 import Template
-
 from app.config.configuration_service import ConfigurationService
 from app.config.constants.arangodb import CollectionNames, RecordRelations
 from app.config.constants.service import config_node_constants
@@ -42,6 +40,7 @@ from app.modules.transformers.blob_storage import BlobStorage
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.services.vector_db.const.const import VECTOR_DB_COLLECTION_NAME
 from app.utils.image_utils import get_extension_from_mimetype
+from app.utils.jinja_templates import compiled_template
 from app.utils.logger import create_logger
 
 valid_group_labels = [
@@ -118,9 +117,10 @@ def is_base64_image(s: str) -> bool:
     if len(b64_data) % 4 != 0:
         return False
 
-    # Try to decode
+    # 272 chars -> 204 bytes: more than the longest magic number (8) and the
+    # SVG sniff's decoded[:200], and a multiple of 4 so the decoder accepts it.
     try:
-        decoded = base64.b64decode(b64_data)
+        decoded = base64.b64decode(b64_data[:272])
     except Exception:
         return False
 
@@ -2851,7 +2851,7 @@ def record_to_message_content(
 
                         if child_results:
                             if not has_row_images:
-                                template = Template(table_prompt)
+                                template = compiled_template(table_prompt)
                                 rendered_form = template.render(
                                     block_group_index=block_group_index,
                                     block_group_web_url="",
@@ -2875,7 +2875,7 @@ def record_to_message_content(
                 block_group_id = f"{record.get('virtual_record_id', '')}-{parent_index}"
                 if block_group_id in seen_block_groups:
                     continue
-                template = Template(block_group_prompt)
+                template = compiled_template(block_group_prompt)
                 if parent_index >= len(block_groups):
                     continue
                 block_group = block_groups[parent_index]
@@ -3046,7 +3046,7 @@ def record_to_text(record: dict[str, Any]) -> str:
                                                     child_results.append({"content": _safe_stringify_content(frag_data)})
 
                         if child_results:
-                            template = Template(agent_block_group_prompt)
+                            template = compiled_template(agent_block_group_prompt)
                             rendered_form = template.render(
                                 block_group_index=block_group_index,
                                 label=GroupType.TABLE.value,
@@ -3058,7 +3058,7 @@ def record_to_text(record: dict[str, Any]) -> str:
                 block_group_id = f"{record.get('virtual_record_id', '')}-{parent_index}"
                 if block_group_id in seen_block_groups:
                     continue
-                template = Template(agent_block_group_prompt)
+                template = compiled_template(agent_block_group_prompt)
                 if parent_index >= len(block_groups):
                     continue
                 block_group = block_groups[parent_index]
@@ -3173,7 +3173,7 @@ def get_message_content(
                 }
             })
 
-    rendered_form = Template(qna_prompt_simple).render(query=query, chunks=chunks)
+    rendered_form = compiled_template(qna_prompt_simple).render(query=query, chunks=chunks)
     content.append({"type": "text", "text": rendered_form})
     return content, ref_mapper
 
@@ -3239,7 +3239,7 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
             current_frontend_url = record.get("frontend_url", "")
             current_record_id = record.get("id", "")
 
-            template = Template(qna_prompt_context)
+            template = compiled_template(qna_prompt_context)
             rendered_form = template.render(
                 context_metadata=record.get("context_metadata", ""),
             )
@@ -3315,7 +3315,7 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
                     child["citation_ref"] = ref_mapper.get_or_create_ref(child["block_web_url"])
                 current_record_has_blocks = True
                 if not has_row_images:
-                    template = Template(table_prompt)
+                    template = compiled_template(table_prompt)
                     rendered_form = template.render(
                         block_group_index=block_group_index,
                         block_group_web_url="",
@@ -3352,7 +3352,7 @@ def build_message_content_array(flattened_results: list[dict[str, Any]], virtual
                     gb["citation_ref"] = ref_mapper.get_or_create_ref(gb["block_web_url"])
 
                 if not has_images:
-                    template = Template(block_group_prompt)
+                    template = compiled_template(block_group_prompt)
                     rendered_form = template.render(
                         block_group_index=block_group_index,
                         block_group_web_url="",

--- a/backend/python/app/utils/indexing_helpers.py
+++ b/backend/python/app/utils/indexing_helpers.py
@@ -2,10 +2,10 @@ import base64
 import json
 from typing import Any, Dict, List, Optional, Tuple
 
-from jinja2 import Template
 from pydantic import BaseModel, Field
 
 from app.modules.parsers.excel.prompt_template import RowDescriptions
+from app.utils.jinja_templates import compiled_template
 from app.utils.llm import get_llm_for_role
 from app.utils.streaming import invoke_with_structured_output_and_reflection
 
@@ -84,7 +84,7 @@ async def get_table_summary_n_headers(config, table_data) -> Optional[TableSumma
             table_data_str = str(table_data)
 
         # Prepare prompt
-        template = Template(table_summary_prompt_template)
+        template = compiled_template(table_summary_prompt_template)
         rendered_form = template.render(table_data=table_data_str)
         messages = [
             {

--- a/backend/python/app/utils/jinja_templates.py
+++ b/backend/python/app/utils/jinja_templates.py
@@ -1,0 +1,26 @@
+"""Compile-once access to the constant Jinja prompt templates.
+
+The context builders construct templates inside per-record loops from
+module-level constants, recompiling the same handful of sources hundreds of
+times per chat turn (11.5% of query-service CPU).
+
+Its own module because `chat_helpers` and `models.entities` both need it and
+`chat_helpers` already imports from `entities`.
+
+Only pass constant sources: the cache is keyed on the source text, so a
+caller-built string would fill it with single-use entries.
+"""
+from __future__ import annotations
+
+from functools import lru_cache
+
+from jinja2 import Template
+
+__all__ = ["compiled_template"]
+
+
+@lru_cache(maxsize=64)
+def compiled_template(source: str) -> Template:
+    """Shared compiled `Template` — safe because `render()` builds its own
+    context per call and the template itself is not mutated."""
+    return Template(source)

--- a/backend/python/tests/unit/agents/actions/knowledge_graph/test_fetch.py
+++ b/backend/python/tests/unit/agents/actions/knowledge_graph/test_fetch.py
@@ -99,15 +99,15 @@ class TestExecuteFetchRecord:
              ):
             os.environ.pop("PIPESHUB_FULL_RECORD_MAX_BLOCKS", None)
             ctx = _make_context()
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=ctx,
                 virtual_records={"vr-1": {"id": "rec-1"}},
                 citation_ref_mapper=ref_mapper,
                 record_ids="rec-1",
             )
 
-        assert result["success"] is True
-        assert "Hello world" in result["text"]
+        assert output.success is True
+        assert "Hello world" in output.data
         assert "rec-1" in ctx.full_records_fetched
 
     @pytest.mark.asyncio
@@ -131,13 +131,13 @@ class TestExecuteFetchRecord:
             return_value=None,
         ):
             ctx = _make_context()
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=ctx,
                 virtual_records={},
                 citation_ref_mapper=ref_mapper,
                 record_ids="single-id",
             )
-        assert result["success"] is True
+        assert output.success is True
         call_kwargs = fake_tool.coroutine.call_args[1]
         assert call_kwargs["record_ids"] == ["single-id"]
 
@@ -155,14 +155,14 @@ class TestExecuteFetchRecord:
             "app.utils.chat_helpers.get_record_id_shortener_if_enabled",
             return_value=None,
         ):
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=_make_context(),
                 virtual_records={},
                 citation_ref_mapper=ref_mapper,
                 record_ids=["rec-1"],
             )
-        assert result["success"] is False
-        assert "db down" in result["error"]
+        assert output.success is False
+        assert "db down" in output.error
 
     @pytest.mark.asyncio
     async def test_not_available_ids_appended(self) -> None:
@@ -184,15 +184,15 @@ class TestExecuteFetchRecord:
             "app.utils.chat_helpers.get_record_id_shortener_if_enabled",
             return_value=None,
         ):
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=_make_context(),
                 virtual_records={},
                 citation_ref_mapper=ref_mapper,
                 record_ids=["rec-1", "rec-2"],
             )
-        assert result["success"] is True
-        assert "not available" in result["text"]
-        assert "rec-2" in result["text"]
+        assert output.success is True
+        assert "not available" in output.data
+        assert "rec-2" in output.data
 
     @pytest.mark.asyncio
     async def test_non_ok_result_returns_tool_output(self) -> None:
@@ -213,14 +213,14 @@ class TestExecuteFetchRecord:
             "app.agents.agent_loop.tool_adapter._to_tool_output",
             return_value=SimpleNamespace(success=False, data=None, error="record not found"),
         ):
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=_make_context(),
                 virtual_records={},
                 citation_ref_mapper=ref_mapper,
                 record_ids=["rec-1"],
             )
-        assert result["success"] is False
-        assert result["error"] == "record not found"
+        assert output.success is False
+        assert output.error == "record not found"
 
     @pytest.mark.asyncio
     async def test_record_id_shortener_resolves_and_shortens(self) -> None:
@@ -246,15 +246,15 @@ class TestExecuteFetchRecord:
             return_value=shortener,
         ):
             ctx = _make_context()
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=ctx,
                 virtual_records={},
                 citation_ref_mapper=ref_mapper,
                 record_ids=["R1"],
             )
         shortener.resolve.assert_called_once_with("R1")
-        assert result["success"] is True
-        assert "R1" in result["text"]
+        assert output.success is True
+        assert "R1" in output.data
 
     @pytest.mark.asyncio
     async def test_not_available_ids_shortened(self) -> None:
@@ -268,7 +268,7 @@ class TestExecuteFetchRecord:
         shortener = MagicMock()
         shortener.resolve = MagicMock(side_effect=lambda x: x)
         shortener.shorten_record_ids_in_text = MagicMock(side_effect=lambda t: t)
-        shortener.get_or_create_short_id = MagicMock(return_value="R2")
+        shortener.shorten_if_known = MagicMock(return_value="R2")
 
         with patch(
             "app.utils.fetch_full_record.create_fetch_full_record_tool",
@@ -280,13 +280,14 @@ class TestExecuteFetchRecord:
             "app.utils.chat_helpers.get_record_id_shortener_if_enabled",
             return_value=shortener,
         ):
-            result = await execute_fetch_record(
+            output, _ = await execute_fetch_record(
                 context=_make_context(),
                 virtual_records={},
                 citation_ref_mapper=ref_mapper,
                 record_ids=["rec-1", "rec-2"],
             )
-        assert "'R2'" in result["text"]
+        shortener.shorten_if_known.assert_called_once_with("rec-2")
+        assert "'R2'" in output.data
 
 
 class TestFetchRecordToolName:

--- a/backend/python/tests/unit/agents/adapter/test_answer_streamer.py
+++ b/backend/python/tests/unit/agents/adapter/test_answer_streamer.py
@@ -8,7 +8,6 @@ and `streamed_answer` reflecting whichever turn last ended via
 
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -85,12 +84,18 @@ class TestEmitRateLimit:
 
         assert len(sink.events) == emitted
 
-    async def test_interval_elapsing_allows_the_next_emit(self) -> None:
+    async def test_interval_elapsing_allows_the_next_emit(self, monkeypatch) -> None:
+        """Drives a controlled clock rather than sleeping: a real wait makes the
+        test both slow and dependent on how promptly the loop reschedules."""
+        from app.agents.agent_loop import answer_streamer as mod
+
+        now = [1000.0]
+        monkeypatch.setattr(mod.time, "monotonic", lambda: now[0])
         streamer, sink = _make_streamer(emit_interval=0.01)
 
         await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
         await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "a"}))
-        await asyncio.sleep(0.03)
+        now[0] += 0.03
         await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "b"}))
 
         assert len(sink.events) == 2

--- a/backend/python/tests/unit/agents/adapter/test_answer_streamer.py
+++ b/backend/python/tests/unit/agents/adapter/test_answer_streamer.py
@@ -8,6 +8,7 @@ and `streamed_answer` reflecting whichever turn last ended via
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -32,11 +33,78 @@ class _RecordingSink:
         return True
 
 
-def _make_streamer(context=None) -> tuple[TerminalAnswerStreamer, _RecordingSink]:
+def _make_streamer(context=None, *, emit_interval: float = 0.0) -> tuple[TerminalAnswerStreamer, _RecordingSink]:
+    """Throttling is off by default so these tests see one emit per delta and
+    can assert on emit CONTENT; `TestEmitRateLimit` covers the rate itself."""
     context = context or make_context()
     collector = CitationCollector(context)
     sink = _RecordingSink()
-    return TerminalAnswerStreamer(context, collector, sink), sink
+    streamer = TerminalAnswerStreamer(context, collector, sink)
+    streamer._emit_interval = emit_interval
+    return streamer, sink
+
+
+class TestEmitRateLimit:
+    """`_emit_state_delta` re-normalizes the whole accumulated answer and
+    rebuilds every citation, so running it per token is quadratic in answer
+    length — 22% of query-service CPU. It is rate-limited instead; the final
+    state must still be emitted when the turn ends."""
+
+    async def test_deltas_inside_the_interval_do_not_each_emit(self) -> None:
+        streamer, sink = _make_streamer(emit_interval=10.0)
+
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
+        for i in range(50):
+            await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": f"tok{i} "}))
+
+        assert len(sink.events) == 1, "only the first delta of the window emits"
+
+    async def test_withheld_delta_is_flushed_at_agent_complete(self) -> None:
+        streamer, sink = _make_streamer(emit_interval=10.0)
+
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "The answer"}))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": " is 42."}))
+        assert sink.events[-1]["data"]["accumulated"] == "The answer"  # 2nd withheld
+
+        await streamer.on_event(_event(EventType.AGENT_COMPLETE))
+
+        assert sink.events[-1]["data"]["accumulated"] == "The answer is 42."
+        assert streamer.streamed_answer == "The answer is 42."
+
+    async def test_no_extra_emit_when_nothing_was_withheld(self) -> None:
+        """A turn the limiter never throttled must not pay for a second
+        full-size frame at AGENT_COMPLETE."""
+        streamer, sink = _make_streamer(emit_interval=10.0)
+
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "The answer is 42."}))
+        emitted = len(sink.events)
+
+        await streamer.on_event(_event(EventType.AGENT_COMPLETE))
+
+        assert len(sink.events) == emitted
+
+    async def test_interval_elapsing_allows_the_next_emit(self) -> None:
+        streamer, sink = _make_streamer(emit_interval=0.01)
+
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "a"}))
+        await asyncio.sleep(0.03)
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "b"}))
+
+        assert len(sink.events) == 2
+
+    async def test_new_turn_resets_the_window(self) -> None:
+        streamer, sink = _make_streamer(emit_interval=10.0)
+
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "first"}))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_START))
+        await streamer.on_event(_event(EventType.TEXT_MESSAGE_CONTENT, {"delta": "second"}))
+
+        assert [e["data"]["accumulated"] for e in sink.events] == ["first", "second"]
+
 
 
 class TestTextDeltaStreaming:

--- a/backend/python/tests/unit/agents/adapter/test_citation_collector.py
+++ b/backend/python/tests/unit/agents/adapter/test_citation_collector.py
@@ -4,6 +4,7 @@ read-only view over `AgentContext.tool_state`'s citation-related fields, and
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.agents.agent_loop.context import AgentContext
@@ -247,6 +248,129 @@ class TestFetchFullRecordTool:
             await tool.execute(record_ids=["rec-1"])
 
         assert context.tool_state["citation_ref_mapper"] is new_ref_mapper
+
+    async def test_second_fetch_of_the_same_record_does_not_redownload(self) -> None:
+        """`_fetch_multiple_records_impl` is a write-back cache: it stores what
+        it downloads into the `virtual_record_id_to_result` mapping it is
+        handed, so a repeat fetch is a map hit. That only holds if `execute()`
+        hands it the SAME mapping every call — passing a fresh dict makes the
+        write-back unreachable and every repeat re-downloads. Empty map here
+        because that is the navigate/lookup path, where retrieval never ran."""
+        context = _make_context()
+        tool = _FetchFullRecordTool(CitationCollector(context), context)
+
+        downloads: list[str] = []
+
+        def _factory(virtual_records: dict, **_kwargs: object) -> SimpleNamespace:
+            async def _coroutine(record_ids: list[str], reason: str = "") -> dict:
+                records = []
+                for rid in record_ids:
+                    cached = next(
+                        (r for r in virtual_records.values() if r and r.get("id") == rid),
+                        None,
+                    )
+                    if cached is None:
+                        downloads.append(rid)
+                        cached = {"id": rid, "context_metadata": f"Record ID : {rid}"}
+                        virtual_records[f"v-{rid}"] = cached
+                    records.append(cached)
+                return {"ok": True, "records": records, "not_available_ids": []}
+
+            return SimpleNamespace(coroutine=_coroutine)
+
+        with patch(
+            "app.utils.fetch_full_record.create_fetch_full_record_tool",
+            side_effect=_factory,
+        ), patch(
+            "app.utils.chat_helpers.record_to_message_content",
+            side_effect=lambda record, ref_mapper=None, **_k: (
+                [{"type": "text", "text": f"<record>\n{record['id']}\n"}], ref_mapper
+            ),
+        ):
+            first = await tool.execute(record_ids=["rec-1"])
+            second = await tool.execute(record_ids=["rec-1"])
+
+        assert first.success is True
+        assert second.success is True
+        assert downloads == ["rec-1"], "the second fetch must hit the map, not re-download"
+
+    async def test_repeated_ids_within_one_call_are_collapsed(self) -> None:
+        """One call naming the same record twice would render the document
+        twice into the same message."""
+        context = _make_context()
+        tool = _FetchFullRecordTool(CitationCollector(context), context)
+
+        seen: list[list[str]] = []
+
+        async def _coroutine(record_ids: list[str], reason: str = "") -> dict:
+            seen.append(list(record_ids))
+            return {
+                "ok": True,
+                "records": [{"id": r, "context_metadata": r} for r in record_ids],
+                "not_available_ids": [],
+            }
+
+        with patch(
+            "app.utils.fetch_full_record.create_fetch_full_record_tool",
+            return_value=SimpleNamespace(coroutine=_coroutine),
+        ), patch(
+            "app.utils.chat_helpers.record_to_message_content",
+            side_effect=lambda record, ref_mapper=None, **_k: (
+                [{"type": "text", "text": f"<record>\n{record['id']}\n"}], ref_mapper
+            ),
+        ):
+            await tool.execute(record_ids=["rec-a", "rec-a", "rec-b"])
+
+        assert seen == [["rec-a", "rec-b"]]
+
+    async def test_a_second_agent_in_the_tree_gets_real_content_not_a_pointer(self) -> None:
+        """`AgentRuntime` — and so the tool registry, the tool instance and
+        `AgentContext` — is shared across a spawn tree, but every child gets a
+        fresh `ContextManager()`. A cross-call skip guard keyed on the shared
+        context would therefore tell the parent to "re-read it above" for a
+        record only its child ever read, leaving it holding prose and no text.
+        Fetching is idempotent by design; keep it that way."""
+        context = _make_context()
+        collector = CitationCollector(context)
+        first_agent = _FetchFullRecordTool(collector, context)
+        second_agent = _FetchFullRecordTool(collector, context)
+
+        async def _coroutine(record_ids: list[str], reason: str = "") -> dict:
+            return {
+                "ok": True,
+                "records": [{"id": r, "context_metadata": r} for r in record_ids],
+                "not_available_ids": [],
+            }
+
+        with patch(
+            "app.utils.fetch_full_record.create_fetch_full_record_tool",
+            return_value=SimpleNamespace(coroutine=_coroutine),
+        ), patch(
+            "app.utils.chat_helpers.record_to_message_content",
+            side_effect=lambda record, ref_mapper=None, **_k: (
+                [{"type": "text", "text": f"<record>\ncontent of {record['id']}\n"}],
+                ref_mapper,
+            ),
+        ):
+            await first_agent.execute(record_ids=["rec-1"])
+            output = await second_agent.execute(record_ids=["rec-1"])
+
+        assert output.success is True
+        assert "content of rec-1" in output.data
+        for pointer in ("already", "re-read", "not repeated"):
+            assert pointer not in output.data.lower()
+
+    async def test_unexpected_argument_returns_a_correctable_error(self) -> None:
+        """`record_id=` (singular) is a plausible model slip. It must surface as
+        an error naming the real parameters, never as a silent empty fetch."""
+        context = _make_context()
+        tool = _FetchFullRecordTool(CitationCollector(context), context)
+
+        output = await tool.execute(record_id="rec-1")
+
+        assert output.success is False
+        assert "record_id" in output.error
+        assert "record_ids" in output.error
 
     async def test_execute_falls_back_to_to_tool_output_when_not_ok(self) -> None:
         """When the underlying fetch returns `{"ok": False, ...}` (no

--- a/backend/python/tests/unit/agents/adapter/test_citation_tracking.py
+++ b/backend/python/tests/unit/agents/adapter/test_citation_tracking.py
@@ -265,6 +265,41 @@ class TestFullReadStartsAtTheBeginning:
         text = await self._read(record, final_results=[])
         assert "content of block 0" in text
 
+    async def test_continuation_read_after_a_capped_read_returns_the_next_slice(self) -> None:
+        """The truncation hint tells the model to call back with the next
+        `start_block`, and the tool description advertises that. A guard that
+        short-circuits an already-read record would swallow exactly that call,
+        leaving the model with a tail it believes is the whole document."""
+        from app.agents.agent_loop.hooks.citations import _FetchFullRecordTool
+
+        record = _record_with_blocks("rec-1", 10)
+        context = _agent_context()
+        # One context and one tool across both calls — the production shape, and
+        # the only way this pins the regression: a fresh context per call would
+        # never have the record marked fetched in the first place.
+        tool = _FetchFullRecordTool(CitationCollector(context), context)
+
+        structured = MagicMock()
+
+        async def _coroutine(**_: object) -> dict:
+            return {"ok": True, "records": [record]}
+
+        structured.coroutine = _coroutine
+
+        with patch(
+            "app.utils.fetch_full_record.create_fetch_full_record_tool",
+            return_value=structured,
+        ):
+            first = await tool.execute(record_ids=["rec-1"], max_blocks=4)
+            assert "start_block=4" in first.data
+            assert "rec-1" in context.full_records_fetched
+
+            second = await tool.execute(record_ids=["rec-1"], start_block=4)
+
+        assert second.success is True
+        assert "content of block 4" in second.data
+        assert "content of block 0" not in second.data
+
     async def test_oversized_record_is_capped_from_the_start_with_a_hint(self) -> None:
         record = _record_with_blocks("rec-3", 10)
         text = await self._read(

--- a/backend/python/tests/unit/agents/adapter/test_langchain_transport.py
+++ b/backend/python/tests/unit/agents/adapter/test_langchain_transport.py
@@ -871,3 +871,57 @@ class TestReasoningMandatoryFallbackStream:
 
         assert transport._llm is model
         assert store.recorded == []
+class TestBindToolsCaching:
+    """Binding re-derives a JSON schema per tool through pydantic — 5.5% of
+    query-service CPU under load — for output that is identical whenever the
+    tool set is. It is cached per transport (built per request, so never shared
+    across users) and keyed on the tool names."""
+
+    @staticmethod
+    def _schema(name: str) -> ToolSchema:
+        return ToolSchema(name=name, description="d", input_schema={"type": "object", "properties": {}})
+
+    class _CountingModel(_FakeModel):
+        def __init__(self) -> None:
+            super().__init__()
+            self.bind_calls = 0
+
+        def bind_tools(self, tools: list[Any]) -> "_FakeModel":
+            self.bind_calls += 1
+            return super().bind_tools(tools)
+
+    async def test_same_tool_set_binds_once_across_calls(self) -> None:
+        model = self._CountingModel()
+        transport = LangChainTransport(model)
+        tools = [self._schema("a"), self._schema("b")]
+
+        for _ in range(5):
+            # Fresh ToolSchema objects each turn, as registry.schemas() produces.
+            await transport.complete(
+                [UserMessage(content="hi")],
+                tools=[self._schema(t.name) for t in tools],
+            )
+
+        assert model.bind_calls == 1
+
+    async def test_growing_tool_set_rebinds(self) -> None:
+        """`fetch_tools` granting another tool must reach the model."""
+        model = self._CountingModel()
+        transport = LangChainTransport(model)
+
+        await transport.complete([UserMessage(content="hi")], tools=[self._schema("a")])
+        await transport.complete(
+            [UserMessage(content="hi")], tools=[self._schema("a"), self._schema("b")],
+        )
+
+        assert model.bind_calls == 2
+        assert [t.name for t in model.bind_tools_called_with] == ["a", "b"]
+
+    async def test_cache_is_per_transport_instance(self) -> None:
+        model_a, model_b = self._CountingModel(), self._CountingModel()
+        tools = [self._schema("a")]
+
+        await LangChainTransport(model_a).complete([UserMessage(content="hi")], tools=tools)
+        await LangChainTransport(model_b).complete([UserMessage(content="hi")], tools=tools)
+
+        assert model_a.bind_calls == 1 and model_b.bind_calls == 1

--- a/backend/python/tests/unit/agents/adapter/test_sse_bridge.py
+++ b/backend/python/tests/unit/agents/adapter/test_sse_bridge.py
@@ -134,27 +134,25 @@ class TestQueueEventSinkCoalescing:
     async def test_text_message_content_deltas_key_on_message_id(self) -> None:
         """Two different messages' deltas (e.g. main answer vs. a spawned
         sub-agent's) must never merge into each other even though both use
-        the same event name."""
+        the same event name, and each keeps its own pending slot rather than
+        evicting the other."""
         queue: asyncio.Queue = asyncio.Queue(maxsize=1)
         sink = QueueEventSink(queue)
         await self._fill_queue(queue)
 
         await sink.write({"event": "TEXT_MESSAGE_CONTENT", "data": {"messageId": "m1", "delta": "A"}})
-        # Pending now holds m1's delta (queue full, so it wasn't flushed yet).
+        await sink.write({"event": "TEXT_MESSAGE_CONTENT", "data": {"messageId": "m2", "delta": "B"}})
+        # Both held (queue full); neither write blocked on the other's flush.
+        assert queue.qsize() == 1
 
-        write_task = asyncio.ensure_future(
-            sink.write({"event": "TEXT_MESSAGE_CONTENT", "data": {"messageId": "m2", "delta": "B"}})
-        )
-        await asyncio.sleep(0)
-        assert not write_task.done()  # blocked: flushing m1 (different key) needs a freed slot
+        await queue.get()  # drain filler
+        # maxsize=1, so flush() blocks after m1 until the consumer drains it.
+        flush_task = asyncio.ensure_future(sink.flush())
 
-        await queue.get()  # drain filler -> unblocks flushing m1; m2 becomes the new pending
-        await asyncio.wait_for(write_task, timeout=1)
-
+        # Flushed in arrival order, unmerged.
         assert await queue.get() == {"event": "TEXT_MESSAGE_CONTENT", "data": {"messageId": "m1", "delta": "A"}}
-        # m2 never merged into m1 -- different messageId keys them apart.
-        await sink.flush()
         assert await queue.get() == {"event": "TEXT_MESSAGE_CONTENT", "data": {"messageId": "m2", "delta": "B"}}
+        await asyncio.wait_for(flush_task, timeout=1)
 
     async def test_non_coalescable_event_flushes_pending_delta_first_then_blocks(self) -> None:
         """A tool/lifecycle event must never be silently dropped or

--- a/backend/python/tests/unit/models/test_entities.py
+++ b/backend/python/tests/unit/models/test_entities.py
@@ -2752,8 +2752,7 @@ class TestFileRecordToLlmFullContext:
 
         with patch("app.utils.chat_helpers.valid_group_labels", [GroupType.TABLE.value]), \
              patch("app.agents.actions.util.parse_file.LlmTextContent", LlmTextContent):
-            from jinja2 import Template
-            with patch("app.models.entities.Template") as mock_tpl:
+            with patch("app.models.entities.compiled_template") as mock_tpl:
                 mock_tpl.return_value.render = MagicMock(return_value="TABLE_RENDERED")
                 items = rec.to_llm_full_context()
 
@@ -2769,8 +2768,7 @@ class TestFileRecordToLlmFullContext:
         rec = _make_file_record_with_blocks(blocks=[row0, row1], block_groups=[group])
 
         with patch("app.utils.chat_helpers.valid_group_labels", [GroupType.TABLE.value]):
-            from jinja2 import Template
-            with patch("app.models.entities.Template") as mock_tpl:
+            with patch("app.models.entities.compiled_template") as mock_tpl:
                 captured = {}
 
                 def _render(**kwargs):
@@ -2826,7 +2824,7 @@ class TestFileRecordToLlmFullContextExtended:
         group = BlockGroup(index=0, type=GroupType.TABLE, children=children)
         rec = _make_file_record_with_blocks(blocks=[row], block_groups=[group])
         with patch("app.utils.chat_helpers.valid_group_labels", [GroupType.TABLE.value]):
-            with patch("app.models.entities.Template") as mock_tpl:
+            with patch("app.models.entities.compiled_template") as mock_tpl:
                 mock_tpl.return_value.render = MagicMock(return_value="STR_ROW")
                 items = rec.to_llm_full_context()
         assert any("STR_ROW" in i.text for i in items)
@@ -2838,7 +2836,7 @@ class TestFileRecordToLlmFullContextExtended:
         group = BlockGroup(index=0, type=GroupType.TABLE, children=children)
         rec = _make_file_record_with_blocks(blocks=[row0, row1], block_groups=[group])
         with patch("app.utils.chat_helpers.valid_group_labels", [GroupType.TABLE.value]):
-            with patch("app.models.entities.Template") as mock_tpl:
+            with patch("app.models.entities.compiled_template") as mock_tpl:
                 mock_tpl.return_value.render = MagicMock(return_value="TBL")
                 items = rec.to_llm_full_context()
         texts = " ".join(i.text for i in items)
@@ -2872,7 +2870,7 @@ class TestFileRecordToLlmFullContextExtended:
         rec.virtual_record_id = "vr-1"
         with patch("app.utils.chat_helpers.valid_group_labels", [GroupType.LIST.value]), \
              patch("app.utils.chat_helpers.build_group_blocks", return_value=[{"content": "GROUP_BODY"}]):
-            with patch("app.models.entities.Template") as mock_tpl:
+            with patch("app.models.entities.compiled_template") as mock_tpl:
                 mock_tpl.return_value.render = MagicMock(return_value="GROUP_RENDERED")
                 items = rec.to_llm_full_context()
         assert any("GROUP_RENDERED" in i.text for i in items)
@@ -2921,7 +2919,7 @@ class TestFileRecordToLlmFullContextExtended:
         rec = _make_file_record_with_blocks(blocks=[b1, b2], block_groups=[group])
         with patch("app.utils.chat_helpers.valid_group_labels", [GroupType.LIST.value]), \
              patch("app.utils.chat_helpers.build_group_blocks", return_value=[{"content": "G"}]):
-            with patch("app.models.entities.Template") as mock_tpl:
+            with patch("app.models.entities.compiled_template") as mock_tpl:
                 mock_tpl.return_value.render = MagicMock(return_value="ONCE")
                 items = rec.to_llm_full_context()
         assert " ".join(i.text for i in items).count("ONCE") == 1

--- a/backend/python/tests/unit/utils/test_chat_helpers_cov95.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers_cov95.py
@@ -345,6 +345,36 @@ class TestIsBase64ImageBranches:
         monkeypatch.setattr(chat_helpers_module.base64, "b64decode", boom)
         assert is_base64_image("dGVzdA==") is False
 
+    @pytest.mark.parametrize(
+        ("payload", "expected"),
+        [
+            (b"\x89PNG\r\n\x1a\n" + b"\x00" * 40_000, True),
+            (b"\xff\xd8\xff" + b"\x00" * 40_000, True),
+            (b"GIF89a" + b"\x00" * 40_000, True),
+            (b'<svg xmlns="http://www.w3.org/2000/svg">' + b"<rect/>" * 5_000 + b"</svg>", True),
+            (b"not an image at all " * 2_000, False),
+        ],
+        ids=["png", "jpeg", "gif", "svg", "plain-text"],
+    )
+    def test_large_payloads_sniffed_from_prefix(self, payload, expected):
+        """Only the first 204 decoded bytes decide the verdict, so payloads far
+        larger than the decoded prefix must classify exactly as small ones do."""
+        assert is_base64_image(base64.b64encode(payload).decode()) is expected
+
+    def test_large_payload_decodes_only_the_prefix(self, monkeypatch):
+        """Guards the optimisation itself: a 40 KB image must not be fully decoded."""
+        seen: list[int] = []
+        real = chat_helpers_module.base64.b64decode
+
+        def spy(data, *a, **k):
+            seen.append(len(data))
+            return real(data, *a, **k)
+
+        monkeypatch.setattr(chat_helpers_module.base64, "b64decode", spy)
+        big = base64.b64encode(b"\x89PNG\r\n\x1a\n" + b"\x00" * 40_000).decode()
+        assert is_base64_image(big) is True
+        assert seen and max(seen) <= 272, f"decoded {max(seen)} chars, expected <= 272"
+
 
 class TestCreateRecordInstanceMeetingDeal:
     def test_meeting_with_graph_doc(self):

--- a/backend/python/tests/unit/utils/test_jinja_templates.py
+++ b/backend/python/tests/unit/utils/test_jinja_templates.py
@@ -1,0 +1,27 @@
+"""`compiled_template` (`app/utils/jinja_templates.py`) — the whole point is
+that the same source is compiled once and reused, so the test asserts object
+identity rather than that `Template` was called."""
+
+from __future__ import annotations
+
+from app.utils.jinja_templates import compiled_template
+
+
+class TestCompiledTemplate:
+    def test_same_source_returns_the_same_object(self) -> None:
+        source = "test_same_source_returns_the_same_object {{ value }}"
+
+        assert compiled_template(source) is compiled_template(source)
+
+    def test_different_sources_do_not_share_a_template(self) -> None:
+        a = compiled_template("test_different_sources a {{ v }}")
+        b = compiled_template("test_different_sources b {{ v }}")
+
+        assert a is not b
+
+    def test_a_shared_template_renders_independently_per_call(self) -> None:
+        """Reuse is only safe if rendering keeps no state between calls."""
+        source = "test_a_shared_template_renders {{ v }}"
+
+        assert compiled_template(source).render(v="first") == "test_a_shared_template_renders first"
+        assert compiled_template(source).render(v="second") == "test_a_shared_template_renders second"

--- a/loadtest/.env.example
+++ b/loadtest/.env.example
@@ -6,6 +6,8 @@
 # ── Required ─────────────────────────────────────────────────────────────
 # Bearer JWT. Browser devtools -> any API request -> Authorization header.
 # Usually valid ~24h; perftest.sh probes it and aborts if it is not accepted.
+# Needed only when generating load: `./perftest.sh <label> 0 <seconds>` collects
+# from a run someone else is driving and neither sends requests nor asks for it.
 TOKEN=
 
 # ── Deployment ───────────────────────────────────────────────────────────

--- a/loadtest/.env.example
+++ b/loadtest/.env.example
@@ -42,10 +42,16 @@ PIPESHUB_QUERY_PORT=8000
 PIPESHUB_QUERY_PID=
 
 # ── Load shape ───────────────────────────────────────────────────────────
-# Ask something your own corpus can actually answer — a question that returns
-# nothing measures the error path. QUOTE IT: this file is sourced by bash, so
-# an unquoted value with spaces runs its second word as a command.
-PIPESHUB_QUERY="What are the key features described in the documents?"
+# Queries come from `queries.txt` by default — users rotate through it, each
+# starting at a different offset. Edit that file to match your own corpus; a
+# query it cannot answer returns a fast empty turn that inflates req/min.
+PIPESHUB_QUERY_FILE=
+
+# Set this to force every turn to use ONE query instead of the file. Useful
+# for an A/B where you want both arms identically biased, misleading as an
+# absolute capacity number. QUOTE IT: this file is sourced by bash, so an
+# unquoted value with spaces runs its second word as a command.
+PIPESHUB_QUERY=
 
 # Seconds a simulated user waits between turns.
 PIPESHUB_THINK_TIME=3

--- a/loadtest/.env.example
+++ b/loadtest/.env.example
@@ -1,0 +1,51 @@
+# Copy to `.env` and edit:  cp .env.example .env
+# `.env` is gitignored. Real environment variables override anything set here.
+# Every value below is optional except TOKEN — the defaults describe the
+# standard Docker deployment.
+
+# ── Required ─────────────────────────────────────────────────────────────
+# Bearer JWT. Browser devtools -> any API request -> Authorization header.
+# Usually valid ~24h; perftest.sh probes it and aborts if it is not accepted.
+TOKEN=
+
+# ── Deployment ───────────────────────────────────────────────────────────
+# auto    Detected for you: a RUNNING container named PIPESHUB_CONTAINER wins,
+#         otherwise a query process on PIPESHUB_QUERY_PORT.      (default)
+#         A stopped container does not count — that is the machine where
+#         PipesHub moved to host processes and the container is a leftover.
+# docker  Force container mode; read through `docker exec` / `docker logs`.
+# native  Force host-process mode. Fill in the NATIVE section below.
+PIPESHUB_MODE=auto
+
+# The API gateway the load generator posts to. This is the Node backend, NOT
+# the frontend dev server.
+PIPESHUB_HOST=http://localhost:3000
+
+# docker mode only.
+PIPESHUB_CONTAINER=pipeshub-ai
+
+# ── Native mode ──────────────────────────────────────────────────────────
+# Throughput, per-phase latency and backend latency are all parsed out of the
+# query service's console output. In docker mode `docker logs` supplies it; a
+# native run has to be told where it went. Launch the service with its output
+# redirected, e.g.
+#
+#     python -m app.query_main > backend/python/logs/query_stdout.log 2>&1
+#
+# and point this at that file. Leave empty and those three sections report as
+# unavailable — CPU and memory still work.
+PIPESHUB_QUERY_LOG=
+
+# Used to locate the process for memory sampling and CPU profiling. The pid is
+# found automatically from this port; set PIPESHUB_QUERY_PID to skip the lookup.
+PIPESHUB_QUERY_PORT=8000
+PIPESHUB_QUERY_PID=
+
+# ── Load shape ───────────────────────────────────────────────────────────
+# Ask something your own corpus can actually answer — a question that returns
+# nothing measures the error path. QUOTE IT: this file is sourced by bash, so
+# an unquoted value with spaces runs its second word as a command.
+PIPESHUB_QUERY="What are the key features described in the documents?"
+
+# Seconds a simulated user waits between turns.
+PIPESHUB_THINK_TIME=3

--- a/loadtest/.gitignore
+++ b/loadtest/.gitignore
@@ -1,0 +1,8 @@
+# Measurement output — reports, flame graphs, CSVs. Local only.
+results/
+
+# Bearer tokens for the target environment. Never commit.
+.env
+.env.*
+# ...except the template, which is the documentation for all of the above.
+!.env.example

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -25,8 +25,21 @@ pip3 install --user py-spy            # optional, for the CPU flame graph
 `TOKEN` is a bearer JWT — browser devtools, any API request, the
 `Authorization` header. Everything else in `.env` has a working default.
 
-That writes `results/baseline/` with a `report.txt`, a `cpu.svg` flame graph
-and `memory.csv`. The report is also printed to the terminal.
+That writes `results/baseline/`, printing the report to the terminal too:
+
+| file | what it is |
+|---|---|
+| `report.txt` | the printed report |
+| `cpu.svg` / `cpu.raw.gz` | flame graph, and the raw profile for re-analysis |
+| `memory.svg` / `memory.csv` | RSS over the run |
+| `requests.csv` | every request: HTTP code, duration, curl exit |
+| `summary.json` | machine-readable, consumed by `aggregate.py` |
+
+Comparing many configurations:
+
+```bash
+./aggregate.py results        # median + min-max per config, writes matrix.csv
+```
 
 To compare a change, run it again with a different label and diff the reports:
 
@@ -97,6 +110,13 @@ rather than reporting a number it could not have observed.
   completed turns : 88
   window          : 316s
   throughput      : 16.7 req/min  (0.278/s)
+  steady-state    : 84 turns in the 300s load window  (16.8 req/min)
+
+==================== REQUESTS (client-side) ====================
+  requests        : 88
+  succeeded (200) : 88
+  failed          : 0  (0.0%)
+  turn seconds    : p50=24.1 p95=34.9 max=41.2
 
 ==================== TURN LATENCY (per phase, ms) ====================
   turn total  mean=24313  p50=23575  p95=34280
@@ -128,6 +148,14 @@ rather than reporting a number it could not have observed.
 - *Throughput* is counted **server-side**, one per completed turn. Client-side
   counting drops turns that are still streaming when the run stops, which
   penalises exactly the slow configs you are comparing.
+- *steady-state* counts only turns finished while load was still being offered.
+  The line above it divides by elapsed time **including the drain** after load
+  stops, so a config whose last turns take two minutes reports a lower rate for
+  the same work. When the two disagree, the drain is doing the talking.
+- *Requests* is the client's view. A run that mostly failed used to be
+  indistinguishable from a slow one — both just showed low throughput. Above a
+  5% error rate the run is marked `** INVALID` and `aggregate.py` drops it from
+  the medians.
 - *CPU by subsystem* counts a sample for every subsystem in its stack, so
   nested cost lands on whatever caused it. The by-function list underneath is
   the raw leaf view.
@@ -158,7 +186,8 @@ PIPESHUB_MODE=docker ./perftest.sh baseline 8 300
 | `PIPESHUB_QUERY_LOG` | — | native mode: where query console output goes |
 | `PIPESHUB_QUERY_PORT` | `8000` | native mode: used to find the pid |
 | `PIPESHUB_QUERY_PID` | — | native mode: skip the pid lookup |
-| `PIPESHUB_QUERY` | a generic question | ask something your corpus can answer |
+| `PIPESHUB_QUERY_FILE` | `queries.txt` | the query set users rotate through |
+| `PIPESHUB_QUERY` | — | force a single query instead of the file |
 | `PIPESHUB_THINK_TIME` | `3` | seconds between a user's turns |
 
 `perftest.sh` probes the token before starting and aborts if it is not
@@ -197,6 +226,8 @@ elsewhere and use this only to collect:
 | `set_workers.sh` | change the uvicorn worker count (restarts the container) |
 | `restart_query.sh` | restart only the query process, leaving the container up |
 | `locustfile_play.py` | optional locust scenario, if you prefer locust's latency percentiles |
+| `queries.txt` | the query set users draw from — **edit this for your corpus** |
+| `aggregate.py` | rolls many runs' `summary.json` into one table + `matrix.csv` |
 | `_common.sh` | sourced by the rest: finds docker (with/without sudo), finds Python, checks the container is up |
 | `instr/` | the probes copied into the container, plus the report aggregators |
 
@@ -228,5 +259,14 @@ elsewhere and use this only to collect:
 - **One trial is ±10%.** Treat a single run as directional. For a claim worth
   publishing, run 3–4 trials per config and compare medians; CPU-profile
   percentages are far more stable than throughput.
+- **One repeated query is not a workload.** Identical prompt prefixes hit the
+  provider's prefix cache and retrieval stays warm, so a single fixed question
+  overstates throughput substantially — and a question the corpus cannot answer
+  returns a fast empty turn that inflates the rate further. Use `queries.txt`;
+  reach for `PIPESHUB_QUERY` only to pin one query so both arms of an A/B carry
+  the same bias, never to quote a capacity number.
+- **Check the answers, not just the rate.** Turns returning 0 citations are
+  measuring the not-found path, not retrieval. A run can look healthy on
+  req/min while most of its answers are empty.
 - **A growing corpus biases comparisons.** Load tests create records. If a
   baseline and its comparison are days apart, note the record counts.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,232 @@
+# Query-service load testing
+
+Measures what the query service actually does under load: **throughput, turn
+latency, CPU, memory and backend call latency**, from one command.
+
+Everything here is diagnostic tooling. Nothing under `backend/` is modified —
+the probes are copied into the running container and removed again by
+`./instrument.sh off`.
+
+---
+
+## Quick start
+
+On the machine running PipesHub:
+
+```bash
+cd loadtest
+cp .env.example .env                  # then put your TOKEN in it
+pip3 install --user py-spy            # optional, for the CPU flame graph
+
+./instrument.sh on                    # docker only; adds phase + backend timing
+./perftest.sh baseline 8 300          # label, users, seconds
+```
+
+`TOKEN` is a bearer JWT — browser devtools, any API request, the
+`Authorization` header. Everything else in `.env` has a working default.
+
+That writes `results/baseline/` with a `report.txt`, a `cpu.svg` flame graph
+and `memory.csv`. The report is also printed to the terminal.
+
+To compare a change, run it again with a different label and diff the reports:
+
+```bash
+./perftest.sh after 8 300
+diff results/baseline/report.txt results/after/report.txt
+```
+
+### Arguments
+
+```
+./perftest.sh <label> [users] [seconds] [workers]
+```
+
+`workers` is optional; supplying it restarts the container with that many
+uvicorn workers first. Omit it to test whatever is already running.
+
+```bash
+./perftest.sh w1_u8   8  300 1     # 1 worker,  8 users
+./perftest.sh w4_u32 32  300 4     # 4 workers, 32 users
+```
+
+---
+
+## Docker or native
+
+The deployment is detected automatically. A **running** container named
+`pipeshub-ai` wins; otherwise a query service found on port 8000 is used. A
+container that exists but is stopped does not count — that is the machine where
+PipesHub moved to host processes and the container is a leftover. Force it with
+`PIPESHUB_MODE=docker|native` in `.env`.
+
+Native runs measure less, because the probes that produce phase and backend
+timings are installed *into a container* — doing that natively would mean
+editing your working tree:
+
+| section | docker | native |
+|---|---|---|
+| throughput, turn latency, backend calls | yes | needs `PIPESHUB_QUERY_LOG` + instrumentation |
+| CPU flame graph | yes | yes (py-spy attaches to the host pid) |
+| memory | yes | yes |
+| load generation | yes | yes |
+
+For native runs set `PIPESHUB_QUERY_LOG` to wherever the query service's
+console output goes — `docker logs` is what supplies it otherwise. On Windows
+the memory figure is private bytes rather than RSS: Windows trims the working
+set of an idle process, so a working-set graph plots OS behaviour instead of
+the application.
+
+### Requirements
+
+- **A POSIX shell** — Linux, macOS, WSL, or Git Bash.
+- **Python 3.8+** as `python3` or `python`.
+- **Docker** (docker mode only). Access is probed with and without `sudo`, so
+  Docker Desktop, rootless and stock Linux daemons all work.
+- **py-spy** — optional; without it the CPU section is skipped and the rest
+  still runs.
+
+Every script checks its target up front and exits non-zero with the reason,
+rather than reporting a number it could not have observed.
+
+---
+
+## What you get
+
+```
+==================== THROUGHPUT ====================
+  completed turns : 88
+  window          : 316s
+  throughput      : 16.7 req/min  (0.278/s)
+
+==================== TURN LATENCY (per phase, ms) ====================
+  turn total  mean=24313  p50=23575  p95=34280
+  llm_stream       mean=17004   70.0%
+  retrieval_wait   mean= 4820   19.8%
+  agent_create     mean= 1204    5.0%
+  ...
+
+==================== CPU (top functions, real work only) ====================
+  19057 samples of executing Python
+  by subsystem:
+     26.03%  record fetch + decode
+     20.95%  graph driver
+      5.27%  citation processing
+  ...
+
+==================== MEMORY (query service RSS, MB) ====================
+  start=1019 MB  peak=1153 MB  end=1153 MB  growth=+134 MB
+  ▁▁▃▆▆▆▇███████████
+
+==================== BACKEND CALLS (caller-side) ====================
+  backend         calls      p50   p95 worst      max
+  neo4j           47030     16ms      1974ms   1974ms
+  node_api        14938     92ms      2366ms   2366ms
+```
+
+**Reading it**
+
+- *Throughput* is counted **server-side**, one per completed turn. Client-side
+  counting drops turns that are still streaming when the run stops, which
+  penalises exactly the slow configs you are comparing.
+- *CPU by subsystem* counts a sample for every subsystem in its stack, so
+  nested cost lands on whatever caused it. The by-function list underneath is
+  the raw leaf view.
+- *Backend latency* is measured **caller-side**, so it includes queueing. A
+  backend whose own latency is flat while this number grows is not slow — the
+  queue in front of it is.
+- *`cpu.svg`* opens in a browser. Width is time; colour means nothing. Click to
+  zoom, hover for exact percentages, and use the search box (top right) to
+  total up a subsystem.
+
+---
+
+## Configuration
+
+All settings live in `.env` (gitignored; copy `.env.example`). Real environment
+variables override the file, so one-off runs need no edit:
+
+```bash
+PIPESHUB_MODE=docker ./perftest.sh baseline 8 300
+```
+
+| variable | default | what it does |
+|---|---|---|
+| `TOKEN` | — | bearer JWT; required unless `users` is 0 |
+| `PIPESHUB_MODE` | `auto` | `auto` / `docker` / `native` |
+| `PIPESHUB_HOST` | `http://localhost:3000` | API gateway the load hits — the Node backend, not the frontend |
+| `PIPESHUB_CONTAINER` | `pipeshub-ai` | docker mode only |
+| `PIPESHUB_QUERY_LOG` | — | native mode: where query console output goes |
+| `PIPESHUB_QUERY_PORT` | `8000` | native mode: used to find the pid |
+| `PIPESHUB_QUERY_PID` | — | native mode: skip the pid lookup |
+| `PIPESHUB_QUERY` | a generic question | ask something your corpus can answer |
+| `PIPESHUB_THINK_TIME` | `3` | seconds between a user's turns |
+
+`perftest.sh` probes the token before starting and aborts if it is not
+accepted — an expired token turns every request into a 401, which otherwise
+looks exactly like a throughput collapse.
+
+### Without py-spy
+
+CPU profiling is skipped with a note; throughput, latency, memory and backend
+sections still work. py-spy must run on the host (the container has no
+`SYS_PTRACE`), which is why it attaches from outside.
+
+### Load from a second machine
+
+Running the load generator on the host under test costs it some CPU. For a
+demo that is fine. For numbers you intend to publish, drive the load from
+elsewhere and use this only to collect:
+
+```bash
+# on the host: collect for 300s while someone else drives load
+./perftest.sh observed 0 300
+```
+
+`users=0` starts no load of its own.
+
+---
+
+## Files
+
+| file | what it does |
+|---|---|
+| `perftest.sh` | the one command — runs load, collects everything, writes the report |
+| `instrument.sh` | `on` / `off` / `status` for the in-container probes |
+| `throughput.sh` | completed turns in a window (used by `perftest.sh`; usable alone) |
+| `query_rss.sh` | query-service RSS in MB, one number, for sampling |
+| `set_workers.sh` | change the uvicorn worker count (restarts the container) |
+| `restart_query.sh` | restart only the query process, leaving the container up |
+| `locustfile_play.py` | optional locust scenario, if you prefer locust's latency percentiles |
+| `_common.sh` | sourced by the rest: finds docker (with/without sudo), finds Python, checks the container is up |
+| `instr/` | the probes copied into the container, plus the report aggregators |
+
+`results/` is gitignored — reports, profiles and CSVs stay local.
+
+---
+
+## Gotchas that have cost real time
+
+- **A stopped container used to read as an idle service.** `query_rss.sh`
+  returned `0 MB` and `throughput.sh` `0.0 req/min` when there was no container
+  to talk to — indistinguishable from a real measurement of a quiet system.
+  Every script now checks first and refuses to produce a number it cannot back.
+  If PipesHub runs natively here, that check is telling you the truth: use a
+  container deployment, or drive load only and collect nothing.
+- **`docker compose up -d` wipes the probes.** It recreates the container.
+  `docker restart` keeps them. Re-run `./instrument.sh on` after a compose up.
+- **Don't `docker cp` a source file from a branch newer than the running
+  image.** Testing a change by copying files into the container only works if
+  the rest of the codebase agrees with them. Copying a file whose module
+  interface has moved on takes the service down at import time — the symptom is
+  a health check that never passes, and `docker logs` showing
+  `ImportError: cannot import name ... from ...`. Copy files built from the
+  same commit the image was.
+- **Measure on an idle system.** Background indexing inflates latency and CPU
+  and silently corrupts a comparison. Check the record count is stable first.
+- **Never change worker count mid-run** — `set_workers.sh` restarts the
+  container.
+- **One trial is ±10%.** Treat a single run as directional. For a claim worth
+  publishing, run 3–4 trials per config and compare medians; CPU-profile
+  percentages are far more stable than throughput.
+- **A growing corpus biases comparisons.** Load tests create records. If a
+  baseline and its comparison are days apart, note the record counts.

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -91,7 +91,8 @@ the application.
 
 ### Requirements
 
-- **A POSIX shell** — Linux, macOS, WSL, or Git Bash.
+- **Bash** — Linux, macOS, WSL, or Git Bash. The entry points use arrays and
+  `mapfile`, so run them with `bash`, not `sh`.
 - **Python 3.8+** as `python3` or `python`.
 - **Docker** (docker mode only). Access is probed with and without `sudo`, so
   Docker Desktop, rootless and stock Linux daemons all work.
@@ -241,8 +242,10 @@ elsewhere and use this only to collect:
   returned `0 MB` and `throughput.sh` `0.0 req/min` when there was no container
   to talk to — indistinguishable from a real measurement of a quiet system.
   Every script now checks first and refuses to produce a number it cannot back.
-  If PipesHub runs natively here, that check is telling you the truth: use a
-  container deployment, or drive load only and collect nothing.
+  A native deployment is still measurable — CPU and memory work as they are, and
+  load generation is unaffected; only the log-derived sections (throughput, turn
+  latency, backend calls) need `PIPESHUB_QUERY_LOG` pointed at the query
+  service's output.
 - **`docker compose up -d` wipes the probes.** It recreates the container.
   `docker restart` keeps them. Re-run `./instrument.sh on` after a compose up.
 - **Don't `docker cp` a source file from a branch newer than the running

--- a/loadtest/_common.sh
+++ b/loadtest/_common.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# Shared config and environment detection. Sourced by the other scripts.
+#
+# Loads `.env` (see `.env.example`), then fills in the rest with Docker
+# defaults; real environment variables win over the file.
+#
+# The checks here fail loudly on purpose: an unreachable target used to surface
+# as "0 MB" / "0.0 req/min", which reads as a measurement of an idle service
+# rather than as nothing having been measured.
+
+_LT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Python defaults stdout to the ANSI codepage on Windows, which turns the
+# report's non-ASCII punctuation into mojibake mid-table.
+export PYTHONIOENCODING=${PYTHONIOENCODING:-utf-8}
+
+if [ -f "$_LT_DIR/.env" ]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$_LT_DIR/.env"
+    set +a
+fi
+
+PIPESHUB_MODE=${PIPESHUB_MODE:-auto}
+PIPESHUB_HOST=${PIPESHUB_HOST:-http://localhost:3000}
+PIPESHUB_CONTAINER=${PIPESHUB_CONTAINER:-pipeshub-ai}
+PIPESHUB_QUERY_PORT=${PIPESHUB_QUERY_PORT:-8000}
+PIPESHUB_QUERY_LOG=${PIPESHUB_QUERY_LOG:-}
+PIPESHUB_QUERY_PID=${PIPESHUB_QUERY_PID:-}
+PIPESHUB_THINK_TIME=${PIPESHUB_THINK_TIME:-3}
+CONTAINER=$PIPESHUB_CONTAINER
+
+case "$PIPESHUB_MODE" in
+    auto|docker|native) ;;
+    *) echo "ERROR: PIPESHUB_MODE must be 'auto', 'docker' or 'native', got '$PIPESHUB_MODE'." >&2; return 1 2>/dev/null || exit 1 ;;
+esac
+
+# `docker` needs sudo on a stock Linux daemon and rejects it under Docker
+# Desktop / rootless / docker-group setups (on Windows, sudo is often disabled
+# outright). Probe rather than assume.
+detect_docker() {
+    if [ -n "${DOCKER:-}" ]; then return 0; fi
+    if docker info >/dev/null 2>&1; then
+        DOCKER="docker"
+    elif sudo -n docker info >/dev/null 2>&1; then
+        DOCKER="sudo docker"
+    else
+        echo "ERROR: cannot talk to the docker daemon (tried with and without sudo)." >&2
+        echo "       Is Docker running, and may this user reach it?" >&2
+        return 1
+    fi
+}
+
+# `python3` is not a usable name everywhere: on Windows it resolves to the
+# Microsoft Store stub, which prints an ad to stdout and exits non-zero.
+detect_python() {
+    if [ -n "${PYTHON:-}" ]; then return 0; fi
+    for c in python3 python; do
+        if command -v "$c" >/dev/null 2>&1 && "$c" -c 'import sys; sys.exit(0 if sys.version_info >= (3, 8) else 1)' >/dev/null 2>&1; then
+            PYTHON="$c"
+            return 0
+        fi
+    done
+    echo "ERROR: no usable Python 3.8+ on PATH (tried python3, python)." >&2
+    return 1
+}
+
+# py-spy needs root to attach to another process on a stock Linux host; as the
+# same user on a Windows/macOS native run it does not, and `sudo` may not even
+# be enabled. Empty is the safe default — a needless sudo turns a working
+# profile into a permission prompt or a hard failure.
+detect_sudo() {
+    if [ -n "${SUDO+x}" ]; then return 0; fi
+    if [ "$(id -u 2>/dev/null || echo 0)" = "0" ]; then
+        SUDO=""
+    elif sudo -n true 2>/dev/null; then
+        SUDO="sudo"
+    else
+        SUDO=""
+    fi
+}
+
+container_state() {
+    detect_docker 2>/dev/null || return 1
+    $DOCKER inspect -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null
+}
+
+# A running container wins over a host process: if both exist, the container is
+# the deployment under test and the host process is a stray dev server. A
+# container that exists but is stopped does NOT win — that is exactly the
+# machine where PipesHub was moved to host processes and the container is a
+# leftover.
+resolve_mode() {
+    [ "$PIPESHUB_MODE" = "auto" ] || return 0
+    if [ "$(container_state)" = "running" ]; then
+        PIPESHUB_MODE=docker
+    elif query_pid >/dev/null 2>&1; then
+        PIPESHUB_MODE=native
+    else
+        echo "ERROR: found neither a running '$CONTAINER' container nor a query" >&2
+        echo "       service process on port $PIPESHUB_QUERY_PORT." >&2
+        echo "       Start one, or set PIPESHUB_MODE / PIPESHUB_CONTAINER /" >&2
+        echo "       PIPESHUB_QUERY_PID in .env — see .env.example." >&2
+        return 1
+    fi
+}
+
+# Fails when the thing the caller is about to measure cannot be reached, so no
+# script ever reports a number it could not have observed.
+require_target() {
+    detect_python || return 1
+    resolve_mode || return 1
+    if [ "$PIPESHUB_MODE" = "docker" ]; then
+        detect_docker || return 1
+        local state
+        state=$(container_state) || state=""
+        if [ -z "$state" ]; then
+            echo "ERROR: no container named '$CONTAINER'." >&2
+            echo "       Set PIPESHUB_CONTAINER, or PIPESHUB_MODE=native if PipesHub" >&2
+            echo "       runs as host processes here. See .env.example." >&2
+            return 1
+        fi
+        [ "$state" = "running" ] || {
+            echo "ERROR: container '$CONTAINER' is '$state', not running." >&2
+            echo "       Start it: docker start $CONTAINER" >&2
+            return 1
+        }
+    else
+        query_pid >/dev/null || {
+            echo "ERROR: cannot find the query service process." >&2
+            echo "       Set PIPESHUB_QUERY_PID in .env (the pid serving port $PIPESHUB_QUERY_PORT)." >&2
+            return 1
+        }
+    fi
+}
+
+# Echoes the pid or fails silently — callers own the error message, so this is
+# also usable as a probe during mode detection.
+query_pid() {
+    if [ -n "$PIPESHUB_QUERY_PID" ]; then echo "$PIPESHUB_QUERY_PID"; return 0; fi
+    local pid=""
+    if command -v pgrep >/dev/null 2>&1; then
+        pid=$(pgrep -f 'app[._]query_main' 2>/dev/null | tail -1)
+    fi
+    if [ -z "$pid" ] && command -v powershell.exe >/dev/null 2>&1; then
+        pid=$(powershell.exe -NoProfile -Command \
+            "(Get-NetTCPConnection -LocalPort $PIPESHUB_QUERY_PORT -State Listen -EA SilentlyContinue | Select-Object -First 1).OwningProcess" \
+            2>/dev/null | tr -d '\r\n ')
+    fi
+    [ -n "$pid" ] || return 1
+    echo "$pid"
+}
+
+# A "mark" is an opaque token meaning "now", redeemed later by log_read.
+# Docker filters by time; native records a byte offset, which is exact and
+# needs no timestamp parsing.
+log_mark() {
+    if [ "$PIPESHUB_MODE" = "docker" ]; then
+        date -u +%s
+    elif [ -n "$PIPESHUB_QUERY_LOG" ] && [ -f "$PIPESHUB_QUERY_LOG" ]; then
+        wc -c < "$PIPESHUB_QUERY_LOG" | tr -d ' '
+    else
+        echo 0
+    fi
+}
+
+log_read() {
+    local mark=$1
+    if [ "$PIPESHUB_MODE" = "docker" ]; then
+        $DOCKER logs "$CONTAINER" --since "$mark" ${2:+--until "$2"} 2>&1
+    elif [ -n "$PIPESHUB_QUERY_LOG" ] && [ -f "$PIPESHUB_QUERY_LOG" ]; then
+        tail -c "+$((mark + 1))" "$PIPESHUB_QUERY_LOG" 2>/dev/null
+    fi
+}
+
+log_available() {
+    [ "$PIPESHUB_MODE" = "docker" ] && return 0
+    [ -n "$PIPESHUB_QUERY_LOG" ] && [ -f "$PIPESHUB_QUERY_LOG" ]
+}
+
+# Total RSS of the query service in MB (parent + workers), one number.
+query_rss_mb() {
+    if [ "$PIPESHUB_MODE" = "docker" ]; then
+        $DOCKER exec "$CONTAINER" sh -c '
+            par=$(pgrep -f "python -m uvicorn app.query_main" | head -1)
+            [ -n "$par" ] || par=$(pgrep -f "python -m app.query_main" | head -1)
+            [ -n "$par" ] || { echo 0; exit 0; }
+            tot=0
+            for p in $par $(pgrep -P $par 2>/dev/null); do
+                r=$(awk "/^VmRSS:/{print \$2}" /proc/$p/status 2>/dev/null)
+                tot=$((tot + ${r:-0}))
+            done
+            echo $((tot / 1024))' 2>/dev/null || echo 0
+        return
+    fi
+
+    local pid
+    pid=$(query_pid) || { echo 0; return; }
+    if [ -r "/proc/$pid/status" ]; then
+        local tot=0 r
+        for p in $pid $(pgrep -P "$pid" 2>/dev/null); do
+            r=$(awk '/^VmRSS:/{print $2}' "/proc/$p/status" 2>/dev/null)
+            tot=$((tot + ${r:-0}))
+        done
+        echo $((tot / 1024))
+    elif command -v powershell.exe >/dev/null 2>&1; then
+        # PrivateMemorySize64, NOT WorkingSet64. Windows trims the working set
+        # of an idle process, so WorkingSet reports ~15 MB for a query service
+        # holding ~1 GB of commit — a memory graph built on it plots OS trimming
+        # rather than the application. Private bytes is the stable analogue of
+        # Linux VmRSS for "how much has this grown under load".
+        powershell.exe -NoProfile -Command \
+            "\$ids=@($pid); \$ids += (Get-CimInstance Win32_Process -Filter 'ParentProcessId=$pid' -EA SilentlyContinue).ProcessId
+             [int](((Get-Process -Id \$ids -EA SilentlyContinue) | Measure-Object PrivateMemorySize64 -Sum).Sum / 1MB)" \
+            2>/dev/null | tr -d '\r\n ' || echo 0
+    else
+        echo 0
+    fi
+}

--- a/loadtest/_common.sh
+++ b/loadtest/_common.sh
@@ -15,10 +15,16 @@ _LT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 export PYTHONIOENCODING=${PYTHONIOENCODING:-utf-8}
 
 if [ -f "$_LT_DIR/.env" ]; then
+    # Snapshot what the caller already exported and restore it afterwards.
+    # Sourcing alone lets the FILE win, which is backwards: it silently ignores
+    # `PIPESHUB_QUERY= ./perftest.sh ...` and every other one-off override.
+    _lt_preset=$(declare -p $(env | sed -n 's/^\(PIPESHUB_[A-Z_]*\|TOKEN\)=.*/\1/p') 2>/dev/null || true)
     set -a
     # shellcheck disable=SC1091
     . "$_LT_DIR/.env"
     set +a
+    [ -n "$_lt_preset" ] && eval "$_lt_preset"
+    unset _lt_preset
 fi
 
 PIPESHUB_MODE=${PIPESHUB_MODE:-auto}

--- a/loadtest/_common.sh
+++ b/loadtest/_common.sh
@@ -18,13 +18,20 @@ if [ -f "$_LT_DIR/.env" ]; then
     # Snapshot what the caller already exported and restore it afterwards.
     # Sourcing alone lets the FILE win, which is backwards: it silently ignores
     # `PIPESHUB_QUERY= ./perftest.sh ...` and every other one-off override.
-    _lt_preset=$(declare -p $(env | sed -n 's/^\(PIPESHUB_[A-Z_]*\|TOKEN\)=.*/\1/p') 2>/dev/null || true)
+    # One `declare -p` per name. Passing the whole list at once dumps the ENTIRE
+    # environment when the list is empty — the common case on a fresh shell —
+    # and eval would then replay ~130 unrelated declarations. The class allows
+    # digits so a name like PIPESHUB_WORKER_2 is not silently dropped.
+    _lt_preset=""
+    for _lt_name in $(env | sed -n 's/^\(PIPESHUB_[A-Z0-9_]*\|TOKEN\)=.*/\1/p'); do
+        _lt_preset+="$(declare -p "$_lt_name" 2>/dev/null)"$'\n'
+    done
     set -a
     # shellcheck disable=SC1091
     . "$_LT_DIR/.env"
     set +a
-    [ -n "$_lt_preset" ] && eval "$_lt_preset"
-    unset _lt_preset
+    [ -n "${_lt_preset//[[:space:]]/}" ] && eval "$_lt_preset"
+    unset _lt_preset _lt_name
 fi
 
 PIPESHUB_MODE=${PIPESHUB_MODE:-auto}

--- a/loadtest/_common.sh
+++ b/loadtest/_common.sh
@@ -140,7 +140,10 @@ query_pid() {
     if [ -n "$PIPESHUB_QUERY_PID" ]; then echo "$PIPESHUB_QUERY_PID"; return 0; fi
     local pid=""
     if command -v pgrep >/dev/null 2>&1; then
-        pid=$(pgrep -f 'app[._]query_main' 2>/dev/null | tail -1)
+        # Lowest match = the master. `query_rss_mb` sums its children and
+        # py-spy runs with --subprocesses, so starting at the master covers the
+        # workers; starting at a worker would miss its siblings.
+        pid=$(pgrep -f 'app[._]query_main' 2>/dev/null | sort -n | head -1)
     fi
     if [ -z "$pid" ] && command -v powershell.exe >/dev/null 2>&1; then
         pid=$(powershell.exe -NoProfile -Command \

--- a/loadtest/aggregate.py
+++ b/loadtest/aggregate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Roll every run's `summary.json` into one table and a CSV.
+
+    ./aggregate.py [results_dir]
+
+Reports the MEDIAN of each group's trials, not the mean: one run whose drain
+tail stretched the window is an outlier of the measurement, not of the system,
+and a median ignores it. The spread column is min-max, so a group whose trials
+disagree cannot be quoted as a single confident number.
+
+Runs marked INVALID (error rate over threshold) are excluded from the medians
+and counted separately -- a run that mostly failed is not a measurement.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import re
+import statistics as st
+import sys
+from pathlib import Path
+
+FIELDS = [
+    "arm", "workers", "users", "trial", "label", "turns", "throughput_req_min",
+    "steady_state_req_min", "p50_ms", "p95_ms", "requests", "errors", "error_rate",
+    "invalid", "py_samples_per_turn", "mem_start_mb", "mem_peak_mb", "mem_growth_mb",
+    "load_seconds", "wall_seconds", "queries",
+]
+
+
+def _fmt(vals: list[float], places: int = 1) -> str:
+    if not vals:
+        return "-"
+    med = st.median(vals)
+    if len(vals) == 1:
+        return f"{med:.{places}f}"
+    return f"{med:.{places}f} [{min(vals):.{places}f}-{max(vals):.{places}f}]"
+
+
+LABEL_RE = re.compile(r"^(?P<arm>[a-z]+)_w(?P<workers>\d+)_u(?P<users>\d+)_t(?P<trial>\d+)$")
+
+
+def _fill_from_label(run: dict) -> dict:
+    """The matrix driver sets workers once per group rather than per run, so
+    `perftest.sh` has no worker count to record. The label carries it."""
+    m = LABEL_RE.match(run.get("label") or "")
+    if not m:
+        return run
+    for key, cast in (("arm", str), ("workers", str), ("users", int), ("trial", str)):
+        if run.get(key) in (None, "", 0):
+            run[key] = cast(m.group(key))
+    return run
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "results")
+    runs = []
+    for path in sorted(root.glob("*/summary.json")):
+        try:
+            runs.append(_fill_from_label(json.loads(path.read_text(encoding="utf-8"))))
+        except (OSError, json.JSONDecodeError):
+            print(f"  (skipped unreadable {path})", file=sys.stderr)
+    if not runs:
+        print(f"no summary.json under {root}/ — has anything run yet?")
+        return 1
+
+    out = root / "matrix.csv"
+    with out.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=FIELDS)
+        w.writeheader()
+        for r in runs:
+            w.writerow({k: r.get(k) for k in FIELDS})
+
+    groups: dict[tuple, list[dict]] = {}
+    for r in runs:
+        groups.setdefault((r.get("arm") or "?", str(r.get("workers")), r.get("users") or 0), []).append(r)
+
+    print(f"  {len(runs)} runs from {root}/   ->   {out}")
+    print()
+    print(f"  {'arm':<10}{'w':>3}{'users':>7}{'n':>4}{'req/min':>22}"
+          f"{'steady-state':>22}{'p50 s':>20}{'samples/turn':>18}{'err':>8}")
+    print(f"  {'':<10}{'':>3}{'':>7}{'':>4}{'median [min-max]':>22}"
+          f"{'median [min-max]':>22}{'median [min-max]':>20}{'median':>18}{'max':>8}")
+    for key in sorted(groups, key=lambda k: (k[0], int(k[1]) if k[1].isdigit() else 99, k[2])):
+        arm, workers, users = key
+        rows = groups[key]
+        good = [r for r in rows if not r.get("invalid")]
+        bad = len(rows) - len(good)
+        thr = [r["throughput_req_min"] for r in good if r.get("throughput_req_min")]
+        ss = [r["steady_state_req_min"] for r in good if r.get("steady_state_req_min")]
+        p50 = [r["p50_ms"] / 1000 for r in good if r.get("p50_ms")]
+        spt = [r["py_samples_per_turn"] for r in good if r.get("py_samples_per_turn")]
+        err = [r["error_rate"] for r in rows if r.get("error_rate") is not None]
+        flag = f"  ({bad} INVALID)" if bad else ""
+        print(f"  {arm:<10}{workers:>3}{users:>7}{len(good):>4}{_fmt(thr):>22}"
+              f"{_fmt(ss):>22}{_fmt(p50):>20}{_fmt(spt, 0):>18}"
+              f"{(max(err) * 100 if err else 0):>7.1f}%{flag}")
+
+    arms = {r.get("arm") for r in runs if r.get("arm")}
+    if len(arms) == 2:
+        print()
+        print("  before/after by configuration (median throughput, req/min)")
+        a, b = sorted(arms)
+        combos = sorted({(str(r.get("workers")), r.get("users")) for r in runs},
+                        key=lambda k: (int(k[0]) if k[0].isdigit() else 99, k[1]))
+        print(f"  {'workers':>8}{'users':>7}{a:>12}{b:>12}{'change':>10}")
+        for workers, users in combos:
+            def med(arm: str) -> float | None:
+                v = [r["throughput_req_min"] for r in runs
+                     if r.get("arm") == arm and str(r.get("workers")) == workers
+                     and r.get("users") == users and not r.get("invalid")
+                     and r.get("throughput_req_min")]
+                return st.median(v) if v else None
+            x, y = med(a), med(b)
+            delta = f"{(y / x - 1) * 100:+.0f}%" if x and y else "-"
+            print(f"  {workers:>8}{users:>7}{(f'{x:.1f}' if x else '-'):>12}"
+                  f"{(f'{y:.1f}' if y else '-'):>12}{delta:>10}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loadtest/instr/agg_backends.py
+++ b/loadtest/instr/agg_backends.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Summarise BACKENDAGG lines (see instr/backend_timing.py) from stdin.
+
+Latency is measured caller-side, inside the query worker, so it includes time
+the request spent queued at the backend — which is what actually delays a turn.
+A backend whose own p50 stays flat while this grows is not itself slow; the
+queue in front of it is.
+"""
+from __future__ import annotations
+
+import collections
+import re
+import statistics as st
+import sys
+
+LINE = re.compile(r"kind=(\w+) n=(\d+) qps=([\d.]+) p50=(\d+) p95=(\d+) max=(\d+)")
+
+
+def main() -> int:
+    windows: dict[str, list[tuple[int, float, float, float, float]]] = collections.defaultdict(list)
+    for line in sys.stdin:
+        m = LINE.search(line)
+        if m:
+            windows[m.group(1)].append((
+                int(m.group(2)), float(m.group(3)), float(m.group(4)),
+                float(m.group(5)), float(m.group(6)),
+            ))
+    if not windows:
+        print("  (no BACKENDAGG lines — run ./instrument.sh on)")
+        return 0
+
+    print(f"  {'backend':<12}{'calls':>9}{'p50':>9}{'p95 worst':>12}{'max':>9}")
+    for kind, rows in sorted(windows.items(), key=lambda kv: -sum(r[0] for r in kv[1])):
+        calls = sum(r[0] for r in rows)
+        print(
+            f"  {kind:<12}{calls:>9}"
+            f"{st.median(r[2] for r in rows):>8.0f}ms"
+            f"{max(r[3] for r in rows):>11.0f}ms"
+            f"{max(r[4] for r in rows):>8.0f}ms"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loadtest/instr/agg_backends.py
+++ b/loadtest/instr/agg_backends.py
@@ -29,11 +29,15 @@ def main() -> int:
         print("  (no BACKENDAGG lines — run ./instrument.sh on)")
         return 0
 
-    print(f"  {'backend':<12}{'calls':>9}{'p50':>9}{'p95 worst':>12}{'max':>9}")
+    print(f"  {'backend':<12}{'calls':>9}{'qps':>8}{'p50':>9}{'p95 worst':>12}{'max':>9}")
     for kind, rows in sorted(windows.items(), key=lambda kv: -sum(r[0] for r in kv[1])):
         calls = sum(r[0] for r in rows)
         print(
             f"  {kind:<12}{calls:>9}"
+            # Median of the per-window rates, not calls/elapsed: the run's first
+            # and last windows are partial, and averaging over them understates
+            # the rate the backend actually sustained.
+            f"{st.median(r[1] for r in rows):>8.1f}"
             f"{st.median(r[2] for r in rows):>8.0f}ms"
             f"{max(r[3] for r in rows):>11.0f}ms"
             f"{max(r[4] for r in rows):>8.0f}ms"

--- a/loadtest/instr/agg_phases.py
+++ b/loadtest/instr/agg_phases.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Aggregate `PHASE qid=... step=... ms=... cum=...` lines into a per-phase table.
+
+    sudo docker logs --since <ts> pipeshub-ai 2>&1 | agg_phases.py
+
+Only requests that reached a terminal step are counted, so a trial that is cut
+off mid-flight cannot inflate a phase's share by dropping the phases that would
+have followed it.
+"""
+
+import re
+import sys
+from collections import defaultdict
+
+LINE = re.compile(
+    r"PHASE qid=(?P<qid>\w+) step=(?P<step>\w+) ms=(?P<ms>[\d.]+) cum=(?P<cum>[\d.]+)"
+)
+TERMINAL = ("finalize", "llm_stream")
+ORDER = [
+    "llm_config", "user_context", "connector_probe", "attachments", "chat_state",
+    "connector_prefetch", "agent_create", "retrieval_wait", "llm_stream", "finalize",
+]
+
+
+def pct(vals, p):
+    if not vals:
+        return 0.0
+    s = sorted(vals)
+    return s[min(len(s) - 1, int(round((p / 100.0) * (len(s) - 1))))]
+
+
+def main() -> int:
+    per_q: dict = defaultdict(dict)
+    cum_of: dict = {}
+    for raw in sys.stdin:
+        m = LINE.search(raw)
+        if not m:
+            continue
+        qid, step = m["qid"], m["step"]
+        per_q[qid][step] = float(m["ms"])
+        cum_of.setdefault(qid, {})[step] = float(m["cum"])
+
+    complete = [q for q, steps in per_q.items() if any(t in steps for t in TERMINAL)]
+    if not complete:
+        print("no complete requests found", file=sys.stderr)
+        return 1
+
+    totals = [max(cum_of[q].values()) for q in complete]
+    grand = sum(totals)
+
+    print(f"requests: {len(complete)} complete ({len(per_q)} seen)")
+    print(f"turn total  mean={sum(totals)/len(totals):8.0f}ms  "
+          f"p50={pct(totals,50):8.0f}ms  p95={pct(totals,95):8.0f}ms")
+    print()
+    print(f"{'phase':<20}{'n':>5}{'mean ms':>10}{'p50':>9}{'p95':>9}{'max':>9}{'% turn':>9}")
+    print("-" * 71)
+
+    seen = [s for s in ORDER if any(s in per_q[q] for q in complete)]
+    seen += sorted({s for q in complete for s in per_q[q]} - set(seen))
+    for step in seen:
+        vals = [per_q[q][step] for q in complete if step in per_q[q]]
+        if not vals:
+            continue
+        share = 100.0 * sum(vals) / grand if grand else 0.0
+        print(f"{step:<20}{len(vals):>5}{sum(vals)/len(vals):>10.0f}"
+              f"{pct(vals,50):>9.0f}{pct(vals,95):>9.0f}{max(vals):>9.0f}{share:>8.1f}%")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loadtest/instr/agg_requests.py
+++ b/loadtest/instr/agg_requests.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Client-side request outcomes for one run, from `requests.csv`.
+
+Exists because the load generator used to discard every response (`-o /dev/null`
+and `|| true`): a run where every request returned 500 was indistinguishable
+from one that was merely slow, and both showed up only as "low throughput".
+
+An error rate above `INVALID_ABOVE` marks the run INVALID — a run that mostly
+failed is not a measurement, and should not be averaged into a matrix.
+"""
+from __future__ import annotations
+
+import csv
+import statistics as st
+import sys
+
+INVALID_ABOVE = 0.05
+
+# curl's own exit codes, for failures that never produced an HTTP status.
+CURL_ERRORS = {28: "timeout", 7: "connection refused", 52: "empty reply", 56: "recv error"}
+
+
+def main() -> int:
+    try:
+        with open(sys.argv[1], newline="", encoding="utf-8") as fh:
+            rows = list(csv.DictReader(fh))
+    except (OSError, IndexError):
+        print("  (no requests.csv)")
+        return 0
+    if not rows:
+        print("  (no requests recorded)")
+        return 0
+
+    total = len(rows)
+    ok, by_code, by_curl, times = 0, {}, {}, []
+    for r in rows:
+        code, rc = r.get("http_code", "000"), int(r.get("curl_exit") or 0)
+        if rc != 0:
+            by_curl[rc] = by_curl.get(rc, 0) + 1
+        elif code == "200":
+            ok += 1
+            try:
+                times.append(float(r["time_total"]))
+            except (ValueError, KeyError):
+                pass
+        else:
+            by_code[code] = by_code.get(code, 0) + 1
+
+    failed = total - ok
+    rate = failed / total
+    print(f"  requests        : {total}")
+    print(f"  succeeded (200) : {ok}")
+    print(f"  failed          : {failed}  ({rate * 100:.1f}%)")
+    for code, n in sorted(by_code.items()):
+        print(f"     HTTP {code}     : {n}")
+    for rc, n in sorted(by_curl.items()):
+        print(f"     curl {rc:<3}     : {n}  ({CURL_ERRORS.get(rc, 'see curl(1)')})")
+    if times:
+        times.sort()
+        # Client-side, so this includes queueing the server never sees.
+        print(
+            f"  turn seconds    : p50={st.median(times):.1f} "
+            f"p95={times[min(int(len(times) * 0.95), len(times) - 1)]:.1f} "
+            f"max={times[-1]:.1f}"
+        )
+    if rate > INVALID_ABOVE:
+        print(f"  ** INVALID: {rate * 100:.1f}% of requests failed (>{INVALID_ABOVE * 100:.0f}%)")
+        print("     this run measures the error path, not throughput.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loadtest/instr/agg_requests.py
+++ b/loadtest/instr/agg_requests.py
@@ -11,6 +11,7 @@ failed is not a measurement, and should not be averaged into a matrix.
 from __future__ import annotations
 
 import csv
+import math
 import statistics as st
 import sys
 
@@ -58,10 +59,12 @@ def main() -> int:
     if times:
         times.sort()
         # Client-side, so this includes queueing the server never sees.
+        # Nearest-rank: ceil(0.95 * n) - 1. Truncating instead returned the
+        # maximum whenever n was small enough for int() to round up to n-1.
+        p95 = times[max(math.ceil(0.95 * len(times)) - 1, 0)]
         print(
             f"  turn seconds    : p50={st.median(times):.1f} "
-            f"p95={times[min(int(len(times) * 0.95), len(times) - 1)]:.1f} "
-            f"max={times[-1]:.1f}"
+            f"p95={p95:.1f} max={times[-1]:.1f}"
         )
     if rate > INVALID_ABOVE:
         print(f"  ** INVALID: {rate * 100:.1f}% of requests failed (>{INVALID_ABOVE * 100:.0f}%)")

--- a/loadtest/instr/apply_instrumentation.py
+++ b/loadtest/instr/apply_instrumentation.py
@@ -56,8 +56,9 @@ def _sub(src: str, path: str, region: "tuple[int, int]", find: str, repl: str) -
 
 def _insert_shim(src: str, path: str, after: str) -> str:
     """Insert the import shim after `after`, enforcing __future__ placement."""
-    if src.count(after) != 1:
-        raise PatchError(f"{path}: shim anchor not unique: {after!r}")
+    n = src.count(after)
+    if n != 1:
+        raise PatchError(f"{path}: shim anchor must appear exactly once, found {n}: {after!r}")
     at = src.index(after) + len(after)
     fut = src.find("from __future__ import")
     if fut >= 0 and at <= fut:

--- a/loadtest/instr/apply_instrumentation.py
+++ b/loadtest/instr/apply_instrumentation.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Apply per-query phase-timing instrumentation to chatbot.py and bridge.py.
+
+Anchor-text only -- never line numbers, because both files get refactored out
+from under any offset we might record. Every edit is scoped to a named function
+first, since several anchors (notably the BlobStorage construction) appear in
+more than one generator in the same file.
+
+Validation is compile(), not ast.parse(): ast.parse accepts a `from __future__`
+import placed after other statements, which then fails at import time.
+
+Idempotent: re-running on an already-patched file is a no-op.
+
+Usage:  apply_instrumentation.py <chatbot.py> <bridge.py>
+"""
+
+import sys
+
+MARKER = "_phase_mark"
+
+SHIM = '''try:
+    from app.utils.query_phase_timing import phase_mark as _phase_mark, phase_start as _phase_start
+except Exception:  # instrumentation module absent -> no-op, never break the service
+    def _phase_start(logger): return None
+    def _phase_mark(name): return None
+'''
+
+
+class PatchError(RuntimeError):
+    pass
+
+
+def _slice(src: str, path: str, start: str, end: str) -> "tuple[int, int]":
+    i = src.find(start)
+    if i < 0:
+        raise PatchError(f"{path}: function-slice start anchor not found: {start!r}")
+    if src.find(start, i + 1) >= 0:
+        raise PatchError(f"{path}: function-slice start anchor is ambiguous: {start!r}")
+    j = src.find(end, i)
+    if j < 0:
+        raise PatchError(f"{path}: function-slice end anchor not found: {end!r}")
+    return i, j
+
+
+def _sub(src: str, path: str, region: "tuple[int, int]", find: str, repl: str) -> str:
+    lo, hi = region
+    body = src[lo:hi]
+    n = body.count(find)
+    if n != 1:
+        raise PatchError(
+            f"{path}: anchor must appear exactly once in the target function, "
+            f"found {n}:\n---\n{find}\n---"
+        )
+    return src[:lo] + body.replace(find, repl, 1) + src[hi:]
+
+
+def _insert_shim(src: str, path: str, after: str) -> str:
+    """Insert the import shim after `after`, enforcing __future__ placement."""
+    if src.count(after) != 1:
+        raise PatchError(f"{path}: shim anchor not unique: {after!r}")
+    at = src.index(after) + len(after)
+    fut = src.find("from __future__ import")
+    if fut >= 0 and at <= fut:
+        raise PatchError(
+            f"{path}: shim would land before `from __future__ import` -- "
+            "module would fail to import"
+        )
+    return src[:at] + SHIM + src[at:]
+
+
+def patch_chatbot(src: str, path: str) -> str:
+    src = _insert_shim(
+        src,
+        path,
+        "from app.agents.chat_modes import resolve_chat_mode_policy, run_chat_stream\n",
+    )
+    region = _slice(
+        src,
+        path,
+        "async def _generate_chat_stream_via_agent_loop(",
+        '@router.post("/chat/stream"',
+    )
+    src = _sub(
+        src, path, region,
+        "    logger_ = container.logger()\n",
+        "    logger_ = container.logger()\n    _phase_start(logger_)\n",
+    )
+    region = _slice(
+        src, path,
+        "async def _generate_chat_stream_via_agent_loop(",
+        '@router.post("/chat/stream"',
+    )
+    src = _sub(
+        src, path, region,
+        "    policy = resolve_chat_mode_policy(query_info.chatMode)\n",
+        '    _phase_mark("llm_config")\n    policy = resolve_chat_mode_policy(query_info.chatMode)\n',
+    )
+    region = _slice(
+        src, path,
+        "async def _generate_chat_stream_via_agent_loop(",
+        '@router.post("/chat/stream"',
+    )
+    src = _sub(
+        src, path, region,
+        '    client_name = request.headers.get("client-name")\n',
+        '    _phase_mark("user_context")\n    client_name = request.headers.get("client-name")\n',
+    )
+    return src
+
+
+BRIDGE_EDITS = [
+    (
+        "        blob_store = BlobStorage(logger=log, config_service=config_service, graph_provider=graph_provider)\n",
+        '        _phase_mark("connector_probe")\n'
+        "        blob_store = BlobStorage(logger=log, config_service=config_service, graph_provider=graph_provider)\n",
+    ),
+    (
+        '        filters = dict(query_info.get("filters") or {})\n',
+        '        _phase_mark("attachments")\n'
+        '        filters = dict(query_info.get("filters") or {})\n',
+    ),
+    (
+        '        chat_state["citation_ref_mapper"] = ref_mapper\n',
+        '        chat_state["citation_ref_mapper"] = ref_mapper\n'
+        '        _phase_mark("chat_state")\n',
+    ),
+    (
+        "                log=log,\n            )\n    except Exception as exc:\n",
+        "                log=log,\n            )\n"
+        '        _phase_mark("connector_prefetch")\n'
+        "    except Exception as exc:\n",
+    ),
+    (
+        "            prefetch_result = await prefetch_task if prefetch_task is not None else None\n",
+        '            _phase_mark("agent_create")\n'
+        "            prefetch_result = await prefetch_task if prefetch_task is not None else None\n"
+        '            _phase_mark("retrieval_wait")\n',
+    ),
+    (
+        "                result = agent.last_stream_result\n",
+        "                result = agent.last_stream_result\n"
+        '                _phase_mark("llm_stream")\n',
+    ),
+    (
+        "                    streamed_answer=streamer.streamed_answer, reasoning_turns=streamer.reasoning_turns,\n                )\n",
+        "                    streamed_answer=streamer.streamed_answer, reasoning_turns=streamer.reasoning_turns,\n                )\n"
+        '                _phase_mark("finalize")\n',
+    ),
+]
+
+
+def patch_bridge(src: str, path: str) -> str:
+    src = _insert_shim(src, path, "from __future__ import annotations\n")
+    for find, repl in BRIDGE_EDITS:
+        region = _slice(src, path, "async def run_chat_stream(", "__all__ = ")
+        src = _sub(src, path, region, find, repl)
+    return src
+
+
+def main(argv: "list[str]") -> int:
+    if len(argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    targets = [(argv[1], patch_chatbot), (argv[2], patch_bridge)]
+
+    results = []
+    for path, fn in targets:
+        with open(path, encoding="utf-8") as fh:
+            src = fh.read()
+        if MARKER in src:
+            print(f"SKIP  {path} (already instrumented)")
+            continue
+        try:
+            out = fn(src, path)
+        except PatchError as exc:
+            print(f"FAIL  {exc}", file=sys.stderr)
+            return 1
+        try:
+            compile(out, path, "exec")
+        except SyntaxError as exc:
+            print(f"FAIL  {path}: patched source does not compile: {exc}", file=sys.stderr)
+            return 1
+        marks = out.count(f'{MARKER}("')
+        results.append((path, out, marks))
+
+    for path, out, marks in results:
+        with open(path, "w", encoding="utf-8", newline="") as fh:
+            fh.write(out)
+        print(f"OK    {path} ({marks} phase marks)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/loadtest/instr/backend_timing.py
+++ b/loadtest/instr/backend_timing.py
@@ -1,0 +1,134 @@
+"""Caller-side backend latency instrumentation — throwaway load-test tooling.
+
+Measures, from inside the query-service process, how long each backend call
+takes and how many are made per second:
+
+  BACKENDAGG pid=<pid> kind=neo4j     n=..  qps=..  p50=..  p95=..  max=..
+  BACKENDAGG pid=<pid> kind=node_api  ...        (query svc -> Node storage API)
+  BACKENDAGG pid=<pid> kind=blob_url  ...        (signed-URL downloads)
+  BACKENDAGG pid=<pid> kind=http_other ...       (any other aiohttp traffic)
+  LOOPLAG    pid=<pid> n=.. ms_mean=.. ms_p95=.. ms_max=..
+
+Notes on semantics:
+  - neo4j ms  = await of AsyncSession.run (round trip until result ready).
+  - aiohttp ms = until response HEADERS arrive (service+queue latency);
+    body download time is deliberately excluded.
+  - LOOPLAG = overshoot of a 100 ms asyncio timer on this worker's event
+    loop; the direct measure of how long *ready* work waits for the loop.
+
+Wired by importing from app/utils/runtime_threads.py (same pattern as
+llm_timing). Patches apply per-process, so every uvicorn worker reports
+independently under its own pid.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+
+logger = logging.getLogger("backend_timing")
+
+_WINDOW = 5.0
+_PID = os.getpid()
+_stats: dict[str, list[float]] = {}
+_probed_loops: set[int] = set()
+
+
+def _record(kind: str, ms: float) -> None:
+    _stats.setdefault(kind, []).append(ms)
+    _ensure_probes()
+
+
+def _ensure_probes() -> None:
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    if id(loop) in _probed_loops:
+        return
+    _probed_loops.add(id(loop))
+    loop.create_task(_lag_probe())
+    loop.create_task(_flusher())
+
+
+async def _lag_probe() -> None:
+    lags: list[float] = []
+    last = time.perf_counter()
+    while True:
+        t0 = time.perf_counter()
+        await asyncio.sleep(0.1)
+        lags.append(max((time.perf_counter() - t0 - 0.1) * 1000.0, 0.0))
+        now = time.perf_counter()
+        if now - last >= _WINDOW and lags:
+            lags.sort()
+            n = len(lags)
+            logger.info(
+                "LOOPLAG pid=%d n=%d ms_mean=%.1f ms_p95=%.1f ms_max=%.1f",
+                _PID, n, sum(lags) / n, lags[max(int(n * 0.95) - 1, 0)], lags[-1],
+            )
+            lags = []
+            last = now
+
+
+async def _flusher() -> None:
+    while True:
+        await asyncio.sleep(_WINDOW)
+        for kind in list(_stats.keys()):
+            arr = _stats.get(kind) or []
+            if not arr:
+                continue
+            _stats[kind] = []
+            arr.sort()
+            n = len(arr)
+            logger.info(
+                "BACKENDAGG pid=%d kind=%s n=%d qps=%.1f p50=%.0f p95=%.0f max=%.0f",
+                _PID, kind, n, n / _WINDOW,
+                arr[n // 2], arr[max(int(n * 0.95) - 1, 0)], arr[-1],
+            )
+
+
+def _classify_url(url: object) -> str:
+    s = str(url)
+    if ":3000" in s or "localhost" in s or "127.0.0.1" in s or "nodejs" in s:
+        return "node_api"
+    if "blob.core" in s or "amazonaws" in s or "sig=" in s or "X-Amz-" in s:
+        return "blob_url"
+    return "http_other"
+
+
+def _patch_neo4j() -> None:
+    from neo4j import AsyncSession
+    orig = AsyncSession.run
+
+    async def timed_run(self, *a, **k):  # noqa: ANN001
+        t0 = time.perf_counter()
+        try:
+            return await orig(self, *a, **k)
+        finally:
+            _record("neo4j", (time.perf_counter() - t0) * 1000.0)
+
+    AsyncSession.run = timed_run
+    logger.info("backend_timing: neo4j AsyncSession.run patched pid=%d", _PID)
+
+
+def _patch_aiohttp() -> None:
+    import aiohttp
+    orig = aiohttp.ClientSession._request
+
+    async def timed_request(self, method, url, **k):  # noqa: ANN001
+        t0 = time.perf_counter()
+        try:
+            return await orig(self, method, url, **k)
+        finally:
+            _record(_classify_url(url), (time.perf_counter() - t0) * 1000.0)
+
+    aiohttp.ClientSession._request = timed_request
+    logger.info("backend_timing: aiohttp ClientSession._request patched pid=%d", _PID)
+
+
+for _fn in (_patch_neo4j, _patch_aiohttp):
+    try:
+        _fn()
+    except Exception:  # instrumentation must never break the app
+        logger.exception("backend_timing: patch failed: %s", _fn.__name__)

--- a/loadtest/instr/make_summary.py
+++ b/loadtest/instr/make_summary.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Distil one run's artifacts into `summary.json`.
+
+Parses the human `report.txt` the run just produced rather than recomputing
+anything, so the JSON and the printed report can never disagree. `aggregate.py`
+reads these across runs.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+from pathlib import Path
+
+NUM = r"([0-9]+(?:\.[0-9]+)?)"
+
+
+def _search(text: str, pattern: str, cast=float):
+    m = re.search(pattern, text)
+    return cast(m.group(1)) if m else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    for flag in ("outdir", "label", "users", "secs", "workers", "arm", "trial", "wall", "queries"):
+        ap.add_argument(f"--{flag}", default="")
+    args = ap.parse_args()
+
+    out = Path(args.outdir)
+    report = (out / "report.txt").read_text(encoding="utf-8", errors="replace")
+
+    requests = errors = 0
+    if (out / "requests.csv").exists():
+        with (out / "requests.csv").open(newline="", encoding="utf-8") as fh:
+            for row in csv.DictReader(fh):
+                requests += 1
+                if row.get("http_code") != "200" or (row.get("curl_exit") or "0") != "0":
+                    errors += 1
+
+    mem = []
+    if (out / "memory.csv").exists():
+        with (out / "memory.csv").open(newline="", encoding="utf-8") as fh:
+            mem = [float(r[1]) for r in csv.reader(fh) if len(r) >= 2]
+
+    summary = {
+        "label": args.label,
+        "arm": args.arm or None,
+        "workers": args.workers or None,
+        "users": int(args.users or 0),
+        "trial": args.trial or None,
+        "load_seconds": int(args.secs or 0),
+        "wall_seconds": int(args.wall or 0),
+        "queries": int(args.queries or 0),
+        "turns": _search(report, r"completed turns\s*:\s*([0-9]+)", int),
+        "throughput_req_min": _search(report, r"throughput\s*:\s*" + NUM),
+        "steady_state_req_min": _search(report, r"steady-state.*?\(" + NUM + r" req/min\)"),
+        "p50_ms": _search(report, r"turn total.*?p50=\s*([0-9]+)", int),
+        "p95_ms": _search(report, r"turn total.*?p95=\s*([0-9]+)", int),
+        "requests": requests,
+        "errors": errors,
+        "error_rate": round(errors / requests, 4) if requests else None,
+        "invalid": "** INVALID" in report,
+        "py_samples": _search(report, r"([0-9]+) samples of executing Python", int),
+        "mem_start_mb": mem[0] if mem else None,
+        "mem_peak_mb": max(mem) if mem else None,
+        "mem_growth_mb": round(max(mem) - mem[0], 1) if mem else None,
+    }
+    turns, samples = summary["turns"], summary["py_samples"]
+    summary["py_samples_per_turn"] = round(samples / turns, 1) if turns and samples else None
+
+    (out / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loadtest/instr/plot_memory.py
+++ b/loadtest/instr/plot_memory.py
@@ -31,15 +31,17 @@ def main() -> int:
     xs = [t - t0 for t, _ in pts]
     ys = [v for _, v in pts]
     lo, hi = min(ys), max(ys)
-    if hi - lo < 1:
-        hi = lo + 1
+    # Separate scaling bound from the reported peak: widening `hi` for a flat
+    # run kept the line off the top edge, but also made the caption claim a peak
+    # 1 MB above reality and growth of +1 MB where there was none.
+    top = hi if hi - lo >= 1 else lo + 1
     span = xs[-1] or 1
 
     def px(x: float) -> float:
         return PAD + (x / span) * (W - 2 * PAD)
 
     def py(y: float) -> float:
-        return H - PAD - ((y - lo) / (hi - lo)) * (H - 2 * PAD)
+        return H - PAD - ((y - lo) / (top - lo)) * (H - 2 * PAD)
 
     line = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in zip(xs, ys))
     area = f"{px(0):.1f},{H - PAD} {line} {px(xs[-1]):.1f},{H - PAD}"
@@ -48,7 +50,7 @@ def main() -> int:
     # Five gridlines, labelled in MB; x labelled in seconds from load start.
     grid = []
     for i in range(5):
-        v = lo + (hi - lo) * i / 4
+        v = lo + (top - lo) * i / 4
         y = py(v)
         grid.append(f'<line x1="{PAD}" y1="{y:.1f}" x2="{W - PAD}" y2="{y:.1f}" '
                     f'stroke="#e3e3e3" stroke-width="1"/>')

--- a/loadtest/instr/plot_memory.py
+++ b/loadtest/instr/plot_memory.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Render `memory.csv` as an SVG line chart.
+
+Hand-rolled rather than matplotlib: the harness otherwise needs nothing beyond
+a stdlib Python, and a load-test box is the last place to start installing a
+plotting stack.
+
+Usage: plot_memory.py memory.csv out.svg [title]
+"""
+from __future__ import annotations
+
+import csv
+import sys
+
+W, H, PAD = 900, 260, 46
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        print("usage: plot_memory.py <memory.csv> <out.svg> [title]", file=sys.stderr)
+        return 2
+    try:
+        with open(sys.argv[1], newline="", encoding="utf-8") as fh:
+            pts = [(int(r[0]), float(r[1])) for r in csv.reader(fh) if len(r) >= 2]
+    except (OSError, ValueError):
+        return 0
+    if len(pts) < 2:
+        return 0
+
+    t0 = pts[0][0]
+    xs = [t - t0 for t, _ in pts]
+    ys = [v for _, v in pts]
+    lo, hi = min(ys), max(ys)
+    if hi - lo < 1:
+        hi = lo + 1
+    span = xs[-1] or 1
+
+    def px(x: float) -> float:
+        return PAD + (x / span) * (W - 2 * PAD)
+
+    def py(y: float) -> float:
+        return H - PAD - ((y - lo) / (hi - lo)) * (H - 2 * PAD)
+
+    line = " ".join(f"{px(x):.1f},{py(y):.1f}" for x, y in zip(xs, ys))
+    area = f"{px(0):.1f},{H - PAD} {line} {px(xs[-1]):.1f},{H - PAD}"
+    title = sys.argv[3] if len(sys.argv) > 3 else "query service memory"
+
+    # Five gridlines, labelled in MB; x labelled in seconds from load start.
+    grid = []
+    for i in range(5):
+        v = lo + (hi - lo) * i / 4
+        y = py(v)
+        grid.append(f'<line x1="{PAD}" y1="{y:.1f}" x2="{W - PAD}" y2="{y:.1f}" '
+                    f'stroke="#e3e3e3" stroke-width="1"/>')
+        grid.append(f'<text x="{PAD - 8}" y="{y + 4:.1f}" font-size="11" '
+                    f'text-anchor="end" fill="#666">{v:.0f}</text>')
+    for i in range(5):
+        x = px(span * i / 4)
+        grid.append(f'<text x="{x:.1f}" y="{H - PAD + 18:.0f}" font-size="11" '
+                    f'text-anchor="middle" fill="#666">{span * i / 4:.0f}s</text>')
+
+    svg = f"""<svg xmlns="http://www.w3.org/2000/svg" width="{W}" height="{H}" viewBox="0 0 {W} {H}">
+<rect width="{W}" height="{H}" fill="white"/>
+<text x="{PAD}" y="24" font-size="14" font-family="sans-serif" fill="#222">{title}</text>
+<text x="{W - PAD}" y="24" font-size="12" font-family="sans-serif" text-anchor="end" fill="#666">
+start {ys[0]:.0f} MB &#183; peak {hi:.0f} MB &#183; end {ys[-1]:.0f} MB &#183; growth +{hi - ys[0]:.0f} MB</text>
+{chr(10).join(grid)}
+<polygon points="{area}" fill="#4a90d9" fill-opacity="0.12"/>
+<polyline points="{line}" fill="none" stroke="#4a90d9" stroke-width="2"/>
+<text x="{PAD}" y="{H - 8}" font-size="11" font-family="sans-serif" fill="#666">seconds from load start &#183; MB RSS</text>
+</svg>
+"""
+    with open(sys.argv[2], "w", encoding="utf-8") as fh:
+        fh.write(svg)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loadtest/instr/query_phase_timing.py
+++ b/loadtest/instr/query_phase_timing.py
@@ -1,0 +1,77 @@
+"""Per-request phase timing for the query service (load-test instrumentation).
+
+Dropped into the running container at /app/python/app/utils/query_phase_timing.py
+by loadtest/patch_instrumentation.sh. NOT part of the repo's shipped code and
+must never be committed under backend/.
+
+The _Phases object is held in a contextvar rather than threaded through
+run_chat_stream()'s signature, so app/agents/chat_modes/bridge.py can mark
+phases without changing a function signature shared by other call sites.
+
+Context propagation this relies on:
+  - async generators run in the context of whoever drives them, so a set() in
+    chatbot.py's stream generator is visible to bridge.py's run_chat_stream;
+  - asyncio.create_task() copies the current context, so bridge.py's _produce()
+    task sees the same _Phases instance and mutates it by reference.
+Each request is a separate task, so there is no cross-request bleed.
+
+Enabled unless QUERY_PHASE_TIMING is set to a falsey value: the module only
+exists on a patched container, so its presence is already the opt-in.
+"""
+
+import contextvars
+import os
+import time
+import uuid
+
+_ENABLED = os.getenv("QUERY_PHASE_TIMING", "1").strip().lower() not in (
+    "0",
+    "false",
+    "no",
+    "off",
+)
+
+_current: contextvars.ContextVar = contextvars.ContextVar(
+    "query_phase_timing", default=None
+)
+
+
+class _Phases:
+    __slots__ = ("logger", "qid", "t0", "last")
+
+    def __init__(self, logger, qid: str) -> None:
+        self.logger = logger
+        self.qid = qid
+        self.t0 = self.last = time.monotonic()
+
+    def mark(self, name: str) -> None:
+        now = time.monotonic()
+        try:
+            self.logger.info(
+                "PHASE qid=%s step=%s ms=%.0f cum=%.0f",
+                self.qid,
+                name,
+                (now - self.last) * 1000.0,
+                (now - self.t0) * 1000.0,
+            )
+        except Exception:
+            pass
+        self.last = now
+
+
+def phase_start(logger):
+    """Begin timing this request and bind it to the current context."""
+    if not _ENABLED:
+        return None
+    ph = _Phases(logger, uuid.uuid4().hex[:8])
+    _current.set(ph)
+    return ph
+
+
+def phase_mark(name: str) -> None:
+    """Mark a phase against whatever _Phases the current context holds."""
+    if not _ENABLED:
+        return
+    ph = _current.get()
+    if ph is not None:
+        ph.mark(name)

--- a/loadtest/instr/top_functions.py
+++ b/loadtest/instr/top_functions.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Rank the functions that burned CPU in a py-spy raw profile.
+
+    python3 top_functions.py <profile.raw> [top_n]
+
+Two views, because they answer different questions:
+
+* by function — the leaf frame that was executing.
+* by subsystem — every sample whose stack touches a subsystem, so nested cost
+  lands on the thing that caused it. A template compile, for example, spends
+  most of its time in the lexer and parser; the leaf view scatters that across
+  half a dozen jinja2 frames and hides how much it adds up to.
+"""
+from __future__ import annotations
+
+import collections
+import re
+import sys
+
+# Threads parked waiting for work are not doing any; py-spy still samples them.
+IDLE = re.compile(
+    r"thread\.py:9\d|threading\.py:(359|1012|655)|selectors\.py:4|resource_tracker"
+)
+
+SUBSYSTEMS = {
+    "record fetch + decode": ("blob_storage", "base64.py"),
+    "graph driver": ("neo4j/", "arango"),
+    "citation processing": ("citations.py",),
+    "context building": ("chat_helpers.py",),
+    "prompt templates": ("jinja2",),
+    "tool schemas": ("_bind_tools", "json_schema"),
+    "JSON encode": ("json/encoder",),
+    "JSON decode": ("json/decoder",),
+    "LLM stream": ("langchain", "openai/", "httpx"),
+    "asyncio": ("asyncio/",),
+}
+
+
+def load(path: str) -> list[tuple[str, int]]:
+    out = []
+    with open(path, errors="replace") as fh:
+        for line in fh:
+            line = line.rstrip()
+            cut = line.rfind(" ")
+            try:
+                n = int(line[cut + 1:])
+            except ValueError:
+                continue
+            out.append((line[:cut], n))
+    return out
+
+
+def main(path: str, top_n: int = 15) -> int:
+    stacks = load(path)
+    if not stacks:
+        print("  (empty profile)")
+        return 0
+
+    leaves: collections.Counter[str] = collections.Counter()
+    groups: collections.Counter[str] = collections.Counter()
+    total = 0
+    for stack, n in stacks:
+        leaf = stack.split(";")[-1].strip()
+        if IDLE.search(leaf):
+            continue
+        total += n
+        leaves[leaf] += n
+        for name, markers in SUBSYSTEMS.items():
+            if any(m in stack for m in markers):
+                groups[name] += n
+    if not total:
+        print("  (no active samples — the service was idle)")
+        return 0
+
+    print(f"  {total} samples of executing Python\n")
+    print("  by subsystem (a sample counts for every subsystem in its stack):")
+    for name, n in groups.most_common():
+        print(f"    {100 * n / total:6.2f}%  {name}")
+    print(f"\n  by function (top {top_n}):")
+    for leaf, n in leaves.most_common(top_n):
+        print(f"    {100 * n / total:6.2f}%  {leaf[:88]}")
+    return 0
+
+
+if __name__ == "__main__":
+    args = sys.argv[1:]
+    if not args:
+        sys.exit("usage: top_functions.py <profile.raw> [top_n]")
+    sys.exit(main(args[0], int(args[1]) if len(args) > 1 else 15))

--- a/loadtest/instrument.sh
+++ b/loadtest/instrument.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# instrument.sh on|off|status — per-phase and per-backend timing in the
+# query service.
+#
+# `perftest.sh` reports throughput, turn-phase latency and backend latency from
+# log lines this adds. CPU and memory work without it; the rest needs it on.
+#
+# Nothing under backend/ is edited: the probes are copied into the running
+# container and imported from `app/utils/runtime_threads.py`, which
+# `query_main` imports first. `docker restart` keeps them; `docker compose up`
+# recreates the container and drops them — re-run `on` after that.
+set -uo pipefail
+ACTION=${1:-status}
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONTAINER=${PIPESHUB_CONTAINER:-pipeshub-ai}
+RT=/app/python/app/utils/runtime_threads.py
+# shellcheck source=_common.sh
+. "$HERE/_common.sh"
+require_target || exit 1
+if [ "$PIPESHUB_MODE" != "docker" ]; then
+    echo "instrument.sh needs PIPESHUB_MODE=docker — it copies probes into the"
+    echo "container and patches files there. A native deployment would mean"
+    echo "editing your working tree, which this script will not do."
+    echo
+    echo "Native runs still report CPU and memory; throughput, phase latency and"
+    echo "backend latency are the sections that need these probes."
+    exit 1
+fi
+
+in_container() { $DOCKER exec "$CONTAINER" "$@"; }
+
+case "$ACTION" in
+  on)
+    echo "== copying probes into $CONTAINER"
+    $DOCKER cp "$HERE/instr/query_phase_timing.py" "$CONTAINER:/app/python/app/utils/query_phase_timing.py"
+    $DOCKER cp "$HERE/instr/backend_timing.py"     "$CONTAINER:/app/python/app/utils/backend_timing.py"
+    $DOCKER cp "$HERE/instr/apply_instrumentation.py" "$CONTAINER:/tmp/apply_instrumentation.py"
+
+    echo "== patching phase marks into the request path"
+    in_container python3 /tmp/apply_instrumentation.py || {
+      echo "!! phase patch failed — throughput/latency will be unavailable"; }
+
+    echo "== wiring the backend-latency probe"
+    in_container python3 - <<'PY'
+p = "/app/python/app/utils/runtime_threads.py"
+src = open(p).read()
+line = "    from app.utils import backend_timing as _backend_timing  # noqa: F401"
+if "backend_timing" in src:
+    print("   already wired")
+else:
+    marker = "import"
+    lines = src.splitlines(keepends=True)
+    for i, ln in enumerate(lines):
+        if ln.startswith("def ") or ln.startswith("class "):
+            lines.insert(i, "try:\n" + line + "\nexcept Exception:\n    pass\n\n")
+            break
+    out = "".join(lines)
+    compile(out, p, "exec")
+    open(p, "w").write(out)
+    print("   wired")
+PY
+    bash "$HERE/restart_query.sh"
+    ;;
+
+  off)
+    echo "== removing probes"
+    in_container python3 - <<'PY'
+p = "/app/python/app/utils/runtime_threads.py"
+src = open(p).read()
+out = "\n".join(l for l in src.splitlines()
+                if "backend_timing" not in l and "recfetch_probe" not in l) + "\n"
+compile(out, p, "exec")
+open(p, "w").write(out)
+print("   unwired")
+PY
+    in_container sh -c 'rm -f /app/python/app/utils/backend_timing.py' || true
+    $DOCKER cp "$HERE/instr/apply_instrumentation.py" "$CONTAINER:/tmp/apply_instrumentation.py"
+    in_container python3 /tmp/apply_instrumentation.py --revert 2>/dev/null || \
+      echo "   (phase marks: revert not supported by this patcher — recreate the container to clear)"
+    bash "$HERE/restart_query.sh"
+    ;;
+
+  status)
+    echo -n "phase marks : "
+    in_container grep -qc "_phase_mark" /app/python/app/api/routes/chatbot.py 2>/dev/null \
+      && echo "applied" || echo "not applied"
+    echo -n "backend probe: "
+    in_container grep -q "backend_timing" "$RT" 2>/dev/null && echo "wired" || echo "not wired"
+    echo -n "recent lines : "
+    n=$($DOCKER logs "$CONTAINER" --since 10m 2>&1 | grep -ac 'PHASE \|BACKENDAGG' || true)
+    echo "$n in the last 10 min"
+    ;;
+
+  *)
+    echo "usage: ./instrument.sh on|off|status"; exit 1 ;;
+esac

--- a/loadtest/instrument.sh
+++ b/loadtest/instrument.sh
@@ -37,7 +37,11 @@ case "$ACTION" in
     $DOCKER cp "$HERE/instr/apply_instrumentation.py" "$CONTAINER:/tmp/apply_instrumentation.py"
 
     echo "== patching phase marks into the request path"
-    in_container python3 /tmp/apply_instrumentation.py || {
+    # The patcher takes both request-path targets; called bare it prints usage
+    # and exits 2, which meant the phase patch silently never applied.
+    in_container python3 /tmp/apply_instrumentation.py \
+      /app/python/app/api/routes/chatbot.py \
+      /app/python/app/agents/chat_modes/bridge.py || {
       echo "!! phase patch failed — throughput/latency will be unavailable"; }
 
     echo "== wiring the backend-latency probe"
@@ -67,16 +71,33 @@ PY
     in_container python3 - <<'PY'
 p = "/app/python/app/utils/runtime_threads.py"
 src = open(p).read()
-out = "\n".join(l for l in src.splitlines()
-                if "backend_timing" not in l and "recfetch_probe" not in l) + "\n"
+# Drop the whole injected block. Filtering only the lines mentioning the module
+# left a bare `try:` / `except Exception:` behind -- invalid Python, which the
+# compile() below then rejected, so `off` failed and left the probe wired.
+block = (
+    "try:\n"
+    "    from app.utils import backend_timing as _backend_timing  # noqa: F401\n"
+    "except Exception:\n"
+    "    pass\n"
+    "\n"
+)
+if block in src:
+    out = src.replace(block, "")
+elif "backend_timing" not in src:
+    print("   not wired")
+    raise SystemExit(0)
+else:
+    print("   !! probe block not in its expected shape -- leaving the file alone")
+    raise SystemExit(1)
 compile(out, p, "exec")
 open(p, "w").write(out)
 print("   unwired")
 PY
     in_container sh -c 'rm -f /app/python/app/utils/backend_timing.py' || true
-    $DOCKER cp "$HERE/instr/apply_instrumentation.py" "$CONTAINER:/tmp/apply_instrumentation.py"
-    in_container python3 /tmp/apply_instrumentation.py --revert 2>/dev/null || \
-      echo "   (phase marks: revert not supported by this patcher — recreate the container to clear)"
+    in_container sh -c 'rm -f /app/python/app/utils/query_phase_timing.py' || true
+    # The patcher is forward-only. Phase marks stay until the container is
+    # recreated; say so rather than pretending a revert ran.
+    echo "   (phase marks remain — recreate the container to clear them)"
     bash "$HERE/restart_query.sh"
     ;;
 

--- a/loadtest/locustfile_play.py
+++ b/loadtest/locustfile_play.py
@@ -1,0 +1,352 @@
+"""Load test for PipesHub chat and agent streaming.
+
+Measures where the query service stops keeping up, and — more importantly —
+whether its event loop is being blocked. The primary signal is HEALTH:probe
+latency: /health is a trivial async endpoint that does no I/O, so any time it
+takes more than a few milliseconds to answer, the loop was busy or blocked.
+
+Run against a resource-pinned Docker stack (see docker-compose.loadtest.yml).
+Numbers from an unpinned stack are not reproducible.
+
+Usage:
+    export PIPESHUB_TOKEN='<bearer token from browser devtools>'
+    locust -f locustfile.py --headless -u 10 -r 2 -t 10m -H http://localhost:3000
+
+    # ramp to find the knee
+    PIPESHUB_SHAPE=stepramp locust -f locustfile.py --headless \
+        -t 25m -H http://localhost:3000
+
+Scenario classes (name them on the CLI to pin the mix):
+    InternalSearchUser   plain RAG chat
+    AgentUser            agent with tools  <- the one that shows loop blocking
+    HealthProbeUser      always on, independent of -u
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from locust import HttpUser, LoadTestShape, constant, events, task
+
+# --------------------------------------------------------------------------
+# Config
+# --------------------------------------------------------------------------
+
+TOKEN = os.environ.get("PIPESHUB_TOKEN", "")
+AGENT_KEY = os.environ.get("PIPESHUB_AGENT_KEY", "")
+
+# The query service, exposed directly by the loadtest compose overlay. Probing
+# through the Node gateway would fold Node's latency into the measurement.
+HEALTH_URL = os.environ.get("PIPESHUB_HEALTH_URL", "http://localhost:8000/health")
+HEALTH_INTERVAL = float(os.environ.get("PIPESHUB_HEALTH_INTERVAL", "1.0"))
+HEALTH_PROBES = int(os.environ.get("PIPESHUB_HEALTH_PROBES", "1"))
+# Anything above this means the loop was blocked. 100ms is the widely used
+# threshold for "something is wrong"; a healthy idle loop answers in <10ms.
+HEALTH_SLA_MS = float(os.environ.get("PIPESHUB_HEALTH_SLA_MS", "100"))
+
+STREAM_TIMEOUT = float(os.environ.get("PIPESHUB_STREAM_TIMEOUT", "300"))
+THINK_TIME = float(os.environ.get("PIPESHUB_THINK_TIME", "3"))
+
+QUESTIONS = [
+    "What are the key features described in the documents?",
+    "Summarise the main points from the most recent files.",
+    "How is access control and permissions handled?",
+    "What integrations are mentioned across the documents?",
+    "Explain the deployment options that are documented.",
+    "What are the known limitations or open issues?",
+]
+
+# Questions phrased to push an agent toward using its tools rather than
+# answering from retrieved context alone.
+AGENT_QUESTIONS = [
+    "Search my Drive for the most recently modified document and summarise it.",
+    "Find files shared with me in the last week and list them.",
+    "Look up recent messages and tell me what was discussed.",
+    "Check my documents for anything about deployment and summarise it.",
+]
+
+
+def _auth_headers() -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {TOKEN}",
+        "Content-Type": "application/json",
+        "Accept": "text/event-stream",
+    }
+
+
+@events.test_start.add_listener
+def _check_config(environment, **_kwargs) -> None:
+    if not TOKEN:
+        raise SystemExit(
+            "PIPESHUB_TOKEN is not set. Log in to the UI, open devtools > Network, "
+            "and copy the Bearer token from any API request."
+        )
+
+
+# --------------------------------------------------------------------------
+# SSE handling
+# --------------------------------------------------------------------------
+
+
+def consume_sse(response, on_event) -> None:
+    """Feed (event_type, data) to on_event for each SSE frame.
+
+    PipesHub emits `event: <type>\\ndata: <json>\\n\\n` (utils/streaming.py).
+    Blank-line-delimited frames, so track the current event type across lines.
+    """
+    event_type = "message"
+    for raw in response.iter_lines(decode_unicode=True):
+        if raw is None:
+            continue
+        line = raw.strip()
+        if not line:
+            event_type = "message"
+            continue
+        if line.startswith("event:"):
+            event_type = line[6:].strip()
+        elif line.startswith("data:"):
+            payload = line[5:].strip()
+            try:
+                data = json.loads(payload)
+            except json.JSONDecodeError:
+                data = {"raw": payload}
+            on_event(event_type, data)
+
+
+class StreamingChatUser(HttpUser):
+    """Base: POST a streaming chat turn and time each milestone.
+
+    Milestones are reported as separate named requests so Locust gives you
+    percentiles per milestone rather than only for the whole turn.
+    """
+
+    abstract = True
+    wait_time = constant(THINK_TIME)
+
+    prefix: str = "chat"
+    questions: list[str] = QUESTIONS
+    # `/conversations/stream` rejects a request without an explicit chatMode
+    # (es_validators.ts: UNIVERSAL_STREAM_CHAT_MODES). It used to default, so
+    # omitting it silently 400s every request rather than failing loudly.
+    chat_mode: str = "internal_search"
+
+    def endpoint(self) -> str:
+        raise NotImplementedError
+
+    def _fire(self, name: str, start: float, exc: Exception | None = None) -> None:
+        self.environment.events.request.fire(
+            request_type="SSE",
+            name=f"{self.prefix}:{name}",
+            response_time=(time.monotonic() - start) * 1000,
+            response_length=0,
+            exception=exc,
+            context={},
+        )
+
+    @task
+    def turn(self) -> None:
+        question = self.questions[int(time.monotonic() * 1000) % len(self.questions)]
+        body = {"query": question, "chatMode": self.chat_mode}
+        _mk = os.environ.get("PIPESHUB_MODEL_KEY")
+        if _mk:
+            body["modelKey"] = _mk
+        # Retrieval breadth. Unset, the API applies `limit: int | None = 50`
+        # (chatbot.py:53), which produced ~33k tokens of context re-sent on
+        # every LLM call of the turn. Set this to A/B that directly.
+        _lim = os.environ.get("PIPESHUB_LIMIT")
+        if _lim:
+            body["limit"] = int(_lim)
+
+        start = time.monotonic()
+        seen_first_packet = False
+        seen_first_token = False
+        tokens = 0
+
+        try:
+            with self.client.post(
+                self.endpoint(),
+                json=body,
+                headers=_auth_headers(),
+                stream=True,
+                timeout=STREAM_TIMEOUT,
+                catch_response=True,
+                name=f"{self.prefix}:POST",
+            ) as resp:
+                if resp.status_code != 200:
+                    resp.failure(f"HTTP {resp.status_code}: {resp.text[:300]}")
+                    self._fire("total_turn", start, Exception(f"HTTP {resp.status_code}"))
+                    return
+
+                # Event names verified against a live stream 2026-07-28:
+                #   connected | status | answer_chunk | metadata | tool_result | complete
+                st = {"first_packet": False, "first_token": False, "first_tool": False}
+
+                def on_event(event_type: str, data: dict) -> None:
+                    nonlocal tokens
+                    if not st["first_packet"]:
+                        st["first_packet"] = True
+                        self._fire("first_packet", start)
+
+                    # Play/AG-UI protocol: event type is inside the JSON payload,
+                    # emitted as bare `data: {...}` lines with no `event:` header.
+                    etype = data.get("type") if isinstance(data, dict) else None
+                    if etype in ("TEXT_MESSAGE_CONTENT", "TEXT_MESSAGE_START"):
+                        tokens += 1
+                        if not st["first_token"]:
+                            st["first_token"] = True
+                            self._fire("first_answer_token", start)
+                    elif etype == "TOOL_CALL_RESULT" and not st["first_tool"]:
+                        st["first_tool"] = True
+                        self._fire("first_tool_result", start)
+                    elif etype == "RUN_ERROR":
+                        raise RuntimeError(str(data)[:300])
+
+                    if event_type == "answer_chunk":
+                        tokens += 1
+                        if not st["first_token"]:
+                            st["first_token"] = True
+                            self._fire("first_answer_token", start)
+
+                    # Agent runs only: proves the toolset actually fired, and
+                    # times how long the (currently loop-blocking) call took.
+                    elif event_type == "tool_result" and not st["first_tool"]:
+                        st["first_tool"] = True
+                        self._fire("first_tool_result", start)
+
+                    elif event_type == "error" or (
+                        isinstance(data, dict) and data.get("error")
+                    ):
+                        raise RuntimeError(str(data)[:300])
+
+                consume_sse(resp, on_event)
+                seen_first_packet = st["first_packet"]
+                seen_first_token = st["first_token"]
+
+                if not seen_first_packet:
+                    resp.failure("stream produced no events")
+                else:
+                    resp.success()
+
+        except Exception as exc:  # noqa: BLE001 - report, don't crash the user
+            self._fire("total_turn", start, exc)
+            return
+
+        self._fire("total_turn", start, None if seen_first_token else
+                   Exception("no answer content in stream"))
+
+
+# --------------------------------------------------------------------------
+# Scenarios
+# --------------------------------------------------------------------------
+
+
+class InternalSearchUser(StreamingChatUser):
+    """Plain RAG chat — retrieval then LLM, no tools."""
+
+    prefix = "chat"
+    weight = 3
+
+    def endpoint(self) -> str:
+        return "/api/v1/conversations/stream"
+
+
+class ShortAnswerUser(StreamingChatUser):
+    """Same retrieval path as InternalSearchUser, but forces a very short
+    answer. Diagnostic for F2: if loop blocking drops sharply versus
+    InternalSearchUser at equal concurrency, the blocking scales with answer
+    length (the O(N^2) `accumulated` SSE payload). If it doesn't, the cause is
+    retrieval-side and answer length is irrelevant.
+    """
+
+    prefix = "short"
+    weight = 1  # opt-in by naming it on the CLI (weight 0 would never spawn)
+    questions = [
+        q + " Answer in one short sentence, under 15 words. Do not elaborate."
+        for q in QUESTIONS
+    ]
+
+    def endpoint(self) -> str:
+        return "/api/v1/conversations/stream"
+
+
+class AgentUser(StreamingChatUser):
+    """Agent with tools. This is the scenario that surfaces loop blocking:
+    each Google/Slack tool call runs on the event loop today."""
+
+    prefix = "agent"
+    weight = 1
+    questions = AGENT_QUESTIONS
+    # The agent route accepts only 'quick' (es_validators.ts: AGENT_CHAT_MODES).
+    chat_mode = "quick"
+
+    def endpoint(self) -> str:
+        if not AGENT_KEY:
+            raise SystemExit("PIPESHUB_AGENT_KEY is not set — AgentUser cannot run.")
+        return f"/api/v1/agents/{AGENT_KEY}/conversations/stream"
+
+
+class HealthProbeUser(HttpUser):
+    """Hits /health on a fixed cadence, independent of -u.
+
+    This is the experiment's primary signal. /health does no I/O, so its
+    latency IS event loop lag. When HEALTH:probe starts failing, the loop is
+    blocked — which is exactly the failure we're hunting.
+    """
+
+    fixed_count = HEALTH_PROBES
+    wait_time = constant(HEALTH_INTERVAL)
+
+    @task
+    def probe(self) -> None:
+        start = time.monotonic()
+        try:
+            r = self.client.get(
+                HEALTH_URL, name="HEALTH:probe", timeout=30, catch_response=True
+            )
+            elapsed_ms = (time.monotonic() - start) * 1000
+            with r:
+                if r.status_code != 200:
+                    r.failure(f"HTTP {r.status_code}")
+                elif elapsed_ms > HEALTH_SLA_MS:
+                    r.failure(f"event loop lag: {elapsed_ms:.0f}ms > {HEALTH_SLA_MS:.0f}ms")
+                else:
+                    r.success()
+        except Exception as exc:  # noqa: BLE001
+            self.environment.events.request.fire(
+                request_type="GET",
+                name="HEALTH:probe",
+                response_time=(time.monotonic() - start) * 1000,
+                response_length=0,
+                exception=exc,
+                context={},
+            )
+
+
+# --------------------------------------------------------------------------
+# Ramp shape (opt-in via PIPESHUB_SHAPE=stepramp)
+# --------------------------------------------------------------------------
+
+
+# Locust auto-activates ANY LoadTestShape subclass present in the file and lets
+# it override -u/-r. A disabled shape whose tick() returns None reads as "stop
+# the test", so the class must not exist at all unless it's wanted.
+if os.environ.get("PIPESHUB_SHAPE", "") == "stepramp":
+
+    class StepRampShape(LoadTestShape):
+        """Hold at plateaus so the knee is visible in the timeline."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            raw = os.environ.get("PIPESHUB_RAMP_STAGES", "5,10,25,50,100")
+            self.stages = [int(p) for p in raw.split(",") if p.strip()] or [5, 10, 25]
+            self.dwell = max(30, int(os.environ.get("PIPESHUB_RAMP_DWELL", "180")))
+            self.spawn = max(0.5, float(os.environ.get("PIPESHUB_RAMP_SPAWN", "2")))
+
+        def tick(self):
+            run_time = self.get_run_time()
+            for i, users in enumerate(self.stages, start=1):
+                if run_time < i * self.dwell:
+                    return users, self.spawn
+            return None

--- a/loadtest/locustfile_play.py
+++ b/loadtest/locustfile_play.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 import time
 
 from locust import HttpUser, LoadTestShape, constant, events, task
@@ -49,14 +50,19 @@ HEALTH_SLA_MS = float(os.environ.get("PIPESHUB_HEALTH_SLA_MS", "100"))
 STREAM_TIMEOUT = float(os.environ.get("PIPESHUB_STREAM_TIMEOUT", "300"))
 THINK_TIME = float(os.environ.get("PIPESHUB_THINK_TIME", "3"))
 
-QUESTIONS = [
-    "What are the key features described in the documents?",
-    "Summarise the main points from the most recent files.",
-    "How is access control and permissions handled?",
-    "What integrations are mentioned across the documents?",
-    "Explain the deployment options that are documented.",
-    "What are the known limitations or open issues?",
-]
+def _load_questions() -> list[str]:
+    """Shared with `perftest.sh` so both harnesses ask the same thing; the
+    inline list is the fallback when this file is run from elsewhere."""
+    path = Path(os.environ.get("PIPESHUB_QUERY_FILE", Path(__file__).with_name("queries.txt")))
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return ["What are the key features described in the documents?"]
+    found = [ln.strip() for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+    return found or ["What are the key features described in the documents?"]
+
+
+QUESTIONS = _load_questions()
 
 # Questions phrased to push an agent toward using its tools rather than
 # answering from retrieved context alone.

--- a/loadtest/perftest.sh
+++ b/loadtest/perftest.sh
@@ -23,7 +23,7 @@ OUTDIR="$HERE/results/$LABEL"
 # shellcheck source=_common.sh
 . "$HERE/_common.sh"
 HOST=${PIPESHUB_HOST}
-QUERY=${PIPESHUB_QUERY:-"What are the key features described in the documents?"}
+QUERY_FILE=${PIPESHUB_QUERY_FILE:-$HERE/queries.txt}
 # users=0 is the collect-only mode (someone else drives the load): no requests
 # are sent from here, so no credential is needed.
 if [ "$USERS" -gt 0 ]; then
@@ -57,7 +57,25 @@ if [ -n "$WORKERS" ]; then
   bash "$HERE/set_workers.sh" "$WORKERS" >>"$REPORT" 2>&1
 fi
 
-say "== $LABEL: $USERS users, ${SECS}s, host $HOST, mode $PIPESHUB_MODE"
+# One request body per query, JSON-encoded once here rather than per request:
+# the previous inline `python -c json.dumps` forked a process for every single
+# request, adding load to the host being measured.
+if [ -n "${PIPESHUB_QUERY:-}" ]; then
+  QUERIES=("$PIPESHUB_QUERY")
+elif [ -f "$QUERY_FILE" ]; then
+  mapfile -t QUERIES < <(grep -v '^[[:space:]]*#' "$QUERY_FILE" | grep -v '^[[:space:]]*$')
+else
+  say "ABORT: no query file at $QUERY_FILE and PIPESHUB_QUERY is unset."
+  exit 1
+fi
+[ ${#QUERIES[@]} -gt 0 ] || { say "ABORT: $QUERY_FILE contains no queries."; exit 1; }
+mapfile -t BODIES < <(printf '%s\n' "${QUERIES[@]}" | "$PYTHON" -c '
+import json, sys
+for line in sys.stdin.read().splitlines():
+    print(json.dumps({"query": line, "chatMode": "internal_search"}))
+')
+
+say "== $LABEL: $USERS users, ${SECS}s, ${#QUERIES[@]} quer$([ ${#QUERIES[@]} -eq 1 ] && echo y || echo ies), host $HOST, mode $PIPESHUB_MODE"
 say "== started $(date -u +%H:%M:%SZ)"
 START=$(log_mark)
 WALL_START=$(date -u +%s)
@@ -88,17 +106,39 @@ fi
   done ) &
 MEM_PID=$!
 
+# Query order per user, drawn from a PRNG seeded on (label, user index): random
+# across users but reproducible, so two arms of an A/B see the SAME sequence
+# rather than merely the same distribution.
+mapfile -t USER_SEQ < <("$PYTHON" -c '
+import random, sys
+label, users, nq, turns = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+for u in range(1, users + 1):
+    rng = random.Random(f"{label}:{u}")
+    print(" ".join(str(rng.randrange(nq)) for _ in range(turns)))
+' "$LABEL" "$USERS" "${#BODIES[@]}" 500)
+
 # --- load: each user asks, reads the whole answer, thinks, repeats
 THINK=${PIPESHUB_THINK_TIME:-3}
 END=$(( $(date +%s) + SECS ))
+echo "user,turn,query_index,http_code,time_total,curl_exit" > "$OUTDIR/requests.csv"
 LOAD_PIDS=()
-for _ in $(seq 1 "$USERS"); do
-  ( while [ "$(date +%s)" -lt "$END" ]; do
-      curl -s -N -o /dev/null -X POST "$HOST/api/v1/conversations/stream" \
+for u in $(seq 1 "$USERS"); do
+  ( turn=0
+    read -r -a seq <<< "${USER_SEQ[$((u - 1))]}"
+    while [ "$(date +%s)" -lt "$END" ]; do
+      qi=${seq[$(( turn % ${#seq[@]} ))]}
+      # Record the outcome of every request. Previously this was `-o /dev/null
+      # || true`, so a run where every request 500'd was indistinguishable from
+      # one that was merely slow.
+      res=$(curl -s -N -o /dev/null -w '%{http_code} %{time_total}' \
+        -X POST "$HOST/api/v1/conversations/stream" \
         -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
         -H "Accept: text/event-stream" \
-        -d "{\"query\":$(printf '%s' "$QUERY" | "$PYTHON" -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),\"chatMode\":\"internal_search\"}" \
-        --max-time 300 || true
+        -d "${BODIES[$qi]}" \
+        --max-time 300 2>/dev/null) || true
+      rc=$?
+      echo "$u,$turn,$qi,${res:-000 0} $rc" | tr ' ' ',' >> "$OUTDIR/requests.csv"
+      turn=$((turn + 1))
       sleep "$THINK"
     done ) &
   LOAD_PIDS+=($!)
@@ -113,12 +153,25 @@ else
 fi
 FINISH=$(log_mark)
 WALL_SECS=$(( $(date -u +%s) - WALL_START ))
+LOAD_CUTOFF=$(( WALL_START + SECS ))
 kill "$MEM_PID" 2>/dev/null || true
 sleep 3
 
 say ""
 say "==================== THROUGHPUT ===================="
 PIPESHUB_WINDOW_SECONDS=$WALL_SECS bash "$HERE/throughput.sh" "$START" "$FINISH" | tee -a "$REPORT"
+# Turns finished while load was still being OFFERED. The figure above divides by
+# elapsed time including the drain after load stops, so a config whose last
+# turns run long reports a lower rate for the same work. When the two disagree,
+# the drain is doing the talking.
+if [ "$PIPESHUB_MODE" = "docker" ]; then
+  SS_TURNS=$(log_read "$START" "$LOAD_CUTOFF" | grep -ac 'AnswerFinalizer:' || true)
+  say "  steady-state    : $SS_TURNS turns in the ${SECS}s load window  ($("$PYTHON" -c "print(f'{$SS_TURNS*60/$SECS:.1f}')") req/min)"
+fi
+
+say ""
+say "==================== REQUESTS (client-side) ===================="
+"$PYTHON" "$HERE/instr/agg_requests.py" "$OUTDIR/requests.csv" | tee -a "$REPORT"
 
 say ""
 say "==================== TURN LATENCY (per phase, ms) ===================="
@@ -147,6 +200,9 @@ if [ -s "$OUTDIR/memory.csv" ]; then
          s=""; step=(NR>60?int(NR/60)+1:1)
          for(i=1;i<=NR;i+=step){ s=s g[int((v[i]-lo)*7/(m-lo))+1] }
          print "  " s }' "$OUTDIR/memory.csv" | tee -a "$REPORT"
+  "$PYTHON" "$HERE/instr/plot_memory.py" "$OUTDIR/memory.csv" "$OUTDIR/memory.svg" \
+    "$LABEL — ${WORKERS:-?} workers, $USERS users" 2>/dev/null \
+    && say "   memory graph: $OUTDIR/memory.svg"
 else
   say "   (no samples)"
 fi
@@ -160,6 +216,18 @@ if log_available; then
 else
   say "   (no log source - set PIPESHUB_QUERY_LOG in .env; see .env.example)"
 fi
+
+# Machine-readable, so `aggregate.py` can roll many runs into one table without
+# re-parsing the human report. PIPESHUB_ARM/TRIAL are set by the matrix driver.
+"$PYTHON" "$HERE/instr/make_summary.py" \
+  --outdir "$OUTDIR" --label "$LABEL" --users "$USERS" --secs "$SECS" \
+  --workers "${WORKERS:-}" --arm "${PIPESHUB_ARM:-}" --trial "${PIPESHUB_TRIAL:-}" \
+  --wall "$WALL_SECS" --queries "${#QUERIES[@]}" 2>/dev/null \
+  && say "   summary: $OUTDIR/summary.json"
+
+# ~19MB of the ~23MB a run writes. Kept (not deleted) so a profile can be
+# re-analysed later, but not at full size 54 times over.
+[ -s "$OUTDIR/cpu.raw" ] && gzip -f "$OUTDIR/cpu.raw" 2>/dev/null || true
 
 say ""
 say "== done. full report: $REPORT"

--- a/loadtest/perftest.sh
+++ b/loadtest/perftest.sh
@@ -17,6 +17,9 @@ LABEL=${1:?usage: TOKEN=<jwt> ./perftest.sh <label> [users] [seconds] [workers]}
 USERS=${2:-8}
 SECS=${3:-300}
 WORKERS=${4:-}
+case "$SECS" in
+    ''|*[!0-9]*|0) echo "seconds must be a positive integer, got '$SECS'" >&2; exit 1 ;;
+esac
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 OUTDIR="$HERE/results/$LABEL"
@@ -44,7 +47,10 @@ if [ "$USERS" -gt 0 ]; then
   probe=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$HOST/api/v1/conversations/stream" \
     -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
     -H "Accept: text/event-stream" -d "{\"query\":\"ping\",\"chatMode\":\"internal_search\"}" \
-    --max-time 60 2>/dev/null || echo 000)
+    --max-time 60 2>/dev/null) || true
+  # curl already prints 000 when it never got a response; appending a fallback
+  # to the same capture produced "HTTP 000000".
+  [ -n "$probe" ] || probe=000
   if [ "$probe" != "200" ]; then
     say "ABORT: auth probe returned HTTP $probe (expected 200). Refresh TOKEN."
     exit 1
@@ -135,7 +141,11 @@ for u in $(seq 1 "$USERS"); do
         -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
         -H "Accept: text/event-stream" \
         -d "${BODIES[$qi]}" \
-        --max-time 300 2>/dev/null) || true
+        --max-time 300 2>/dev/null)
+      # Immediately, and with no `|| true` in between: that would make this the
+      # exit status of `true` and record every request as curl_exit=0, losing
+      # exactly the timeouts (28) this column exists to surface. Safe without a
+      # guard because the script does not run under `set -e`.
       rc=$?
       echo "$u,$turn,$qi,${res:-000 0} $rc" | tr ' ' ',' >> "$OUTDIR/requests.csv"
       turn=$((turn + 1))

--- a/loadtest/perftest.sh
+++ b/loadtest/perftest.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# perftest.sh — one command to measure the query service under load.
+#
+#   ./perftest.sh <label> [users] [seconds] [workers]
+#
+# Reports, for the measurement window:
+#   * throughput  — completed chat turns per minute, counted server-side
+#   * latency     — per-phase breakdown of a turn (retrieval, LLM, ...)
+#   * CPU         — which Python functions burned CPU, plus a flame graph
+#   * memory      — query-service RSS over time
+#   * backends    — per-call latency and rate for Neo4j and the Node API
+#
+# Run it ON the machine hosting PipesHub. See README.md for setup.
+set -uo pipefail
+
+LABEL=${1:?usage: TOKEN=<jwt> ./perftest.sh <label> [users] [seconds] [workers]}
+USERS=${2:-8}
+SECS=${3:-300}
+WORKERS=${4:-}
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+OUTDIR="$HERE/results/$LABEL"
+# shellcheck source=_common.sh
+. "$HERE/_common.sh"
+HOST=${PIPESHUB_HOST}
+QUERY=${PIPESHUB_QUERY:-"What are the key features described in the documents?"}
+# users=0 is the collect-only mode (someone else drives the load): no requests
+# are sent from here, so no credential is needed.
+if [ "$USERS" -gt 0 ]; then
+  : "${TOKEN:?set TOKEN in loadtest/.env, or export it — see .env.example}"
+fi
+# Checked before the run, not after: every reporting section below reads the
+# query service, so a 300s run against an unreachable one produces only zeroes.
+require_target || exit 1
+
+mkdir -p "$OUTDIR"
+REPORT="$OUTDIR/report.txt"
+: > "$REPORT"
+say() { echo "$@" | tee -a "$REPORT"; }
+
+# --- guard: an expired token turns every request into a 401, which looks
+# --- exactly like a throughput collapse. Fail fast instead.
+if [ "$USERS" -gt 0 ]; then
+  probe=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$HOST/api/v1/conversations/stream" \
+    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -H "Accept: text/event-stream" -d "{\"query\":\"ping\",\"chatMode\":\"internal_search\"}" \
+    --max-time 60 2>/dev/null || echo 000)
+  if [ "$probe" != "200" ]; then
+    say "ABORT: auth probe returned HTTP $probe (expected 200). Refresh TOKEN."
+    exit 1
+  fi
+fi
+
+if [ -n "$WORKERS" ]; then
+  [ "$PIPESHUB_MODE" = "docker" ] || { say "ABORT: the workers argument needs PIPESHUB_MODE=docker."; exit 1; }
+  say "== setting query workers to $WORKERS (restarts the container)"
+  bash "$HERE/set_workers.sh" "$WORKERS" >>"$REPORT" 2>&1
+fi
+
+say "== $LABEL: $USERS users, ${SECS}s, host $HOST, mode $PIPESHUB_MODE"
+say "== started $(date -u +%H:%M:%SZ)"
+START=$(log_mark)
+WALL_START=$(date -u +%s)
+
+# --- CPU profile (py-spy attaches to the live process; --gil samples only
+# --- while Python is actually executing, so idle threads never appear)
+if command -v py-spy >/dev/null 2>&1 || [ -x "$HOME/.local/bin/py-spy" ]; then
+  PYSPY=$(command -v py-spy || echo "$HOME/.local/bin/py-spy")
+  QPID=$(query_pid 2>/dev/null || true)
+  if [ -n "$QPID" ]; then
+    detect_sudo
+    $SUDO "$PYSPY" record --pid "$QPID" --subprocesses --gil --nonblocking \
+      -d "$SECS" -r 100 -f flamegraph -o "$OUTDIR/cpu.svg" >/dev/null 2>&1 &
+    $SUDO "$PYSPY" record --pid "$QPID" --subprocesses --gil --nonblocking \
+      -d "$SECS" -r 100 -f raw -o "$OUTDIR/cpu.raw" >/dev/null 2>&1 &
+  else
+    say "   (py-spy: no query process found — skipping CPU profile)"
+  fi
+else
+  say "   (py-spy not installed — skipping CPU profile; see README.md)"
+fi
+
+# --- memory sampler
+( END_M=$(( $(date +%s) + SECS + 15 ))
+  while [ "$(date +%s)" -lt "$END_M" ]; do
+    echo "$(date +%s),$(query_rss_mb)" >> "$OUTDIR/memory.csv"
+    sleep 2
+  done ) &
+MEM_PID=$!
+
+# --- load: each user asks, reads the whole answer, thinks, repeats
+THINK=${PIPESHUB_THINK_TIME:-3}
+END=$(( $(date +%s) + SECS ))
+LOAD_PIDS=()
+for _ in $(seq 1 "$USERS"); do
+  ( while [ "$(date +%s)" -lt "$END" ]; do
+      curl -s -N -o /dev/null -X POST "$HOST/api/v1/conversations/stream" \
+        -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+        -H "Accept: text/event-stream" \
+        -d "{\"query\":$(printf '%s' "$QUERY" | "$PYTHON" -c 'import json,sys; print(json.dumps(sys.stdin.read()))'),\"chatMode\":\"internal_search\"}" \
+        --max-time 300 || true
+      sleep "$THINK"
+    done ) &
+  LOAD_PIDS+=($!)
+done
+# Wait on the load generators BY PID. A bare `wait` (which is what an empty
+# filtered list degrades to) also waits for the memory sampler, overrunning the
+# window by its trailing samples and understating throughput.
+if [ ${#LOAD_PIDS[@]} -gt 0 ]; then
+  wait "${LOAD_PIDS[@]}" 2>/dev/null || true
+else
+  sleep "$SECS"
+fi
+FINISH=$(log_mark)
+WALL_SECS=$(( $(date -u +%s) - WALL_START ))
+kill "$MEM_PID" 2>/dev/null || true
+sleep 3
+
+say ""
+say "==================== THROUGHPUT ===================="
+PIPESHUB_WINDOW_SECONDS=$WALL_SECS bash "$HERE/throughput.sh" "$START" "$FINISH" | tee -a "$REPORT"
+
+say ""
+say "==================== TURN LATENCY (per phase, ms) ===================="
+if log_available; then
+  log_read "$START" "$FINISH" | "$PYTHON" "$HERE/instr/agg_phases.py" 2>/dev/null | tee -a "$REPORT" \
+    || say "   (no phase data - run ./instrument.sh on to enable)"
+else
+  say "   (no log source - set PIPESHUB_QUERY_LOG in .env; see .env.example)"
+fi
+
+say ""
+say "==================== CPU (top functions, real work only) ===================="
+if [ -s "$OUTDIR/cpu.raw" ]; then
+  "$PYTHON" "$HERE/instr/top_functions.py" "$OUTDIR/cpu.raw" | tee -a "$REPORT"
+  say "   flame graph: $OUTDIR/cpu.svg"
+else
+  say "   (no profile captured)"
+fi
+
+say ""
+say "==================== MEMORY (query service RSS, MB) ===================="
+if [ -s "$OUTDIR/memory.csv" ]; then
+  awk -F, 'NR==1{f=$2} {v[NR]=$2; if($2>m) m=$2; l=$2}
+    END{ printf "  start=%d MB  peak=%d MB  end=%d MB  growth=+%d MB\n", f, m, l, m-f
+         lo=(f<l?f:l); if(m<=lo) m=lo+1; split("▁ ▂ ▃ ▄ ▅ ▆ ▇ █",g," ")
+         s=""; step=(NR>60?int(NR/60)+1:1)
+         for(i=1;i<=NR;i+=step){ s=s g[int((v[i]-lo)*7/(m-lo))+1] }
+         print "  " s }' "$OUTDIR/memory.csv" | tee -a "$REPORT"
+else
+  say "   (no samples)"
+fi
+
+say ""
+say "==================== BACKEND CALLS (caller-side) ===================="
+if log_available; then
+  log_read "$START" "$FINISH" | grep -a BACKENDAGG \
+    | "$PYTHON" "$HERE/instr/agg_backends.py" 2>/dev/null | tee -a "$REPORT" \
+    || say "   (no backend data - run ./instrument.sh on to enable)"
+else
+  say "   (no log source - set PIPESHUB_QUERY_LOG in .env; see .env.example)"
+fi
+
+say ""
+say "== done. full report: $REPORT"

--- a/loadtest/queries.txt
+++ b/loadtest/queries.txt
@@ -1,0 +1,25 @@
+# One query per line. Blank lines and lines starting with # are ignored.
+#
+# Each user picks from this list with a PRNG seeded from (run label, user
+# index): random-looking and spread across users, but identical between two
+# arms of an A/B so both see the same workload.
+#
+# WHY A LIST AND NOT ONE QUERY: a single repeated query gets its prompt prefix
+# cached by the LLM provider and returns the same warm records every turn, so
+# it overstates throughput. Use `PIPESHUB_QUERY` to force a single query only
+# when you want both arms of an A/B identically biased -- never to quote a
+# capacity number.
+#
+# REPLACE THESE for your own corpus, then check a run's answers: turns coming
+# back with 0 citations are measuring the not-found path, not retrieval.
+
+How do I set up an agent, and what configuration does it need?
+Which AI model providers are supported and how are they configured?
+How are spending limits and AI budgets applied to users and teams?
+What does the connector integration playbook say about adding a new connector?
+How is access control and permissions handled across connectors?
+Summarise the task runner and concurrency architecture for background syncs.
+What issues were found in the recent bug bash sessions?
+What does the Asana SOC 3 report cover?
+What has been discussed recently about MCP and the context layer?
+What is on the PipesHub capabilities roadmap?

--- a/loadtest/query_rss.sh
+++ b/loadtest/query_rss.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# query_rss.sh — total RSS in MB of the query service (parent + workers).
+#
+# Prints a single number so it can be sampled in a loop. `docker stats` is not
+# usable here: it reports the whole container, which also holds the Node,
+# indexing and connector processes.
+set -uo pipefail
+# shellcheck source=_common.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+require_target || exit 1
+
+query_rss_mb

--- a/loadtest/restart_query.sh
+++ b/loadtest/restart_query.sh
@@ -5,7 +5,6 @@
 # container itself is never touched.
 set -euo pipefail
 
-CONTAINER=${CONTAINER:-${PIPESHUB_CONTAINER:-pipeshub-ai}}
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
 require_target || exit 1
 [ "$PIPESHUB_MODE" = "docker" ] || { echo "$(basename "$0") needs PIPESHUB_MODE=docker (it restarts the container)."; exit 1; }
@@ -27,7 +26,8 @@ while :; do
         exit 1
     fi
     code=$($DOCKER exec "$CONTAINER" \
-        curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/health" 2>/dev/null || true)
+        curl -s -o /dev/null -w '%{http_code}' --connect-timeout 3 --max-time 10 \
+        "http://localhost:${PORT}/health" 2>/dev/null || true)
     new=$($DOCKER exec "$CONTAINER" pgrep -f 'app\.query_main' | head -1 || true)
     # The pid MUST have changed. Polling health alone returns 200 from the
     # still-running old process before the kill lands, which reports success

--- a/loadtest/restart_query.sh
+++ b/loadtest/restart_query.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Restart ONLY the query service inside the container and wait for it to be
+# healthy again. process_monitor.sh polls every CHECK_INTERVAL (20s) and
+# restarts a dead query process, so killing it is the whole mechanism -- the
+# container itself is never touched.
+set -euo pipefail
+
+CONTAINER=${CONTAINER:-${PIPESHUB_CONTAINER:-pipeshub-ai}}
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+require_target || exit 1
+[ "$PIPESHUB_MODE" = "docker" ] || { echo "$(basename "$0") needs PIPESHUB_MODE=docker (it restarts the container)."; exit 1; }
+PORT=${QUERY_PORT:-8000}
+DEADLINE=${DEADLINE:-180}
+
+echo
+echo "== Restart query service (container untouched)"
+old=$($DOCKER exec "$CONTAINER" pgrep -f 'app\.query_main' | head -1 || true)
+echo "   old pid: ${old:-none}"
+
+$DOCKER exec "$CONTAINER" pkill -f 'app\.query_main' || true
+
+start=$(date +%s)
+while :; do
+    now=$(( $(date +%s) - start ))
+    if [ "$now" -ge "$DEADLINE" ]; then
+        echo "   FAILED: query service not healthy after ${DEADLINE}s" >&2
+        exit 1
+    fi
+    code=$($DOCKER exec "$CONTAINER" \
+        curl -s -o /dev/null -w '%{http_code}' "http://localhost:${PORT}/health" 2>/dev/null || true)
+    new=$($DOCKER exec "$CONTAINER" pgrep -f 'app\.query_main' | head -1 || true)
+    # The pid MUST have changed. Polling health alone returns 200 from the
+    # still-running old process before the kill lands, which reports success
+    # while the old code is still loaded -- silently measuring stale code.
+    if [ "$code" = "200" ] && [ -n "$new" ] && [ "$new" != "$old" ]; then
+        echo "   healthy after ${now}s (new pid: ${new})"
+        exit 0
+    fi
+    sleep 3
+done

--- a/loadtest/restart_query.sh
+++ b/loadtest/restart_query.sh
@@ -9,7 +9,7 @@ CONTAINER=${CONTAINER:-${PIPESHUB_CONTAINER:-pipeshub-ai}}
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
 require_target || exit 1
 [ "$PIPESHUB_MODE" = "docker" ] || { echo "$(basename "$0") needs PIPESHUB_MODE=docker (it restarts the container)."; exit 1; }
-PORT=${QUERY_PORT:-8000}
+PORT=${PIPESHUB_QUERY_PORT:-8000}
 DEADLINE=${DEADLINE:-180}
 
 echo

--- a/loadtest/set_workers.sh
+++ b/loadtest/set_workers.sh
@@ -23,8 +23,15 @@ case "$N" in
     ''|*[!0-9]*) echo "usage: set_workers.sh <N|restore> -- worker count must be a positive integer, got '$N'" >&2; exit 1 ;;
     0) echo "usage: set_workers.sh <N|restore> -- worker count must be > 0" >&2; exit 1 ;;
 esac
-CONTAINER=${CONTAINER:-${PIPESHUB_CONTAINER:-pipeshub-ai}}
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+# The port is interpolated into a launcher line that runs inside the container,
+# so anything but a plain port number would be executed there.
+case "$PIPESHUB_QUERY_PORT" in
+    ''|*[!0-9]*) echo "PIPESHUB_QUERY_PORT must be 1-65535, got '$PIPESHUB_QUERY_PORT'" >&2; exit 1 ;;
+esac
+[ "$PIPESHUB_QUERY_PORT" -ge 1 ] && [ "$PIPESHUB_QUERY_PORT" -le 65535 ] || {
+    echo "PIPESHUB_QUERY_PORT must be 1-65535, got '$PIPESHUB_QUERY_PORT'" >&2; exit 1; }
+
 require_target || exit 1
 [ "$PIPESHUB_MODE" = "docker" ] || { echo "$(basename "$0") needs PIPESHUB_MODE=docker (it restarts the container)."; exit 1; }
 ORIG=${ORIG:-$HOME/lt-backup/process_monitor.sh.orig}
@@ -53,8 +60,11 @@ $DOCKER restart "$CONTAINER" >/dev/null
 
 echo -n "== waiting for /health "
 for _ in $(seq 1 120); do
+    # Bounded: an unresponsive service would otherwise let a single curl hang
+    # past the whole 120-iteration budget.
     code=$($DOCKER exec "$CONTAINER" curl -s -o /dev/null -w '%{http_code}' \
-           http://localhost:${PIPESHUB_QUERY_PORT}/health 2>/dev/null || true)
+           --connect-timeout 3 --max-time 10 \
+           "http://localhost:${PIPESHUB_QUERY_PORT}/health" 2>/dev/null || true)
     [ "$code" = "200" ] && break
     printf '.'; sleep 5
 done
@@ -64,6 +74,9 @@ echo " ok"
 if [ "$N" = "restore" ]; then
     got=$($DOCKER exec "$CONTAINER" sh -c "ps -eo args | grep -c '[p]ython -m app.query_main'" || echo 0)
     echo "== launcher processes: $got (expect 1)"
+    # Checked like the other branches: 0 means the restore did not take, and
+    # anything above 1 means duplicate launchers are competing for the port.
+    [ "$got" = "1" ] || { echo "LAUNCHER COUNT MISMATCH -- restore did not take" >&2; exit 1; }
 elif [ "$N" = "1" ]; then
     # uvicorn only starts the multiprocess supervisor when workers > 1; at
     # --workers 1 the parent serves the app itself and spawns no children.

--- a/loadtest/set_workers.sh
+++ b/loadtest/set_workers.sh
@@ -15,6 +15,14 @@
 set -euo pipefail
 
 N=${1:?usage: set_workers.sh <N|restore>}
+# Validated before anything is written: an unvalidated value reaches the sed as
+# `--workers $N`, and the grep that follows would confirm its own bad string,
+# so the container restarts into a uvicorn that cannot start.
+case "$N" in
+    restore) ;;
+    ''|*[!0-9]*) echo "usage: set_workers.sh <N|restore> -- worker count must be a positive integer, got '$N'" >&2; exit 1 ;;
+    0) echo "usage: set_workers.sh <N|restore> -- worker count must be > 0" >&2; exit 1 ;;
+esac
 CONTAINER=${CONTAINER:-${PIPESHUB_CONTAINER:-pipeshub-ai}}
 . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
 require_target || exit 1
@@ -78,7 +86,7 @@ fi
 
 echo "== phase instrumentation still applied:"
 $DOCKER exec "$CONTAINER" grep -c '_phase_mark("' \
-    /app/python/app/api/routes/chatbot.py /app/python/app/agents/chat_modes/bridge.py
+    /app/python/app/api/routes/chatbot.py /app/python/app/agents/chat_modes/bridge.py || true
 
 echo "== settling ${SETTLE}s (restart also bounces indexing/connector; F6 showed"
 echo "   background indexing inflates latency and contaminated an early baseline)"

--- a/loadtest/set_workers.sh
+++ b/loadtest/set_workers.sh
@@ -40,7 +40,7 @@ if [ "$N" = "restore" ]; then
     want=1
 else
     echo "== Setting query service to $N uvicorn worker(s)"
-    sed -i "s|    python -m app.query_main &|    python -m uvicorn app.query_main:app --host 0.0.0.0 --port 8000 --workers $N \&|" "$TMP"
+    sed -i "s|    python -m app.query_main &|    python -m uvicorn app.query_main:app --host 0.0.0.0 --port ${PIPESHUB_QUERY_PORT} --workers $N \&|" "$TMP"
     grep -q -- "--workers $N" "$TMP" || { echo "sed did not match the launch line" >&2; exit 1; }
     want=$N
 fi
@@ -54,7 +54,7 @@ $DOCKER restart "$CONTAINER" >/dev/null
 echo -n "== waiting for /health "
 for _ in $(seq 1 120); do
     code=$($DOCKER exec "$CONTAINER" curl -s -o /dev/null -w '%{http_code}' \
-           http://localhost:8000/health 2>/dev/null || true)
+           http://localhost:${PIPESHUB_QUERY_PORT}/health 2>/dev/null || true)
     [ "$code" = "200" ] && break
     printf '.'; sleep 5
 done

--- a/loadtest/set_workers.sh
+++ b/loadtest/set_workers.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Switch the query service to N uvicorn workers and wait until it is serving.
+#
+#   ./set_workers.sh <N>
+#   ./set_workers.sh restore     # put back the untouched original launcher
+#
+# Regenerated from ~/lt-backup/process_monitor.sh.orig every time -- never from
+# a previously patched copy, so worker counts can't stack up. loadtest/pm.sh is
+# deliberately NOT used: it hardcodes 4 workers and was never the file Play ran.
+#
+# process_monitor.sh is the container entrypoint, so changing it needs a
+# `docker restart`. That is fine BETWEEN configs; never do it mid-trial.
+# `docker restart` preserves docker cp'd files, so the phase-timing patch
+# survives -- only `docker compose up -d` would wipe it.
+set -euo pipefail
+
+N=${1:?usage: set_workers.sh <N|restore>}
+CONTAINER=${CONTAINER:-${PIPESHUB_CONTAINER:-pipeshub-ai}}
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+require_target || exit 1
+[ "$PIPESHUB_MODE" = "docker" ] || { echo "$(basename "$0") needs PIPESHUB_MODE=docker (it restarts the container)."; exit 1; }
+ORIG=${ORIG:-$HOME/lt-backup/process_monitor.sh.orig}
+SETTLE=${SETTLE:-60}
+
+[ -f "$ORIG" ] || { echo "missing $ORIG -- refusing to guess" >&2; exit 1; }
+
+TMP=$(mktemp); trap 'rm -f "$TMP"' EXIT
+cp "$ORIG" "$TMP"
+
+if [ "$N" = "restore" ]; then
+    echo "== Restoring original launcher (python -m app.query_main)"
+    want=1
+else
+    echo "== Setting query service to $N uvicorn worker(s)"
+    sed -i "s|    python -m app.query_main &|    python -m uvicorn app.query_main:app --host 0.0.0.0 --port 8000 --workers $N \&|" "$TMP"
+    grep -q -- "--workers $N" "$TMP" || { echo "sed did not match the launch line" >&2; exit 1; }
+    want=$N
+fi
+
+$DOCKER cp "$TMP" "$CONTAINER:/app/process_monitor.sh"
+$DOCKER exec "$CONTAINER" chmod +x /app/process_monitor.sh
+
+echo "== docker restart $CONTAINER"
+$DOCKER restart "$CONTAINER" >/dev/null
+
+echo -n "== waiting for /health "
+for _ in $(seq 1 120); do
+    code=$($DOCKER exec "$CONTAINER" curl -s -o /dev/null -w '%{http_code}' \
+           http://localhost:8000/health 2>/dev/null || true)
+    [ "$code" = "200" ] && break
+    printf '.'; sleep 5
+done
+[ "${code:-}" = "200" ] || { echo " FAILED"; exit 1; }
+echo " ok"
+
+if [ "$N" = "restore" ]; then
+    got=$($DOCKER exec "$CONTAINER" sh -c "ps -eo args | grep -c '[p]ython -m app.query_main'" || echo 0)
+    echo "== launcher processes: $got (expect 1)"
+elif [ "$N" = "1" ]; then
+    # uvicorn only starts the multiprocess supervisor when workers > 1; at
+    # --workers 1 the parent serves the app itself and spawns no children.
+    got=$($DOCKER exec "$CONTAINER" sh -c "ps -eo args | grep -c '[p]ython -m uvicorn app.query_main'" || echo 0)
+    echo "== serving processes: $got (expect 1, no spawned children by design)"
+    [ "$got" = "1" ] || { echo "WORKER COUNT MISMATCH -- do not trial this config" >&2; exit 1; }
+else
+    # Count spawn_main children only. `grep -c "python -c from"` also matches
+    # multiprocessing's resource_tracker, so it reports N+1 for N workers.
+    got=$($DOCKER exec "$CONTAINER" sh -c '
+        par=$(pgrep -f "python -m uvicorn app.query_main" | head -1)
+        n=0
+        for c in $(pgrep -P $par 2>/dev/null); do
+            grep -qa spawn_main /proc/$c/cmdline 2>/dev/null && n=$((n+1))
+        done
+        echo $n' || echo 0)
+    echo "== spawned workers: $got (expect $want)"
+    [ "$got" = "$want" ] || { echo "WORKER COUNT MISMATCH -- do not trial this config" >&2; exit 1; }
+fi
+
+echo "== phase instrumentation still applied:"
+$DOCKER exec "$CONTAINER" grep -c '_phase_mark("' \
+    /app/python/app/api/routes/chatbot.py /app/python/app/agents/chat_modes/bridge.py
+
+echo "== settling ${SETTLE}s (restart also bounces indexing/connector; F6 showed"
+echo "   background indexing inflates latency and contaminated an early baseline)"
+sleep "$SETTLE"
+echo "== ready"

--- a/loadtest/throughput.sh
+++ b/loadtest/throughput.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# throughput.sh <mark> [end_mark] — completed chat turns, server-side.
+#
+# Counts `step=finalize` marks in the query service log, one per completed
+# turn. Client-side counting undercounts: a turn still streaming when the load
+# generator stops is never counted, which penalises exactly the slow configs
+# you are trying to compare.
+#
+# <mark> comes from `log_mark` (see _common.sh) — an epoch in docker mode, a
+# byte offset in native mode. `perftest.sh` passes it through automatically.
+set -uo pipefail
+START=${1:?usage: throughput.sh <mark> [end_mark]}
+END=${2:-}
+# shellcheck source=_common.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+require_target || exit 1
+
+if ! log_available; then
+    echo "  (no log source — set PIPESHUB_QUERY_LOG in .env; see .env.example)"
+    exit 0
+fi
+
+# `step=finalize` is emitted by the instrumentation patch (./instrument.sh on).
+# Without it, fall back to a line the application already logs once per
+# completed turn — `respond.py`'s AnswerFinalizer. Fall back rather than count
+# both: an instrumented run emits BOTH, and summing them doubles every turn.
+LOGTEXT=$(log_read "$START" "$END")
+marks=$(printf '%s' "$LOGTEXT" | grep -ac 'step=finalize' || true)
+if [ "$marks" -eq 0 ]; then
+    # `AnswerFinalizer:` and not `...: finalized response` — a turn that ends
+    # with an empty answer logs "empty response, using fallback" instead, and
+    # the two are mutually exclusive. It still completed and still cost a turn.
+    marks=$(printf '%s' "$LOGTEXT" | grep -ac "${PIPESHUB_TURN_MARKER:-AnswerFinalizer:}" || true)
+fi
+
+if [ "$PIPESHUB_MODE" = "docker" ]; then
+    window=$(( ${END:-$(date -u +%s)} - START ))
+else
+    window=${PIPESHUB_WINDOW_SECONDS:-0}
+fi
+[ "$window" -gt 0 ] || window=1
+
+"$PYTHON" - "$marks" "$window" <<'PY'
+import sys
+marks, window = int(sys.argv[1]), int(sys.argv[2])
+per_min = marks * 60.0 / window
+print(f"  completed turns : {marks}")
+print(f"  window          : {window}s")
+print(f"  throughput      : {per_min:.1f} req/min  ({marks/window:.3f}/s)")
+if not marks:
+    print("  (zero - no completed turns found in the log for this window)")
+PY


### PR DESCRIPTION
# Query-service performance

What was slow, what changed, and what to do next. Raw evidence for every figure below is in
`baseline/` — flame graphs and full reports from the Play runs. Reproduce any of it with
`./perftest.sh`; see `README.md`.

## Summary

A chat turn re-did work proportional to the **whole answer** on **every streamed token** —
roughly 700 times per turn — in three independent places. This fixes all three, plus a
record-cache bug that made repeat fetches re-download whole documents.

**~1.8× throughput, p50 latency halved, SSE traffic down 28×.** The answer itself is unchanged.

| | before | after |
|---|---|---|
| throughput, 4 workers / 16 users | 23 req/min | **43 req/min** |
| p50 turn latency, same config | 36 s | **17.8 s** |
| throughput, 1 worker / 32 users (4 trials) | 11.1 req/min | **17.9 req/min** |
| executed Python per turn | 589 samples | **256 samples** |
| SSE bytes per turn | 39.4 MB | **1.4 MB** |

---

## The problem

Profiling found the same pattern in three places at once, which is why the service was
CPU-bound while every individual component looked idle:

1. `TerminalAnswerStreamer._emit_state_delta` re-ran citation normalization over the entire
   accumulated answer, per token. Citation processing alone was **22% of query-service CPU**.
2. Each of those emits produced a `STATE_DELTA` carrying the whole answer plus every
   citation's full text. One measured turn sent **1,030 frames averaging 37 KB — 39 MB of SSE
   to deliver a 1.5 KB answer** — all encoded here and relayed by the single-threaded Node
   gateway.
3. Jinja templates were recompiled from constant sources inside per-record loops (**11.5% of
   CPU**), and tool JSON schemas were regenerated on every LLM call (**5.5%**).

Only ~8% of CPU was handling the LLM response. The rest was retrieval-payload processing and
recomputation of things that never change.

## What changed

| change | effect |
|---|---|
| Rate-limit live citation resolution (`PIPESHUB_ANSWER_DELTA_INTERVAL_MS`, default 100 ms) | citation processing 22.4% → 3.9% of CPU |
| Per-key pending slots in `QueueEventSink` so coalescing actually engages | SSE 39.4 MB → 1.4 MB per turn |
| `lru_cache` the constant Jinja templates | jinja2 11.5% → 0.9% |
| Cache bound tools per tool set, per request | 5.5% → 2.5%; binds/turn 3.3 → 1.0 |
| Pass the **live** virtual-record map to the fetch tool | repeat fetches hit the map instead of re-downloading |
| Sniff base64 images from a 204-byte prefix | no measurable gain; kept as strictly less work |

Two of these deserve a note.

**The SSE coalescing was a no-op before this PR.** `QueueEventSink` held one shared pending
slot, but the answer stream interleaves two coalescable kinds (`TEXT_MESSAGE_CONTENT` and an
`answer_delta` `STATE_DELTA`) per token — so each write evicted the other kind and neither
ever merged. Per-key slots fix it.

**The record cache never worked on the navigate/lookup path.**
`_fetch_multiple_records_impl` is a write-back cache, but `CitationCollector.virtual_records`
returns `... or {}`, handing it a *throwaway* dict whenever the map is still empty — which is
exactly the navigate/lookup path, where retrieval never ran. The write-back was discarded and
every repeat fetch re-downloaded the document. This also retires a duplicate implementation:
`ops/fetch.py::execute_fetch_record` had been dead since it was created, so
`_FetchFullRecordTool.execute` now delegates to it instead of duplicating its body.

## Validation on Play

Deployed to Play (8 CPU, 31 GB, Neo4j, `internal_search`, gpt-5.4-mini on Azure) and measured
with `loadtest/perftest.sh`. Throughput counted server-side, one mark per completed turn.

### 4 workers / 16 users / 300 s

```
THROUGHPUT   216 turns / 318s  =  40.8 req/min
LATENCY      p50 18.4s   p95 29.3s   mean 19.0s
CPU          60,586 samples of executing Python
MEMORY       4179 -> 6268 MB (+2089)
BACKENDS     neo4j     8ms p50 / 66,273 calls
             node_api 384ms p50 / 21,046 calls
```

| phase | mean | % of turn |
|---|---|---|
| llm_stream | 12,431 ms | 65.3% |
| retrieval_wait | 5,316 ms | 27.8% |
| agent_create | 1,141 ms | 6.0% |
| everything else | <150 ms each | <1% |

### 1 worker / 32 users / 300 s

```
THROUGHPUT   95 turns / 394s  =  14.5 req/min
LATENCY      p50 115.4s  p95 147.5s  mean 117.9s
CPU          19,926 samples
MEMORY       1018 -> 2678 MB (+1660)
BACKENDS     neo4j    18ms p50 / 28,603 calls
             node_api 119ms p50 /  9,096 calls
```

| config | before | earlier after (reference) | this run |
|---|---|---|---|
| 4 workers / 16 users | 23 req/min | 42.3 | **40.8** |
| 1 worker / 32 users | 11.1 req/min | 17.9 (4-trial mean) | **14.5** |

The 4-worker figure reproduces. The 1-worker figure is +31% over baseline but 19% below the
earlier 4-trial mean — outside the ±10% single-trial band, so treat it as directional, not as
a refutation. Contributing factors: one trial vs a four-trial mean; the window ran 394 s
because 115 s turns overhang the cutoff; and the corpus has grown since the earlier runs.

## Known limitation: the rate limit disengages under saturation

The emit limiter gates on **wall-clock**, not on work done, so it stops helping exactly when
the service is most loaded:

| | 4w / 16u | 1w / 32u | before this PR |
|---|---|---|---|
| citation processing | 5.14% | **21.15%** | 22.4% |
| `iterencode` | 1.06% | 4.27% | ~5% |

At 4 workers the answer streams at ~18 ms/token, so the 100 ms gate drops about four of every
five emits. At 1 worker under 32 users it streams at ~95 ms/token, so nearly every token
clears the gate and per-token whole-answer normalization returns —
`_renumber_citation_links`, `_wrap_bare_refs` and `normalize_citations_and_chunks` all
reappear in the top 15 functions, where they are absent at 4 workers.

This is **not a regression** — it is never worse than the previous behaviour, and it is a
large win at normal latency. But the "22.4% → 3.9%" figure holds only while turns are fast.
The follow-up is to gate on accumulated work as well as time (e.g. also require N new
characters since the last emit).

## What this does NOT change

- Raw answer text still streams **per token**. Only the live citation overlay refreshes less
  often, and `AnswerFinalizer` still emits the authoritative corrected answer before
  `complete`.
- `PIPESHUB_ANSWER_DELTA_INTERVAL_MS=0` restores the exact previous per-token behaviour.
- One side effect is intentional: records reached via navigate/lookup now persist in the
  virtual-record map, so their citations become resolvable where previously they were not.

## Where the bottleneck is now

The query service is no longer the constraint. At 16 users the Node gateway shows
**384 ms p50 over 21k calls while Neo4j stays at 8 ms over 66k** — one process on one core in
front of every SSE stream and every document download. Memory also plateaus around **6.3 GB
at 16 users**; it does not leak, but there is no admission limit, so the failure mode under a
spike is an OOM kill rather than backpressure.

Ranked follow-ups, none in this PR: Node cluster mode; block-scoped fetch (a turn downloads
and decodes ~96 whole documents to quote a few paragraphs); batching the ~690 Neo4j calls per
turn; fewer LLM calls per turn.

## The harness

A one-command harness — `./perftest.sh <label> [users] [seconds] [workers]` — reporting
throughput, per-phase latency, a CPU flame graph, memory and backend latency. It auto-detects
a Docker vs native deployment, is configured through `.env` (see `.env.example`), and writes
to a gitignored `results/`. Nothing under `backend/` is modified: the probes are copied into
the running container and removed by `./instrument.sh off`.

Every script fails loudly when its target is unreachable rather than reporting a number it
could not have observed — a stopped container used to surface as "0 MB" and "0.0 req/min",
which reads as a measurement of an idle service.

## Testing

- Unit tests green across `agents/adapter`, `agents/actions/knowledge_graph`,
  `agents/chat_modes`, `modules/agents`, `utils`, `models`.
- New tests pin each fix: emit rate limiting, per-key SSE coalescing, tool-bind caching,
  base64 prefix sniffing, intra-call fetch de-duplication, and `start_block` continuation
  reads.
- The record-cache test **fails on `main`** — it asserts the document downloads once across
  two fetches, and on `main` it downloads twice.
- Deployed to Play and verified: modules import cleanly, no import errors after restart, and
  all five perf behaviours confirmed live before the numbers above were taken.

## Reproducing

```bash
cd loadtest
cp .env.example .env          # add TOKEN
./instrument.sh on            # phase + backend timing (docker deployments)
./perftest.sh baseline 16 300 4
```

Measurement caveats worth knowing: every turn uses a **single fixed question**, so these
compare like with like rather than modelling a real query mix; a single trial is ±10%, and
CPU-profile percentages are far more stable than throughput; and a growing corpus biases any
comparison made days apart.


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

with loadtest, scripts for that have been added to loadtest folder

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [x] **Search capabilities** are working correctly
- [x] **Knowledge search** is functioning properly
- [x] **Connector indexing** is working as expected
- [x] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [x] Feature works in development environment
- [x] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [x] Performance impact assessed
- [ ] Security implications reviewed

### Test Results
1 worker :
<img width="1200" height="778" alt="w1_u32_cpu" src="https://github.com/user-attachments/assets/d49c4995-5d5f-4bba-bb43-c25a535ba8e0" />
[w1_u32_report.txt](https://github.com/user-attachments/files/30662084/w1_u32_report.txt)

4 worker :
<img width="1200" height="794" alt="w4_u16_cpu" src="https://github.com/user-attachments/assets/6ed96d01-da55-48cb-a785-cd0cda02c03c" />
[w4_u16_report.txt](https://github.com/user-attachments/files/30662088/w4_u16_report.txt)


## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [x] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive load-testing toolkit with configurable scenarios, profiling, throughput measurement, backend metrics, phase timing, worker management, and operational scripts.
  * Added documentation and example configuration for Docker and native environments.
  * Added reusable template compilation to improve repeated rendering performance.

* **Bug Fixes**
  * Improved full-record fetching with duplicate prevention, continuation support, and consistent error handling.
  * Smoothed streaming citation updates while preserving final updates.
  * Improved event-stream coalescing for concurrent answer and reasoning messages.
  * Reduced processing overhead when validating large images.
  * Improved reuse of configured tools across repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->