### PR TITLE
fix(openapi): drop duplicate oauth2 requirement blocking SDK generation

### DIFF
--- a/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
+++ b/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
@@ -30787,7 +30787,6 @@ paths:
       x-pipeshub-sdk: true
       security:
         - bearerAuth: []
-        - oauth2: [kb:read]
         - oauth2: [connector:read]
       parameters:
         - name: nodeId
@@ -30987,7 +30986,6 @@ paths:
       x-pipeshub-sdk: true
       security:
         - bearerAuth: []
-        - oauth2: [kb:read]
         - oauth2: [connector:read]
       parameters:
         - name: identifiers


### PR DESCRIPTION
## Problem

All three SDK generation jobs in `pipeshub-ai/open-api` have failed since 2026-08-10. Latest failure: [run 31578107218](https://github.com/pipeshub-ai/open-api/actions/runs/31578107218).

```
ERROR validation error: [line 18264:9] concurrent use of multiple OAuth2 built-in security flows is not currently supported.
Step Failed: Validating Document
```

The reported line number is in Speakeasy's own copy of the spec, `source_specs/pipeshub-sdk-openapi.yaml`, not in this file. It points here:

```yaml
      security:
      - bearerAuth: []
      - oauth2:
        - kb:read
      - oauth2:          # <- line 18264, column 9
        - connector:read
```

Two entries in one `security` list both name the `oauth2` scheme. Speakeasy treats each entry as an independent auth path, so this reads as two concurrent built-in OAuth2 flows. It will not generate code for that.

Introduced by #2937 on two operations:

| Operation | Path |
|---|---|
| `navigateKnowledgeGraph` | `GET /connectors/navigate` |
| `lookupRecordByIdentifier` | `GET /connectors/record/lookup` |

Confirmed by bisecting the two CI runs. Both ran the same pinned Speakeasy `v1.731.2`, and only the spec files differed. The last green run had zero duplicate blocks; the failing run has two.

## Fix

Keep `connector:read`, drop `kb:read`, on both operations.

## Why this is safe at runtime

Both guards are **OR**, so a `connector:read`-only token already passes today:

- `require-scopes.middleware.ts:42` — `.some()`
- `api/middlewares/auth.py:233` — `any(...)`

And the scope is a **gate, not a filter** — it never reaches the graph query:

- `_knowledge_graph_context` (`router.py:1617`) reads only `userId` and `orgId`
- `router.py:1727` passes `connector_ids=None`
- `navigator.py:323` calls `get_nodes()` with no `origins`

Results stay bounded by per-node graph permissions alone. `navigate` still returns Knowledge Base nodes alongside connector nodes, exactly as before. No response changes.

## Why not merge both scopes into one entry

`- oauth2: [kb:read, connector:read]` would also remove the duplicate, but it is riskier. A `clientCredentials` SDK requests every listed scope when it fetches a token, and `scope.validator.service.ts:53` rejects any scope the app does not hold with `INVALID_SCOPE` (400). An OAuth app granted only `connector:read` would then fail at the **token** step, before ever calling the endpoint. A single scope cannot cause that.

This also matches `getConnectorStats`, which already documents one scope while `requireScopes` accepts either.

## Known cost

A client holding only `kb:read` can still call both endpoints, and the spec no longer says so. Worth a follow-up, along with two related items this surfaced:

- `requireScopes` on `/record/lookup` (`connectors.routes.ts:581`, `router.py:1747`) advertises `kb:read`, but the resolver returns early when the connector catalog is empty (`router.py:1795`), and that catalog excludes `type='KB'`. So `kb:read` alone can never match there.
- `scripts/filter_sdk_spec.py` in `open-api` could collapse repeated scheme names when building the SDK spec, so this cannot regress.

## Verification

- `js-yaml` loads the file; 234 paths parse
- Both operations now resolve to `[{bearerAuth: []}, {oauth2: [connector:read]}]`
- Zero duplicate `oauth2` entries remain anywhere in the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API authentication requirements for two operations, removing an unnecessary knowledge-base read permission while retaining bearer and connector-read authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->