### PR TITLE
ci(it): fail-fast helper unit tests before Docker (merge before #2910)

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -228,6 +228,14 @@ jobs:
           uv venv
           uv pip install -e .
 
+      # Pure helper unit tests (mocks only) — fail fast before Docker/services come up.
+      - name: Run helper unit tests
+        working-directory: integration-tests
+        run: |
+          source .venv/bin/activate
+          mkdir -p reports
+          pytest unit/ -v --tb=short --junitxml=reports/unit-results.xml
+
       - name: 'Neo4j: Start services'
         if: matrix.graph_db == 'neo4j' || matrix.graph_db == 'both'
         working-directory: deployment/docker-compose

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -552,6 +552,29 @@ jobs:
             PR_FIELD_TEXT=""
           fi
 
+          # Parse helper unit-test JUnit XML (runs before Docker; no graph backend).
+          UNIT_TESTS=0
+          UNIT_PASSED=0
+          UNIT_FAILED=0
+          UNIT_ERRORS=0
+          UNIT_SKIPPED=0
+          if [ -f "reports/unit-results.xml" ]; then
+            unit_tests=$(grep -oP 'tests="\K[0-9]+' "reports/unit-results.xml" | head -1)
+            unit_failures=$(grep -oP 'failures="\K[0-9]+' "reports/unit-results.xml" | head -1)
+            unit_errors=$(grep -oP 'errors="\K[0-9]+' "reports/unit-results.xml" | head -1)
+            unit_skipped=$(grep -oP 'skipped="\K[0-9]+' "reports/unit-results.xml" | head -1)
+            UNIT_TESTS=${unit_tests:-0}
+            UNIT_FAILED=${unit_failures:-0}
+            UNIT_ERRORS=${unit_errors:-0}
+            UNIT_SKIPPED=${unit_skipped:-0}
+            UNIT_PASSED=$((UNIT_TESTS - UNIT_FAILED - UNIT_ERRORS - UNIT_SKIPPED))
+          fi
+          if [ "$UNIT_TESTS" -gt 0 ]; then
+            UNIT_PASS_RATE=$(( (UNIT_PASSED * 100) / UNIT_TESTS ))
+          else
+            UNIT_PASS_RATE=0
+          fi
+
           # Parse Playwright JUnit XML
           PW_TESTS=0
           PW_PASSED=0
@@ -578,7 +601,7 @@ jobs:
           # Green only when suites pass AND the job is healthy — a stack that never
           # came up yields zero counts, which would otherwise read as success.
           OVERALL_OK=true
-          if [ "$TOTAL_FAILED" -gt 0 ] || [ "$TOTAL_ERRORS" -gt 0 ] || [ "$PW_FAILED" -gt 0 ] || [ "$PW_ERRORS" -gt 0 ]; then
+          if [ "$TOTAL_FAILED" -gt 0 ] || [ "$TOTAL_ERRORS" -gt 0 ] || [ "$UNIT_FAILED" -gt 0 ] || [ "$UNIT_ERRORS" -gt 0 ] || [ "$PW_FAILED" -gt 0 ] || [ "$PW_ERRORS" -gt 0 ]; then
             OVERALL_OK=false
           fi
           if [ "$JOB_STATUS" != "success" ] || [ "$TOTAL_TESTS" -eq 0 ]; then
@@ -591,6 +614,12 @@ jobs:
           echo "TOTAL_ERRORS=$TOTAL_ERRORS" >> "$GITHUB_OUTPUT"
           echo "TOTAL_SKIPPED=$TOTAL_SKIPPED" >> "$GITHUB_OUTPUT"
           echo "PASS_RATE=$PASS_RATE" >> "$GITHUB_OUTPUT"
+          echo "UNIT_TESTS=$UNIT_TESTS" >> "$GITHUB_OUTPUT"
+          echo "UNIT_PASSED=$UNIT_PASSED" >> "$GITHUB_OUTPUT"
+          echo "UNIT_FAILED=$UNIT_FAILED" >> "$GITHUB_OUTPUT"
+          echo "UNIT_ERRORS=$UNIT_ERRORS" >> "$GITHUB_OUTPUT"
+          echo "UNIT_SKIPPED=$UNIT_SKIPPED" >> "$GITHUB_OUTPUT"
+          echo "UNIT_PASS_RATE=$UNIT_PASS_RATE" >> "$GITHUB_OUTPUT"
           echo "PW_TESTS=$PW_TESTS" >> "$GITHUB_OUTPUT"
           echo "PW_PASSED=$PW_PASSED" >> "$GITHUB_OUTPUT"
           echo "PW_FAILED=$PW_FAILED" >> "$GITHUB_OUTPUT"
@@ -669,6 +698,15 @@ jobs:
                       { "type": "raw_text", "text": "Errors"    },
                       { "type": "raw_text", "text": "Skipped"   },
                       { "type": "raw_text", "text": "Pass Rate" }
+                    ],
+                    [
+                      { "type": "raw_text", "text": "Helper unit (pytest)"                                           },
+                      { "type": "raw_text", "text": "${{ steps.test-results.outputs.UNIT_TESTS }}"                 },
+                      { "type": "raw_text", "text": "${{ steps.test-results.outputs.UNIT_PASSED }}"                },
+                      { "type": "raw_text", "text": "${{ steps.test-results.outputs.UNIT_FAILED }}"                },
+                      { "type": "raw_text", "text": "${{ steps.test-results.outputs.UNIT_ERRORS }}"                },
+                      { "type": "raw_text", "text": "${{ steps.test-results.outputs.UNIT_SKIPPED }}"               },
+                      { "type": "raw_text", "text": "${{ steps.test-results.outputs.UNIT_PASS_RATE }}%"            }
                     ],
                     [
                       { "type": "raw_text", "text": "Backend (pytest)"                                              },
@@ -756,7 +794,7 @@ jobs:
             -d "$COMPLETE_PAYLOAD"
 
       - name: Send failed tests list to Slack thread
-        if: ${{ !cancelled() && (steps.test-results.outputs.TOTAL_FAILED != '0' || steps.test-results.outputs.TOTAL_ERRORS != '0' || steps.test-results.outputs.PW_FAILED != '0' || steps.test-results.outputs.PW_ERRORS != '0') }}
+        if: ${{ !cancelled() && (steps.test-results.outputs.TOTAL_FAILED != '0' || steps.test-results.outputs.TOTAL_ERRORS != '0' || steps.test-results.outputs.UNIT_FAILED != '0' || steps.test-results.outputs.UNIT_ERRORS != '0' || steps.test-results.outputs.PW_FAILED != '0' || steps.test-results.outputs.PW_ERRORS != '0') }}
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           CHANNEL_ID: ${{ vars.SLACK_CI_CHANNEL_ID }}
@@ -782,7 +820,12 @@ jobs:
               sys.exit(0)
 
           names = []
-          for xml_path in ['reports/neo4j-results.xml', 'reports/arango-results.xml', 'reports/playwright/playwright-junit.xml']:
+          for xml_path in [
+              'reports/unit-results.xml',
+              'reports/neo4j-results.xml',
+              'reports/arango-results.xml',
+              'reports/playwright/playwright-junit.xml',
+          ]:
               if not os.path.exists(xml_path):
                   continue
               backend = os.path.basename(xml_path).replace('-results.xml', '')

--- a/integration-tests/helper/storage_incremental.py
+++ b/integration-tests/helper/storage_incremental.py
@@ -1,0 +1,154 @@
+"""Shared helpers for storage-connector incremental sync integration tests.
+
+Constructor fixtures only wait until ``count_records >= uploaded_files``, so the
+graph can still grow (folder records, late file rows) when TC-INCR starts. These
+helpers settle a stable baseline, restart sync with enough headroom for Kafka
+disable/enable, and require the new file names — not merely a rising count.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING, Callable, Mapping
+
+from helper.graph_provider_utils import (
+    async_wait_for_stable_record_count,
+    wait_for_sync_completion,
+    wait_until_graph_condition,
+)
+
+if TYPE_CHECKING:
+    from helper.graph_provider import GraphProviderProtocol
+    from pipeshub_client import PipeshubClient
+
+logger = logging.getLogger("storage-incremental")
+
+DEFAULT_SYNC_TIMEOUT_SEC = 240
+DEFAULT_MAX_SYNC_ATTEMPTS = 3
+DEFAULT_NAME_GRACE_TIMEOUT_SEC = 60
+
+
+def restart_sync(pipeshub_client: "PipeshubClient", connector_id: str) -> None:
+    """Disable then re-enable to trigger a fresh incremental sync."""
+    pipeshub_client.toggle_sync(connector_id, enable=False)
+    pipeshub_client.wait(5)
+    pipeshub_client.toggle_sync(connector_id, enable=True)
+    pipeshub_client.wait(8)
+
+
+def unique_incremental_csv_files(
+    *,
+    prefix: str = "incremental-test",
+    suffix: str | None = None,
+) -> dict[str, bytes]:
+    """Return two uniquely named CSV blobs under *prefix* for incremental upload."""
+    token = suffix if suffix is not None else uuid.uuid4().hex[:8]
+    return {
+        f"{prefix}/new-file-alpha-{token}.csv": (
+            b"id,name,value\n1,alpha,100\n2,bravo,200\n"
+        ),
+        f"{prefix}/new-file-beta-{token}.csv": (
+            b"id,name,value\n1,charlie,300\n2,delta,400\n"
+        ),
+    }
+
+
+def record_names_from_keys(object_keys: Mapping[str, bytes] | list[str]) -> list[str]:
+    """Basename list for uploaded object keys (dict keys or plain key list)."""
+    keys = object_keys.keys() if isinstance(object_keys, Mapping) else object_keys
+    return [Path(key).name for key in keys]
+
+
+async def settle_record_baseline(
+    pipeshub_client: "PipeshubClient",
+    graph_provider: "GraphProviderProtocol",
+    connector_id: str,
+    *,
+    timeout: int = DEFAULT_SYNC_TIMEOUT_SEC,
+) -> int:
+    """Wait until the connector is IDLE and record count is stable; return that count."""
+    await wait_for_sync_completion(
+        pipeshub_client,
+        graph_provider,
+        connector_id,
+        timeout=timeout,
+        sync_start_timeout=0,
+    )
+    before_count = await async_wait_for_stable_record_count(
+        graph_provider, connector_id
+    )
+    logger.info(
+        "Incremental baseline settled: %d records (connector %s)",
+        before_count,
+        connector_id,
+    )
+    return before_count
+
+
+async def sync_until_names_visible(
+    pipeshub_client: "PipeshubClient",
+    graph_provider: "GraphProviderProtocol",
+    connector_id: str,
+    new_names: list[str],
+    *,
+    max_attempts: int = DEFAULT_MAX_SYNC_ATTEMPTS,
+    sync_timeout: int = DEFAULT_SYNC_TIMEOUT_SEC,
+    name_grace_timeout: int = DEFAULT_NAME_GRACE_TIMEOUT_SEC,
+    restart_fn: Callable[["PipeshubClient", str], None] | None = None,
+) -> int:
+    """Restart sync until all *new_names* appear in the graph; return final count.
+
+    Retries absorb a late Kafka ``appDisabled`` cancelling the first re-enable.
+    """
+    do_restart = restart_fn or restart_sync
+
+    async def _new_files_visible() -> bool:
+        return await graph_provider.record_paths_or_names_contain(
+            connector_id, new_names
+        )
+
+    for sync_attempt in range(max_attempts):
+        do_restart(pipeshub_client, connector_id)
+        await wait_for_sync_completion(
+            pipeshub_client,
+            graph_provider,
+            connector_id,
+            timeout=sync_timeout,
+        )
+        if await _new_files_visible():
+            break
+        if sync_attempt < max_attempts - 1:
+            logger.warning(
+                "New files not in graph after sync, re-triggering "
+                "(attempt %d/%d) (connector %s)",
+                sync_attempt + 2,
+                max_attempts,
+                connector_id,
+            )
+
+    await wait_until_graph_condition(
+        connector_id,
+        check=_new_files_visible,
+        timeout=name_grace_timeout,
+        poll_interval=5,
+        description="incremental sync new file names",
+    )
+    return await graph_provider.count_records(connector_id)
+
+
+async def assert_incremental_new_files(
+    graph_provider: "GraphProviderProtocol",
+    connector_id: str,
+    *,
+    before_count: int,
+    after_count: int,
+    new_names: list[str],
+) -> None:
+    """Assert count grew by at least len(new_names) and each name is present."""
+    assert after_count >= before_count + len(new_names), (
+        f"Expected at least {len(new_names)} new records after incremental sync; "
+        f"before={before_count}, after={after_count} (connector {connector_id})"
+    )
+    await graph_provider.assert_record_paths_or_names_contain(connector_id, new_names)

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -6,6 +6,7 @@ minversion = 7.0
 # the server unhealthy, which trips up session-scoped Kafka/connector
 # fixtures from earlier suites when they tear down afterwards.
 testpaths =
+    unit
     messaging
     connectors
 # storage skip for now
@@ -20,6 +21,7 @@ python_functions = test_*
 # Markers
 markers =
     integration: marks tests as integration tests (require external services)
+    unit: marks fast helper unit tests (no external services)
     asyncio: marks tests as asyncio-based tests
     slow: marks tests as slow (deselect with '-m "not slow"')
     s3: marks tests specific to S3 connector

--- a/integration-tests/unit/test_storage_incremental.py
+++ b/integration-tests/unit/test_storage_incremental.py
@@ -1,0 +1,98 @@
+"""Unit tests for storage incremental-sync IT helpers (no live services)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from helper.storage_incremental import (
+    assert_incremental_new_files,
+    settle_record_baseline,
+    sync_until_names_visible,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_settle_baseline_and_assert_new_files_happy_path() -> None:
+    """IDLE settle + count/name assertions succeed for a completed incremental sync."""
+    client = MagicMock()
+    graph = MagicMock()
+    graph.assert_record_paths_or_names_contain = AsyncMock()
+
+    with (
+        patch(
+            "helper.storage_incremental.wait_for_sync_completion",
+            new_callable=AsyncMock,
+        ) as wait_sync,
+        patch(
+            "helper.storage_incremental.async_wait_for_stable_record_count",
+            new_callable=AsyncMock,
+            return_value=5,
+        ) as wait_stable,
+    ):
+        before = await settle_record_baseline(client, graph, "conn-1", timeout=120)
+
+    assert before == 5
+    wait_sync.assert_awaited_once_with(
+        client, graph, "conn-1", timeout=120, sync_start_timeout=0
+    )
+    wait_stable.assert_awaited_once_with(graph, "conn-1")
+
+    await assert_incremental_new_files(
+        graph,
+        "conn-1",
+        before_count=5,
+        after_count=7,
+        new_names=["a.csv", "b.csv"],
+    )
+    graph.assert_record_paths_or_names_contain.assert_awaited_once_with(
+        "conn-1", ["a.csv", "b.csv"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_until_names_visible_retries_then_fails_short_delta() -> None:
+    """Retry when names are missing after the first sync; reject too-small count deltas."""
+    client = MagicMock()
+    graph = MagicMock()
+    graph.record_paths_or_names_contain = AsyncMock(side_effect=[False, True, True])
+    graph.count_records = AsyncMock(return_value=10)
+    restarts: list[str] = []
+
+    def _restart(_client: object, connector_id: str) -> None:
+        restarts.append(connector_id)
+
+    with (
+        patch(
+            "helper.storage_incremental.wait_for_sync_completion",
+            new_callable=AsyncMock,
+        ) as wait_sync,
+        patch(
+            "helper.storage_incremental.wait_until_graph_condition",
+            new_callable=AsyncMock,
+        ),
+    ):
+        after = await sync_until_names_visible(
+            client,
+            graph,
+            "conn-1",
+            ["a.csv", "b.csv"],
+            max_attempts=3,
+            restart_fn=_restart,
+        )
+
+    assert after == 10
+    assert restarts == ["conn-1", "conn-1"]
+    assert wait_sync.await_count == 2
+
+    with pytest.raises(AssertionError, match="at least 2 new records"):
+        await assert_incremental_new_files(
+            graph,
+            "conn-1",
+            before_count=5,
+            after_count=6,
+            new_names=["a.csv", "b.csv"],
+        )


### PR DESCRIPTION
## Why this PR exists

Integration Tests use `pull_request_target`. That means:

| Piece | Comes from |
|---|---|
| Workflow YAML (`.github/workflows/integration-tests.yml`) | **`main`** |
| Test code checked out for the run | the **PR branch** |

So if a feature PR adds a new CI step, that step **does not run** until the YAML is on `main`.

This PR lands that YAML (and the tiny unit suite it runs) first. The connector flake fix that *uses* the helper is [#2910](https://github.com/pipeshub-ai/pipeshub-ai/pull/2910) — merge **this** PR, then rebase/run ITs on #2910.

## What changed

1. **CI** — new step `Run helper unit tests` after Python deps install, **before** Neo4j/Arango `docker compose up`. Pure unit failures fail fast; no Docker cost.
2. **Helper** — `integration-tests/helper/storage_incremental.py` (settle baseline, restart sync, wait for new file names, assert delta).
3. **Unit tests** — `integration-tests/unit/` (2 tests: happy path + retry/failure).
4. **pytest.ini** — collect `unit/` and register the `unit` marker.

## What this PR does *not* do

It does **not** change S3 / GCS / Azure Blob / Azure Files connector tests. That is [#2910](https://github.com/pipeshub-ai/pipeshub-ai/pull/2910).

## Merge order

```text
1) Merge this PR (#2913)  →  workflow + helper on main
2) Rebase #2910 onto main
3) Run Integration Tests on #2910
```

## Test plan

- [x] `cd integration-tests && pytest unit/ -q` (2 passed)
- [ ] Merge this PR
- [ ] Rebase + run ITs on #2910

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added fast unit coverage for incremental storage synchronization helpers without requiring live services.
  * Added validation for baseline settlement, retry handling, connector restarts, new-file visibility, and record-count changes.
  * Integration test reporting now includes helper-test results and failures in status notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->