### PR TITLE
fix(it): stop search-history tests racing, and surface Slack upload failures

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -722,30 +722,55 @@ jobs:
           fi
           THREAD_TS=$(echo "$MESSAGE_RESPONSE" | jq -r '.ts // empty')
           FILE_SIZE=$(stat -c%s reports.zip)
+          UPLOAD_OUT="$RUNNER_TEMP/slack-upload.out"
 
-          RESPONSE=$(curl -s -X POST "https://slack.com/api/files.getUploadURLExternal" \
-            -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-            -d "filename=integration-test-reports-${{ matrix.graph_db }}.zip" \
-            -d "length=$FILE_SIZE")
-          OK=$(echo "$RESPONSE" | jq -r '.ok')
-          if [ "$OK" != "true" ]; then
-            echo "::warning::Failed to get Slack upload URL: $RESPONSE"
+          # upload_url is CloudFront-fronted and 504s whenever the POST outruns its
+          # ~30s origin timeout, which is throughput- rather than size-dependent. An
+          # unchecked upload still lets completeUploadExternal return ok:true, but for
+          # a file with no bytes behind it, so it never renders in the channel. Retry
+          # the whole attempt: a consumed upload_url cannot be reused.
+          FILE_ID=""
+          for attempt in 1 2 3; do
+            RESPONSE=$(curl -sS -X POST "https://slack.com/api/files.getUploadURLExternal" \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -d "filename=integration-test-reports-${{ matrix.graph_db }}.zip" \
+              -d "length=$FILE_SIZE") || RESPONSE=""
+            if [ "$(echo "$RESPONSE" | jq -r '.ok // empty')" != "true" ]; then
+              echo "::warning::attempt $attempt: files.getUploadURLExternal failed: $RESPONSE"
+              sleep 5
+              continue
+            fi
+            UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url')
+            CANDIDATE_ID=$(echo "$RESPONSE" | jq -r '.file_id')
+
+            HTTP_CODE=$(curl -sS -o "$UPLOAD_OUT" -w '%{http_code}' \
+              --connect-timeout 30 --max-time 300 \
+              -X POST "$UPLOAD_URL" -F "file=@reports.zip") || HTTP_CODE="000"
+            if [ "$HTTP_CODE" = "200" ]; then
+              FILE_ID="$CANDIDATE_ID"
+              break
+            fi
+            echo "::warning::attempt $attempt: uploading reports.zip failed (HTTP $HTTP_CODE): $(head -c 300 "$UPLOAD_OUT")"
+            sleep 5
+          done
+
+          if [ -z "$FILE_ID" ]; then
+            echo "::warning::Could not upload reports.zip to Slack after 3 attempts; use the reports-${{ matrix.graph_db }} run artifact instead"
             exit 0
           fi
-          UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url')
-          FILE_ID=$(echo "$RESPONSE" | jq -r '.file_id')
-
-          curl -s -X POST "$UPLOAD_URL" -F "file=@reports.zip"
 
           COMPLETE_PAYLOAD="{\"files\":[{\"id\":\"$FILE_ID\",\"title\":\"Integration Test Reports (${{ matrix.graph_db }})\"}],\"channel_id\":\"$CHANNEL_ID\""
           if [ -n "$THREAD_TS" ]; then
             COMPLETE_PAYLOAD="$COMPLETE_PAYLOAD,\"thread_ts\":\"$THREAD_TS\""
           fi
           COMPLETE_PAYLOAD="$COMPLETE_PAYLOAD}"
-          curl -s -X POST "https://slack.com/api/files.completeUploadExternal" \
+          COMPLETE=$(curl -sS -X POST "https://slack.com/api/files.completeUploadExternal" \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "$COMPLETE_PAYLOAD"
+            -d "$COMPLETE_PAYLOAD") || COMPLETE=""
+          if [ "$(echo "$COMPLETE" | jq -r '.ok // empty')" != "true" ]; then
+            echo "::warning::files.completeUploadExternal failed: $COMPLETE"
+          fi
 
       - name: Send failed tests list to Slack thread
         if: ${{ !cancelled() && (steps.test-results.outputs.TOTAL_FAILED != '0' || steps.test-results.outputs.TOTAL_ERRORS != '0' || steps.test-results.outputs.PW_FAILED != '0' || steps.test-results.outputs.PW_ERRORS != '0') }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -724,6 +724,8 @@ jobs:
           FILE_SIZE=$(stat -c%s reports.zip)
           UPLOAD_OUT="$RUNNER_TEMP/slack-upload.out"
 
+          # Unchecked, a failed upload still completes as ok:true with no bytes
+          # behind it. Retry from a fresh URL -- a consumed one cannot be reused.
           FILE_ID=""
           for attempt in 1 2 3; do
             RESPONSE=$(curl -sS -X POST "https://slack.com/api/files.getUploadURLExternal" \
@@ -736,8 +738,7 @@ jobs:
               sleep 5
               continue
             fi
-            # `strings` drops nulls and non-string types, so a malformed ok:true
-            # response is reported here rather than as a confusing curl failure.
+            # `strings` yields nothing for null/non-string, so both are caught below.
             UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url | strings')
             CANDIDATE_ID=$(echo "$RESPONSE" | jq -r '.file_id | strings')
             if [ -z "$UPLOAD_URL" ] || [ -z "$CANDIDATE_ID" ]; then

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -724,15 +724,11 @@ jobs:
           FILE_SIZE=$(stat -c%s reports.zip)
           UPLOAD_OUT="$RUNNER_TEMP/slack-upload.out"
 
-          # upload_url is CloudFront-fronted and 504s whenever the POST outruns its
-          # ~30s origin timeout, which is throughput- rather than size-dependent. An
-          # unchecked upload still lets completeUploadExternal return ok:true, but for
-          # a file with no bytes behind it, so it never renders in the channel. Retry
-          # the whole attempt: a consumed upload_url cannot be reused.
           FILE_ID=""
           for attempt in 1 2 3; do
             RESPONSE=$(curl -sS -X POST "https://slack.com/api/files.getUploadURLExternal" \
               -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              --connect-timeout 10 --max-time 30 \
               -d "filename=integration-test-reports-${{ matrix.graph_db }}.zip" \
               -d "length=$FILE_SIZE") || RESPONSE=""
             if [ "$(echo "$RESPONSE" | jq -r '.ok // empty')" != "true" ]; then
@@ -740,8 +736,15 @@ jobs:
               sleep 5
               continue
             fi
-            UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url')
-            CANDIDATE_ID=$(echo "$RESPONSE" | jq -r '.file_id')
+            # `strings` drops nulls and non-string types, so a malformed ok:true
+            # response is reported here rather than as a confusing curl failure.
+            UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url | strings')
+            CANDIDATE_ID=$(echo "$RESPONSE" | jq -r '.file_id | strings')
+            if [ -z "$UPLOAD_URL" ] || [ -z "$CANDIDATE_ID" ]; then
+              echo "::warning::attempt $attempt: files.getUploadURLExternal returned ok without a usable upload_url/file_id: $RESPONSE"
+              sleep 5
+              continue
+            fi
 
             HTTP_CODE=$(curl -sS -o "$UPLOAD_OUT" -w '%{http_code}' \
               --connect-timeout 30 --max-time 300 \
@@ -767,6 +770,7 @@ jobs:
           COMPLETE=$(curl -sS -X POST "https://slack.com/api/files.completeUploadExternal" \
             -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
             -H "Content-Type: application/json" \
+            --connect-timeout 10 --max-time 30 \
             -d "$COMPLETE_PAYLOAD") || COMPLETE=""
           if [ "$(echo "$COMPLETE" | jq -r '.ok // empty')" != "true" ]; then
             echo "::warning::files.completeUploadExternal failed: $COMPLETE"

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -531,9 +531,11 @@ def pytest_collection_modifyitems(
 
     The connector suites depend on ``--order-scope=module`` ordering and on
     module-scoped fixtures that drive a whole connector sync, both of which
-    assume a single process. Enterprise-search tests hold no shared state --
+    assume a single process. Most enterprise-search tests hold no shared state --
     each builds its own conversation and the autouse setup only wires clients
-    onto ``self`` -- so they are safe to distribute per test.
+    onto ``self`` -- so they are safe to distribute per test. A module that does
+    share state declares its own ``xdist_group`` (see the search suite, which
+    shares one per-user search history), which this hook leaves alone.
 
     Under ``--dist loadgroup`` all tests carrying the same ``xdist_group`` mark
     run on one worker, so this keeps the connectors serial and in order while
@@ -698,7 +700,19 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Write integration test HTML report under reports/ with timestamp."""
+    """Write integration test HTML report under reports/ with timestamp.
+
+    Controller only. This hook fires in every xdist worker too, and each worker
+    holds just the shard it ran -- so an unguarded write emits one partial report
+    per worker alongside the real one, several of them claiming a green verdict
+    for a run that failed elsewhere. Workers also exit as their queue drains, and
+    the filename is only second-resolution, so two finishing in the same second
+    silently overwrite each other. The controller sees every worker's
+    ``pytest_runtest_logreport``, so its report is already the complete run.
+    """
+    if hasattr(session.config, "workerinput"):
+        return
+
     by_nodeid: Dict[str, TestReportEntry] | None = getattr(
         session.config, "_integration_test_reports_by_nodeid", None,
     )

--- a/integration-tests/conftest.py
+++ b/integration-tests/conftest.py
@@ -533,9 +533,8 @@ def pytest_collection_modifyitems(
     module-scoped fixtures that drive a whole connector sync, both of which
     assume a single process. Most enterprise-search tests hold no shared state --
     each builds its own conversation and the autouse setup only wires clients
-    onto ``self`` -- so they are safe to distribute per test. A module that does
-    share state declares its own ``xdist_group`` (see the search suite, which
-    shares one per-user search history), which this hook leaves alone.
+    onto ``self`` -- so they are safe to distribute per test. One that does share
+    state declares its own ``xdist_group``, which this hook leaves alone.
 
     Under ``--dist loadgroup`` all tests carrying the same ``xdist_group`` mark
     run on one worker, so this keeps the connectors serial and in order while
@@ -700,16 +699,8 @@ def pytest_runtest_logreport(report: pytest.TestReport) -> None:
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Write integration test HTML report under reports/ with timestamp.
-
-    Controller only. This hook fires in every xdist worker too, and each worker
-    holds just the shard it ran -- so an unguarded write emits one partial report
-    per worker alongside the real one, several of them claiming a green verdict
-    for a run that failed elsewhere. Workers also exit as their queue drains, and
-    the filename is only second-resolution, so two finishing in the same second
-    silently overwrite each other. The controller sees every worker's
-    ``pytest_runtest_logreport``, so its report is already the complete run.
-    """
+    """Write integration test HTML report under reports/ with timestamp."""
+    # Controller only -- this fires in every worker too, each holding a partial run.
     if hasattr(session.config, "workerinput"):
         return
 

--- a/integration-tests/response-validation/enterprise-search/search/integration_test_search.py
+++ b/integration-tests/response-validation/enterprise-search/search/integration_test_search.py
@@ -34,11 +34,8 @@ SEARCH_QUERY = "every year asana undertakes which exercise?"
 # CONNECTOR_APP_ID = "ed6d6cc4-70bd-4838-9aeb-488e910c833a"
 SHARE_TARGET_USER_ID = os.getenv("PIPESHUB_TEST_SHARE_TARGET_USER_ID", "").strip()
 
-# Search history is one shared per-user collection, and
-# test_delete_search_history_response_matches_spec wipes all of it. Spread across
-# xdist workers that wipe deletes rows other tests are mid-way through using, so
-# the whole module shares one group and stays on a single worker. Conversations
-# and agents still fan out; nothing outside this file touches search history.
+# Search history is shared per user and the delete-history test wipes all of it,
+# so this module stays on one worker.
 pytestmark = pytest.mark.xdist_group("search-history")
 
 

--- a/integration-tests/response-validation/enterprise-search/search/integration_test_search.py
+++ b/integration-tests/response-validation/enterprise-search/search/integration_test_search.py
@@ -34,6 +34,13 @@ SEARCH_QUERY = "every year asana undertakes which exercise?"
 # CONNECTOR_APP_ID = "ed6d6cc4-70bd-4838-9aeb-488e910c833a"
 SHARE_TARGET_USER_ID = os.getenv("PIPESHUB_TEST_SHARE_TARGET_USER_ID", "").strip()
 
+# Search history is one shared per-user collection, and
+# test_delete_search_history_response_matches_spec wipes all of it. Spread across
+# xdist workers that wipe deletes rows other tests are mid-way through using, so
+# the whole module shares one group and stays on a single worker. Conversations
+# and agents still fan out; nothing outside this file touches search history.
+pytestmark = pytest.mark.xdist_group("search-history")
+
 
 class SearchTestBase:
     """Shared search_client fixture and request timeout."""
@@ -167,23 +174,17 @@ class TestSemanticSearch(SearchTestBase):
         )
 
     def test_archive_unarchive_lifecycle_matches_spec_and_history(self) -> None:
+        search_id = self._create_search()
+
         before_history = self._list_active_history()
         for row in before_history:
             assert row.get("isArchived") is False, (
                 f"active history returned an archived row {row.get('_id')!r}: "
                 f"isArchived={row.get('isArchived')!r}"
             )
-
-        if not before_history:
-            self._create_search()
-            before_history = self._list_active_history()
-            assert before_history, (
-                "active history is still empty after creating a new search"
-            )
-
-        search_id = before_history[0].get("_id")
-        assert search_id, f"active history row is missing `_id`: {before_history[0]!r}"
-        before_count = len(before_history)
+        assert search_id in {row.get("_id") for row in before_history}, (
+            f"newly created search {search_id!r} is missing from active history"
+        )
 
         archive_resp = self.search.archive_search(search_id, timeout=self.timeout)
         assert archive_resp.status_code == 200, (
@@ -208,10 +209,6 @@ class TestSemanticSearch(SearchTestBase):
             f"archived search {search_id!r} should not appear in active history, "
             f"but it did"
         )
-        assert len(after_archive_history) == before_count - 1, (
-            f"active history count should drop by 1 after archive, "
-            f"was {before_count}, now {len(after_archive_history)}"
-        )
 
         unarchive_resp = self.search.unarchive_search(search_id, timeout=self.timeout)
         assert unarchive_resp.status_code == 200, (
@@ -235,10 +232,6 @@ class TestSemanticSearch(SearchTestBase):
         assert search_id in after_unarchive_ids, (
             f"unarchived search {search_id!r} should be back in active history, "
             f"but is missing"
-        )
-        assert len(after_unarchive_history) == before_count, (
-            f"active history count should return to {before_count} after unarchive, "
-            f"got {len(after_unarchive_history)}"
         )
         for row in after_unarchive_history:
             if row.get("_id") == search_id:


### PR DESCRIPTION
Three independent defects behind [run 30844080842](https://github.com/pipeshub-ai/pipeshub-ai/actions/runs/30844080842) (the 2026-08-03 nightly).

## 1. `test_archive_unarchive_lifecycle` races its own suite

```
AssertionError: active history count should return to 1 after unarchive, got 2
```

The test asserted on an **absolute count of the test user's entire search history**, but every sibling test in the class calls `_create_search()` against that same shared per-user collection — and `_PARALLEL_SAFE_PATHS` (`conftest.py:518`) deliberately spreads this suite across all 5 xdist workers.

Neo4j interleaving from the log:

| time | worker | test |
|---|---|---|
| 19:22:54.98 | gw1 | archive_unarchive starts (`before_count = 1`) |
| 19:22:55.61 | gw2 | `test_post_search_with_kb_filter` → +1 row |
| 19:22:56.34 | gw0 | `test_get_search_history` → +1 row |
| 19:22:56.59 | gw1 | **FAILED** |

ArangoDB passed only because the scheduler happened to put the whole file on gw4 sequentially (20:41:31→20:41:36). Nothing about the backend was involved.

**Fix.** The count assertions are deleted. They never covered anything the id-membership assertions (`search_id not in after_archive_ids` / `search_id in after_unarchive_ids`) didn't already cover — they only added a dependency on rows the test doesn't own. The test also used to archive `before_history[0]`, an arbitrary row it never created; it now creates the search it archives.

The module additionally takes an `xdist_group`, because `test_delete_search_history` wipes history globally and asserts `== []`. No amount of scoping makes that safe next to concurrent workers.

## 2. One HTML report per xdist worker

`pytest_sessionfinish` had no worker guard, so it fired in all 5 workers **and** the controller. That run produced 11 HTML files for two backends:

```
neo4j:  67 + 85 + 96 + 98 + 441 = 787  (worker shards)  +  787  (controller)
arango: 85 + 49 + 108 + 441     = 683  (one shard lost) +  787  (controller)
```

Four of the neo4j files report `Verdict: PASSED` for a run that failed. Arango's shards don't sum to 787 because two workers finished within the same second and the second-resolution filename silently overwrote one. The controller report was always the complete run.

## 3. Slack upload failed silently

The `upload_url` POST was unchecked:

```bash
curl -s -X POST "$UPLOAD_URL" -F "file=@reports.zip"
```

It returned a CloudFront **504 Gateway Timeout** after 30.8s (`21:19:07.560` → `21:19:38.370` — the default origin response timeout). `files.completeUploadExternal` then returned `ok:true` for a file with no bytes behind it, the step stayed green, and no zip ever appeared in the channel.

Size was not the trigger — the manual run 4.5h earlier pushed a **larger** zip (7,702,804 B vs 7,607,581 B) through the same endpoint successfully. Slack's limit is 1 GB. The failure is throughput-dependent, not size-dependent.

The step now checks the HTTP status and retries the whole attempt up to 3× with a fresh `upload_url` each time (a consumed one can't be reused), and checks `completeUploadExternal`'s `ok`. It still exits 0 on failure so it never masks the test result.

## Scope check

Only `response-validation/enterprise-search` is exempt from the serial pin, so this race class is confined to those 7 files. Every count/emptiness assertion in them was reviewed; the rest are correctly scoped to rows they own (`integration_test_conversation.py:626` passes `conversationId=`; `agent_conversation_listing.py:946` queries a `missing-agent-{uuid4}` key; `:636/:661` rely on `agentLimit=1`). Nothing outside `integration_test_search.py` touches search history.

## Verification

- xdist routing: 11 search tests → `search-history`, 335 conversation/agent tests still spread, knowledgebase still `serial`
- `-n 3` run now writes 1 HTML report, not 4
- workflow YAML parses; the step's bash body passes `bash -n`
- ruff reports the same 6 pre-existing errors as `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved integration test report upload reliability with retries, timeouts, response validation, and warnings when uploads fail.
  - Prevented incomplete or conflicting HTML reports during parallel test runs.
  - Improved search-history test reliability by isolating related tests and using test-owned history entries.

- **Tests**
  - Updated parallel test execution guidance for scenarios involving shared state.
  - Improved report generation consistency across distributed test workers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->