### PR TITLE
docs(openapi): declare defaultReasoningEffort on agent schemas

### DIFF
--- a/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
+++ b/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
@@ -8454,6 +8454,11 @@ components:
             - provider
           example:
             provider: "serper"
+        defaultReasoningEffort:
+          type: string
+          nullable: true
+          enum: [none, low, medium, high, max]
+          description: Agent-level reasoning effort used when a chat request omits its own. Null when unset.
         tags:
           type: array
           items:
@@ -8620,6 +8625,11 @@ components:
               type: string
             providerLabel:
               type: string
+        defaultReasoningEffort:
+          type: string
+          nullable: true
+          enum: [none, low, medium, high, max]
+          description: Agent-level reasoning effort used when a chat request omits its own. Null when unset.
         shareWithOrg:
           type: boolean
           description: Whether the agent is shared with the organization.
@@ -8981,6 +8991,11 @@ components:
             $ref: '#/components/schemas/AgentSkillAssignment'
         webSearch:
           $ref: '#/components/schemas/AgentCreateWebSearch'
+        defaultReasoningEffort:
+          type: string
+          nullable: true
+          enum: [none, low, medium, high, max]
+          description: Agent-level reasoning effort used when a chat request omits its own.
 
     AgentCreateWarning:
       type: object
@@ -9117,6 +9132,11 @@ components:
                 providerLabel:
                   type: string
             - type: 'null'
+        defaultReasoningEffort:
+          type: string
+          nullable: true
+          enum: [none, low, medium, high, max]
+          description: Agent-level reasoning effort used when a chat request omits its own. Null when unset.
         isActive:
           type: boolean
         isServiceAccount:
@@ -9247,6 +9267,11 @@ components:
             $ref: '#/components/schemas/AgentSkillAssignment'
         webSearch:
           $ref: '#/components/schemas/AgentCreateWebSearch'
+        defaultReasoningEffort:
+          type: string
+          nullable: true
+          enum: [none, low, medium, high, max]
+          description: Agent-level reasoning effort used when a chat request omits its own.
 
     AgentUpdateResponse:
       type: object


### PR DESCRIPTION
## Problem

The first integration run that got past collection ([run 30823025340](https://github.com/pipeshub-ai/pipeshub-ai/actions/runs/30823025340)) executed all 787 tests and reported **9 agent failures**, identical on both graph backends:

```
jsonschema.exceptions.ValidationError: Additional properties are not allowed
('defaultReasoningEffort' was unexpected)
```

| Failing test | Schema |
|---|---|
| `TestCreateAgent::test_create_agent_response_matches_openapi_spec` | `AgentCreateResponseAgent` |
| `TestCreateAgent::test_create_agent_rich_payload_matches_openapi_and_creates` | `AgentCreateResponseAgent` |
| `TestGetAgent::test_get_agent_response_matches_openapi_spec` | `Agent` |
| `TestGetAgent::test_get_agent_with_knowledge_matches_openapi_spec` | `Agent` |
| `TestListAgents` × 5 (envelope, page/limit, search, sort asc, sort desc) | `AgentListItem` |

## Root cause

The reasoning-effort work (#2858) added `defaultReasoningEffort` to the agent create/update handlers and response formatters, but the OpenAPI document was never updated. Every agent response schema sets `additionalProperties: false`, so the response-validation tests rejected the new field outright.

The tests are correct here — they caught a real spec/handler drift. The fix belongs in the document.

## Fix

Declared `defaultReasoningEffort` on five schemas:

- **Response** (what the tests validate): `Agent`, `AgentListItem`, `AgentCreateResponseAgent`
- **Request** (what the API now accepts): `AgentCreateRequest`, `AgentUpdateRequest`

Typed as a nullable enum of the five `REASONING_EFFORT_VALUES` from `enterprise_search/constants/constants.ts` (`none`, `low`, `medium`, `high`, `max`), matching the Zod union `z.union([z.null(), z.enum(REASONING_EFFORT_VALUES)]).optional()` in `es_validators.ts:500`.

The request schemas aren't needed to make the tests pass; they're included so the document describes the endpoint rather than just satisfying the assertions.

## Verification

Ran the exact create-response payload from the failing CI run through the tests' own validation helper:

- `defaultReasoningEffort: null` → passes (the helper rewrites `nullable: true` into `anyOf: [..., {type: null}]`, so the enum doesn't reject null)
- all five enum values → pass
- `defaultReasoningEffort: "extreme"` → correctly rejected
- spec still parses; all 357 schemas load

## Not addressed here

Two other failures in the same run, both unrelated to this field and left for separate work:

- `search/integration_test_search.py:239` `test_archive_unarchive_lifecycle_matches_spec_and_history` (neo4j only) — `active history count should return to 1 after unarchive, got 2`. Two history rows for the same query created 0.7s apart under the same org/user. This looks like cross-test interference now that enterprise-search fans out across xdist workers, not a product bug — and it passed on arango, which fits a race rather than a deterministic fault.
- `google_drive_workspace ... test_tc_sd_ff_002_nested_subfolder_expands_scope` (arango only) — connector suite, outside enterprise-search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional default reasoning effort setting for agents.
  * Supported levels include none, low, medium, high, and max.
  * The agent-level setting applies when a chat request does not specify a reasoning effort.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->