### PR TITLE
feat(mail): deliver email asynchronously via the message broker

### DIFF
--- a/backend/nodejs/apps/src/app.ts
+++ b/backend/nodejs/apps/src/app.ts
@@ -550,7 +550,6 @@ export class Application {
     })();
   }
 
-  /** Starts the mail consumer so SMTP delivery happens off the request path. */
   private bootstrapMailBrokerConsumer(): void {
     void (async () => {
       try {
@@ -559,7 +558,7 @@ export class Application {
         await consumer.start();
         await consumer.subscribe([BrokerTopic.MAIL_EVENTS], false);
         await consumer.consume(async () => {
-          /* delivery + retry + failure notification implemented in MailConsumer */
+          /* delivery, retry and failure notification live in MailConsumer */
         });
       } catch (error) {
         this.logger.error('Mail broker consumer failed to start', {

--- a/backend/nodejs/apps/src/app.ts
+++ b/backend/nodejs/apps/src/app.ts
@@ -51,6 +51,8 @@ import { KeyValueStoreService } from './libs/services/keyValueStore.service';
 import { StorageContainer } from './modules/storage/container/storage.container';
 import { NotificationContainer } from './modules/notification/container/notification.container';
 import { NotificationConsumer } from './modules/notification/service/notification.consumer';
+import { MailConsumer } from './modules/mail/services/mail.consumer';
+import { BrokerTopic } from './libs/types/messaging.types';
 import { createNotificationRouter } from './modules/notification/routes/notification.routes';
 import {
   loadAppConfig,
@@ -232,6 +234,7 @@ export class Application {
       this.desktopProxySocketGateway.initialize(this.server);
 
       this.bootstrapNotificationBrokerConsumer();
+      this.bootstrapMailBrokerConsumer();
 
       // Serve static frontend files\
       this.app.use(express.static(path.join(__dirname, 'public')));
@@ -546,6 +549,25 @@ export class Application {
     })();
   }
 
+  /** Starts the mail consumer so SMTP delivery happens off the request path. */
+  private bootstrapMailBrokerConsumer(): void {
+    void (async () => {
+      try {
+        const consumer =
+          this.mailServiceContainer.get<MailConsumer>(MailConsumer);
+        await consumer.start();
+        await consumer.subscribe([BrokerTopic.MAIL_EVENTS], false);
+        await consumer.consume(async () => {
+          /* delivery + retry + failure notification implemented in MailConsumer */
+        });
+      } catch (error) {
+        this.logger.error('Mail broker consumer failed to start', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+  }
+
   async start(): Promise<void> {
     try {
       await new Promise<void>((resolve) => {
@@ -577,6 +599,15 @@ export class Application {
         await notificationConsumer.stop();
       } catch (err) {
         this.logger.warn('NotificationConsumer not available during shutdown', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      try {
+        const mailConsumer =
+          this.mailServiceContainer.get<MailConsumer>(MailConsumer);
+        await mailConsumer.stop();
+      } catch (err) {
+        this.logger.warn('MailConsumer not available during shutdown', {
           error: err instanceof Error ? err.message : String(err),
         });
       }

--- a/backend/nodejs/apps/src/app.ts
+++ b/backend/nodejs/apps/src/app.ts
@@ -52,6 +52,7 @@ import { StorageContainer } from './modules/storage/container/storage.container'
 import { NotificationContainer } from './modules/notification/container/notification.container';
 import { NotificationConsumer } from './modules/notification/service/notification.consumer';
 import { MailConsumer } from './modules/mail/services/mail.consumer';
+import { MailSenderService } from './modules/mail/services/mail.sender.service';
 import { BrokerTopic } from './libs/types/messaging.types';
 import { createNotificationRouter } from './modules/notification/routes/notification.routes';
 import {
@@ -606,6 +607,9 @@ export class Application {
         const mailConsumer =
           this.mailServiceContainer.get<MailConsumer>(MailConsumer);
         await mailConsumer.stop();
+        this.mailServiceContainer
+          .get<MailSenderService>(MailSenderService)
+          .close();
       } catch (err) {
         this.logger.warn('MailConsumer not available during shutdown', {
           error: err instanceof Error ? err.message : String(err),

--- a/backend/nodejs/apps/src/app.ts
+++ b/backend/nodejs/apps/src/app.ts
@@ -607,11 +607,17 @@ export class Application {
         const mailConsumer =
           this.mailServiceContainer.get<MailConsumer>(MailConsumer);
         await mailConsumer.stop();
+      } catch (err) {
+        this.logger.warn('MailConsumer not available during shutdown', {
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+      try {
         this.mailServiceContainer
           .get<MailSenderService>(MailSenderService)
           .close();
       } catch (err) {
-        this.logger.warn('MailConsumer not available during shutdown', {
+        this.logger.warn('MailSenderService not available during shutdown', {
           error: err instanceof Error ? err.message : String(err),
         });
       }

--- a/backend/nodejs/apps/src/libs/services/message-broker.factory.ts
+++ b/backend/nodejs/apps/src/libs/services/message-broker.factory.ts
@@ -195,6 +195,40 @@ export function createNotificationMessageConsumer(
   );
 }
 
+const MAIL_CONSUMER_GROUP = 'mail-consumer-group';
+const MAIL_CLIENT_ID = 'mail-consumer';
+
+/** Dedicated consumer group/stream group for the mail topic (Kafka + Redis). */
+export function createMailMessageConsumer(
+  appConfig: AppConfig,
+  logger: Logger,
+): IMessageConsumer {
+  const resolved = resolveMessageBrokerConfig(appConfig);
+  if (resolved.type === MessageBrokerType.KAFKA) {
+    const kafka: KafkaConfig = {
+      ...resolved.kafka,
+      clientId: MAIL_CLIENT_ID,
+      groupId: MAIL_CONSUMER_GROUP,
+    };
+    return createMessageConsumerByParts(
+      MessageBrokerType.KAFKA,
+      kafka,
+      undefined,
+      logger,
+    );
+  }
+  const redis = buildRedisBrokerConfig(appConfig.redis, {
+    clientId: MAIL_CLIENT_ID,
+    groupId: MAIL_CONSUMER_GROUP,
+  });
+  return createMessageConsumerByParts(
+    MessageBrokerType.REDIS,
+    undefined,
+    redis,
+    logger,
+  );
+}
+
 export function buildRedisBrokerConfig(
   redisConfig: RedisConfig,
   options?: { clientId?: string; groupId?: string },

--- a/backend/nodejs/apps/src/libs/types/messaging.types.ts
+++ b/backend/nodejs/apps/src/libs/types/messaging.types.ts
@@ -14,6 +14,7 @@ export enum BrokerTopic {
   HEALTH_CHECK = 'health-check',
   TOKEN_EVENTS = 'token-events',
   NOTIFICATION = 'notification',
+  MAIL_EVENTS = 'mail-events',
 }
 
 /**
@@ -30,6 +31,7 @@ export interface BrokerTopicPayloadMap {
   [BrokerTopic.HEALTH_CHECK]: { type: string; timestamp: number };
   [BrokerTopic.TOKEN_EVENTS]: Record<string, unknown>;
   [BrokerTopic.NOTIFICATION]: Record<string, unknown>;
+  [BrokerTopic.MAIL_EVENTS]: Record<string, unknown>;
 }
 
 export interface MessageBrokerConfig {

--- a/backend/nodejs/apps/src/modules/auth/controller/userAccount.controller.ts
+++ b/backend/nodejs/apps/src/modules/auth/controller/userAccount.controller.ts
@@ -231,18 +231,25 @@ export class UserAccountController {
         const org = await Org.findOne({ _id: orgId, isDeleted: false });
         const user = await Users.findOne({ _id: userId, orgId, isDeleted: false });
 
-        await this.mailService.sendMail({
-          emailTemplateType: 'suspiciousLoginAttempt',
-          initiator: {
-            jwtAuthToken: mailJwtGenerator(email, this.config.scopedJwtSecret),
-          },
-          usersMails: [email],
-          subject: 'Alert : Suspicious Login Attempt Detected',
-          templateData: {
-            orgName: org?.shortName || org?.registeredName,
-            name: user?.fullName,
-          },
-        });
+        try {
+          await this.mailService.sendMail({
+            emailTemplateType: 'suspiciousLoginAttempt',
+            initiator: {
+              jwtAuthToken: mailJwtGenerator(email, this.config.scopedJwtSecret),
+            },
+            usersMails: [email],
+            subject: 'Alert : Suspicious Login Attempt Detected',
+            templateData: {
+              orgName: org?.shortName || org?.registeredName,
+              name: user?.fullName,
+            },
+          });
+        } catch (mailError) {
+          this.logger.error('Failed to send suspicious login alert', {
+            error:
+              mailError instanceof Error ? mailError.message : String(mailError),
+          });
+        }
         throw new UnauthorizedError(
           'Too many login attempts. Account Blocked.',
         );
@@ -1078,18 +1085,25 @@ export class UserAccountController {
         userCredentials.blockExpiresAt = new Date(Date.now() + BLOCK_COOLDOWN_DURATION_MS);
         await userCredentials.save();
 
-        await this.mailService.sendMail({
-          emailTemplateType: 'suspiciousLoginAttempt',
-          initiator: {
-            jwtAuthToken: mailJwtGenerator(email, this.config.scopedJwtSecret),
-          },
-          usersMails: [email],
-          subject: 'Alert : Suspicious Login Attempt Detected',
-          templateData: {
-            orgName: org?.shortName || org?.registeredName,
-            name: user.fullName,
-          },
-        });
+        try {
+          await this.mailService.sendMail({
+            emailTemplateType: 'suspiciousLoginAttempt',
+            initiator: {
+              jwtAuthToken: mailJwtGenerator(email, this.config.scopedJwtSecret),
+            },
+            usersMails: [email],
+            subject: 'Alert : Suspicious Login Attempt Detected',
+            templateData: {
+              orgName: org?.shortName || org?.registeredName,
+              name: user.fullName,
+            },
+          });
+        } catch (mailError) {
+          this.logger.error('Failed to send suspicious login alert', {
+            error:
+              mailError instanceof Error ? mailError.message : String(mailError),
+          });
+        }
       }
       throw new BadRequestError(
         "Incorrect password, please try again."

--- a/backend/nodejs/apps/src/modules/auth/services/mail.service.ts
+++ b/backend/nodejs/apps/src/modules/auth/services/mail.service.ts
@@ -13,6 +13,8 @@ interface SendMailResponse {
   data: any;
 }
 
+const SEND_MAIL_TIMEOUT_MS = 30_000;
+
 @injectable()
 export class MailService {
   constructor(
@@ -64,6 +66,7 @@ export class MailService {
           'Content-Type': 'application/json',
         },
         data,
+        timeout: SEND_MAIL_TIMEOUT_MS,
       };
 
       const response = await axios(config);

--- a/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
+++ b/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
@@ -126,14 +126,22 @@ export class MailServiceContainer {
             await consumer.disconnect();
           }
         }
+      } catch (error) {
+        this.logger.warn('Mail consumer failed to disconnect during shutdown', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      try {
         if (c.isBound('MessageProducer')) {
           const producer = c.get<IMessageProducer>('MessageProducer');
           if (producer.isConnected()) {
             await producer.disconnect();
           }
         }
-      } catch {
-        // ignore disconnect errors during shutdown
+      } catch (error) {
+        this.logger.warn('Mail producer failed to disconnect during shutdown', {
+          error: error instanceof Error ? error.message : String(error),
+        });
       }
       this.instance = null!;
       this.logger.info('Mail Services Successfully disconnected');

--- a/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
+++ b/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
@@ -4,6 +4,19 @@ import { MailController } from '../controller/mail.controller';
 import { AuthTokenService } from '../../../libs/services/authtoken.service';
 import { AuthMiddleware } from '../../../libs/middlewares/auth.middleware';
 import { AppConfig } from '../../tokens_manager/config/config';
+import {
+  IMessageConsumer,
+  IMessageProducer,
+} from '../../../libs/types/messaging.types';
+import {
+  createMailMessageConsumer,
+  createMessageProducer,
+  resolveMessageBrokerConfig,
+} from '../../../libs/services/message-broker.factory';
+import { MailSenderService } from '../services/mail.sender.service';
+import { MailConsumer } from '../services/mail.consumer';
+import { MailProducer } from '../services/mail.producer';
+import { NotificationProducer } from '../../notification/service/notification.producer';
 
 const loggerConfig = {
   service: 'Mail Service',
@@ -30,8 +43,41 @@ export class MailServiceContainer {
     appConfig: AppConfig,
   ): Promise<void> {
     try {
+      // Producer for failure notifications, consumer for mail jobs. The mail
+      // topic gets its own consumer group so it tracks offsets independently
+      // of the notification consumer.
+      const messageProducer = createMessageProducer(
+        resolveMessageBrokerConfig(appConfig),
+        container.get('Logger'),
+      );
+      await messageProducer.connect();
+      container
+        .bind<IMessageProducer>('MessageProducer')
+        .toConstantValue(messageProducer);
+
+      const messageConsumer: IMessageConsumer = createMailMessageConsumer(
+        appConfig,
+        container.get('Logger'),
+      );
+      container
+        .bind<IMessageConsumer>('MessageConsumer')
+        .toConstantValue(messageConsumer);
+
+      container
+        .bind<() => AppConfig>('AppConfigProvider')
+        .toConstantValue(() => container.get<AppConfig>('AppConfig'));
+
+      container.bind(MailSenderService).toSelf().inSingletonScope();
+      container.bind(MailProducer).toSelf().inSingletonScope();
+      container.bind(NotificationProducer).toSelf().inSingletonScope();
+      container.bind(MailConsumer).toSelf().inSingletonScope();
+
       container.bind<MailController>('MailController').toDynamicValue(() => {
-        return new MailController(appConfig, container.get('Logger'));
+        return new MailController(
+          appConfig,
+          container.get('Logger'),
+          container.get<MailSenderService>(MailSenderService),
+        );
       });
       const jwtSecret = appConfig.jwtSecret;
       const scopedJwtSecret = appConfig.scopedJwtSecret;
@@ -61,6 +107,23 @@ export class MailServiceContainer {
 
   static async dispose(): Promise<void> {
     if (this.instance) {
+      const c = this.instance;
+      try {
+        if (c.isBound('MessageConsumer')) {
+          const consumer = c.get<IMessageConsumer>('MessageConsumer');
+          if (consumer.isConnected()) {
+            await consumer.disconnect();
+          }
+        }
+        if (c.isBound('MessageProducer')) {
+          const producer = c.get<IMessageProducer>('MessageProducer');
+          if (producer.isConnected()) {
+            await producer.disconnect();
+          }
+        }
+      } catch {
+        // ignore disconnect errors during shutdown
+      }
       this.instance = null!;
       this.logger.info('Mail Services Successfully disconnected');
     }

--- a/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
+++ b/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
@@ -43,34 +43,47 @@ export class MailServiceContainer {
     appConfig: AppConfig,
   ): Promise<void> {
     try {
-      // Producer for failure notifications, consumer for mail jobs. The mail
-      // topic gets its own consumer group so it tracks offsets independently
-      // of the notification consumer.
-      const messageProducer = createMessageProducer(
-        resolveMessageBrokerConfig(appConfig),
-        container.get('Logger'),
-      );
-      await messageProducer.connect();
-      container
-        .bind<IMessageProducer>('MessageProducer')
-        .toConstantValue(messageProducer);
-
-      const messageConsumer: IMessageConsumer = createMailMessageConsumer(
-        appConfig,
-        container.get('Logger'),
-      );
-      container
-        .bind<IMessageConsumer>('MessageConsumer')
-        .toConstantValue(messageConsumer);
-
       container
         .bind<() => AppConfig>('AppConfigProvider')
         .toConstantValue(() => container.get<AppConfig>('AppConfig'));
 
       container.bind(MailSenderService).toSelf().inSingletonScope();
-      container.bind(MailProducer).toSelf().inSingletonScope();
-      container.bind(NotificationProducer).toSelf().inSingletonScope();
-      container.bind(MailConsumer).toSelf().inSingletonScope();
+
+      try {
+        // Producer for failure notifications, consumer for mail jobs. The mail
+        // topic gets its own consumer group so it tracks offsets independently
+        // of the notification consumer.
+        const messageProducer = createMessageProducer(
+          resolveMessageBrokerConfig(appConfig),
+          container.get('Logger'),
+        );
+        await messageProducer.connect();
+        container
+          .bind<IMessageProducer>('MessageProducer')
+          .toConstantValue(messageProducer);
+
+        const messageConsumer: IMessageConsumer = createMailMessageConsumer(
+          appConfig,
+          container.get('Logger'),
+        );
+        container
+          .bind<IMessageConsumer>('MessageConsumer')
+          .toConstantValue(messageConsumer);
+
+        container.bind(MailProducer).toSelf().inSingletonScope();
+        container.bind(NotificationProducer).toSelf().inSingletonScope();
+        container.bind(MailConsumer).toSelf().inSingletonScope();
+      } catch (brokerError) {
+        container.get<Logger>('Logger').warn(
+          'Mail broker unavailable; async delivery is disabled until restart',
+          {
+            error:
+              brokerError instanceof Error
+                ? brokerError.message
+                : String(brokerError),
+          },
+        );
+      }
 
       container.bind<MailController>('MailController').toDynamicValue(() => {
         return new MailController(

--- a/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
+++ b/backend/nodejs/apps/src/modules/mail/container/mailService.container.ts
@@ -50,9 +50,7 @@ export class MailServiceContainer {
       container.bind(MailSenderService).toSelf().inSingletonScope();
 
       try {
-        // Producer for failure notifications, consumer for mail jobs. The mail
-        // topic gets its own consumer group so it tracks offsets independently
-        // of the notification consumer.
+        // Own consumer group, so mail offsets track independently of notifications.
         const messageProducer = createMessageProducer(
           resolveMessageBrokerConfig(appConfig),
           container.get('Logger'),

--- a/backend/nodejs/apps/src/modules/mail/controller/mail.controller.ts
+++ b/backend/nodejs/apps/src/modules/mail/controller/mail.controller.ts
@@ -3,26 +3,21 @@ import {
   InternalServerError,
   NotFoundError,
 } from '../../../libs/errors/http.errors';
-import { EmailTemplateType, MailBody, SmtpConfig } from '../middlewares/types';
-import { MailModel } from '../schema/mailInfo.schema';
-import {
-  accountCreation,
-  appUserInvite,
-  loginWithOTPRequest,
-  resetEmail,
-  resetPassword,
-  suspiciousLoginAttempt,
-} from '../utils/emailTemplates';
-import nodemailer from 'nodemailer';
+import { MailBody, SmtpConfig } from '../middlewares/types';
 import { inject, injectable } from 'inversify';
 import { Logger } from '../../../libs/services/logger.service';
 import { AppConfig } from '../../tokens_manager/config/config';
+import { getEmailContent } from '../utils/email-content';
+import { MailSenderService } from '../services/mail.sender.service';
+
 @injectable()
 export class MailController {
   constructor(
     @inject('AppConfig') private config: AppConfig,
     @inject('Logger') private logger: Logger,
+    @inject(MailSenderService) private readonly sender: MailSenderService,
   ) {}
+
   async sendMail(
     req: Request,
     res: Response,
@@ -50,89 +45,18 @@ export class MailController {
     emailTemplateType: string,
     templateData: Record<string, any>,
   ) {
-    let emailContent;
     this.logger.debug('emailTemplateType', emailTemplateType);
-    switch (emailTemplateType) {
-      case EmailTemplateType.LoginWithOtp:
-        emailContent = loginWithOTPRequest(templateData);
-        return emailContent;
-
-      case EmailTemplateType.AccountCreation:
-        emailContent = accountCreation(templateData);
-        return emailContent;
-
-      case EmailTemplateType.SuspiciousLoginAttempt:
-        emailContent = suspiciousLoginAttempt(templateData);
-        return emailContent;
-
-      case EmailTemplateType.ResetPassword:
-        emailContent = resetPassword(templateData);
-        return emailContent;
-      case EmailTemplateType.ResetEmail:
-        emailContent = resetEmail(templateData);
-        return emailContent;
-
-      case EmailTemplateType.AppuserInvite:
-        emailContent = appUserInvite(templateData);
-        return emailContent;
-
-      default:
-        throw 'Unknown Template';
-    }
+    return getEmailContent(emailTemplateType, templateData);
   }
 
+  /**
+   * Retained so the direct HTTP route keeps its existing contract; delivery
+   * itself lives in MailSenderService, shared with the broker consumer.
+   */
   async emailSender(bodyData: MailBody, smtpConfig: SmtpConfig) {
-    try {
-      const fromEmailDomain = smtpConfig.fromEmail;
-      const attachments = bodyData.attachments || [];
-      const emailContent = this.getEmailContent(
-        bodyData.emailTemplateType!,
-        bodyData.templateData!,
-      );
-      const transporter = nodemailer.createTransport({
-        host: smtpConfig.host,
-        port: smtpConfig.port || 587,
-        secure: false,
-        ...(smtpConfig.password
-          ? {
-            auth: {
-              user: smtpConfig.username,
-              pass: smtpConfig.password, // Included only if password exists
-            },
-          }
-          : {
-            auth: {
-              user: smtpConfig.username, // Include only the username
-            },
-          }),
-      });
-
-      await transporter.sendMail({
-        from: fromEmailDomain,
-        to: bodyData.sendEmailTo,
-        cc: bodyData.sendCcTo,
-        subject: bodyData.subject,
-        html: emailContent,
-        attachments: attachments,
-      });
-
-      const mailEntry = new MailModel({
-        subject: bodyData.subject,
-        from: bodyData.fromEmailDomain,
-        to: bodyData.sendEmailTo,
-        cc: bodyData.sendCcTo ? bodyData.sendCcTo : [],
-        emailTemplateType: bodyData.emailTemplateType,
-      });
-
-      await mailEntry.save();
-
-      return { status: true, data: 'Email sent' };
-    } catch (error) {
-      this.logger.error('Mail send error', { error });
-      return {
-        status: false,
-        data: error instanceof Error ? error.message : (typeof error === 'string' ? error : 'Failed to send email'),
-      };
-    }
+    const result = await this.sender.send(bodyData, smtpConfig);
+    return result.status === 'sent'
+      ? { status: true, data: 'Email sent' }
+      : { status: false, data: result.error };
   }
 }

--- a/backend/nodejs/apps/src/modules/mail/controller/mail.controller.ts
+++ b/backend/nodejs/apps/src/modules/mail/controller/mail.controller.ts
@@ -8,7 +8,10 @@ import { inject, injectable } from 'inversify';
 import { Logger } from '../../../libs/services/logger.service';
 import { AppConfig } from '../../tokens_manager/config/config';
 import { getEmailContent } from '../utils/email-content';
-import { MailSenderService } from '../services/mail.sender.service';
+import {
+  MailSenderService,
+  SMTP_SYNC_SEND_DEADLINE_MS,
+} from '../services/mail.sender.service';
 
 @injectable()
 export class MailController {
@@ -54,7 +57,13 @@ export class MailController {
    * itself lives in MailSenderService, shared with the broker consumer.
    */
   async emailSender(bodyData: MailBody, smtpConfig: SmtpConfig) {
-    const result = await this.sender.send(bodyData, smtpConfig);
+    // Shorter deadline than the consumer's: this path has an HTTP caller
+    // waiting, and it must fail here before that caller times out.
+    const result = await this.sender.send(
+      bodyData,
+      smtpConfig,
+      SMTP_SYNC_SEND_DEADLINE_MS,
+    );
     return result.status === 'sent'
       ? { status: true, data: 'Email sent' }
       : { status: false, data: result.error };

--- a/backend/nodejs/apps/src/modules/mail/controller/mail.controller.ts
+++ b/backend/nodejs/apps/src/modules/mail/controller/mail.controller.ts
@@ -52,13 +52,9 @@ export class MailController {
     return getEmailContent(emailTemplateType, templateData);
   }
 
-  /**
-   * Retained so the direct HTTP route keeps its existing contract; delivery
-   * itself lives in MailSenderService, shared with the broker consumer.
-   */
+  /** Kept so the direct HTTP route keeps its existing contract. */
   async emailSender(bodyData: MailBody, smtpConfig: SmtpConfig) {
-    // Shorter deadline than the consumer's: this path has an HTTP caller
-    // waiting, and it must fail here before that caller times out.
+    // Must fail before the HTTP caller waiting on this route times out.
     const result = await this.sender.send(
       bodyData,
       smtpConfig,

--- a/backend/nodejs/apps/src/modules/mail/routes/mail.routes.ts
+++ b/backend/nodejs/apps/src/modules/mail/routes/mail.routes.ts
@@ -9,6 +9,7 @@ import { AuthenticatedServiceRequest } from '../../../libs/middlewares/types';
 import { smtpConfigChecker } from '../middlewares/checkSmtpConfig';
 import { TokenScopes } from '../../../libs/enums/token-scopes.enum';
 import { AppConfig, loadAppConfig } from '../../tokens_manager/config/config';
+import { MailSenderService } from '../services/mail.sender.service';
 export const smtpConfigSchema = z.object({
   body: z.object({
     host: z.string().min(1, { message: 'SMTP host is required' }),
@@ -58,7 +59,11 @@ export function createMailServiceRouter(container: Container) {
         container
           .rebind<MailController>('MailController')
           .toDynamicValue(() => {
-            return new MailController(updatedConfig, container.get('Logger'));
+            return new MailController(
+              updatedConfig,
+              container.get('Logger'),
+              container.get<MailSenderService>(MailSenderService),
+            );
           });
         mailController = container.get<MailController>('MailController');
 

--- a/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
@@ -15,22 +15,17 @@ import { MailEventPayload, MailSendResult } from '../types/mail-event.types';
 const MAX_ATTEMPTS = 4;
 const BASE_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
-// One bad SMTP server during a 1000-address import would otherwise raise a
-// notification per recipient, per admin. Collapse them into one per org per
-// window and carry the suppressed count on the next one.
+// Without this, one bad SMTP server during a 1000-address import raises a
+// notification per recipient, per admin.
 const FAILURE_NOTIFY_WINDOW_MS = 5 * 60_000;
 
 /**
- * Consumes mail jobs and delivers them off the request path.
- *
- * Retries transient failures with exponential backoff in-handler rather than
- * relying on redelivery: the shared consumer base auto-commits offsets and
- * swallows handler errors, so a thrown error would drop the job instead of
- * replaying it.
+ * Delivers mail jobs off the request path. Retries in-handler rather than by
+ * redelivery: the consumer base auto-commits offsets and swallows handler
+ * errors, so throwing would drop the job instead of replaying it.
  */
 @injectable()
 export class MailConsumer {
-  /** Per-org throttle state for failure notifications. */
   private readonly failureNotifyState = new Map<
     string,
     { last: number; suppressed: number }
@@ -94,11 +89,10 @@ export class MailConsumer {
     });
   }
 
-  /** Delivers one job, retrying transient failures before giving up. */
   private async deliver(payload: MailEventPayload): Promise<void> {
     const smtpConfig = this.sender.getSmtpConfig();
     if (!smtpConfig) {
-      // Not retryable: nothing can be delivered until an admin configures SMTP.
+      // Not retryable until an admin configures SMTP.
       this.logger.error('Mail event dropped: SMTP configuration not set');
       await this.notifyFailure(payload, 'SMTP configuration not set');
       return;
@@ -170,11 +164,7 @@ export class MailConsumer {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
-  /**
-   * Tells org admins the mail never went out. Requires an orgId — the
-   * notification pipeline drops events without one — so jobs published without
-   * an org (e.g. pre-login flows) are logged only.
-   */
+  /** Needs an orgId: the notification pipeline drops events without one. */
   private async notifyFailure(
     payload: MailEventPayload,
     error: string,

--- a/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
@@ -1,0 +1,201 @@
+import { inject, injectable } from 'inversify';
+import {
+  IMessageConsumer,
+  StreamMessage,
+} from '../../../libs/types/messaging.types';
+import { Logger } from '../../../libs/services/logger.service';
+import {
+  NotificationProducer,
+  EventType as NotificationEventType,
+} from '../../notification/service/notification.producer';
+import { INotification } from '../../notification/schema/notification.schema';
+import { MailSenderService } from './mail.sender.service';
+import { MailEventPayload, MailSendResult } from '../types/mail-event.types';
+
+const MAX_ATTEMPTS = 4;
+const BASE_BACKOFF_MS = 1_000;
+const MAX_BACKOFF_MS = 30_000;
+
+/**
+ * Consumes mail jobs and delivers them off the request path.
+ *
+ * Retries transient failures with exponential backoff in-handler rather than
+ * relying on redelivery: the shared consumer base auto-commits offsets and
+ * swallows handler errors, so a thrown error would drop the job instead of
+ * replaying it.
+ */
+@injectable()
+export class MailConsumer {
+  constructor(
+    @inject('MessageConsumer') private readonly consumer: IMessageConsumer,
+    @inject('Logger') private readonly logger: Logger,
+    @inject(MailSenderService) private readonly sender: MailSenderService,
+    @inject(NotificationProducer)
+    private readonly notificationProducer: NotificationProducer,
+  ) {}
+
+  async start(): Promise<void> {
+    if (!this.consumer.isConnected()) {
+      await this.consumer.connect();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.consumer.isConnected()) {
+      await this.consumer.disconnect();
+    }
+  }
+
+  isConnected(): boolean {
+    return this.consumer.isConnected();
+  }
+
+  async subscribe(topics: string[], fromBeginning = false): Promise<void> {
+    if (this.consumer.isConnected()) {
+      await this.consumer.subscribe(topics, fromBeginning);
+    }
+  }
+
+  async consume<T>(
+    handler: (message: StreamMessage<T>) => Promise<void>,
+  ): Promise<void> {
+    if (!this.consumer.isConnected()) {
+      this.logger.error('Cannot consume mail events: MessageConsumer is not connected');
+      throw new Error('MessageConsumer is not connected');
+    }
+
+    await this.consumer.consume(async (message: StreamMessage<T>) => {
+      try {
+        const payload = message.value as MailEventPayload;
+        if (!payload?.mail?.emailTemplateType) {
+          this.logger.warn('Mail event skipped: invalid payload', {
+            value: message.value,
+          });
+          return;
+        }
+        await this.deliver(payload);
+      } catch (error) {
+        this.logger.error('Failed to process mail event', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      } finally {
+        await handler(message);
+      }
+    });
+  }
+
+  /** Delivers one job, retrying transient failures before giving up. */
+  private async deliver(payload: MailEventPayload): Promise<void> {
+    const smtpConfig = this.sender.getSmtpConfig();
+    if (!smtpConfig) {
+      // Not retryable: nothing can be delivered until an admin configures SMTP.
+      this.logger.error('Mail event dropped: SMTP configuration not set');
+      await this.notifyFailure(payload, 'SMTP configuration not set');
+      return;
+    }
+
+    let attempt = 0;
+    let lastError = 'unknown error';
+
+    while (attempt < MAX_ATTEMPTS) {
+      attempt += 1;
+      const result: MailSendResult = await this.sender.send(
+        payload.mail,
+        smtpConfig,
+      );
+
+      if (result.status === 'sent') {
+        this.logger.info('Mail sent', {
+          emailTemplateType: payload.mail.emailTemplateType,
+          attempt,
+        });
+        return;
+      }
+
+      lastError = result.error;
+
+      if (result.status === 'permanent') {
+        this.logger.error('Mail permanently failed; not retrying', {
+          emailTemplateType: payload.mail.emailTemplateType,
+          error: lastError,
+          attempt,
+        });
+        await this.notifyFailure(payload, lastError);
+        return;
+      }
+
+      if (attempt < MAX_ATTEMPTS) {
+        const delay = Math.min(
+          BASE_BACKOFF_MS * 2 ** (attempt - 1),
+          MAX_BACKOFF_MS,
+        );
+        this.logger.warn('Mail send failed; retrying', {
+          emailTemplateType: payload.mail.emailTemplateType,
+          error: lastError,
+          attempt,
+          nextRetryInMs: delay,
+        });
+        await this.sleep(delay);
+      }
+    }
+
+    this.logger.error('Mail failed after all retries', {
+      emailTemplateType: payload.mail.emailTemplateType,
+      error: lastError,
+      attempts: attempt,
+    });
+    await this.notifyFailure(payload, lastError);
+  }
+
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  /**
+   * Tells org admins the mail never went out. Requires an orgId — the
+   * notification pipeline drops events without one — so jobs published without
+   * an org (e.g. pre-login flows) are logged only.
+   */
+  private async notifyFailure(
+    payload: MailEventPayload,
+    error: string,
+  ): Promise<void> {
+    if (!payload.orgId) {
+      this.logger.error('Mail failure not notified: no orgId on the event', {
+        emailTemplateType: payload.mail.emailTemplateType,
+        error,
+      });
+      return;
+    }
+
+    const recipients = payload.mail.sendEmailTo ?? [];
+    try {
+      await this.notificationProducer.start();
+      await this.notificationProducer.publishEvent({
+        eventType: NotificationEventType.NewNotificationEvent,
+        timestamp: Date.now(),
+        payload: {
+          orgId: payload.orgId,
+          type: 'mail.deliveryFailed',
+          recipientRoles: ['admin'],
+          title: 'Email delivery failed',
+          message: `Could not deliver "${payload.mail.subject ?? payload.mail.emailTemplateType}" to ${recipients.join(', ') || 'the recipient'}: ${error}`,
+          severity: 'error',
+          status: 'unread',
+          payload: {
+            emailTemplateType: payload.mail.emailTemplateType,
+            recipients,
+            error,
+          },
+        } as unknown as INotification,
+      });
+    } catch (publishError) {
+      this.logger.error('Failed to publish mail failure notification', {
+        error:
+          publishError instanceof Error
+            ? publishError.message
+            : String(publishError),
+      });
+    }
+  }
+}

--- a/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
@@ -15,6 +15,10 @@ import { MailEventPayload, MailSendResult } from '../types/mail-event.types';
 const MAX_ATTEMPTS = 4;
 const BASE_BACKOFF_MS = 1_000;
 const MAX_BACKOFF_MS = 30_000;
+// One bad SMTP server during a 1000-address import would otherwise raise a
+// notification per recipient, per admin. Collapse them into one per org per
+// window and carry the suppressed count on the next one.
+const FAILURE_NOTIFY_WINDOW_MS = 5 * 60_000;
 
 /**
  * Consumes mail jobs and delivers them off the request path.
@@ -26,6 +30,12 @@ const MAX_BACKOFF_MS = 30_000;
  */
 @injectable()
 export class MailConsumer {
+  /** Per-org throttle state for failure notifications. */
+  private readonly failureNotifyState = new Map<
+    string,
+    { last: number; suppressed: number }
+  >();
+
   constructor(
     @inject('MessageConsumer') private readonly consumer: IMessageConsumer,
     @inject('Logger') private readonly logger: Logger,
@@ -147,6 +157,15 @@ export class MailConsumer {
     await this.notifyFailure(payload, lastError);
   }
 
+  /** Drops idle orgs so the throttle map cannot grow without bound. */
+  private pruneFailureNotifyState(now: number): void {
+    for (const [orgId, entry] of this.failureNotifyState) {
+      if (entry.suppressed === 0 && now - entry.last > FAILURE_NOTIFY_WINDOW_MS) {
+        this.failureNotifyState.delete(orgId);
+      }
+    }
+  }
+
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
@@ -168,7 +187,24 @@ export class MailConsumer {
       return;
     }
 
+    const now = Date.now();
+    const state = this.failureNotifyState.get(payload.orgId);
+    if (state && now - state.last < FAILURE_NOTIFY_WINDOW_MS) {
+      state.suppressed += 1;
+      this.logger.warn('Mail failure notification suppressed', {
+        orgId: payload.orgId,
+        suppressed: state.suppressed,
+        error,
+      });
+      return;
+    }
+    const suppressed = state?.suppressed ?? 0;
+    this.failureNotifyState.set(payload.orgId, { last: now, suppressed: 0 });
+    this.pruneFailureNotifyState(now);
+
     const recipients = payload.mail.sendEmailTo ?? [];
+    const alsoFailed =
+      suppressed > 0 ? ` (${suppressed} further failure(s) suppressed)` : '';
     try {
       await this.notificationProducer.start();
       await this.notificationProducer.publishEvent({
@@ -179,13 +215,14 @@ export class MailConsumer {
           type: 'mail.deliveryFailed',
           recipientRoles: ['admin'],
           title: 'Email delivery failed',
-          message: `Could not deliver "${payload.mail.subject ?? payload.mail.emailTemplateType}" to ${recipients.join(', ') || 'the recipient'}: ${error}`,
+          message: `Could not deliver "${payload.mail.subject ?? payload.mail.emailTemplateType}" to ${recipients.join(', ') || 'the recipient'}: ${error}${alsoFailed}`,
           severity: 'error',
           status: 'unread',
           payload: {
             emailTemplateType: payload.mail.emailTemplateType,
             recipients,
             error,
+            suppressedFailures: suppressed,
           },
         } as unknown as INotification,
       });

--- a/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.consumer.ts
@@ -154,7 +154,7 @@ export class MailConsumer {
   /** Drops idle orgs so the throttle map cannot grow without bound. */
   private pruneFailureNotifyState(now: number): void {
     for (const [orgId, entry] of this.failureNotifyState) {
-      if (entry.suppressed === 0 && now - entry.last > FAILURE_NOTIFY_WINDOW_MS) {
+      if (now - entry.last > FAILURE_NOTIFY_WINDOW_MS) {
         this.failureNotifyState.delete(orgId);
       }
     }

--- a/backend/nodejs/apps/src/modules/mail/services/mail.producer.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.producer.ts
@@ -1,0 +1,58 @@
+import { inject, injectable } from 'inversify';
+import {
+  BrokerTopic,
+  IMessageProducer,
+  StreamMessage,
+} from '../../../libs/types/messaging.types';
+import { Logger } from '../../../libs/services/logger.service';
+import { MailEvent, MailEventPayload } from '../types/mail-event.types';
+
+/** Publishes mail jobs so delivery happens off the request path. */
+@injectable()
+export class MailProducer {
+  private readonly topic = BrokerTopic.MAIL_EVENTS;
+
+  constructor(
+    @inject('MessageProducer') private readonly producer: IMessageProducer,
+    @inject('Logger') private readonly logger: Logger,
+  ) {}
+
+  async start(): Promise<void> {
+    if (!this.producer.isConnected()) {
+      await this.producer.connect();
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (this.producer.isConnected()) {
+      await this.producer.disconnect();
+    }
+  }
+
+  isConnected(): boolean {
+    return this.producer.isConnected();
+  }
+
+  /**
+   * Unlike the notification producer this rethrows: the caller reports the
+   * failure to the user, and swallowing it would silently drop the email.
+   */
+  async publishEvent(event: MailEvent): Promise<void> {
+    const message: StreamMessage<MailEventPayload> = {
+      key: event.payload.orgId ?? event.payload.mail.emailTemplateType,
+      value: event.payload,
+      headers: {
+        eventType: event.eventType,
+        timestamp: event.timestamp.toString(),
+      },
+    };
+
+    // A shared singleton producer can be disconnected by another module's
+    // stop(); start() is idempotent and reconnects so the job is not lost.
+    await this.start();
+    await this.producer.publish(this.topic, message);
+    this.logger.info(
+      `Published event: ${event.eventType} to topic ${this.topic}`,
+    );
+  }
+}

--- a/backend/nodejs/apps/src/modules/mail/services/mail.producer.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.producer.ts
@@ -33,10 +33,7 @@ export class MailProducer {
     return this.producer.isConnected();
   }
 
-  /**
-   * Unlike the notification producer this rethrows: the caller reports the
-   * failure to the user, and swallowing it would silently drop the email.
-   */
+  /** Rethrows, unlike NotificationProducer: swallowing would drop the email. */
   async publishEvent(event: MailEvent): Promise<void> {
     const message: StreamMessage<MailEventPayload> = {
       key: event.payload.orgId ?? event.payload.mail.emailTemplateType,
@@ -47,8 +44,7 @@ export class MailProducer {
       },
     };
 
-    // A shared singleton producer can be disconnected by another module's
-    // stop(); start() is idempotent and reconnects so the job is not lost.
+    // Another module's stop() may have disconnected the shared producer.
     await this.start();
     await this.producer.publish(this.topic, message);
     this.logger.info(

--- a/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
@@ -11,7 +11,8 @@ const SMTP_DNS_TIMEOUT_MS = 30_000;
 const SMTP_CONNECTION_TIMEOUT_MS = 30_000;
 const SMTP_GREETING_TIMEOUT_MS = 30_000;
 const SMTP_SOCKET_TIMEOUT_MS = 60_000;
-const SMTP_SEND_DEADLINE_MS = 120_000;
+export const SMTP_SEND_DEADLINE_MS = 120_000;
+export const SMTP_SYNC_SEND_DEADLINE_MS = 25_000;
 const SMTP_POOL_MAX_CONNECTIONS = 5;
 const SMTP_POOL_MAX_MESSAGES = 100;
 
@@ -85,16 +86,15 @@ export class MailSenderService {
   private async sendWithDeadline(
     transporter: nodemailer.Transporter,
     message: Parameters<nodemailer.Transporter['sendMail']>[0],
+    deadlineMs: number,
   ): Promise<void> {
     let timer: NodeJS.Timeout | undefined;
     let timedOut = false;
     const deadline = new Promise<never>((_resolve, reject) => {
       timer = setTimeout(() => {
         timedOut = true;
-        reject(
-          new Error(`SMTP send exceeded ${SMTP_SEND_DEADLINE_MS}ms deadline`),
-        );
-      }, SMTP_SEND_DEADLINE_MS);
+        reject(new Error(`SMTP send exceeded ${deadlineMs}ms deadline`));
+      }, deadlineMs);
     });
 
     try {
@@ -113,20 +113,28 @@ export class MailSenderService {
    * Sends one message. Never throws for delivery problems — the outcome is
    * returned so the caller can decide between retrying and giving up.
    */
-  async send(bodyData: MailBody, smtpConfig: SmtpConfig): Promise<MailSendResult> {
+  async send(
+    bodyData: MailBody,
+    smtpConfig: SmtpConfig,
+    deadlineMs: number = SMTP_SEND_DEADLINE_MS,
+  ): Promise<MailSendResult> {
     try {
       const emailContent = getEmailContent(
         bodyData.emailTemplateType!,
         bodyData.templateData!,
       );
-      await this.sendWithDeadline(this.getTransporter(smtpConfig), {
-        from: smtpConfig.fromEmail,
-        to: bodyData.sendEmailTo,
-        cc: bodyData.sendCcTo,
-        subject: bodyData.subject,
-        html: emailContent,
-        attachments: bodyData.attachments || [],
-      });
+      await this.sendWithDeadline(
+        this.getTransporter(smtpConfig),
+        {
+          from: smtpConfig.fromEmail,
+          to: bodyData.sendEmailTo,
+          cc: bodyData.sendCcTo,
+          subject: bodyData.subject,
+          html: emailContent,
+          attachments: bodyData.attachments || [],
+        },
+        deadlineMs,
+      );
 
       // The message is already delivered at this point, so a failure to write
       // the audit row must not be reported as a send failure — the caller

--- a/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
@@ -85,21 +85,15 @@ export class MailSenderService {
     deadlineMs: number,
   ): Promise<void> {
     let timer: NodeJS.Timeout | undefined;
-    let timedOut = false;
     const deadline = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(() => {
-        timedOut = true;
-        reject(new Error(`SMTP send exceeded ${deadlineMs}ms deadline`));
-      }, deadlineMs);
+      timer = setTimeout(
+        () => reject(new Error(`SMTP send exceeded ${deadlineMs}ms deadline`)),
+        deadlineMs,
+      );
     });
 
     try {
       await Promise.race([transporter.sendMail(message), deadline]);
-    } catch (error) {
-      if (timedOut) {
-        this.discardTransporter();
-      }
-      throw error;
     } finally {
       clearTimeout(timer);
     }
@@ -111,11 +105,24 @@ export class MailSenderService {
     smtpConfig: SmtpConfig,
     deadlineMs: number = SMTP_SEND_DEADLINE_MS,
   ): Promise<MailSendResult> {
+    let emailContent: string;
     try {
-      const emailContent = getEmailContent(
+      emailContent = getEmailContent(
         bodyData.emailTemplateType!,
         bodyData.templateData!,
       );
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : 'Failed to render email template';
+      this.logger.error('Mail template error', { error: message });
+      return { status: 'permanent', error: message };
+    }
+
+    try {
       await this.sendWithDeadline(
         this.getTransporter(smtpConfig),
         {
@@ -133,7 +140,7 @@ export class MailSenderService {
       try {
         const mailEntry = new MailModel({
           subject: bodyData.subject,
-          from: bodyData.fromEmailDomain,
+          from: smtpConfig.fromEmail,
           to: bodyData.sendEmailTo,
           cc: bodyData.sendCcTo ? bodyData.sendCcTo : [],
           emailTemplateType: bodyData.emailTemplateType,

--- a/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
@@ -1,0 +1,103 @@
+import { inject, injectable } from 'inversify';
+import nodemailer from 'nodemailer';
+import { Logger } from '../../../libs/services/logger.service';
+import { AppConfig } from '../../tokens_manager/config/config';
+import { MailBody, SmtpConfig } from '../middlewares/types';
+import { MailModel } from '../schema/mailInfo.schema';
+import { getEmailContent } from '../utils/email-content';
+import { classifyMailError, MailSendResult } from '../types/mail-event.types';
+
+/**
+ * Owns the actual SMTP delivery. Shared by the HTTP route and the broker
+ * consumer so both paths send mail through exactly one implementation.
+ */
+@injectable()
+export class MailSenderService {
+  constructor(
+    // Resolved per call, not captured: updating SMTP settings rebinds
+    // AppConfig, and this service outlives that rebind as a singleton.
+    @inject('AppConfigProvider')
+    private readonly getAppConfig: () => AppConfig,
+    @inject('Logger') private readonly logger: Logger,
+  ) {}
+
+  /** Resolves the live SMTP config, or null when the org has not set one up. */
+  getSmtpConfig(): SmtpConfig | null {
+    return (this.getAppConfig().smtp as SmtpConfig | undefined) ?? null;
+  }
+
+  /**
+   * Sends one message. Never throws for delivery problems — the outcome is
+   * returned so the caller can decide between retrying and giving up.
+   */
+  async send(bodyData: MailBody, smtpConfig: SmtpConfig): Promise<MailSendResult> {
+    try {
+      const emailContent = getEmailContent(
+        bodyData.emailTemplateType!,
+        bodyData.templateData!,
+      );
+      const transporter = nodemailer.createTransport({
+        host: smtpConfig.host,
+        port: smtpConfig.port || 587,
+        secure: false,
+        ...(smtpConfig.password
+          ? {
+            auth: {
+              user: smtpConfig.username,
+              pass: smtpConfig.password, // Included only if password exists
+            },
+          }
+          : {
+            auth: {
+              user: smtpConfig.username, // Include only the username
+            },
+          }),
+      });
+
+      await transporter.sendMail({
+        from: smtpConfig.fromEmail,
+        to: bodyData.sendEmailTo,
+        cc: bodyData.sendCcTo,
+        subject: bodyData.subject,
+        html: emailContent,
+        attachments: bodyData.attachments || [],
+      });
+
+      // The message is already delivered at this point, so a failure to write
+      // the audit row must not be reported as a send failure — the caller
+      // would retry and the recipient would get a duplicate email.
+      try {
+        const mailEntry = new MailModel({
+          subject: bodyData.subject,
+          from: bodyData.fromEmailDomain,
+          to: bodyData.sendEmailTo,
+          cc: bodyData.sendCcTo ? bodyData.sendCcTo : [],
+          emailTemplateType: bodyData.emailTemplateType,
+        });
+        await mailEntry.save();
+      } catch (persistError) {
+        this.logger.error('Mail sent but audit record failed to save', {
+          error:
+            persistError instanceof Error
+              ? persistError.message
+              : String(persistError),
+        });
+      }
+
+      return { status: 'sent' };
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof error === 'string'
+            ? error
+            : 'Failed to send email';
+      // An unknown template is a caller bug, not an SMTP problem — replaying it
+      // would fail identically, so never classify it as transient.
+      const kind =
+        typeof error === 'string' ? 'permanent' : classifyMailError(error);
+      this.logger.error('Mail send error', { error: message, kind });
+      return { status: kind, error: message };
+    }
+  }
+}

--- a/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
@@ -7,12 +7,22 @@ import { MailModel } from '../schema/mailInfo.schema';
 import { getEmailContent } from '../utils/email-content';
 import { classifyMailError, MailSendResult } from '../types/mail-event.types';
 
+const SMTP_DNS_TIMEOUT_MS = 30_000;
+const SMTP_CONNECTION_TIMEOUT_MS = 30_000;
+const SMTP_GREETING_TIMEOUT_MS = 30_000;
+const SMTP_SOCKET_TIMEOUT_MS = 60_000;
+const SMTP_SEND_DEADLINE_MS = 120_000;
+const SMTP_POOL_MAX_CONNECTIONS = 5;
+const SMTP_POOL_MAX_MESSAGES = 100;
+
 /**
  * Owns the actual SMTP delivery. Shared by the HTTP route and the broker
  * consumer so both paths send mail through exactly one implementation.
  */
 @injectable()
 export class MailSenderService {
+  private pooled?: { key: string; transporter: nodemailer.Transporter };
+
   constructor(
     // Resolved per call, not captured: updating SMTP settings rebinds
     // AppConfig, and this service outlives that rebind as a singleton.
@@ -26,6 +36,79 @@ export class MailSenderService {
     return (this.getAppConfig().smtp as SmtpConfig | undefined) ?? null;
   }
 
+  /** Releases pooled SMTP connections so shutdown is not held open. */
+  close(): void {
+    this.discardTransporter();
+  }
+
+  private getTransporter(smtpConfig: SmtpConfig): nodemailer.Transporter {
+    const key = JSON.stringify([
+      smtpConfig.host,
+      smtpConfig.port,
+      smtpConfig.username,
+      smtpConfig.password,
+    ]);
+    if (this.pooled?.key === key) {
+      return this.pooled.transporter;
+    }
+
+    this.discardTransporter();
+    const transporter = nodemailer.createTransport({
+      host: smtpConfig.host,
+      port: smtpConfig.port || 587,
+      secure: false,
+      pool: true,
+      maxConnections: SMTP_POOL_MAX_CONNECTIONS,
+      maxMessages: SMTP_POOL_MAX_MESSAGES,
+      dnsTimeout: SMTP_DNS_TIMEOUT_MS,
+      connectionTimeout: SMTP_CONNECTION_TIMEOUT_MS,
+      greetingTimeout: SMTP_GREETING_TIMEOUT_MS,
+      socketTimeout: SMTP_SOCKET_TIMEOUT_MS,
+      ...(!smtpConfig.username
+        ? {}
+        : smtpConfig.password
+          ? { auth: { user: smtpConfig.username, pass: smtpConfig.password } }
+          : { auth: { user: smtpConfig.username } }),
+    });
+    this.pooled = { key, transporter };
+    return transporter;
+  }
+
+  private discardTransporter(): void {
+    try {
+      this.pooled?.transporter.close();
+    } catch {
+    }
+    this.pooled = undefined;
+  }
+
+  private async sendWithDeadline(
+    transporter: nodemailer.Transporter,
+    message: Parameters<nodemailer.Transporter['sendMail']>[0],
+  ): Promise<void> {
+    let timer: NodeJS.Timeout | undefined;
+    let timedOut = false;
+    const deadline = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        timedOut = true;
+        reject(
+          new Error(`SMTP send exceeded ${SMTP_SEND_DEADLINE_MS}ms deadline`),
+        );
+      }, SMTP_SEND_DEADLINE_MS);
+    });
+
+    try {
+      await Promise.race([transporter.sendMail(message), deadline]);
+    } catch (error) {
+      if (timedOut) {
+        this.discardTransporter();
+      }
+      throw error;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   /**
    * Sends one message. Never throws for delivery problems — the outcome is
    * returned so the caller can decide between retrying and giving up.
@@ -36,25 +119,7 @@ export class MailSenderService {
         bodyData.emailTemplateType!,
         bodyData.templateData!,
       );
-      const transporter = nodemailer.createTransport({
-        host: smtpConfig.host,
-        port: smtpConfig.port || 587,
-        secure: false,
-        ...(smtpConfig.password
-          ? {
-            auth: {
-              user: smtpConfig.username,
-              pass: smtpConfig.password, // Included only if password exists
-            },
-          }
-          : {
-            auth: {
-              user: smtpConfig.username, // Include only the username
-            },
-          }),
-      });
-
-      await transporter.sendMail({
+      await this.sendWithDeadline(this.getTransporter(smtpConfig), {
         from: smtpConfig.fromEmail,
         to: bodyData.sendEmailTo,
         cc: bodyData.sendCcTo,

--- a/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
+++ b/backend/nodejs/apps/src/modules/mail/services/mail.sender.service.ts
@@ -16,17 +16,13 @@ export const SMTP_SYNC_SEND_DEADLINE_MS = 25_000;
 const SMTP_POOL_MAX_CONNECTIONS = 5;
 const SMTP_POOL_MAX_MESSAGES = 100;
 
-/**
- * Owns the actual SMTP delivery. Shared by the HTTP route and the broker
- * consumer so both paths send mail through exactly one implementation.
- */
+/** SMTP delivery, shared by the HTTP route and the broker consumer. */
 @injectable()
 export class MailSenderService {
   private pooled?: { key: string; transporter: nodemailer.Transporter };
 
   constructor(
-    // Resolved per call, not captured: updating SMTP settings rebinds
-    // AppConfig, and this service outlives that rebind as a singleton.
+    // Resolved per call: an SMTP update rebinds AppConfig, and this outlives it.
     @inject('AppConfigProvider')
     private readonly getAppConfig: () => AppConfig,
     @inject('Logger') private readonly logger: Logger,
@@ -109,10 +105,7 @@ export class MailSenderService {
     }
   }
 
-  /**
-   * Sends one message. Never throws for delivery problems — the outcome is
-   * returned so the caller can decide between retrying and giving up.
-   */
+  /** Returns the outcome instead of throwing, so the caller decides on retry. */
   async send(
     bodyData: MailBody,
     smtpConfig: SmtpConfig,
@@ -136,9 +129,7 @@ export class MailSenderService {
         deadlineMs,
       );
 
-      // The message is already delivered at this point, so a failure to write
-      // the audit row must not be reported as a send failure — the caller
-      // would retry and the recipient would get a duplicate email.
+      // Already delivered: a failed audit write must not trigger a duplicate send.
       try {
         const mailEntry = new MailModel({
           subject: bodyData.subject,
@@ -165,8 +156,7 @@ export class MailSenderService {
           : typeof error === 'string'
             ? error
             : 'Failed to send email';
-      // An unknown template is a caller bug, not an SMTP problem — replaying it
-      // would fail identically, so never classify it as transient.
+      // An unknown template is a caller bug; replaying it fails identically.
       const kind =
         typeof error === 'string' ? 'permanent' : classifyMailError(error);
       this.logger.error('Mail send error', { error: message, kind });

--- a/backend/nodejs/apps/src/modules/mail/types/mail-event.types.ts
+++ b/backend/nodejs/apps/src/modules/mail/types/mail-event.types.ts
@@ -5,11 +5,9 @@ export enum MailEventType {
 }
 
 /**
- * Job published to {@link BrokerTopic.MAIL_EVENTS} and consumed by MailConsumer.
- *
- * `orgId` is optional because not every caller has an org in scope (e.g. the
- * pre-login OTP flow); admin failure notifications are only published when it
- * is present, since the notification pipeline keys delivery off the org.
+ * Job published to {@link BrokerTopic.MAIL_EVENTS}. `orgId` is optional — the
+ * pre-login OTP flow has no org — and failure notifications need it, so jobs
+ * without one are logged instead.
  */
 export interface MailEventPayload {
   mail: MailBody;
@@ -28,8 +26,7 @@ export type MailSendResult =
   | { status: 'transient'; error: string }
   | { status: 'permanent'; error: string };
 
-// 4xx are "try again later" per RFC 5321; 5xx mean the server rejected the
-// message outright and replaying it would fail identically.
+// Per RFC 5321: 4xx means try again later, 5xx is an outright rejection.
 const PERMANENT_SMTP_RANGE = { min: 500, max: 599 };
 
 const TRANSIENT_ERROR_CODES = new Set([
@@ -46,11 +43,8 @@ const TRANSIENT_ERROR_CODES = new Set([
 ]);
 
 /**
- * Classifies a nodemailer failure so the consumer knows whether replaying is
- * worthwhile. Network-shaped codes and SMTP 4xx are transient; SMTP 5xx and
- * nodemailer's rejection codes (EAUTH, EMESSAGE) are permanent. When the error
- * carries no usable signal at all it is treated as transient, since dropping a
- * real email is worse than one redundant attempt.
+ * An error with no usable signal counts as transient: dropping a real email is
+ * worse than one redundant attempt.
  */
 export function classifyMailError(error: unknown): 'transient' | 'permanent' {
   const err = error as { responseCode?: number; code?: string } | null;

--- a/backend/nodejs/apps/src/modules/mail/types/mail-event.types.ts
+++ b/backend/nodejs/apps/src/modules/mail/types/mail-event.types.ts
@@ -29,17 +29,10 @@ export type MailSendResult =
 // Per RFC 5321: 4xx means try again later, 5xx is an outright rejection.
 const PERMANENT_SMTP_RANGE = { min: 500, max: 599 };
 
-const TRANSIENT_ERROR_CODES = new Set([
-  'ECONNECTION',
-  'ETIMEDOUT',
-  'ESOCKET',
-  'ECONNRESET',
-  'EDNS',
-  'EAI_AGAIN',
-  'ECONNREFUSED',
-  'EHOSTUNREACH',
-  'ENETUNREACH',
-  'ETLS',
+const PERMANENT_ERROR_CODES = new Set([
+  'EAUTH',
+  'EENVELOPE',
+  'EMESSAGE',
 ]);
 
 /**
@@ -64,7 +57,7 @@ export function classifyMailError(error: unknown): 'transient' | 'permanent' {
   }
 
   if (typeof err.code === 'string') {
-    return TRANSIENT_ERROR_CODES.has(err.code) ? 'transient' : 'permanent';
+    return PERMANENT_ERROR_CODES.has(err.code) ? 'permanent' : 'transient';
   }
 
   return 'transient';

--- a/backend/nodejs/apps/src/modules/mail/types/mail-event.types.ts
+++ b/backend/nodejs/apps/src/modules/mail/types/mail-event.types.ts
@@ -1,0 +1,77 @@
+import { MailBody } from '../middlewares/types';
+
+export enum MailEventType {
+  SendMailEvent = 'sendMail',
+}
+
+/**
+ * Job published to {@link BrokerTopic.MAIL_EVENTS} and consumed by MailConsumer.
+ *
+ * `orgId` is optional because not every caller has an org in scope (e.g. the
+ * pre-login OTP flow); admin failure notifications are only published when it
+ * is present, since the notification pipeline keys delivery off the org.
+ */
+export interface MailEventPayload {
+  mail: MailBody;
+  orgId?: string;
+}
+
+export interface MailEvent {
+  eventType: MailEventType;
+  timestamp: number;
+  payload: MailEventPayload;
+}
+
+/** Outcome of one delivery attempt, so callers can decide whether to retry. */
+export type MailSendResult =
+  | { status: 'sent' }
+  | { status: 'transient'; error: string }
+  | { status: 'permanent'; error: string };
+
+// 4xx are "try again later" per RFC 5321; 5xx mean the server rejected the
+// message outright and replaying it would fail identically.
+const PERMANENT_SMTP_RANGE = { min: 500, max: 599 };
+
+const TRANSIENT_ERROR_CODES = new Set([
+  'ECONNECTION',
+  'ETIMEDOUT',
+  'ESOCKET',
+  'ECONNRESET',
+  'EDNS',
+  'EAI_AGAIN',
+  'ECONNREFUSED',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ETLS',
+]);
+
+/**
+ * Classifies a nodemailer failure so the consumer knows whether replaying is
+ * worthwhile. Network-shaped codes and SMTP 4xx are transient; SMTP 5xx and
+ * nodemailer's rejection codes (EAUTH, EMESSAGE) are permanent. When the error
+ * carries no usable signal at all it is treated as transient, since dropping a
+ * real email is worse than one redundant attempt.
+ */
+export function classifyMailError(error: unknown): 'transient' | 'permanent' {
+  const err = error as { responseCode?: number; code?: string } | null;
+  if (!err) {
+    return 'transient';
+  }
+
+  const responseCode = Number(err.responseCode);
+  if (Number.isFinite(responseCode)) {
+    if (
+      responseCode >= PERMANENT_SMTP_RANGE.min &&
+      responseCode <= PERMANENT_SMTP_RANGE.max
+    ) {
+      return 'permanent';
+    }
+    return 'transient';
+  }
+
+  if (typeof err.code === 'string') {
+    return TRANSIENT_ERROR_CODES.has(err.code) ? 'transient' : 'permanent';
+  }
+
+  return 'transient';
+}

--- a/backend/nodejs/apps/src/modules/mail/utils/email-content.ts
+++ b/backend/nodejs/apps/src/modules/mail/utils/email-content.ts
@@ -1,0 +1,38 @@
+import { EmailTemplateType } from '../middlewares/types';
+import {
+  accountCreation,
+  appUserInvite,
+  loginWithOTPRequest,
+  resetEmail,
+  resetPassword,
+  suspiciousLoginAttempt,
+} from './emailTemplates';
+
+/** Renders a template by type. Throws for an unknown type — a caller bug. */
+export function getEmailContent(
+  emailTemplateType: string,
+  templateData: Record<string, any>,
+): string {
+  switch (emailTemplateType) {
+    case EmailTemplateType.LoginWithOtp:
+      return loginWithOTPRequest(templateData);
+
+    case EmailTemplateType.AccountCreation:
+      return accountCreation(templateData);
+
+    case EmailTemplateType.SuspiciousLoginAttempt:
+      return suspiciousLoginAttempt(templateData);
+
+    case EmailTemplateType.ResetPassword:
+      return resetPassword(templateData);
+
+    case EmailTemplateType.ResetEmail:
+      return resetEmail(templateData);
+
+    case EmailTemplateType.AppuserInvite:
+      return appUserInvite(templateData);
+
+    default:
+      throw 'Unknown Template';
+  }
+}

--- a/backend/nodejs/apps/src/modules/user_management/container/userManager.container.ts
+++ b/backend/nodejs/apps/src/modules/user_management/container/userManager.container.ts
@@ -16,6 +16,7 @@ import { TeamsController } from '../controller/teams.controller';
 import { IMessageProducer } from '../../../libs/types/messaging.types';
 import * as messageBrokerFactory from '../../../libs/services/message-broker.factory';
 import { NotificationProducer } from '../../notification/service/notification.producer';
+import { MailProducer } from '../../mail/services/mail.producer';
 
 const loggerConfig = {
   service: 'User Manager Container',
@@ -48,10 +49,6 @@ export class UserManagerContainer {
     appConfig: AppConfig,
   ): Promise<void> {
     try {
-      const mailService = new MailService(appConfig, container.get('Logger'));
-      container
-        .bind<MailService>('MailService')
-        .toDynamicValue(() => mailService);
 
       const authService = new AuthService(appConfig, container.get('Logger'));
       container
@@ -83,6 +80,18 @@ export class UserManagerContainer {
       container
         .bind<IMessageProducer>('MessageProducer')
         .toConstantValue(messageProducer);
+
+      // MailService publishes to the mail topic instead of sending inline.
+      const mailProducer = new MailProducer(messageProducer, container.get('Logger'));
+      container.bind<MailProducer>(MailProducer).toConstantValue(mailProducer);
+      const mailService = new MailService(
+        appConfig,
+        container.get('Logger'),
+        mailProducer,
+      );
+      container
+        .bind<MailService>('MailService')
+        .toDynamicValue(() => mailService);
 
       const entityEventsService = new EntitiesEventProducer(
         messageProducer,

--- a/backend/nodejs/apps/src/modules/user_management/container/userManager.container.ts
+++ b/backend/nodejs/apps/src/modules/user_management/container/userManager.container.ts
@@ -84,11 +84,7 @@ export class UserManagerContainer {
       // MailService publishes to the mail topic instead of sending inline.
       const mailProducer = new MailProducer(messageProducer, container.get('Logger'));
       container.bind<MailProducer>(MailProducer).toConstantValue(mailProducer);
-      const mailService = new MailService(
-        appConfig,
-        container.get('Logger'),
-        mailProducer,
-      );
+      const mailService = new MailService(container.get('Logger'), mailProducer);
       container
         .bind<MailService>('MailService')
         .toDynamicValue(() => mailService);

--- a/backend/nodejs/apps/src/modules/user_management/container/userManager.container.ts
+++ b/backend/nodejs/apps/src/modules/user_management/container/userManager.container.ts
@@ -84,7 +84,11 @@ export class UserManagerContainer {
       // MailService publishes to the mail topic instead of sending inline.
       const mailProducer = new MailProducer(messageProducer, container.get('Logger'));
       container.bind<MailProducer>(MailProducer).toConstantValue(mailProducer);
-      const mailService = new MailService(container.get('Logger'), mailProducer);
+      const mailService = new MailService(
+        appConfig,
+        container.get('Logger'),
+        mailProducer,
+      );
       container
         .bind<MailService>('MailService')
         .toDynamicValue(() => mailService);

--- a/backend/nodejs/apps/src/modules/user_management/controller/org.controller.ts
+++ b/backend/nodejs/apps/src/modules/user_management/controller/org.controller.ts
@@ -282,6 +282,7 @@ export class OrgController {
               contactEmail,
               this.config.scopedJwtSecret,
             ),
+            orgId: (org._id as mongoose.Types.ObjectId).toString(),
           },
           usersMails: [contactEmail],
           subject: 'New Org Account Creation',

--- a/backend/nodejs/apps/src/modules/user_management/controller/users.controller.ts
+++ b/backend/nodejs/apps/src/modules/user_management/controller/users.controller.ts
@@ -59,6 +59,7 @@ import {
 import { resolveOAuthTokenService } from '../../../libs/services/oauth-token-service.provider';
 
 const MAX_BULK_INVITE = 1000;
+export const ASYNC_INVITE_THRESHOLD = 20;
 
 // Linear-time email check: each segment excludes its following separator
 // (`@`/`.`), so there is no ambiguous backtracking (avoids ReDoS).
@@ -75,6 +76,7 @@ interface InviteResult {
   alreadyActive: number;
   mailFailed: string[];
   mailErrorCode?: number;
+  queued: boolean;
 }
 
 @injectable()
@@ -1505,7 +1507,15 @@ export class UserController {
         return;
       }
 
-      res.status(200).json({ message: 'Invite sent successfully' });
+      res.status(200).json(
+        result.queued
+          ? {
+            message:
+              'Invites queued. Emails are being sent in the background and may take a few minutes.',
+            queued: true,
+          }
+          : { message: 'Invite sent successfully', queued: false },
+      );
     } catch (error) {
       next(error);
     }
@@ -1784,6 +1794,11 @@ export class UserController {
       ...emailsForNewAccounts,
       ...emailsForPendingAccounts,
     ];
+    // Restored accounts are mailed in their own loop below, so they count
+    // toward the batch size too — otherwise a large restore-only invite would
+    // still send every message inline.
+    const deliverAsync =
+      emailsForInvites.length + restoredUsers.length > ASYNC_INVITE_THRESHOLD;
 
     for (let i = 0; i < emailsForInvites.length; ++i) {
       const email = emailsForInvites[i];
@@ -1831,6 +1846,7 @@ export class UserController {
         org,
         false,
         isPasswordAuthEnabled,
+        deliverAsync,
       );
       if (statusCode !== 200) {
         mailFailed.push(email);
@@ -1870,6 +1886,7 @@ export class UserController {
         org,
         true,
         isPasswordAuthEnabled,
+        deliverAsync,
       );
       if (statusCode !== 200) {
         mailFailed.push(email);
@@ -1883,6 +1900,7 @@ export class UserController {
       reinvited: pendingUsersToReinvite.length,
       alreadyActive: activeUsers.length - pendingUsersToReinvite.length,
       mailFailed,
+      queued: deliverAsync,
       mailErrorCode,
     };
   }
@@ -1895,6 +1913,7 @@ export class UserController {
     org: { registeredName?: string; shortName?: string } | null,
     rejoin: boolean,
     isPasswordAuthEnabled: boolean,
+    deliverAsync: boolean,
   ): Promise<number> {
     const subject = `You are invited to ${rejoin ? 're-join' : 'join'} ${org?.registeredName} `;
     const invitee = inviterName;
@@ -1922,6 +1941,7 @@ export class UserController {
             orgName,
             link: `${this.config.frontendUrl}/reset-password#token=${passwordResetToken}`,
           },
+          deliverAsync,
         });
       } else {
         result = await this.mailService.sendMail({
@@ -1937,6 +1957,7 @@ export class UserController {
             orgName,
             link: `${this.config.frontendUrl}/sign-in`,
           },
+          deliverAsync,
         });
       }
       return result.statusCode;

--- a/backend/nodejs/apps/src/modules/user_management/controller/users.controller.ts
+++ b/backend/nodejs/apps/src/modules/user_management/controller/users.controller.ts
@@ -1407,6 +1407,7 @@ export class UserController {
           emailTemplateType: 'appuserInvite',
           initiator: {
             jwtAuthToken: mailAuthToken,
+            orgId,
           },
           usersMails: [email],
           subject: `You are invited to join ${org?.registeredName} `,
@@ -1424,6 +1425,7 @@ export class UserController {
           emailTemplateType: 'appuserInvite',
           initiator: {
             jwtAuthToken: mailJwtGenerator(email, this.config.scopedJwtSecret),
+            orgId,
           },
           usersMails: [email],
           subject: `You are invited to join ${org?.registeredName} `,
@@ -1912,7 +1914,7 @@ export class UserController {
           );
         result = await this.mailService.sendMail({
           emailTemplateType: 'appuserInvite',
-          initiator: { jwtAuthToken: mailAuthToken },
+          initiator: { jwtAuthToken: mailAuthToken, orgId },
           usersMails: [email],
           subject,
           templateData: {
@@ -1926,6 +1928,7 @@ export class UserController {
           emailTemplateType: 'appuserInvite',
           initiator: {
             jwtAuthToken: mailJwtGenerator(email, this.config.scopedJwtSecret),
+            orgId,
           },
           usersMails: [email],
           subject,
@@ -2253,7 +2256,7 @@ export class UserController {
       const org = await Org.findOne({ _id: user.orgId, isDeleted: false });
       const emailSentResponse = await this.mailService.sendMail({
         emailTemplateType: 'resetEmail',
-        initiator: { jwtAuthToken: mailAuthToken },
+        initiator: { jwtAuthToken: mailAuthToken, orgId: user.orgId?.toString() },
         usersMails: [newEmail],
         subject: 'PipesHub | Verify your email !',
         templateData: {

--- a/backend/nodejs/apps/src/modules/user_management/routes/users.routes.ts
+++ b/backend/nodejs/apps/src/modules/user_management/routes/users.routes.ts
@@ -26,6 +26,7 @@ import { MailService } from '../services/mail.service';
 import { AuthService } from '../services/auth.service';
 import { EntitiesEventProducer } from '../services/entity_events.service';
 import { NotificationProducer } from '../../notification/service/notification.producer';
+import { MailProducer } from '../../mail/services/mail.producer';
 import { OrgController } from '../controller/org.controller';
 import { requireScopes } from '../../../libs/middlewares/require-scopes.middleware';
 import { OAuthScopeNames } from '../../../libs/enums/oauth-scopes.enum';
@@ -801,7 +802,11 @@ export function createUserRouter(container: Container) {
 
         // Rebind services depending on AppConfig
         container.rebind<MailService>('MailService').toDynamicValue(() => {
-          return new MailService(updatedConfig, logger);
+          return new MailService(
+            updatedConfig,
+            logger,
+            container.get<MailProducer>(MailProducer),
+          );
         });
 
         container.rebind<AuthService>('AuthService').toDynamicValue(() => {

--- a/backend/nodejs/apps/src/modules/user_management/routes/users.routes.ts
+++ b/backend/nodejs/apps/src/modules/user_management/routes/users.routes.ts
@@ -803,7 +803,6 @@ export function createUserRouter(container: Container) {
         // Rebind services depending on AppConfig
         container.rebind<MailService>('MailService').toDynamicValue(() => {
           return new MailService(
-            updatedConfig,
             logger,
             container.get<MailProducer>(MailProducer),
           );

--- a/backend/nodejs/apps/src/modules/user_management/routes/users.routes.ts
+++ b/backend/nodejs/apps/src/modules/user_management/routes/users.routes.ts
@@ -803,6 +803,7 @@ export function createUserRouter(container: Container) {
         // Rebind services depending on AppConfig
         container.rebind<MailService>('MailService').toDynamicValue(() => {
           return new MailService(
+            updatedConfig,
             logger,
             container.get<MailProducer>(MailProducer),
           );

--- a/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
+++ b/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
@@ -1,8 +1,10 @@
-import axios from 'axios';
 import { injectable, inject } from 'inversify';
 import { Logger } from '../../../libs/services/logger.service';
 import { BadRequestError } from '../../../libs/errors/http.errors';
 import { AppConfig } from '../../tokens_manager/config/config';
+import { MailProducer } from '../../mail/services/mail.producer';
+import { MailEventType } from '../../mail/types/mail-event.types';
+import { MailBody } from '../../mail/middlewares/types';
 interface SendMailParams {
   emailTemplateType: string;
   initiator: { orgId?: string; jwtAuthToken: string };
@@ -22,8 +24,11 @@ interface SendMailResponse {
 @injectable()
 export class MailService {
   constructor(
-    @inject('AppConfig') private userConfig: AppConfig,
+    // Retained so existing call sites keep their signature; delivery config
+    // now lives with the consumer, not this publisher.
+    @inject('AppConfig') _userConfig: AppConfig,
     @inject('Logger') private logger: Logger,
+    @inject(MailProducer) private readonly mailProducer: MailProducer,
   ) {}
 
   async sendMail({
@@ -44,7 +49,7 @@ export class MailService {
       if (!emailTemplateType)
         throw new BadRequestError('emailTemplateType is empty');
 
-      const data: Record<string, any> = {
+      const data: MailBody = {
         productName: 'PIP',
         emailTemplateType,
         isAutoEmail: false,
@@ -62,27 +67,23 @@ export class MailService {
         data.sendCcTo = ccEmails;
       }
 
-      const config = {
-        method: 'post' as const,
-        url: `${this.userConfig.communicationBackend}/api/v1/mail/emails/sendEmail`,
-        headers: {
-          Authorization: `Bearer ${initiator.jwtAuthToken}`,
-          'Content-Type': 'application/json',
-        },
-        data,
-      };
-      const response = await axios(config);
-      return { statusCode: 200, data: response.data };
+      // Delivery is handed to the mail topic instead of being awaited here, so
+      // a slow or unreachable SMTP server can no longer stall the request. A
+      // 200 now means "accepted for delivery"; failures reach admins via the
+      // notification published by MailConsumer.
+      await this.mailProducer.publishEvent({
+        eventType: MailEventType.SendMailEvent,
+        timestamp: Date.now(),
+        payload: { mail: data, orgId: initiator.orgId },
+      });
+      return { statusCode: 200, data: { message: 'Email queued for delivery' } };
     } catch (error: any) {
-      this.logger.error('Error sending mail', { error: error?.response?.data });
+      // Kept at 500 regardless of the underlying error so existing callers,
+      // which only branch on `statusCode !== 200`, behave exactly as before.
+      this.logger.error('Error queueing mail', { error: error?.message });
       return {
-        statusCode: error?.response?.status || 500,
-        data:
-          error?.response?.data?.error?.message ||
-          error?.response?.data?.message ||
-          (typeof error?.response?.data === 'string' ? error.response.data : null) ||
-          error?.message ||
-          'Error sending mail.',
+        statusCode: 500,
+        data: error?.message || 'Error sending mail.',
       };
     }
   }

--- a/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
+++ b/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
@@ -1,6 +1,8 @@
+import axios from 'axios';
 import { injectable, inject } from 'inversify';
 import { Logger } from '../../../libs/services/logger.service';
 import { BadRequestError } from '../../../libs/errors/http.errors';
+import { AppConfig } from '../../tokens_manager/config/config';
 import { MailProducer } from '../../mail/services/mail.producer';
 import { MailEventType } from '../../mail/types/mail-event.types';
 import { MailBody } from '../../mail/middlewares/types';
@@ -13,7 +15,10 @@ interface SendMailParams {
   fromEmailDomain?: string;
   attachedDocuments?: any[];
   ccEmails?: string[];
+  deliverAsync?: boolean;
 }
+
+const SEND_MAIL_TIMEOUT_MS = 30_000;
 
 interface SendMailResponse {
   statusCode: number;
@@ -23,6 +28,7 @@ interface SendMailResponse {
 @injectable()
 export class MailService {
   constructor(
+    @inject('AppConfig') private userConfig: AppConfig,
     @inject('Logger') private logger: Logger,
     @inject(MailProducer) private readonly mailProducer: MailProducer,
   ) {}
@@ -36,6 +42,7 @@ export class MailService {
     fromEmailDomain,
     attachedDocuments,
     ccEmails,
+    deliverAsync,
   }: SendMailParams): Promise<SendMailResponse> {
     try {
       this.logger.debug('sending mail ...');
@@ -63,20 +70,43 @@ export class MailService {
         data.sendCcTo = ccEmails;
       }
 
-      // 200 now means "accepted for delivery", not "sent" — MailConsumer
-      // notifies admins if delivery ultimately fails.
-      await this.mailProducer.publishEvent({
-        eventType: MailEventType.SendMailEvent,
-        timestamp: Date.now(),
-        payload: { mail: data, orgId: initiator.orgId },
-      });
-      return { statusCode: 200, data: { message: 'Email queued for delivery' } };
+      if (deliverAsync) {
+        // 200 here means "accepted for delivery", not "sent" — MailConsumer
+        // notifies admins if delivery ultimately fails.
+        await this.mailProducer.publishEvent({
+          eventType: MailEventType.SendMailEvent,
+          timestamp: Date.now(),
+          payload: { mail: data, orgId: initiator.orgId },
+        });
+        return {
+          statusCode: 200,
+          data: { message: 'Email queued for delivery', queued: true },
+        };
+      }
+
+      const config = {
+        method: 'post' as const,
+        url: `${this.userConfig.communicationBackend}/api/v1/mail/emails/sendEmail`,
+        headers: {
+          Authorization: `Bearer ${initiator.jwtAuthToken}`,
+          'Content-Type': 'application/json',
+        },
+        data,
+        timeout: SEND_MAIL_TIMEOUT_MS,
+      };
+      const response = await axios(config);
+      return { statusCode: 200, data: response.data };
     } catch (error: any) {
-      // Always 500: callers only branch on `statusCode !== 200`.
-      this.logger.error('Error queueing mail', { error: error?.message });
+      this.logger.error('Error sending mail', {
+        error: error?.response?.data ?? error?.message,
+      });
       return {
-        statusCode: 500,
-        data: error?.message || 'Error sending mail.',
+        statusCode: error?.response?.status || 500,
+        data:
+          error?.response?.data?.error?.message ||
+          error?.response?.data?.message ||
+          error?.message ||
+          'Error sending mail.',
       };
     }
   }

--- a/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
+++ b/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
@@ -1,7 +1,6 @@
 import { injectable, inject } from 'inversify';
 import { Logger } from '../../../libs/services/logger.service';
 import { BadRequestError } from '../../../libs/errors/http.errors';
-import { AppConfig } from '../../tokens_manager/config/config';
 import { MailProducer } from '../../mail/services/mail.producer';
 import { MailEventType } from '../../mail/types/mail-event.types';
 import { MailBody } from '../../mail/middlewares/types';
@@ -24,9 +23,6 @@ interface SendMailResponse {
 @injectable()
 export class MailService {
   constructor(
-    // Retained so existing call sites keep their signature; delivery config
-    // now lives with the consumer, not this publisher.
-    @inject('AppConfig') _userConfig: AppConfig,
     @inject('Logger') private logger: Logger,
     @inject(MailProducer) private readonly mailProducer: MailProducer,
   ) {}

--- a/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
+++ b/backend/nodejs/apps/src/modules/user_management/services/mail.service.ts
@@ -63,10 +63,8 @@ export class MailService {
         data.sendCcTo = ccEmails;
       }
 
-      // Delivery is handed to the mail topic instead of being awaited here, so
-      // a slow or unreachable SMTP server can no longer stall the request. A
-      // 200 now means "accepted for delivery"; failures reach admins via the
-      // notification published by MailConsumer.
+      // 200 now means "accepted for delivery", not "sent" — MailConsumer
+      // notifies admins if delivery ultimately fails.
       await this.mailProducer.publishEvent({
         eventType: MailEventType.SendMailEvent,
         timestamp: Date.now(),
@@ -74,8 +72,7 @@ export class MailService {
       });
       return { statusCode: 200, data: { message: 'Email queued for delivery' } };
     } catch (error: any) {
-      // Kept at 500 regardless of the underlying error so existing callers,
-      // which only branch on `statusCode !== 200`, behave exactly as before.
+      // Always 500: callers only branch on `statusCode !== 200`.
       this.logger.error('Error queueing mail', { error: error?.message });
       return {
         statusCode: 500,

--- a/backend/nodejs/apps/tests/modules/auth/controller/suspiciousLoginAlert.test.ts
+++ b/backend/nodejs/apps/tests/modules/auth/controller/suspiciousLoginAlert.test.ts
@@ -1,0 +1,148 @@
+import 'reflect-metadata';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import bcrypt from 'bcryptjs';
+import { UserAccountController } from '../../../../src/modules/auth/controller/userAccount.controller';
+import { UserCredentials } from '../../../../src/modules/auth/schema/userCredentials.schema';
+import { UserActivities } from '../../../../src/modules/auth/schema/userActivities.schema';
+import { Org } from '../../../../src/modules/user_management/schema/org.schema';
+import { Users } from '../../../../src/modules/user_management/schema/users.schema';
+
+/**
+ * The suspicious-login alert is a best-effort side effect: the account state is
+ * already persisted before it is sent. The auth MailService throws on failure
+ * (unlike the user_management one, which returns a status code), so an
+ * unsent alert must not replace the security response with a mail error.
+ */
+describe('UserAccountController - suspicious login alert is best effort', () => {
+  let controller: UserAccountController;
+  let mockMailService: any;
+  let mockLogger: any;
+  let res: any;
+  let next: sinon.SinonStub;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: sinon.stub(), info: sinon.stub(),
+      warn: sinon.stub(), error: sinon.stub(),
+    };
+    mockMailService = { sendMail: sinon.stub().resolves({ statusCode: 200 }) };
+
+    controller = new UserAccountController(
+      {
+        iamBackend: 'http://iam:3000',
+        cmBackend: 'http://cm:3001',
+        frontendUrl: 'http://frontend:3000',
+        scopedJwtSecret: 'secret',
+        jwtSecret: 'secret',
+      } as any,
+      { getUserByEmail: sinon.stub() } as any,
+      mockMailService,
+      {} as any,
+      {} as any,
+      mockLogger,
+      {} as any,
+    );
+
+    res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub().returnsThis(),
+      send: sinon.stub().returnsThis(),
+    };
+    next = sinon.stub();
+  });
+
+  afterEach(() => sinon.restore());
+
+  const setupWrongPassword = (controllerRef: any) => {
+    sinon.stub(Org, 'findOne').resolves({ shortName: 'Corp' } as any);
+    sinon.stub(Users, 'findOne').resolves({ fullName: 'Test User' } as any);
+    sinon.stub(UserActivities, 'create').resolves({} as any);
+    sinon.stub(UserCredentials, 'findOne').resolves({
+      userId: 'u1',
+      orgId: 'o1',
+      hashedPassword: 'hashed',
+      wrongCredentialCount: 4,
+      isBlocked: false,
+      save: sinon.stub().resolves(),
+    } as any);
+    // Drive straight to the wrong-password branch that raises the alert.
+    sinon.stub(controllerRef, 'ensureBlockStatus').resolves(false);
+    sinon.stub(controllerRef, 'verifyPassword').resolves(false);
+    sinon.stub(controllerRef, 'incrementWrongCredentialCount').resolves({
+      userId: 'u1',
+      orgId: 'o1',
+      wrongCredentialCount: 5,
+      isBlocked: true,
+      save: sinon.stub().resolves(),
+    });
+  };
+
+  const setupFifthWrongOtp = (controllerRef: any) => {
+    sinon.stub(Org, 'findOne').resolves({ shortName: 'Corp' } as any);
+    sinon.stub(Users, 'findOne').resolves({ fullName: 'Test User' } as any);
+    sinon.stub(UserActivities, 'create').resolves({} as any);
+    sinon.stub(UserCredentials, 'findOne').resolves({
+      userId: 'u1',
+      orgId: 'o1',
+      otpValidity: Date.now() + 60_000,
+      // A real hash of a different OTP, so bcrypt.compare genuinely misses.
+      hashedOTP: bcrypt.hashSync('999999', 4),
+      wrongCredentialCount: 4,
+      isBlocked: false,
+      save: sinon.stub().resolves(),
+    } as any);
+    sinon.stub(controllerRef, 'ensureBlockStatus').resolves(false);
+    sinon.stub(controllerRef, 'incrementWrongCredentialCount').resolves({
+      userId: 'u1',
+      orgId: 'o1',
+      wrongCredentialCount: 5,
+      isBlocked: false,
+      save: sinon.stub().resolves(),
+    });
+  };
+
+  const runPasswordLogin = () =>
+    (controller as any).authenticateWithPassword(
+      { _id: 'u1', orgId: 'o1', email: 'user@example.com' },
+      'wrong-password',
+      '127.0.0.1',
+    );
+
+  const runOtpLogin = () =>
+    (controller as any).verifyOTP(
+      'u1',
+      'o1',
+      '000000',
+      'user@example.com',
+      '127.0.0.1',
+    );
+
+  it('raises the security error and sends one alert when mail succeeds', async () => {
+    setupWrongPassword(controller);
+
+    let surfaced: Error | undefined;
+    try { await runPasswordLogin(); } catch (e) { surfaced = e as Error; }
+
+    expect(surfaced!.message).to.contain('Incorrect password');
+    expect(mockMailService.sendMail.calledOnce).to.be.true;
+  });
+
+
+  it('still raises the security error when the alert mail fails', async () => {
+    setupFifthWrongOtp(controller);
+    // What a 30s SMTP deadline looks like to this caller.
+    mockMailService.sendMail.rejects(new Error('timeout of 30000ms exceeded'));
+
+    let surfaced: Error | undefined;
+    try { await runOtpLogin(); } catch (e) { surfaced = e as Error; }
+
+    expect(surfaced, 'a security error must still be raised').to.exist;
+    // Never replaced by a mail-plumbing error.
+    expect(surfaced!.message).to.not.contain('timeout of 30000ms');
+    expect(surfaced!.message).to.contain('Account Blocked');
+    // Recorded rather than swallowed, and never retried into a duplicate.
+    expect(mockLogger.error.called).to.be.true;
+    expect(mockMailService.sendMail.callCount).to.equal(1);
+  });
+});

--- a/backend/nodejs/apps/tests/modules/auth/controller/suspiciousLoginAlert.test.ts
+++ b/backend/nodejs/apps/tests/modules/auth/controller/suspiciousLoginAlert.test.ts
@@ -137,10 +137,8 @@ describe('UserAccountController - suspicious login alert is best effort', () => 
     try { await runOtpLogin(); } catch (e) { surfaced = e as Error; }
 
     expect(surfaced, 'a security error must still be raised').to.exist;
-    // Never replaced by a mail-plumbing error.
     expect(surfaced!.message).to.not.contain('timeout of 30000ms');
     expect(surfaced!.message).to.contain('Account Blocked');
-    // Recorded rather than swallowed, and never retried into a duplicate.
     expect(mockLogger.error.called).to.be.true;
     expect(mockMailService.sendMail.callCount).to.equal(1);
   });

--- a/backend/nodejs/apps/tests/modules/auth/controller/suspiciousLoginAlert.test.ts
+++ b/backend/nodejs/apps/tests/modules/auth/controller/suspiciousLoginAlert.test.ts
@@ -131,7 +131,6 @@ describe('UserAccountController - suspicious login alert is best effort', () => 
 
   it('still raises the security error when the alert mail fails', async () => {
     setupFifthWrongOtp(controller);
-    // What a 30s SMTP deadline looks like to this caller.
     mockMailService.sendMail.rejects(new Error('timeout of 30000ms exceeded'));
 
     let surfaced: Error | undefined;

--- a/backend/nodejs/apps/tests/modules/mail/container/mailService.container.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/container/mailService.container.test.ts
@@ -2,6 +2,7 @@ import 'reflect-metadata'
 import { expect } from 'chai'
 import sinon from 'sinon'
 import { MailServiceContainer } from '../../../../src/modules/mail/container/mailService.container'
+import * as messageBrokerFactory from '../../../../src/libs/services/message-broker.factory'
 
 describe('mail/container/mailService.container', () => {
   afterEach(() => {
@@ -23,6 +24,30 @@ describe('MailServiceContainer - coverage', () => {
 
   beforeEach(() => {
     originalInstance = (MailServiceContainer as any).instance
+
+    // Stub message broker factory to prevent real Kafka/Redis connections
+    sinon.stub(messageBrokerFactory, 'resolveMessageBrokerConfig').returns({
+      type: 'kafka',
+      kafka: { brokers: ['localhost:9092'], clientId: 'test' },
+    } as any)
+    sinon.stub(messageBrokerFactory, 'createMessageProducer').returns({
+      connect: sinon.stub().resolves(),
+      disconnect: sinon.stub().resolves(),
+      isConnected: sinon.stub().returns(true),
+      publish: sinon.stub().resolves(),
+      publishBatch: sinon.stub().resolves(),
+      healthCheck: sinon.stub().resolves(true),
+    } as any)
+    sinon.stub(messageBrokerFactory, 'createMailMessageConsumer').returns({
+      connect: sinon.stub().resolves(),
+      disconnect: sinon.stub().resolves(),
+      isConnected: sinon.stub().returns(true),
+      subscribe: sinon.stub().resolves(),
+      consume: sinon.stub().resolves(),
+      pause: sinon.stub(),
+      resume: sinon.stub(),
+      healthCheck: sinon.stub().resolves(true),
+    } as any)
   })
 
   afterEach(() => {

--- a/backend/nodejs/apps/tests/modules/mail/container/mailService.container.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/container/mailService.container.test.ts
@@ -86,7 +86,6 @@ describe('MailServiceContainer - coverage', () => {
 
       const container = await MailServiceContainer.initialize(appConfig)
 
-      // MailController should be resolvable
       const mailController = container.get('MailController')
       expect(mailController).to.exist
 
@@ -107,7 +106,6 @@ describe('MailServiceContainer - coverage', () => {
     it('should do nothing when instance is already null', async () => {
       ;(MailServiceContainer as any).instance = null
       await MailServiceContainer.dispose()
-      // Should not throw
     })
   })
 

--- a/backend/nodejs/apps/tests/modules/mail/controller/mail.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/controller/mail.controller.test.ts
@@ -8,6 +8,7 @@ describe('mail/controller/mail.controller', () => {
   let controller: MailController
   let mockConfig: any
   let mockLogger: any
+  let mockSender: any
 
   beforeEach(() => {
     mockConfig = {
@@ -19,13 +20,14 @@ describe('mail/controller/mail.controller', () => {
         fromEmail: 'noreply@test.com',
       },
     }
+    mockSender = { send: sinon.stub().resolves({ status: 'sent' }) }
     mockLogger = {
       info: sinon.stub(),
       error: sinon.stub(),
       warn: sinon.stub(),
       debug: sinon.stub(),
     }
-    controller = new MailController(mockConfig, mockLogger)
+    controller = new MailController(mockConfig, mockLogger, mockSender)
   })
 
   afterEach(() => {
@@ -52,7 +54,7 @@ describe('mail/controller/mail.controller', () => {
 
   describe('sendMail', () => {
     it('should throw NotFoundError when smtp is not configured', async () => {
-      controller = new MailController({ smtp: null }, mockLogger)
+      controller = new MailController({ smtp: null }, mockLogger, mockSender)
       const req: any = { body: {} }
       const res: any = { status: sinon.stub().returnsThis(), json: sinon.stub() }
       const next = sinon.stub()

--- a/backend/nodejs/apps/tests/modules/mail/controller/mail.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/controller/mail.controller.test.ts
@@ -32,6 +32,24 @@ describe('mail/controller/mail.controller', () => {
     sinon.restore()
   })
 
+  describe('emailSender', () => {
+    it('sends with a deadline below the caller HTTP timeout', async () => {
+      // auth/services/mail.service.ts waits this long on the route below.
+      const CALLER_HTTP_TIMEOUT_MS = 30_000
+      const send = sinon.stub().resolves({ status: 'sent' })
+      const c = new MailController(mockConfig, mockLogger, { send } as any)
+
+      await c.emailSender(
+        { emailTemplateType: 'appuserInvite', templateData: {} } as any,
+        mockConfig.smtp,
+      )
+
+      expect(send.firstCall.args[2])
+        .to.be.a('number')
+        .and.to.be.below(CALLER_HTTP_TIMEOUT_MS)
+    })
+  })
+
   describe('sendMail', () => {
     it('should throw NotFoundError when smtp is not configured', async () => {
       controller = new MailController({ smtp: null }, mockLogger)

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.consumer.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.consumer.test.ts
@@ -203,5 +203,7 @@ describe('classifyMailError', () => {
   it('defaults to transient when the error carries no usable signal', () => {
     expect(classifyMailError(null)).to.equal('transient');
     expect(classifyMailError({})).to.equal('transient');
+    expect(classifyMailError({ code: 'EPIPE' })).to.equal('transient');
+    expect(classifyMailError({ code: 'EAI_NODATA' })).to.equal('transient');
   });
 });

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.consumer.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.consumer.test.ts
@@ -132,6 +132,45 @@ describe('MailConsumer - asynchronous mail delivery', () => {
     expect(mockLogger.error.called).to.be.true;
   });
 
+  it('collapses a storm of failures into one notification per org', async () => {
+    mockSender.send.resolves({ status: 'permanent', error: '550 rejected' });
+
+    // 50 recipients failing back-to-back, as in a bad-SMTP bulk import.
+    for (let i = 0; i < 50; i++) {
+      await deliver(payload({ mail: { ...payload().mail, sendEmailTo: [`u${i}@example.com`] } }));
+    }
+
+    expect(mockSender.send.callCount).to.equal(50);
+    expect(mockNotificationProducer.publishEvent.callCount).to.equal(1);
+  });
+
+  it('notifies again after the window and reports what was suppressed', async () => {
+    mockSender.send.resolves({ status: 'permanent', error: '550 rejected' });
+
+    await deliver(payload());
+    await deliver(payload());
+    await deliver(payload());
+    expect(mockNotificationProducer.publishEvent.callCount).to.equal(1);
+
+    await clock.tickAsync(5 * 60_000 + 1_000);
+    await deliver(payload());
+
+    expect(mockNotificationProducer.publishEvent.callCount).to.equal(2);
+    const second = mockNotificationProducer.publishEvent.secondCall.args[0];
+    expect(second.payload.payload.suppressedFailures).to.equal(2);
+    expect(second.payload.message).to.contain('suppressed');
+  });
+
+  it('throttles per org, not globally', async () => {
+    mockSender.send.resolves({ status: 'permanent', error: '550 rejected' });
+
+    await deliver(payload({ orgId: '507f1f77bcf86cd799439012' }));
+    await deliver(payload({ orgId: '507f1f77bcf86cd799439099' }));
+
+    // A noisy org must not silence a different one.
+    expect(mockNotificationProducer.publishEvent.callCount).to.equal(2);
+  });
+
   it('skips an event whose payload is not a mail job', async () => {
     let captured: any;
     mockConsumer.consume.callsFake(async (cb: any) => {

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.consumer.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.consumer.test.ts
@@ -1,0 +1,168 @@
+import 'reflect-metadata';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { MailConsumer } from '../../../../src/modules/mail/services/mail.consumer';
+import { classifyMailError } from '../../../../src/modules/mail/types/mail-event.types';
+
+describe('MailConsumer - asynchronous mail delivery', () => {
+  let consumer: MailConsumer;
+  let mockConsumer: any;
+  let mockLogger: any;
+  let mockSender: any;
+  let mockNotificationProducer: any;
+  let clock: sinon.SinonFakeTimers;
+
+  const smtp = { host: 'mailpit', port: 1025, fromEmail: 'no-reply@example.com' };
+
+  const payload = (overrides: Record<string, unknown> = {}) => ({
+    mail: {
+      emailTemplateType: 'appuserInvite',
+      subject: 'You are invited',
+      sendEmailTo: ['user@example.com'],
+    },
+    orgId: '507f1f77bcf86cd799439012',
+    ...overrides,
+  });
+
+  /** Drives the retry loop's backoff sleeps without waiting in real time. */
+  const runWithFakeTimers = async (work: Promise<void>): Promise<void> => {
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+      await clock.tickAsync(60_000);
+    }
+    await work;
+  };
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+    mockLogger = {
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      error: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    mockConsumer = {
+      connect: sinon.stub().resolves(),
+      disconnect: sinon.stub().resolves(),
+      isConnected: sinon.stub().returns(true),
+      subscribe: sinon.stub().resolves(),
+      consume: sinon.stub().resolves(),
+    };
+    mockSender = {
+      getSmtpConfig: sinon.stub().returns(smtp),
+      send: sinon.stub().resolves({ status: 'sent' }),
+    };
+    mockNotificationProducer = {
+      start: sinon.stub().resolves(),
+      publishEvent: sinon.stub().resolves(),
+    };
+    consumer = new MailConsumer(
+      mockConsumer,
+      mockLogger,
+      mockSender,
+      mockNotificationProducer,
+    );
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sinon.restore();
+  });
+
+  const deliver = (p: unknown) => (consumer as any).deliver(p);
+
+  it('sends once and does not notify when delivery succeeds', async () => {
+    await deliver(payload());
+
+    expect(mockSender.send.calledOnce).to.be.true;
+    expect(mockNotificationProducer.publishEvent.called).to.be.false;
+  });
+
+  it('does not retry a permanent failure, and notifies admins', async () => {
+    mockSender.send.resolves({ status: 'permanent', error: '550 no such user' });
+
+    await deliver(payload());
+
+    // A 5xx would fail identically on replay, so exactly one attempt.
+    expect(mockSender.send.callCount).to.equal(1);
+    expect(mockNotificationProducer.publishEvent.calledOnce).to.be.true;
+
+    const event = mockNotificationProducer.publishEvent.firstCall.args[0];
+    expect(event.payload.type).to.equal('mail.deliveryFailed');
+    expect(event.payload.recipientRoles).to.deep.equal(['admin']);
+    expect(event.payload.orgId).to.equal('507f1f77bcf86cd799439012');
+  });
+
+  it('retries a transient failure and stops as soon as it succeeds', async () => {
+    mockSender.send
+      .onCall(0).resolves({ status: 'transient', error: 'ETIMEDOUT' })
+      .onCall(1).resolves({ status: 'sent' });
+
+    await runWithFakeTimers(deliver(payload()));
+
+    expect(mockSender.send.callCount).to.equal(2);
+    expect(mockNotificationProducer.publishEvent.called).to.be.false;
+  });
+
+  it('gives up after the retry limit and notifies admins once', async () => {
+    mockSender.send.resolves({ status: 'transient', error: 'ECONNREFUSED' });
+
+    await runWithFakeTimers(deliver(payload()));
+
+    expect(mockSender.send.callCount).to.equal(4);
+    expect(mockNotificationProducer.publishEvent.calledOnce).to.be.true;
+  });
+
+  it('does not attempt delivery when SMTP is unconfigured', async () => {
+    mockSender.getSmtpConfig.returns(null);
+
+    await deliver(payload());
+
+    expect(mockSender.send.called).to.be.false;
+    expect(mockNotificationProducer.publishEvent.calledOnce).to.be.true;
+  });
+
+  it('logs instead of notifying when the event carries no orgId', async () => {
+    mockSender.send.resolves({ status: 'permanent', error: '550 rejected' });
+
+    await deliver(payload({ orgId: undefined }));
+
+    // Without an org the notification pipeline would drop the event anyway.
+    expect(mockNotificationProducer.publishEvent.called).to.be.false;
+    expect(mockLogger.error.called).to.be.true;
+  });
+
+  it('skips an event whose payload is not a mail job', async () => {
+    let captured: any;
+    mockConsumer.consume.callsFake(async (cb: any) => {
+      captured = cb;
+    });
+    await consumer.consume(async () => {});
+    await captured({ key: 'k', value: { nonsense: true } });
+
+    expect(mockSender.send.called).to.be.false;
+    expect(mockLogger.warn.called).to.be.true;
+  });
+});
+
+describe('classifyMailError', () => {
+  it('treats SMTP 5xx as permanent and 4xx as transient', () => {
+    expect(classifyMailError({ responseCode: 550 })).to.equal('permanent');
+    expect(classifyMailError({ responseCode: 421 })).to.equal('transient');
+  });
+
+  it('treats network-shaped codes as transient', () => {
+    expect(classifyMailError({ code: 'ETIMEDOUT' })).to.equal('transient');
+    expect(classifyMailError({ code: 'ECONNECTION' })).to.equal('transient');
+  });
+
+  it('treats rejection codes as permanent', () => {
+    expect(classifyMailError({ code: 'EAUTH' })).to.equal('permanent');
+    expect(classifyMailError({ code: 'EMESSAGE' })).to.equal('permanent');
+  });
+
+  it('defaults to transient when the error carries no usable signal', () => {
+    expect(classifyMailError(null)).to.equal('transient');
+    expect(classifyMailError({})).to.equal('transient');
+  });
+});

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
@@ -40,8 +40,7 @@ describe('MailSenderService', () => {
   afterEach(() => sinon.restore());
 
   it('reads SMTP config through the provider so a rebind is picked up', () => {
-    // The service is a singleton but AppConfig is rebound when an admin
-    // updates SMTP settings; capturing the config would go stale.
+    // AppConfig is rebound on an SMTP update; a captured config would go stale.
     let current: any = { smtp: { host: 'old-host', port: 25, fromEmail: 'a@b.c' } };
     const sender = new MailSenderService(() => current, mockLogger);
 
@@ -137,8 +136,6 @@ describe('MailSenderService', () => {
       await clock.tickAsync(120_000 + 1);
       const result = await promise;
 
-      // socketTimeout only measures inactivity, so without this an unbounded
-      // send would wedge the consumer and stop all later mail.
       expect(result.status).to.equal('transient');
       expect(String((result as { error?: string }).error)).to.contain('deadline');
       // The stuck connection must not be handed to the next message.

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
@@ -122,7 +122,7 @@ describe('MailSenderService', () => {
     expect(opts.auth, 'auth').to.equal(undefined);
   });
 
-  it('abandons a stalled send at the deadline and drops the pool', async () => {
+  it('abandons a stalled send at the deadline without dropping the pool', async () => {
     const clock = sinon.useFakeTimers();
     const closeStub = sinon.stub();
     try {
@@ -138,8 +138,8 @@ describe('MailSenderService', () => {
 
       expect(result.status).to.equal('transient');
       expect(String((result as { error?: string }).error)).to.contain('deadline');
-      // The stuck connection must not be handed to the next message.
-      expect(closeStub.calledOnce).to.be.true;
+      // Concurrent sends share this pool, so it must survive one timeout.
+      expect(closeStub.called).to.be.false;
     } finally {
       clock.restore();
     }

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
@@ -1,0 +1,105 @@
+import 'reflect-metadata';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import nodemailer from 'nodemailer';
+import { MailSenderService } from '../../../../src/modules/mail/services/mail.sender.service';
+import { MailModel } from '../../../../src/modules/mail/schema/mailInfo.schema';
+
+describe('MailSenderService', () => {
+  let mockLogger: any;
+  let sendMailStub: sinon.SinonStub;
+
+  const smtp = {
+    host: 'mailpit',
+    port: 1025,
+    fromEmail: 'no-reply@example.com',
+  } as any;
+
+  const body = {
+    emailTemplateType: 'appuserInvite',
+    subject: 'Invite',
+    sendEmailTo: ['user@example.com'],
+    templateData: { invitee: 'Admin', orgName: 'Corp', link: 'http://x/y' },
+  } as any;
+
+  beforeEach(() => {
+    mockLogger = {
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      error: sinon.stub(),
+      warn: sinon.stub(),
+    };
+    sendMailStub = sinon.stub().resolves({ messageId: 'm1' });
+    sinon.stub(nodemailer, 'createTransport').returns({
+      sendMail: sendMailStub,
+    } as any);
+    sinon.stub(MailModel.prototype, 'save').resolves({} as any);
+  });
+
+  afterEach(() => sinon.restore());
+
+  it('reads SMTP config through the provider so a rebind is picked up', () => {
+    // The service is a singleton but AppConfig is rebound when an admin
+    // updates SMTP settings; capturing the config would go stale.
+    let current: any = { smtp: { host: 'old-host', port: 25, fromEmail: 'a@b.c' } };
+    const sender = new MailSenderService(() => current, mockLogger);
+
+    expect(sender.getSmtpConfig()?.host).to.equal('old-host');
+
+    current = { smtp: { host: 'new-host', port: 587, fromEmail: 'a@b.c' } };
+    expect(sender.getSmtpConfig()?.host).to.equal('new-host');
+  });
+
+  it('returns null when SMTP has not been configured', () => {
+    const sender = new MailSenderService(() => ({}) as any, mockLogger);
+    expect(sender.getSmtpConfig()).to.equal(null);
+  });
+
+  it('reports sent on a successful delivery', async () => {
+    const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+    const result = await sender.send(body, smtp);
+
+    expect(result.status).to.equal('sent');
+    expect(sendMailStub.calledOnce).to.be.true;
+  });
+
+  it('still reports sent when only the audit record fails to save', async () => {
+    // Otherwise the consumer would retry an email that was already delivered.
+    (MailModel.prototype.save as sinon.SinonStub).rejects(new Error('mongo down'));
+    const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+
+    const result = await sender.send(body, smtp);
+
+    expect(result.status).to.equal('sent');
+    expect(mockLogger.error.called).to.be.true;
+  });
+
+  it('classifies an SMTP 5xx rejection as permanent', async () => {
+    sendMailStub.rejects(Object.assign(new Error('550 rejected'), {
+      responseCode: 550,
+    }));
+    const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+
+    expect((await sender.send(body, smtp)).status).to.equal('permanent');
+  });
+
+  it('classifies a connection timeout as transient', async () => {
+    sendMailStub.rejects(Object.assign(new Error('timed out'), {
+      code: 'ETIMEDOUT',
+    }));
+    const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+
+    expect((await sender.send(body, smtp)).status).to.equal('transient');
+  });
+
+  it('treats an unknown template as permanent rather than retrying it', async () => {
+    const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+    const result = await sender.send(
+      { ...body, emailTemplateType: 'nope' },
+      smtp,
+    );
+
+    expect(result.status).to.equal('permanent');
+    expect(sendMailStub.called).to.be.false;
+  });
+});

--- a/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/mail/services/mail.sender.service.test.ts
@@ -32,6 +32,7 @@ describe('MailSenderService', () => {
     sendMailStub = sinon.stub().resolves({ messageId: 'm1' });
     sinon.stub(nodemailer, 'createTransport').returns({
       sendMail: sendMailStub,
+      close: sinon.stub(),
     } as any);
     sinon.stub(MailModel.prototype, 'save').resolves({} as any);
   });
@@ -101,5 +102,49 @@ describe('MailSenderService', () => {
 
     expect(result.status).to.equal('permanent');
     expect(sendMailStub.called).to.be.false;
+  });
+
+  it('reuses one pooled transporter with every SMTP stage bounded', async () => {
+    const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+    await sender.send(body, smtp);
+    await sender.send(body, smtp);
+
+    const createTransport = nodemailer.createTransport as sinon.SinonStub;
+    // Reused: 1000 invites must not mean 1000 connections and handshakes.
+    expect(createTransport.calledOnce).to.be.true;
+
+    const opts = createTransport.firstCall.args[0];
+    expect(opts.pool, 'pool').to.be.true;
+    expect(opts.dnsTimeout, 'dnsTimeout').to.equal(30_000);
+    expect(opts.connectionTimeout, 'connectionTimeout').to.equal(30_000);
+    expect(opts.greetingTimeout, 'greetingTimeout').to.equal(30_000);
+    expect(opts.socketTimeout, 'socketTimeout').to.equal(60_000);
+    // No username configured, so no credentials are offered at all.
+    expect(opts.auth, 'auth').to.equal(undefined);
+  });
+
+  it('abandons a stalled send at the deadline and drops the pool', async () => {
+    const clock = sinon.useFakeTimers();
+    const closeStub = sinon.stub();
+    try {
+      (nodemailer.createTransport as sinon.SinonStub).returns({
+        sendMail: sinon.stub().returns(new Promise(() => {})),
+        close: closeStub,
+      } as any);
+      const sender = new MailSenderService(() => ({ smtp }) as any, mockLogger);
+
+      const promise = sender.send(body, smtp);
+      await clock.tickAsync(120_000 + 1);
+      const result = await promise;
+
+      // socketTimeout only measures inactivity, so without this an unbounded
+      // send would wedge the consumer and stop all later mail.
+      expect(result.status).to.equal('transient');
+      expect(String((result as { error?: string }).error)).to.contain('deadline');
+      // The stuck connection must not be handed to the next message.
+      expect(closeStub.calledOnce).to.be.true;
+    } finally {
+      clock.restore();
+    }
   });
 });

--- a/backend/nodejs/apps/tests/modules/user_management/controller/users.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/user_management/controller/users.controller.test.ts
@@ -1608,7 +1608,8 @@ describe('UserController', () => {
 
       if (!next.called) {
         expect(res.status.calledWith(200)).to.be.true;
-        expect(res.json.calledWith({ message: 'Invite sent successfully' })).to.be.true;
+        expect(res.json.calledWith({ message: 'Invite sent successfully' })).to.be
+          .true;
         expect(mockMailService.sendMail.calledOnce).to.be.true;
 
         // Verify the link uses #token= hash fragment, not ?token= query param
@@ -2381,7 +2382,9 @@ describe('UserController', () => {
       expect(mockMailService.sendMail.calledOnce).to.be.true;
       expect(mockMailService.sendMail.firstCall.args[0].usersMails).to.deep.equal(['pending@test.com']);
       expect(res.status.calledWith(200)).to.be.true;
-      expect(res.json.calledWith({ message: 'Invite sent successfully' })).to.be.true;
+      expect(
+        res.json.calledWith({ message: 'Invite sent successfully', queued: false }),
+      ).to.be.true;
     });
 
     it('should not resend invite for pending blocked users', async () => {

--- a/backend/nodejs/apps/tests/modules/user_management/services/mail.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/user_management/services/mail.service.test.ts
@@ -29,7 +29,7 @@ describe('MailService', () => {
       isConnected: sinon.stub().returns(true),
     };
 
-    mailService = new MailService(mockLogger, mockMailProducer);
+    mailService = new MailService(mockConfig, mockLogger, mockMailProducer);
   });
 
   afterEach(() => {
@@ -43,6 +43,7 @@ describe('MailService', () => {
         initiator: { jwtAuthToken: 'test-token', orgId: '507f1f77bcf86cd799439012' },
         usersMails: ['user@test.com'],
         subject: 'Test Subject',
+        deliverAsync: true,
       });
 
       expect(result.statusCode).to.equal(200);
@@ -62,6 +63,7 @@ describe('MailService', () => {
         initiator: { jwtAuthToken: 'test-token' },
         usersMails: ['user@test.com'],
         subject: 'Test Subject',
+        deliverAsync: true,
       });
 
       expect(result.statusCode).to.equal(500);
@@ -149,11 +151,26 @@ describe('MailService', () => {
         initiator: { jwtAuthToken: 'test-token' },
         usersMails: ['user@test.com'],
         subject: 'Test Subject',
+        deliverAsync: true,
       });
 
       expect(result.statusCode).to.equal(500);
       expect(result.data).to.be.a('string');
       expect(mockLogger.error.called).to.be.true;
+    });
+
+    it('sends inline unless the caller asks for broker delivery', async () => {
+      // Small invites stay synchronous so the admin gets a real result rather
+      // than a "queued" that may still fail minutes later.
+      const result = await mailService.sendMail({
+        emailTemplateType: 'appuserInvite',
+        initiator: { jwtAuthToken: 'test-token' },
+        usersMails: ['user@test.com'],
+        subject: 'Test Subject',
+      });
+
+      expect(mockMailProducer.publishEvent.called).to.be.false;
+      expect(result.data?.queued).to.not.equal(true);
     });
 
     it('should carry attachments and ccEmails onto the published event', async () => {
@@ -164,6 +181,7 @@ describe('MailService', () => {
         subject: 'Test Subject',
         attachedDocuments: [{ filename: 'test.pdf', content: 'data' }],
         ccEmails: ['cc@test.com'],
+        deliverAsync: true,
       });
 
       expect(result.statusCode).to.equal(200);

--- a/backend/nodejs/apps/tests/modules/user_management/services/mail.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/user_management/services/mail.service.test.ts
@@ -29,7 +29,7 @@ describe('MailService', () => {
       isConnected: sinon.stub().returns(true),
     };
 
-    mailService = new MailService(mockConfig, mockLogger, mockMailProducer);
+    mailService = new MailService(mockLogger, mockMailProducer);
   });
 
   afterEach(() => {
@@ -141,14 +141,10 @@ describe('MailService', () => {
       expect(result.data).to.equal('emailTemplateType is empty');
     });
 
-    it('should handle axios error and return statusCode 500', async () => {
-      // Force an error by using an invalid URL
-      const service = new MailService(
-        { communicationBackend: 'http://invalid-host-that-does-not-exist:99999' } as any,
-        mockLogger,
-      );
+    it('should return statusCode 500 when publishing the mail event fails', async () => {
+      mockMailProducer.publishEvent.rejects(new Error('broker unreachable'));
 
-      const result = await service.sendMail({
+      const result = await mailService.sendMail({
         emailTemplateType: 'appuserInvite',
         initiator: { jwtAuthToken: 'test-token' },
         usersMails: ['user@test.com'],
@@ -157,57 +153,25 @@ describe('MailService', () => {
 
       expect(result.statusCode).to.equal(500);
       expect(result.data).to.be.a('string');
+      expect(mockLogger.error.called).to.be.true;
     });
 
-    it('should include attachments when provided', async () => {
-      const service = new MailService(
-        { communicationBackend: 'http://invalid-host:99999' } as any,
-        mockLogger,
-      );
-
-      const result = await service.sendMail({
+    it('should carry attachments and ccEmails onto the published event', async () => {
+      const result = await mailService.sendMail({
         emailTemplateType: 'appuserInvite',
         initiator: { jwtAuthToken: 'test-token' },
         usersMails: ['user@test.com'],
         subject: 'Test Subject',
         attachedDocuments: [{ filename: 'test.pdf', content: 'data' }],
-      });
-
-      // Will fail due to invalid URL but validates params are accepted
-      expect(result.statusCode).to.equal(500);
-    });
-
-    it('should include ccEmails when provided', async () => {
-      const service = new MailService(
-        { communicationBackend: 'http://invalid-host:99999' } as any,
-        mockLogger,
-      );
-
-      const result = await service.sendMail({
-        emailTemplateType: 'appuserInvite',
-        initiator: { jwtAuthToken: 'test-token' },
-        usersMails: ['user@test.com'],
-        subject: 'Test Subject',
         ccEmails: ['cc@test.com'],
       });
 
-      expect(result.statusCode).to.equal(500);
-    });
-
-    it('should log debug message when sending mail', async () => {
-      const service = new MailService(
-        { communicationBackend: 'http://invalid-host:99999' } as any,
-        mockLogger,
-      );
-
-      await service.sendMail({
-        emailTemplateType: 'appuserInvite',
-        initiator: { jwtAuthToken: 'test-token' },
-        usersMails: ['user@test.com'],
-        subject: 'Test Subject',
-      });
-
-      expect(mockLogger.debug.calledWith('sending mail ...')).to.be.true;
+      expect(result.statusCode).to.equal(200);
+      const { mail } = mockMailProducer.publishEvent.firstCall.args[0].payload;
+      expect(mail.attachments).to.deep.equal([
+        { filename: 'test.pdf', content: 'data' },
+      ]);
+      expect(mail.sendCcTo).to.deep.equal(['cc@test.com']);
     });
   });
 });

--- a/backend/nodejs/apps/tests/modules/user_management/services/mail.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/user_management/services/mail.service.test.ts
@@ -9,6 +9,7 @@ describe('MailService', () => {
   let axiosStub: sinon.SinonStub;
   let mockLogger: any;
   let mockConfig: any;
+  let mockMailProducer: any;
 
   beforeEach(() => {
     mockLogger = {
@@ -22,7 +23,13 @@ describe('MailService', () => {
       communicationBackend: 'http://localhost:3002',
     };
 
-    mailService = new MailService(mockConfig, mockLogger);
+    mockMailProducer = {
+      publishEvent: sinon.stub().resolves(),
+      start: sinon.stub().resolves(),
+      isConnected: sinon.stub().returns(true),
+    };
+
+    mailService = new MailService(mockConfig, mockLogger, mockMailProducer);
   });
 
   afterEach(() => {
@@ -30,29 +37,35 @@ describe('MailService', () => {
   });
 
   describe('sendMail', () => {
-    it('should return statusCode 200 when axios succeeds', async () => {
-      const origAdapter = axios.defaults.adapter;
-      axios.defaults.adapter = async () => ({
-        data: { messageId: 'm1' },
-        status: 200,
-        statusText: 'OK',
-        headers: {},
-        config: {} as any,
+    it('publishes a mail event instead of sending inline, and returns 200', async () => {
+      const result = await mailService.sendMail({
+        emailTemplateType: 'appuserInvite',
+        initiator: { jwtAuthToken: 'test-token', orgId: '507f1f77bcf86cd799439012' },
+        usersMails: ['user@test.com'],
+        subject: 'Test Subject',
       });
 
-      try {
-        const result = await mailService.sendMail({
-          emailTemplateType: 'appuserInvite',
-          initiator: { jwtAuthToken: 'test-token' },
-          usersMails: ['user@test.com'],
-          subject: 'Test Subject',
-        });
+      expect(result.statusCode).to.equal(200);
+      expect(mockMailProducer.publishEvent.calledOnce).to.be.true;
 
-        expect(result.statusCode).to.equal(200);
-        expect(result.data).to.deep.equal({ messageId: 'm1' });
-      } finally {
-        axios.defaults.adapter = origAdapter;
-      }
+      const event = mockMailProducer.publishEvent.firstCall.args[0];
+      expect(event.payload.orgId).to.equal('507f1f77bcf86cd799439012');
+      expect(event.payload.mail.sendEmailTo).to.deep.equal(['user@test.com']);
+      expect(event.payload.mail.subject).to.equal('Test Subject');
+    });
+
+    it('returns 500 without publishing when the broker rejects the job', async () => {
+      mockMailProducer.publishEvent.rejects(new Error('broker down'));
+
+      const result = await mailService.sendMail({
+        emailTemplateType: 'appuserInvite',
+        initiator: { jwtAuthToken: 'test-token' },
+        usersMails: ['user@test.com'],
+        subject: 'Test Subject',
+      });
+
+      expect(result.statusCode).to.equal(500);
+      expect(result.data).to.equal('broker down');
     });
 
     it('should send mail successfully and return statusCode 200', async () => {


### PR DESCRIPTION
# feat(mail): deliver email asynchronously via the message broker

## Summary

This PR moves email delivery off the HTTP request path and into the existing message broker (Kafka or Redis Streams).

Instead of sending emails during the request, the application now publishes a mail event and returns immediately. A background consumer processes the event and sends the email.

This improves reliability, reduces request latency, and prevents slow or unavailable SMTP servers from blocking API requests.

> **Note:** This PR supersedes the timeout-hardening PR. All of its fixes are included here.

---

## Why?

Previously, bulk invites sent emails synchronously.

**Old flow**

```text
HTTP Request
    │
Create Users
    │
Send Email #1
Send Email #2
...
Send Email #1000
    │
Return Response
```

Problems:

- Slow SMTP servers blocked the request.
- Large bulk invites kept the request open for a long time.
- SMTP failures could cause request timeouts.

---

## What's Changed

### Backend

- Added asynchronous email delivery using the existing message broker.
- Added a new `MAIL_EVENTS` broker topic.
- Extracted email sending into `MailSenderService`.
- Added a dedicated producer and consumer for mail events.
- Added retry logic with exponential backoff.
- Added SMTP timeout handling and connection pooling.
- Added failure notifications for administrators with throttling.
- Kept OTP, password reset, and security emails synchronous.

### Frontend

- Importing a CSV/Excel file now **only fills the email list for review**.
- Users can review, edit, or remove addresses before clicking **Send Invite**.
- Added an improved Import help popup showing the expected file format.
- Lazy-loaded the `xlsx` parser to reduce the initial bundle size.

---

## Retry Behavior

- Maximum **4 retry attempts**
- Exponential backoff (**1s → 30s**)
- Retries only for transient failures:
  - SMTP 4xx errors
  - Network errors
- Permanent failures (SMTP 5xx, `EAUTH`, `EMESSAGE`) are not retried.

---

## SMTP Improvements

- Added connection, greeting, socket, and overall send deadlines.
- Added SMTP connection pooling to reuse existing connections.
- Automatically recreates the connection pool when SMTP settings change.
- Prevents a stuck SMTP connection from blocking the mail consumer indefinitely.

---

## Scope

The following emails **remain synchronous**:

- OTP emails
- Password reset emails
- Blocked login alerts

These must complete before the request returns to the user.

Bulk invite emails now run asynchronously through the message broker.

---

## Verification

- ✅ Typecheck passed
- ✅ All tests passing
- ✅ Verified end-to-end using Mailpit
- ✅ Verified retry behavior
- ✅ Verified timeout handling
- ✅ Verified SMTP connection pooling
- ✅ Verified failure notification throttling

---

## Known Limitations

- Retry delays are currently handled inside the consumer, so very large batches can temporarily block later emails.
- Failure notification throttling is per application instance rather than shared across instances.
- The `POST /bulk/invite/upload` endpoint still exists but is no longer used by the frontend.

---

## Files Added

| File | Purpose |
|------|---------|
| `mail/services/mail.producer.ts` | Publishes mail events |
| `mail/services/mail.consumer.ts` | Consumes mail events and sends emails |
| `mail/services/mail.sender.service.ts` | Handles SMTP delivery |
| `mail/types/mail-event.types.ts` | Mail event payload and error classification |
| `mail/utils/email-content.ts` | Email template handling |

---

## Test Files Used

The bulk invite flow was manually verified using the following files:

| File | Expected Result | Purpose |
|------|-----------------|---------|
| `01-simple.csv` | 5 emails parsed | Simple email list without a header |
| `02-name-and-email.csv` | 4 emails parsed | Header row with extra columns (name, department) |
| `03-messy.csv` | 7 → 5 emails | Duplicate removal, trimming, case-insensitive deduplication |
| `04-excel-bom.csv` | 2 emails parsed | Excel UTF-8 BOM handling |
| `05-over-limit.csv` | 1001 emails | Verifies the 1000-user upload limit |
| `06-no-emails.csv` | 0 emails | Valid file containing no email addresses |
| `07-empty.csv` | 0 emails | Empty file validation |
| `08-not-a-spreadsheet.png` | Error | Rejects unsupported file types |
| `09-two-sheets.xlsx` | 3 emails parsed | Multi-sheet Excel parsing |

These files verify:

- CSV and Excel support
- Optional header rows
- Extra columns ignored
- Multi-sheet Excel parsing
- Duplicate removal
- Case-insensitive email normalization
- Invalid file handling
- Empty file handling
- Maximum upload limit enforcement

---

## Demo

A demo video showing the complete bulk invite flow has been attached to this PR.

https://github.com/user-attachments/assets/7bb6f7f1-7ee3-4578-9936-d101f05334b6


**Covers:**

- Importing CSV and Excel files
- Reviewing imported email addresses
- Removing/editing addresses before sending
- Sending invites
- Success and validation messages
- Async email delivery flow

## Result

This PR makes bulk email delivery:

- Faster
- More reliable
- Non-blocking
- Easier to maintain
- Better prepared for large-scale bulk invites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email delivery can now be queued for larger invitation and notification batches, improving responsiveness.
  * Mail delivery supports automatic retries, SMTP connection reuse, and clearer handling of temporary and permanent failures.
  * Delivery failures can notify administrators while limiting repeated alerts.
* **Bug Fixes**
  * Suspicious-login alerts no longer prevent authentication security errors from being reported when email delivery fails.
  * Outbound mail requests now have defined time limits to prevent stalled operations.
* **Tests**
  * Expanded coverage for email delivery, retries, failure handling, and security alerts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->