### PR TITLE
fix: forward retrieved images to multimodal chat models

### DIFF
--- a/backend/python/app/agents/chat_modes/prefetch.py
+++ b/backend/python/app/agents/chat_modes/prefetch.py
@@ -123,6 +123,7 @@ async def prefetch_retrieval(
             user_id=user_id,
             limit=limit,
             filter_groups=filters,
+            include_image_content=is_multimodal_llm,
         )
     except Exception as exc:  # noqa: BLE001 - surfaced as a graceful empty prefetch
         logger.error("prefetch_retrieval: search_with_filters failed: %s", exc, exc_info=True)

--- a/backend/python/app/api/routes/chatbot.py
+++ b/backend/python/app/api/routes/chatbot.py
@@ -38,7 +38,7 @@ from app.modules.transformers.graphdb import GraphDBTransformer
 from app.modules.transformers.sink_orchestrator import SinkOrchestrator
 from app.modules.transformers.transformer import TransformContext
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
-from app.utils.aimodels import get_generator_model_async
+from app.utils.aimodels import get_generator_model_async, is_multimodal_llm as supports_multimodal
 from app.utils.attachment_mime_types import (
     DELIMITED_MIME_TYPES,
     DOCX_MIME_TYPES,
@@ -966,7 +966,7 @@ async def _generate_chat_stream_via_agent_loop(
         logger_.debug("Could not load system prompts config", exc_info=True)
 
     policy = resolve_chat_mode_policy(query_info.chatMode)
-    is_multimodal_llm = bool(model_config.get("isMultimodal"))
+    is_multimodal_llm = supports_multimodal(model_config)
     context_length = model_config.get("contextLength") or DEFAULT_CONTEXT_LENGTH
 
     # When the request carries agentCapabilities and we're in agent mode,

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -372,6 +372,7 @@ class RetrievalService:
         virtual_record_ids_from_tool: list[str] | None = None,
         knowledge_search: bool = False,
         time_range: dict[str, int] | None = None,
+        include_image_content: bool = False,
     ) -> dict[str, Any]:
         """Perform semantic search on records the given user may access (graph permission checks)."""
 
@@ -721,8 +722,14 @@ class RetrievalService:
             ]
 
             if new_type_results:
-                is_multimodal_llm = False   #doesn't matter for retrieval service
-                flattened_results = await get_flattened_results(new_type_results, self.blob_store, org_id, is_multimodal_llm, virtual_record_id_to_record, from_retrieval_service=True)
+                flattened_results = await get_flattened_results(
+                    new_type_results,
+                    self.blob_store,
+                    org_id,
+                    include_image_content,
+                    virtual_record_id_to_record,
+                    from_retrieval_service=True,
+                )
                 for result in flattened_results:
                     block_type = result.get("block_type")
                     if block_type == GroupType.TABLE.value or block_type in valid_group_labels:

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -2271,7 +2271,7 @@ async def get_flattened_results(result_set: List[Dict[str, Any]], blob_store: Bl
         elif block_type == BlockType.IMAGE.value:
             data = block.get("data")
             if data:
-                if from_retrieval_service:
+                if from_retrieval_service and not is_multimodal_llm:
                     result["content"] = f"image_{image_index}"
                     image_index += 1
                 else:

--- a/backend/python/tests/unit/agents/chat_modes/test_prefetch.py
+++ b/backend/python/tests/unit/agents/chat_modes/test_prefetch.py
@@ -192,6 +192,12 @@ class TestPrefetchImageCollection:
             "image_url": {"url": "data:image/png;base64,xx"},
             "virtual_record_id": "vr1",
         }]
+        assert (
+            retrieval_service.search_with_filters.await_args.kwargs[
+                "include_image_content"
+            ]
+            is True
+        )
 
     async def test_shared_image_budget_is_forwarded_to_formatter(self) -> None:
         """A shared `ImageBudget` passed in by the caller (`bridge.py`'s

--- a/backend/python/tests/unit/api/routes/test_chatbot_agent_loop_dispatch.py
+++ b/backend/python/tests/unit/api/routes/test_chatbot_agent_loop_dispatch.py
@@ -94,6 +94,37 @@ class TestGenerateChatStreamViaAgentLoop:
 
         assert mock_run_chat_stream.call_args.kwargs["protocol"] == "agui"
 
+    async def test_nested_multimodal_configuration_is_forwarded(self):
+        from app.api.routes.chatbot import ChatQuery, _generate_chat_stream_via_agent_loop
+
+        request = self._mock_request({})
+        query_info = ChatQuery(query="describe the image")
+
+        async def _fake_run_chat_stream(*args, **kwargs):
+            yield "event: complete\ndata: {}\n\n"
+
+        with (
+            patch(
+                "app.api.routes.chatbot.get_llm_for_chat",
+                new=AsyncMock(return_value=(
+                    MagicMock(),
+                    {"provider": "openAICompatible", "configuration": {"isMultimodal": True}},
+                    {},
+                )),
+            ),
+            patch(
+                "app.api.routes.chatbot.run_chat_stream", side_effect=_fake_run_chat_stream,
+            ) as mock_run_chat_stream,
+        ):
+            [
+                chunk
+                async for chunk in _generate_chat_stream_via_agent_loop(
+                    request, query_info, AsyncMock(), MagicMock(), AsyncMock(),
+                )
+            ]
+
+        assert mock_run_chat_stream.call_args.kwargs["is_multimodal_llm"] is True
+
     async def test_builds_query_dict_and_user_info_and_forwards_policy(self):
         """The plain-dict contract `run_chat_stream()` expects -- see
         `chat_modes/bridge.py`'s module docstring for why it never sees

--- a/backend/python/tests/unit/utils/test_chat_helpers.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers.py
@@ -3016,7 +3016,7 @@ class TestGetFlattenedResults:
 
     @pytest.mark.asyncio
     async def test_image_from_retrieval_service(self):
-        """For from_retrieval_service, image blocks get image_N content."""
+        """Multimodal retrieval preserves image content for downstream chat."""
         img_block = _make_image_block(index=0, uri="data:image/png;base64,abc")
         record = _make_record_blob()
         record["block_containers"]["blocks"] = [img_block]
@@ -3037,7 +3037,7 @@ class TestGetFlattenedResults:
         )
         image_results = [r for r in results if r.get("block_type") == BlockType.IMAGE.value]
         assert len(image_results) == 1
-        assert image_results[0]["content"] == "image_0"
+        assert image_results[0]["content"] == "data:image/png;base64,abc"
 
     @pytest.mark.asyncio
     async def test_table_with_range_based_children(self):


### PR DESCRIPTION
## Description

Forward retrieved knowledge-base images to multimodal chat models so visual questions can use the original image rather than an `image_N` placeholder.

Current upstream already provides shared image budgeting, citation pairing, and image injection. This rebased change keeps that implementation and restores the missing retrieval flag that preserves image data only when the selected chat model is multimodal. Text-only models retain the existing placeholder behavior.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

- #2952
- #2961

## How Has This Been Tested?

- [x] Focused unit tests pass: 411 passed
- [x] Docker image rebuilt successfully
- [x] Rebuilt PipesHub container is healthy
- [x] `git diff --check` passes

The focused tests cover:

- preserving image data returned through the retrieval service for multimodal chat;
- retaining placeholder behavior for text-only retrieval;
- forwarding multimodal capability from both supported configuration layouts;
- requesting image content only for multimodal prefetch;
- passing preserved images into upstream's existing shared image collector.

Live validation also identified a separate deployment-data issue: the historical test image belongs to an old private-KB App node that no longer has a permission edge from the current user after migration. Retrieval correctly rejects that stale record as inaccessible, so it cannot be used as end-to-end evidence for this PR without repairing its permissions. No permission data is changed here.

## Code Quality Checklist

- [x] Changes are rebased on current `main`
- [x] Merge conflicts are resolved
- [x] Existing upstream image budgeting and citation logic is reused
- [x] No new dependencies
- [x] No authentication or authorization bypass
- [x] Non-multimodal behavior remains unchanged

## Performance Impact

Only multimodal requests ask retrieval to preserve image data. Existing upstream conversation-wide image budgeting remains responsible for limiting payloads; this PR introduces no separate hard-coded count or byte limit.

## Deployment Notes

Rebuild/redeploy PipesHub. Existing indexes do not require migration when the embedding provider has already indexed image records.

---

**For reviewers:** Please focus on the `include_image_content` handoff from prefetch to retrieval and the preservation of text-only behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multimodal chat responses now preserve and include images from retrieval results when supported.
  * Improved detection of models that can process image content.

* **Bug Fixes**
  * Prevented images from being replaced with placeholder text in multimodal conversations.
  * Improved image retrieval during chat prefetching.

* **Tests**
  * Added coverage for multimodal retrieval, image handling, configuration forwarding, and related safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->