### PR TITLE
fix(it): make parametrized model keys deterministic for xdist

### DIFF
--- a/integration-tests/response-validation/ai-model-providers/integration_test_ai_model_providers.py
+++ b/integration-tests/response-validation/ai-model-providers/integration_test_ai_model_providers.py
@@ -59,6 +59,11 @@ from openapi_schema_validator import (  # noqa: E402
 logger = logging.getLogger("ai-model-providers-integration-test")
 
 _MODEL_TYPE_LLM = "llm"
+# Parametrize arguments are evaluated at import time, and every xdist worker imports
+# this module separately -- a uuid4() here gives each worker a different test id and
+# aborts the whole run with a collection mismatch. These cases are rejected by
+# validation before the key is looked up, so any well-formed absent key will do.
+_ABSENT_MODEL_KEY = "00000000-0000-4000-8000-000000000000"
 _AI_MODEL_BUCKET_KEYS = (
     "ocr",
     "embedding",
@@ -640,7 +645,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
             (
                 "invalid modelType path",
                 "not-a-real-type",
-                str(uuid.uuid4()),
+                _ABSENT_MODEL_KEY,
                 _minimal_update_body(
                     _PROVIDER_OPENAI,
                     {"model": "gpt-4o-mini", "apiKey": "sk-test"},
@@ -649,7 +654,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
             (
                 "missing provider",
                 _MODEL_TYPE_LLM,
-                str(uuid.uuid4()),
+                _ABSENT_MODEL_KEY,
                 {
                     "configuration": {"model": "gpt-4o-mini", "apiKey": "sk-test"},
                     "isMultimodal": False,
@@ -660,7 +665,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
             (
                 "missing configuration",
                 _MODEL_TYPE_LLM,
-                str(uuid.uuid4()),
+                _ABSENT_MODEL_KEY,
                 {
                     "provider": _PROVIDER_OPENAI,
                     "isMultimodal": False,
@@ -671,7 +676,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
             (
                 "empty provider",
                 _MODEL_TYPE_LLM,
-                str(uuid.uuid4()),
+                _ABSENT_MODEL_KEY,
                 _minimal_update_body(
                     "",
                     {"model": "gpt-4o-mini", "apiKey": "sk-test"},
@@ -680,7 +685,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
             (
                 "modelFriendlyName with comma-separated models",
                 _MODEL_TYPE_LLM,
-                str(uuid.uuid4()),
+                _ABSENT_MODEL_KEY,
                 _minimal_update_body(
                     _PROVIDER_OPENAI,
                     {
@@ -693,7 +698,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
             (
                 "contextLength wrong type",
                 _MODEL_TYPE_LLM,
-                str(uuid.uuid4()),
+                _ABSENT_MODEL_KEY,
                 {
                     "provider": _PROVIDER_OPENAI,
                     "configuration": {"model": "gpt-4o-mini", "apiKey": "sk-test"},
@@ -952,7 +957,7 @@ class TestDeleteAIModelProviderValidation(AIModelsTestBase):
     @pytest.mark.parametrize(
         "label,model_type,model_key",
         [
-            ("invalid modelType path", "not-a-real-type", str(uuid.uuid4())),
+            ("invalid modelType path", "not-a-real-type", _ABSENT_MODEL_KEY),
         ],
     )
     def test_validation_rejects_invalid_delete(

--- a/integration-tests/response-validation/ai-model-providers/integration_test_ai_model_providers.py
+++ b/integration-tests/response-validation/ai-model-providers/integration_test_ai_model_providers.py
@@ -59,11 +59,6 @@ from openapi_schema_validator import (  # noqa: E402
 logger = logging.getLogger("ai-model-providers-integration-test")
 
 _MODEL_TYPE_LLM = "llm"
-# Parametrize arguments are evaluated at import time, and every xdist worker imports
-# this module separately -- a uuid4() here gives each worker a different test id and
-# aborts the whole run with a collection mismatch. These cases are rejected by
-# validation before the key is looked up, so any well-formed absent key will do.
-_ABSENT_MODEL_KEY = "00000000-0000-4000-8000-000000000000"
 _AI_MODEL_BUCKET_KEYS = (
     "ocr",
     "embedding",
@@ -639,53 +634,61 @@ class TestAddAIModelProviderNonAdmin(AIModelsTestBase):
 class TestUpdateAIModelProviderValidation(AIModelsTestBase):
     """Invalid params/bodies rejected by Zod before health-check."""
 
+    # Explicit ids are required, not cosmetic: parametrize arguments are evaluated at
+    # import time and every xdist worker imports this module separately, so a uuid4()
+    # folded into an auto-generated id makes each worker collect a different test id
+    # and aborts the whole run with a collection mismatch.
     @pytest.mark.parametrize(
         "label,model_type,model_key,payload",
         [
-            (
+            pytest.param(
                 "invalid modelType path",
                 "not-a-real-type",
-                _ABSENT_MODEL_KEY,
+                str(uuid.uuid4()),
                 _minimal_update_body(
                     _PROVIDER_OPENAI,
                     {"model": "gpt-4o-mini", "apiKey": "sk-test"},
                 ),
+                id="invalid-model-type-path",
             ),
-            (
+            pytest.param(
                 "missing provider",
                 _MODEL_TYPE_LLM,
-                _ABSENT_MODEL_KEY,
+                str(uuid.uuid4()),
                 {
                     "configuration": {"model": "gpt-4o-mini", "apiKey": "sk-test"},
                     "isMultimodal": False,
                     "isReasoning": False,
                     "isDefault": False,
                 },
+                id="missing-provider",
             ),
-            (
+            pytest.param(
                 "missing configuration",
                 _MODEL_TYPE_LLM,
-                _ABSENT_MODEL_KEY,
+                str(uuid.uuid4()),
                 {
                     "provider": _PROVIDER_OPENAI,
                     "isMultimodal": False,
                     "isReasoning": False,
                     "isDefault": False,
                 },
+                id="missing-configuration",
             ),
-            (
+            pytest.param(
                 "empty provider",
                 _MODEL_TYPE_LLM,
-                _ABSENT_MODEL_KEY,
+                str(uuid.uuid4()),
                 _minimal_update_body(
                     "",
                     {"model": "gpt-4o-mini", "apiKey": "sk-test"},
                 ),
+                id="empty-provider",
             ),
-            (
+            pytest.param(
                 "modelFriendlyName with comma-separated models",
                 _MODEL_TYPE_LLM,
-                _ABSENT_MODEL_KEY,
+                str(uuid.uuid4()),
                 _minimal_update_body(
                     _PROVIDER_OPENAI,
                     {
@@ -694,11 +697,12 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
                         "modelFriendlyName": "Not allowed",
                     },
                 ),
+                id="friendly-name-with-comma-separated-models",
             ),
-            (
+            pytest.param(
                 "contextLength wrong type",
                 _MODEL_TYPE_LLM,
-                _ABSENT_MODEL_KEY,
+                str(uuid.uuid4()),
                 {
                     "provider": _PROVIDER_OPENAI,
                     "configuration": {"model": "gpt-4o-mini", "apiKey": "sk-test"},
@@ -707,6 +711,7 @@ class TestUpdateAIModelProviderValidation(AIModelsTestBase):
                     "isDefault": False,
                     "contextLength": "not-a-number",
                 },
+                id="context-length-wrong-type",
             ),
         ],
     )
@@ -957,7 +962,12 @@ class TestDeleteAIModelProviderValidation(AIModelsTestBase):
     @pytest.mark.parametrize(
         "label,model_type,model_key",
         [
-            ("invalid modelType path", "not-a-real-type", _ABSENT_MODEL_KEY),
+            pytest.param(
+                "invalid modelType path",
+                "not-a-real-type",
+                str(uuid.uuid4()),
+                id="invalid-model-type-path",
+            ),
         ],
     )
     def test_validation_rejects_invalid_delete(


### PR DESCRIPTION
## Problem

The first parallel integration-test run after #2871 ([run 30813824855](https://github.com/pipeshub-ai/pipeshub-ai/actions/runs/30813824855)) aborted in 34s (arango) / 59s (neo4j) with **zero tests executed**. Both jobs reported four `Different tests were collected between gw1 and gwN` errors.

Playwright was unaffected (228 passed, 0 failures).

## Root cause

`@pytest.mark.parametrize` argument lists are evaluated at **import** time, and every xdist worker imports the test module in its own process. Seven `str(uuid.uuid4())` calls sat inside parametrize argument lists in `integration_test_ai_model_providers.py`, so each worker generated different values — and since pytest folds parameter values into the generated test id, each worker collected a different set of ids:

```
gw1: test_validation_rejects_invalid_put[missing provider-llm-dd52e0b3-...-payload1]
gw2: test_validation_rejects_invalid_put[missing provider-llm-1768cd51-...-payload1]
```

xdist compares every worker's collected id list before scheduling and refuses to run the session on any mismatch.

## Fix

Keep the `uuid4()` values and stop them reaching the id, by giving every case an explicit `pytest.param(..., id=...)`.

This targets the actual cause — a value leaking into an identifier — rather than constraining the value. The keys stay unique, so there is no shared-constant hazard if a future edit makes one of these cases create a record. It matches the `pytest.param(id=...)` convention already used in `response-validation/toolsets/integration_test_get_my_toolsets.py:225`.

Ids get considerably shorter as a side effect:

```
before: test_validation_rejects_invalid_put[missing provider-llm-dd52e0b3-98ea-4d0c-89ef-badfc389e80e-payload1]
after:  test_validation_rejects_invalid_put[missing-provider]
```

The nine other `uuid.uuid4()` calls in the file are inside test bodies, evaluated at run time by whichever single worker owns the test, and are left unchanged.

The first commit on this branch took the other route (replacing the values with a fixed constant); the second commit supersedes it. Squash on merge.

## Verification

- Three independent `--collect-only` runs of this file in separate processes produce byte-identical id lists.
- `-n 2 --dist loadgroup` on this file reports `2 workers [70 items] / scheduling tests via LoadGroupScheduling` with zero collection mismatches. The run then errors on connection refused (no local server), which is after scheduling — the part under test.
- Reproduced locally: this file alone under `-n 2` produced the mismatch before the change, and not after.
- The CI failure output is a complete diff of all 787 collected ids across workers — it contained exactly two hunks and exactly the seven ids changed here, so no other test in the suite was affected.
- Static checks across all 133 integration test files: every `parametrize` with non-literal argvalues was reviewed (10 already pass explicit `ids=`; the rest use module-level string constants or per-case `pytest.param(id=...)`); no module-level constant is built from `uuid4`/`random`/`now()`/`token_hex`/temp-file/hostname/pid; no `pytest_generate_tests` hooks exist.

## Notes

`--collect-only` does **not** exercise xdist's cross-worker collection comparison, so it cannot catch this class of bug. `pytest -n 2 <file>` surfaces it in seconds.

The habit worth adopting: any `parametrize` value that varies between runs needs an explicit id.

This unblocks scheduling only. The suite has never completed a parallel run, so parallel-execution behaviour of the enterprise-search tests that fan out is still unproven by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added clear, stable labels to AI model provider validation scenarios.
  * Improved test result readability and consistency while preserving existing validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->