### PR TITLE
fix(it): accept unpadded Record ID labels in content IT

### DIFF
--- a/integration-tests/response-validation/connector/integration_test_record_content.py
+++ b/integration-tests/response-validation/connector/integration_test_record_content.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import sys
 from pathlib import Path
 from uuid import uuid4
@@ -63,8 +64,13 @@ class TestConnectorRecordContent:
 
         # content leads with the pre-formatted metadata header plus an LLM-written
         # summary, so assert only the deterministic Record ID line — the prose is
-        # paraphrased, never verbatim.
-        assert f"Record ID       : {record_id}" in content, content[:500]
+        # paraphrased, never verbatim. Spacing around the colon is not part of the
+        # contract (Prompt tuning #2848 dropped column padding).
+        assert re.search(
+            rf"^Record ID\s*:\s*{re.escape(record_id)}\s*$",
+            content,
+            re.MULTILINE,
+        ), content[:500]
         assert indexed_text_record["record_name_stem"] in content
 
         # the parsed block text is flattened into the same string, so the uploaded

--- a/integration-tests/response-validation/connector/integration_test_record_content.py
+++ b/integration-tests/response-validation/connector/integration_test_record_content.py
@@ -67,7 +67,7 @@ class TestConnectorRecordContent:
         # paraphrased, never verbatim. Spacing around the colon is not part of the
         # contract (Prompt tuning #2848 dropped column padding).
         assert re.search(
-            rf"^Record ID\s*:\s*{re.escape(record_id)}\s*$",
+            rf"^Record ID[^\S\r\n]*:[^\S\r\n]*{re.escape(record_id)}[^\S\r\n]*$",
             content,
             re.MULTILINE,
         ), content[:500]


### PR DESCRIPTION
## Summary
- After [Prompt tuning (#2848)](https://github.com/pipeshub-ai/pipeshub-ai/pull/2848), `Record.to_llm_context()` emits compact labels (`Record ID:`) instead of column-padded ones (`Record ID       :`).
- `test_get_record_content_returns_parsed_content` still expected the old padded form, so Integration Tests fail deterministically on Neo4j and ArangoDB for every PR that includes #2848 (including Omnigent).
- **Fix choice:** update the IT assertion (not revert product formatting). #2848 intentionally compacted LLM context; production and KG unit tests already use `Record ID:`. The IT should pin the record id line, not whitespace padding.

## Test plan
- [x] Confirm CI Integration Tests pass `test_get_record_content_returns_parsed_content` on both graph backends
- [x] Spot-check that content still includes the record id, name stem, and uploaded sentinel


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of displayed record details by accepting flexible spacing and formatting around record IDs.
  * Prevented valid record identifiers from being rejected due to special characters or layout differences.
  * Improved compatibility with varying record-detail layouts while preserving accurate validation of displayed information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->