### PR TITLE
perf:qeury service throughput phase 2

### DIFF
--- a/backend/nodejs/apps/src/libs/services/authtoken.service.ts
+++ b/backend/nodejs/apps/src/libs/services/authtoken.service.ts
@@ -19,12 +19,29 @@ interface TokenPayload extends Record<string, any> {}
  *
  * Passing a KeyObject skips the try/throw entirely. PEM input is still handled
  * so an asymmetric deployment keeps working.
+ *
+ * The empty-secret check is load-bearing, not defensive tidiness. verify()
+ * rejects a falsy secret with "secret or public key must be provided" *before*
+ * it coerces the key, so an empty string used to fail closed. A KeyObject is
+ * always truthy, so without this guard an empty secret sails past that check
+ * and every token forged with an empty HMAC key verifies successfully.
  */
 function toVerificationKey(secret: string): KeyObject {
+  if (!secret) {
+    throw new Error('JWT secret is not configured');
+  }
   if (secret.includes('-----BEGIN')) {
     return createPublicKey(secret);
   }
   return createSecretKey(Buffer.from(secret));
+}
+
+/** Algorithms a key type can legitimately verify, so a token's own `alg`
+ * header cannot steer verification onto a weaker scheme. */
+function algorithmsFor(key: KeyObject): jwt.Algorithm[] {
+  return key.type === 'secret'
+    ? ['HS256', 'HS384', 'HS512']
+    : ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512'];
 }
 
 @injectable()
@@ -34,20 +51,23 @@ export class AuthTokenService {
   private readonly scopedJwtSecret: string;
   private readonly jwtVerificationKey: KeyObject;
   private readonly scopedJwtVerificationKey: KeyObject;
+  private readonly jwtAlgorithms: jwt.Algorithm[];
+  private readonly scopedJwtAlgorithms: jwt.Algorithm[];
 
   constructor(jwtSecret: string, scopedJwtSecret: string) {
     this.jwtSecret = jwtSecret;
     this.scopedJwtSecret = scopedJwtSecret;
     this.jwtVerificationKey = toVerificationKey(jwtSecret);
     this.scopedJwtVerificationKey = toVerificationKey(scopedJwtSecret);
+    this.jwtAlgorithms = algorithmsFor(this.jwtVerificationKey);
+    this.scopedJwtAlgorithms = algorithmsFor(this.scopedJwtVerificationKey);
   }
 
   async verifyToken(token: string): Promise<TokenPayload> {
     try {
-      const decoded = jwt.verify(
-        token,
-        this.jwtVerificationKey,
-      ) as TokenPayload;
+      const decoded = jwt.verify(token, this.jwtVerificationKey, {
+        algorithms: this.jwtAlgorithms,
+      }) as TokenPayload;
 
       return decoded;
     } catch (error) {
@@ -59,10 +79,9 @@ export class AuthTokenService {
   async verifyScopedToken(token: string, scope: string): Promise<TokenPayload> {
     let decoded: TokenPayload;
     try {
-      decoded = jwt.verify(
-        token,
-        this.scopedJwtVerificationKey,
-      ) as TokenPayload;
+      decoded = jwt.verify(token, this.scopedJwtVerificationKey, {
+        algorithms: this.scopedJwtAlgorithms,
+      }) as TokenPayload;
     } catch (error) {
       this.logger.error('Token verification failed', { error });
       throw new UnauthorizedError('Invalid token');

--- a/backend/nodejs/apps/src/libs/services/authtoken.service.ts
+++ b/backend/nodejs/apps/src/libs/services/authtoken.service.ts
@@ -44,7 +44,10 @@ export class AuthTokenService {
 
   async verifyToken(token: string): Promise<TokenPayload> {
     try {
-      const decoded = jwt.verify(token, this.jwtVerificationKey) as TokenPayload;
+      const decoded = jwt.verify(
+        token,
+        this.jwtVerificationKey,
+      ) as TokenPayload;
 
       return decoded;
     } catch (error) {
@@ -56,7 +59,10 @@ export class AuthTokenService {
   async verifyScopedToken(token: string, scope: string): Promise<TokenPayload> {
     let decoded: TokenPayload;
     try {
-      decoded = jwt.verify(token, this.scopedJwtVerificationKey) as TokenPayload;
+      decoded = jwt.verify(
+        token,
+        this.scopedJwtVerificationKey,
+      ) as TokenPayload;
     } catch (error) {
       this.logger.error('Token verification failed', { error });
       throw new UnauthorizedError('Invalid token');

--- a/backend/nodejs/apps/src/libs/services/authtoken.service.ts
+++ b/backend/nodejs/apps/src/libs/services/authtoken.service.ts
@@ -1,24 +1,50 @@
 // authtoken.service.ts
 import { injectable } from 'inversify';
+import { createPublicKey, createSecretKey, KeyObject } from 'node:crypto';
 import { UnauthorizedError } from '../errors/http.errors';
 import { Logger } from '../services/logger.service';
 import jwt, { SignOptions } from 'jsonwebtoken';
 
 interface TokenPayload extends Record<string, any> {}
+
+/**
+ * Turn a configured secret into a KeyObject once, at construction.
+ *
+ * Given a raw string, jsonwebtoken's verify() calls createPublicKey() on it for
+ * every single call. Our tokens are HS256 (generateToken signs without an
+ * algorithm option, so jsonwebtoken defaults to HS256), which means that parse
+ * can never succeed: OpenSSL tries the string as PEM/DER, fails, throws, and
+ * verify() falls back to createSecretKey. Profiling the gateway under load put
+ * that failed-parse path at ~20% of its total CPU.
+ *
+ * Passing a KeyObject skips the try/throw entirely. PEM input is still handled
+ * so an asymmetric deployment keeps working.
+ */
+function toVerificationKey(secret: string): KeyObject {
+  if (secret.includes('-----BEGIN')) {
+    return createPublicKey(secret);
+  }
+  return createSecretKey(Buffer.from(secret));
+}
+
 @injectable()
 export class AuthTokenService {
   private readonly logger = Logger.getInstance();
   private readonly jwtSecret: string;
   private readonly scopedJwtSecret: string;
+  private readonly jwtVerificationKey: KeyObject;
+  private readonly scopedJwtVerificationKey: KeyObject;
 
   constructor(jwtSecret: string, scopedJwtSecret: string) {
     this.jwtSecret = jwtSecret;
     this.scopedJwtSecret = scopedJwtSecret;
+    this.jwtVerificationKey = toVerificationKey(jwtSecret);
+    this.scopedJwtVerificationKey = toVerificationKey(scopedJwtSecret);
   }
 
   async verifyToken(token: string): Promise<TokenPayload> {
     try {
-      const decoded = jwt.verify(token, this.jwtSecret) as TokenPayload;
+      const decoded = jwt.verify(token, this.jwtVerificationKey) as TokenPayload;
 
       return decoded;
     } catch (error) {
@@ -30,7 +56,7 @@ export class AuthTokenService {
   async verifyScopedToken(token: string, scope: string): Promise<TokenPayload> {
     let decoded: TokenPayload;
     try {
-      decoded = jwt.verify(token, this.scopedJwtSecret) as TokenPayload;
+      decoded = jwt.verify(token, this.scopedJwtVerificationKey) as TokenPayload;
     } catch (error) {
       this.logger.error('Token verification failed', { error });
       throw new UnauthorizedError('Invalid token');

--- a/backend/nodejs/apps/src/libs/services/authtoken.service.ts
+++ b/backend/nodejs/apps/src/libs/services/authtoken.service.ts
@@ -41,7 +41,17 @@ function toVerificationKey(secret: string): KeyObject {
 function algorithmsFor(key: KeyObject): jwt.Algorithm[] {
   return key.type === 'secret'
     ? ['HS256', 'HS384', 'HS512']
-    : ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512', 'PS256', 'PS384', 'PS512'];
+    : [
+        'RS256',
+        'RS384',
+        'RS512',
+        'ES256',
+        'ES384',
+        'ES512',
+        'PS256',
+        'PS384',
+        'PS512',
+      ];
 }
 
 @injectable()
@@ -94,11 +104,19 @@ export class AuthTokenService {
     return decoded;
   }
 
-  generateToken(payload: TokenPayload, expiresIn: SignOptions['expiresIn'] = '7d'): string {
+  generateToken(
+    payload: TokenPayload,
+    expiresIn: SignOptions['expiresIn'] = '7d',
+  ): string {
     return jwt.sign(payload, this.jwtSecret, { expiresIn } as SignOptions);
   }
 
-  generateScopedToken(payload: TokenPayload, expiresIn: SignOptions['expiresIn'] = '1h'): string {
-    return jwt.sign(payload, this.scopedJwtSecret, { expiresIn } as SignOptions);
+  generateScopedToken(
+    payload: TokenPayload,
+    expiresIn: SignOptions['expiresIn'] = '1h',
+  ): string {
+    return jwt.sign(payload, this.scopedJwtSecret, {
+      expiresIn,
+    } as SignOptions);
   }
 }

--- a/backend/nodejs/apps/src/libs/services/logger.service.ts
+++ b/backend/nodejs/apps/src/libs/services/logger.service.ts
@@ -223,6 +223,17 @@ export class Logger {
   }
 
   private logWithLevel(level: string, message: string, meta?: any) {
+    // Bail before getCallerInfo(): it captures and symbolises a stack trace,
+    // which profiling put at ~5% of gateway CPU -- and it was being paid in
+    // full for debug lines that the configured level then discarded.
+    // Guarded on the method existing: `logger` starts life as an empty cast
+    // and is only replaced once initializeLogger has run.
+    if (
+      typeof this.logger.isLevelEnabled === 'function' &&
+      !this.logger.isLevelEnabled(level)
+    ) {
+      return;
+    }
     const callerInfo = this.getCallerInfo();
     // Read at emit time; omitted entirely when there is no context.
     const traceMeta = getRequestContext()

--- a/backend/nodejs/apps/src/modules/storage/controllers/storage.controller.ts
+++ b/backend/nodejs/apps/src/modules/storage/controllers/storage.controller.ts
@@ -32,6 +32,7 @@ import { StorageService } from '../storage.service';
 import {
   getCurrentFilePath,
   DocumentInfoResponse,
+  LeanDocumentInfoResponse,
   getDocumentRootPath,
   extractOrgId,
   extractUserId,
@@ -337,9 +338,13 @@ export class StorageController {
       const version = req.query.version;
       const expirationTimeInSeconds = req.query.expirationTimeInSeconds;
 
-      const docResult: DocumentInfoResponse | undefined = await getDocumentInfo(
+      // lean: this path only reads fields off the document and signs a URL, so
+      // it does not need a hydrated model. Hydration is ~20% of gateway CPU and
+      // this is the hottest route on it.
+      const docResult: LeanDocumentInfoResponse | undefined = await getDocumentInfo(
         req,
         next,
+        true,
       ); // Use the middleware to get docInfo
       if (!docResult) {
         throw new NotFoundError('Document does not exist');

--- a/backend/nodejs/apps/src/modules/storage/utils/utils.ts
+++ b/backend/nodejs/apps/src/modules/storage/utils/utils.ts
@@ -28,6 +28,21 @@ export interface DocumentInfoResponse {
   document: mongoose.Document<unknown, {}, DocumentModel> & DocumentModel;
 }
 
+/**
+ * Read-only callers can ask for a plain object instead of a hydrated model.
+ *
+ * Mongoose hydration -- schema defaults, casting, getters, change tracking --
+ * measured ~20% of gateway CPU under load, and the download path reads a
+ * handful of fields and never saves. Opt-in rather than default because other
+ * callers of getDocumentInfo do mutate and save the document.
+ */
+// `Document` here is the plain data interface from storage.service.types.
+// NOT DocumentModel: that is declared `extends IDocument, MongooseDocument`, so
+// it carries save()/markModified()/etc and a lean object typed as it would
+// still compile against the hydrated-only API -- exactly the runtime crash the
+// lean path is meant to make impossible.
+export type LeanDocumentInfoResponse = { document: Document };
+
 export function encodeRFC5987(str: string): string {
   return encodeURIComponent(str)
     .replace(/'/g, '%27')
@@ -39,7 +54,18 @@ export function encodeRFC5987(str: string): string {
 async function getDocumentInfoFromDb(
   documentId: string,
   orgId: mongoose.Types.ObjectId,
-): Promise<DocumentInfoResponse | undefined> {
+  lean: true,
+): Promise<LeanDocumentInfoResponse | undefined>;
+async function getDocumentInfoFromDb(
+  documentId: string,
+  orgId: mongoose.Types.ObjectId,
+  lean?: false,
+): Promise<DocumentInfoResponse | undefined>;
+async function getDocumentInfoFromDb(
+  documentId: string,
+  orgId: mongoose.Types.ObjectId,
+  lean = false,
+): Promise<DocumentInfoResponse | LeanDocumentInfoResponse | undefined> {
   try {
     // Validate documentId is a valid ObjectId
     if (!mongoose.isValidObjectId(documentId)) {
@@ -47,11 +73,12 @@ async function getDocumentInfoFromDb(
     }
 
     // Fetch the document from MongoDB
-    const document = await DocumentModel.findOne({
+    const query = DocumentModel.findOne({
       _id: documentId,
       orgId,
       isDeleted: false,
     });
+    const document = lean ? await query.lean<Document>().exec() : await query;
 
     if (!document) {
       throw new NotFoundError('Document not found');
@@ -79,7 +106,18 @@ async function getDocumentInfoFromDb(
 export async function getDocumentInfo(
   req: AuthenticatedUserRequest | AuthenticatedServiceRequest,
   next: NextFunction,
-): Promise<DocumentInfoResponse | undefined> {
+  lean: true,
+): Promise<LeanDocumentInfoResponse | undefined>;
+export async function getDocumentInfo(
+  req: AuthenticatedUserRequest | AuthenticatedServiceRequest,
+  next: NextFunction,
+  lean?: false,
+): Promise<DocumentInfoResponse | undefined>;
+export async function getDocumentInfo(
+  req: AuthenticatedUserRequest | AuthenticatedServiceRequest,
+  next: NextFunction,
+  lean = false,
+): Promise<DocumentInfoResponse | LeanDocumentInfoResponse | undefined> {
   try {
     const orgId = extractOrgId(req);
     const documentId = req.params.documentId;
@@ -88,7 +126,11 @@ export async function getDocumentInfo(
     if (!documentId) {
       throw new NotFoundError('Document ID is required');
     }
-    const documentInfo = await getDocumentInfoFromDb(documentId, orgID);
+    // Branch rather than pass the boolean through: the overloads are what stop
+    // a lean object being handed to a caller expecting a hydrated document.
+    const documentInfo = lean
+      ? await getDocumentInfoFromDb(documentId, orgID, true)
+      : await getDocumentInfoFromDb(documentId, orgID, false);
     if (!documentInfo) {
       throw new NotFoundError('Document not found');
     }

--- a/backend/nodejs/apps/src/modules/tokens_manager/container/token-manager.container.ts
+++ b/backend/nodejs/apps/src/modules/tokens_manager/container/token-manager.container.ts
@@ -68,7 +68,8 @@ export class TokenManagerContainer {
         .toConstantValue(redisService);
 
       // Initialize KeyValueStoreService for PrometheusService dependency
-      const configurationManagerConfig = container.get<ConfigurationManagerConfig>('ConfigurationManagerConfig');
+      const configurationManagerConfig =
+        container.get<ConfigurationManagerConfig>('ConfigurationManagerConfig');
       const keyValueStoreService = KeyValueStoreService.getInstance(
         configurationManagerConfig,
       );
@@ -79,7 +80,10 @@ export class TokenManagerContainer {
 
       // Create broker-agnostic message producer
       const brokerConfig = resolveMessageBrokerConfig(config);
-      const messageProducer = createMessageProducer(brokerConfig, container.get('Logger'));
+      const messageProducer = createMessageProducer(
+        brokerConfig,
+        container.get('Logger'),
+      );
       await messageProducer.connect();
 
       container
@@ -123,10 +127,15 @@ export class TokenManagerContainer {
 
       const jwtSecret = config.jwtSecret;
       const scopedJwtSecret = config.scopedJwtSecret;
-      const authTokenService = new AuthTokenService(
-        jwtSecret || ' ',
-        scopedJwtSecret || ' ',
-      );
+      // Substituting a placeholder here authenticated the gateway with a secret
+      // that is published in this repository: any token signed with it verifies.
+      // A missing secret must stop startup, not silently weaken auth.
+      if (!jwtSecret || !scopedJwtSecret) {
+        throw new Error(
+          'JWT secrets are not configured; refusing to start the token manager',
+        );
+      }
+      const authTokenService = new AuthTokenService(jwtSecret, scopedJwtSecret);
       const authMiddleware = new AuthMiddleware(
         container.get('Logger'),
         authTokenService,

--- a/backend/nodejs/apps/tests/libs/services/authtoken.service.test.ts
+++ b/backend/nodejs/apps/tests/libs/services/authtoken.service.test.ts
@@ -201,4 +201,114 @@ describe('AuthTokenService', () => {
       }
     });
   });
+  // Verification keys are derived once in the constructor instead of letting
+  // jsonwebtoken re-parse the secret on every call. Signing still passes the
+  // raw string, so every test above already proves the HS256 round trip
+  // survived that change. The asymmetric branch is what nothing else reaches.
+  describe('PEM verification keys', () => {
+    const { generateKeyPairSync } = require('node:crypto');
+
+    const makeKeyPair = () =>
+      generateKeyPairSync('rsa', {
+        modulusLength: 2048,
+        publicKeyEncoding: { type: 'spki', format: 'pem' },
+        privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+      });
+
+    it('should verify a token signed with the matching private key', async () => {
+      const { publicKey, privateKey } = makeKeyPair();
+      const pemService = new AuthTokenService(publicKey, scopedJwtSecret);
+      const token = jwt.sign({ userId: 'user1' }, privateKey, {
+        algorithm: 'RS256',
+        expiresIn: '1h',
+      });
+
+      const decoded = await pemService.verifyToken(token);
+      expect(decoded.userId).to.equal('user1');
+    });
+
+    it('should reject a token signed with a different private key', async () => {
+      const { publicKey } = makeKeyPair();
+      const other = makeKeyPair();
+      const pemService = new AuthTokenService(publicKey, scopedJwtSecret);
+      const token = jwt.sign({ userId: 'user1' }, other.privateKey, {
+        algorithm: 'RS256',
+        expiresIn: '1h',
+      });
+
+      try {
+        await pemService.verifyToken(token);
+        expect.fail('Should have thrown');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UnauthorizedError);
+      }
+    });
+
+    it('should accept a PEM secret for scoped tokens too', async () => {
+      const { publicKey, privateKey } = makeKeyPair();
+      const pemService = new AuthTokenService(jwtSecret, publicKey);
+      const token = jwt.sign({ userId: 'user1', scopes: ['token:refresh'] }, privateKey, {
+        algorithm: 'RS256',
+        expiresIn: '1h',
+      });
+
+      const decoded = await pemService.verifyScopedToken(token, 'token:refresh');
+      expect(decoded.userId).to.equal('user1');
+    });
+  });
+  // verify() rejects a falsy secret before it coerces the key, so an empty
+  // secret used to fail closed. Deriving the KeyObject at construction skips
+  // that check, and a token forged with an empty HMAC key then verifies.
+  describe('empty secret', () => {
+    const { createHmac } = require('node:crypto');
+
+    const forgeWithEmptyKey = (payload: Record<string, unknown>) => {
+      const b64 = (o: unknown) =>
+        Buffer.from(JSON.stringify(o)).toString('base64url');
+      const head = b64({ alg: 'HS256', typ: 'JWT' });
+      const body = b64({ ...payload, exp: Math.floor(Date.now() / 1000) + 3600 });
+      const sig = createHmac('sha256', Buffer.from(''))
+        .update(`${head}.${body}`)
+        .digest('base64url');
+      return `${head}.${body}.${sig}`;
+    };
+
+    it('should refuse to construct with an empty jwt secret', () => {
+      expect(() => new AuthTokenService('', scopedJwtSecret)).to.throw(
+        /JWT secret is not configured/,
+      );
+    });
+
+    it('should refuse to construct with an empty scoped secret', () => {
+      expect(() => new AuthTokenService(jwtSecret, '')).to.throw(
+        /JWT secret is not configured/,
+      );
+    });
+
+    it('should not accept a token forged with an empty HMAC key', async () => {
+      const forged = forgeWithEmptyKey({ userId: 'attacker', orgId: 'victim' });
+      try {
+        await service.verifyToken(forged);
+        expect.fail('Forged token was accepted');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UnauthorizedError);
+      }
+    });
+  });
+
+  // A token's own `alg` header must not steer verification.
+  describe('algorithm pinning', () => {
+    it('should reject an unsigned (alg=none) token', async () => {
+      const b64 = (o: unknown) =>
+        Buffer.from(JSON.stringify(o)).toString('base64url');
+      const unsigned =
+        `${b64({ alg: 'none', typ: 'JWT' })}.${b64({ userId: 'attacker' })}.`;
+      try {
+        await service.verifyToken(unsigned);
+        expect.fail('Unsigned token was accepted');
+      } catch (error) {
+        expect(error).to.be.instanceOf(UnauthorizedError);
+      }
+    });
+  });
 });

--- a/backend/python/app/agent_loop_lib/core/messages.py
+++ b/backend/python/app/agent_loop_lib/core/messages.py
@@ -80,6 +80,18 @@ class ImageSource(BaseModel):
     data: str = ""                 # base64 string (type="base64") or URL (type="url")
 
 
+def image_data_url(source: "ImageSource") -> str:
+    """An `ImageSource` as a URL the OpenAI-family APIs accept.
+
+    They take one string for both cases: a plain URL, or a `data:` URI carrying
+    base64. Kept here next to the model so each transport does not re-derive it.
+    """
+    if source.type == "base64":
+        media_type = source.media_type or "image/jpeg"
+        return f"data:{media_type};base64,{source.data}"
+    return source.data
+
+
 class TextPart(BaseModel):
     type: Literal["text"] = "text"
     text: str

--- a/backend/python/app/agent_loop_lib/transport/anthropic.py
+++ b/backend/python/app/agent_loop_lib/transport/anthropic.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -24,6 +25,7 @@ from app.agent_loop_lib.core.streaming import (
 )
 from app.agent_loop_lib.core.tool_schema import ToolSchema
 from app.agent_loop_lib.transport.base import LLMTransport
+from app.agent_loop_lib.transport.openai_responses import normalise_tool_call
 
 # Status codes considered transient/retryable regardless of which SDK exception
 # type raised them. Kept in sync with RetryConfig.retryable_status_codes default.
@@ -63,6 +65,11 @@ class AnthropicTransport(LLMTransport):
         api_key: str,
         model: str = DEFAULT_MODEL,
         max_tokens: int = DEFAULT_MAX_TOKENS,
+        thinking: dict[str, Any] | None = None,
+        temperature: float | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        model_key: str | None = None,
     ) -> None:
         super().__init__()
         try:
@@ -76,7 +83,18 @@ class AnthropicTransport(LLMTransport):
         self._api_key = api_key
         self._model = model
         self._max_tokens = max_tokens
-        self._client = _anthropic.AsyncAnthropic(api_key=api_key)
+        # Captured from the configured model, not passed per call: LangChain
+        # bakes thinking into the model object, so threading it per call would
+        # itself be a behavioural difference. See from_langchain_model.
+        self._thinking = thinking
+        self._temperature = temperature
+        self._model_key = model_key
+        client_kwargs: dict[str, Any] = {"api_key": api_key}
+        if timeout is not None:
+            client_kwargs["timeout"] = timeout
+        if max_retries is not None:
+            client_kwargs["max_retries"] = max_retries
+        self._client = _anthropic.AsyncAnthropic(**client_kwargs)
         # Cumulative usage across all calls on this transport instance —
         # diagnostic only; `Agent.usage` (a `RunUsage` built from each call's
         # returned `ModelResponse.usage`) is the source of truth callers
@@ -86,6 +104,81 @@ class AnthropicTransport(LLMTransport):
         self.total_llm_calls: int = 0
         self.total_cache_read_tokens: int = 0
         self.total_cache_write_tokens: int = 0
+
+
+    @classmethod
+    def from_langchain_model(
+        cls, llm: Any, model_name: str = "", model_key: str | None = None,
+    ) -> "AnthropicTransport":
+        """Build from an already-configured `ChatAnthropic`.
+
+        Same contract as the OpenAI/Azure transports: capture what the LangChain
+        arm would send rather than re-deriving it.
+
+        Thinking is read out of the request payload LangChain builds, not off an
+        attribute. `aimodels` sets `reasoning_effort`, and langchain-anthropic
+        translates that into `thinking` only at request-build time -- on the live
+        deployment it produces `{"type": "adaptive", "display": "summarized"}`,
+        which is not something to hand-derive from the effort string without
+        drifting the moment that mapping changes. Falls back to an explicit
+        `thinking` attribute, then to nothing.
+        """
+        def _val(name: str) -> str:
+            raw = getattr(llm, name, None)
+            secret = getattr(raw, "get_secret_value", None)
+            return (secret() if callable(secret) else raw) or ""
+
+        api_key = _val("anthropic_api_key") or _val("api_key")
+        if not api_key:
+            raise ValueError(
+                f"{type(llm).__name__} has no anthropic_api_key; the direct "
+                "Anthropic transport only supports ChatAnthropic-configured models"
+            )
+
+        max_tokens = getattr(llm, "max_tokens", None) or cls.DEFAULT_MAX_TOKENS
+        thinking = cls._thinking_from(llm)
+        if thinking is None:
+            configured = getattr(llm, "thinking", None)
+            thinking = configured if isinstance(configured, dict) else None
+
+        timeout = getattr(llm, "default_request_timeout", None)
+        if timeout is None:
+            timeout = getattr(llm, "timeout", None)
+        max_retries = getattr(llm, "max_retries", None)
+
+        return cls(
+            api_key=api_key,
+            model=model_name or getattr(llm, "model", "") or cls.DEFAULT_MODEL,
+            max_tokens=int(max_tokens),
+            thinking=thinking,
+            # Anthropic rejects temperature together with extended thinking, and
+            # aimodels already leaves it unset for thinking models -- carry
+            # whatever it decided rather than second-guessing it here.
+            temperature=getattr(llm, "temperature", None),
+            timeout=timeout if isinstance(timeout, (int, float)) else None,
+            max_retries=max_retries if isinstance(max_retries, int) else None,
+            model_key=model_key,
+        )
+
+    @staticmethod
+    def _thinking_from(llm: Any) -> dict[str, Any] | None:
+        """`thinking` out of the payload langchain-anthropic would POST.
+
+        Private SDK surface, so it is wrapped: a langchain-anthropic upgrade that
+        renames it degrades to no thinking rather than raising mid-request, and
+        the parity test pins the behaviour so the build catches it first.
+        """
+        builder = getattr(llm, "_get_request_payload", None)
+        if not callable(builder):
+            return None
+        try:
+            from langchain_core.messages import HumanMessage
+
+            payload = builder([HumanMessage(content="x")], stop=None)
+        except Exception:
+            return None
+        thinking = payload.get("thinking") if isinstance(payload, dict) else None
+        return thinking if isinstance(thinking, dict) else None
 
     @property
     def provider(self) -> str:
@@ -148,11 +241,17 @@ class AnthropicTransport(LLMTransport):
         text: str | None = None
         for block in response.content:
             if block.type == "tool_use":
+                # Through the shared normaliser for the same 128-char name clamp
+                # the LangChain arm applies (converters._clamp_tool_call_name):
+                # an over-long hallucinated name otherwise reaches history and is
+                # re-sent every turn. Arguments arrive already parsed here -- the
+                # SDK accumulates input_json_delta itself -- so the JSON repair
+                # half is a no-op, unlike the OpenAI paths.
                 tool_calls.append(
-                    ToolCall(
-                        id=block.id,
-                        name=block.name,
-                        arguments=dict(block.input),
+                    normalise_tool_call(
+                        block.id,
+                        block.name,
+                        json.dumps(dict(block.input or {})),
                     )
                 )
             elif block.type == "text":
@@ -327,6 +426,19 @@ class AnthropicTransport(LLMTransport):
             # thinking budget — grow it rather than silently truncating output.
             kwargs["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
             kwargs["max_tokens"] = max(self._max_tokens, thinking_budget + 1024)
+        elif self._thinking:
+            kwargs["thinking"] = dict(self._thinking)
+            # A captured {"type": "enabled", "budget_tokens": N} needs headroom
+            # above N for the same reason the per-call branch above does, or the
+            # request 400s. "adaptive" carries no budget and needs nothing.
+            budget = self._thinking.get("budget_tokens")
+            if isinstance(budget, int) and budget:
+                kwargs["max_tokens"] = max(self._max_tokens, budget + 1024)
+        # Anthropic rejects temperature alongside extended thinking, so it is
+        # only sent when thinking is off — matching what LangChain puts on the
+        # wire for the same configuration.
+        if self._temperature is not None and "thinking" not in kwargs:
+            kwargs["temperature"] = self._temperature
         # effort has no Anthropic equivalent today — accepted for interface
         # parity with other providers and intentionally a no-op here.
         system_list = self._build_system_kwargs(system, system_blocks)
@@ -410,6 +522,16 @@ class AnthropicTransport(LLMTransport):
         if thinking_budget:
             kwargs["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
             kwargs["max_tokens"] = max(self._max_tokens, thinking_budget + 1024)
+        elif self._thinking:
+            kwargs["thinking"] = dict(self._thinking)
+            # A captured {"type": "enabled", "budget_tokens": N} needs headroom
+            # above N for the same reason the per-call branch above does, or the
+            # request 400s. "adaptive" carries no budget and needs nothing.
+            budget = self._thinking.get("budget_tokens")
+            if isinstance(budget, int) and budget:
+                kwargs["max_tokens"] = max(self._max_tokens, budget + 1024)
+        if self._temperature is not None and "thinking" not in kwargs:
+            kwargs["temperature"] = self._temperature
         # effort has no Anthropic equivalent today — same no-op as complete().
         system_list = self._build_system_kwargs(system, system_blocks)
         if system_list:

--- a/backend/python/app/agent_loop_lib/transport/anthropic.py
+++ b/backend/python/app/agent_loop_lib/transport/anthropic.py
@@ -434,10 +434,15 @@ class AnthropicTransport(LLMTransport):
             budget = self._thinking.get("budget_tokens")
             if isinstance(budget, int) and budget:
                 kwargs["max_tokens"] = max(self._max_tokens, budget + 1024)
-        # Anthropic rejects temperature alongside extended thinking, so it is
-        # only sent when thinking is off — matching what LangChain puts on the
-        # wire for the same configuration.
-        if self._temperature is not None and "thinking" not in kwargs:
+        # Anthropic rejects temperature alongside extended thinking (enabled /
+        # adaptive). {"type": "disabled"} is truthy but allows temperature —
+        # match LangChain, which still sends it for that configuration.
+        thinking_cfg = kwargs.get("thinking")
+        thinking_active = (
+            isinstance(thinking_cfg, dict)
+            and thinking_cfg.get("type") in ("enabled", "adaptive")
+        )
+        if self._temperature is not None and not thinking_active:
             kwargs["temperature"] = self._temperature
         # effort has no Anthropic equivalent today — accepted for interface
         # parity with other providers and intentionally a no-op here.
@@ -530,7 +535,12 @@ class AnthropicTransport(LLMTransport):
             budget = self._thinking.get("budget_tokens")
             if isinstance(budget, int) and budget:
                 kwargs["max_tokens"] = max(self._max_tokens, budget + 1024)
-        if self._temperature is not None and "thinking" not in kwargs:
+        thinking_cfg = kwargs.get("thinking")
+        thinking_active = (
+            isinstance(thinking_cfg, dict)
+            and thinking_cfg.get("type") in ("enabled", "adaptive")
+        )
+        if self._temperature is not None and not thinking_active:
             kwargs["temperature"] = self._temperature
         # effort has no Anthropic equivalent today — same no-op as complete().
         system_list = self._build_system_kwargs(system, system_blocks)

--- a/backend/python/app/agent_loop_lib/transport/azure_openai.py
+++ b/backend/python/app/agent_loop_lib/transport/azure_openai.py
@@ -1,0 +1,193 @@
+"""Azure OpenAI through the official SDK, without LangChain.
+
+`LangChainTransport` builds an `AIMessageChunk` per streamed token and pydantic
+runs two model validators on each one; that measured 8.96% of query-service CPU
+under load, and there is no upstream fix (langchain-core 1.5.3 still carries the
+validators, marked with its own "TODO: remove this logic if possible").
+
+Most of the request machinery is inherited from `OpenAITransport` -- Azure speaks
+the same shapes -- so only the client and the configuration capture differ, plus
+the two single-retry fallbacks `LangChainTransport` carries for request-shape
+conflicts.
+
+**Configuration is captured at construction, not passed per call.** That mirrors
+`LangChainTransport`, which ignores per-call `effort`/`thinking_budget` because
+`aimodels.get_generator_model` baked every knob into the model object. Reading
+those knobs back off the same object is what keeps the two transports issuing
+identical requests; reading only the credentials is what let them drift, sending
+different endpoints and no reasoning at all.
+
+Registered as provider "azure_direct"; "langchain" stays the default so this can
+be switched per deployment and reverted without a code change.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from app.agent_loop_lib.transport.openai import OpenAITransport, RequestDefaults
+
+if TYPE_CHECKING:  # noqa: F401 - kept for the class docstring's references
+    pass
+
+logger = logging.getLogger(__name__)
+
+# Re-exported: RequestDefaults moved to `openai.py` when the direct OpenAI
+# transport started needing it too. Kept importable from here because that is
+# where it was introduced and callers already import it from this module.
+__all__ = ["AzureOpenAITransport", "RequestDefaults"]
+
+class AzureOpenAITransport(OpenAITransport):
+    """Azure OpenAI via AsyncAzureOpenAI.
+
+    `deployment` is Azure's routing key: the model name in a request is the
+    deployment name, not the underlying model. Callers pass whatever
+    `aimodels.py` already resolved from configuration.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        azure_endpoint: str,
+        api_version: str,
+        deployment: str,
+        model: str | None = None,
+        defaults: RequestDefaults | None = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        model_key: str | None = None,
+    ) -> None:
+        # Skip OpenAITransport.__init__ (it builds AsyncOpenAI) but keep the
+        # LLMTransport base contract and the cumulative counters its callers read.
+        super(OpenAITransport, self).__init__()
+        try:
+            import openai as _openai
+        except ImportError as exc:
+            raise ImportError(
+                "openai SDK is required for AzureOpenAITransport. "
+                "Install it with: pip install 'agent-loop[openai]'"
+            ) from exc
+        self._openai = _openai
+        self._deployment = deployment
+        # Azure routes on the deployment name; the model field of a request must
+        # carry it, so default the model to the deployment rather than a public
+        # model id.
+        self._model = model or deployment
+        self._defaults = defaults or RequestDefaults()
+        # Key the learned api-mode store is written under; None disables the
+        # persistence half, exactly as it does for LangChainTransport.
+        self._model_key = model_key
+        client_kwargs: dict[str, Any] = {
+            "api_key": api_key,
+            "azure_endpoint": azure_endpoint,
+            "api_version": api_version,
+            "azure_deployment": deployment,
+        }
+        # Left unset the SDK applies its own (longer) default; LangChain pins
+        # DEFAULT_LLM_TIMEOUT, so a slow turn must fail at the same point.
+        if timeout is not None:
+            client_kwargs["timeout"] = timeout
+        if max_retries is not None:
+            client_kwargs["max_retries"] = max_retries
+        self._client = _openai.AsyncAzureOpenAI(**client_kwargs)
+        self.total_input_tokens: int = 0
+        self.total_output_tokens: int = 0
+        self.total_llm_calls: int = 0
+        self.total_cache_read_tokens: int = 0
+        self.total_cache_write_tokens: int = 0
+
+    @classmethod
+    def from_langchain_model(
+        cls, llm: Any, model_name: str = "", model_key: str | None = None,
+    ) -> "AzureOpenAITransport":
+        """Build from an already-configured `AzureChatOpenAI`.
+
+        Everything is read off the model the LangChain path already uses, rather
+        than re-resolving it from configuration, so the two transports cannot
+        drift apart. That includes the behaviour knobs, not just the
+        credentials: `aimodels.get_generator_model` sets temperature, timeout and
+        the reasoning configuration on the model rather than passing them per
+        call, so copying only the credentials silently produced a different
+        request -- Chat Completions with no reasoning, where LangChain used the
+        Responses API at the configured effort.
+
+        Raises ValueError when `llm` is not Azure-shaped -- this transport is
+        Azure-only, and silently falling back would hide a misconfiguration
+        behind a slower path.
+        """
+        def _val(name: str) -> str:
+            raw = getattr(llm, name, None)
+            # Credentials arrive as pydantic SecretStr on the LangChain model.
+            secret = getattr(raw, "get_secret_value", None)
+            return (secret() if callable(secret) else raw) or ""
+
+        endpoint = _val("azure_endpoint")
+        deployment = _val("deployment_name")
+        api_key = _val("openai_api_key")
+        api_version = _val("openai_api_version")
+        missing = [
+            n for n, v in (
+                ("azure_endpoint", endpoint), ("deployment_name", deployment),
+                ("openai_api_key", api_key), ("openai_api_version", api_version),
+            ) if not v
+        ]
+        if missing:
+            raise ValueError(
+                f"{type(llm).__name__} is missing Azure settings {missing}; "
+                "azure_direct only supports AzureChatOpenAI-configured models"
+            )
+
+        reasoning = getattr(llm, "reasoning", None)
+        defaults = RequestDefaults(
+            temperature=getattr(llm, "temperature", None),
+            reasoning=reasoning if isinstance(reasoning, dict) else None,
+            reasoning_effort=getattr(llm, "reasoning_effort", None),
+            use_responses_api=bool(getattr(llm, "use_responses_api", False)),
+            model=model_name or deployment,
+        )
+        timeout = getattr(llm, "request_timeout", None)
+        if timeout is None:
+            timeout = getattr(llm, "timeout", None)
+        return cls(
+            api_key=api_key, azure_endpoint=endpoint, api_version=api_version,
+            deployment=deployment, model=model_name or deployment,
+            defaults=defaults,
+            timeout=timeout if isinstance(timeout, (int, float)) else None,
+            max_retries=getattr(llm, "max_retries", None),
+            model_key=model_key,
+        )
+
+    @property
+    def provider(self) -> str:
+        return "azure_direct"
+
+    def _default_request_kwargs(self) -> dict[str, Any]:
+        """Temperature and reasoning captured from the configured model.
+
+        The Chat Completions path uses `reasoning_effort`; the Responses path
+        uses `reasoning={"effort": ...}`. RequestDefaults emits whichever
+        matches the endpoint this transport was configured for, so a request
+        never carries the wrong spelling.
+        """
+        return self._defaults.request_kwargs()
+
+    def _wants_responses(self) -> bool:
+        """Taken from the configured model, never re-derived.
+
+        `aimodels._reasoning_effort_kwargs` has already folded the model-name
+        heuristic and the learned `LLMApiMode` fact into `use_responses_api`.
+        Recomputing that here would be a second source of truth that drifts
+        from the LangChain arm the first time either rule changes.
+        """
+        return self._defaults.use_responses_api
+
+    def _responses_model_id(self) -> str:
+        """The DEPLOYMENT name, not the model name.
+
+        Azure puts `/deployments/{name}/` in the path for Chat Completions but
+        not for `/openai/responses`, so on the Responses API the deployment has
+        to travel in the body instead. Sending the model name there is a
+        DeploymentNotFound 404.
+        """
+        return self._deployment

--- a/backend/python/app/agent_loop_lib/transport/gemini.py
+++ b/backend/python/app/agent_loop_lib/transport/gemini.py
@@ -566,7 +566,7 @@ class GeminiTransport(LLMTransport):
     async def complete_structured(
         self,
         messages: list[Message],
-        schema: dict[str, Any],
+        output_schema: dict[str, Any],
         system: str | None = None,
         model: str | None = None,
         system_blocks: list[str] | None = None,
@@ -578,7 +578,7 @@ class GeminiTransport(LLMTransport):
 
         tool = _ToolSchema(
             name="respond", description="Respond with the required structure.",
-            input_schema=schema,
+            input_schema=output_schema,
         )
         response = await self.complete(
             messages=messages, tools=[tool], system=system, model=model,

--- a/backend/python/app/agent_loop_lib/transport/gemini.py
+++ b/backend/python/app/agent_loop_lib/transport/gemini.py
@@ -1,0 +1,673 @@
+"""Google Gemini through the google-genai SDK, without LangChain.
+
+Same rationale as the OpenAI/Anthropic direct transports: LangChain builds an
+`AIMessageChunk` per streamed token and pydantic validates each one, which
+measured ~9% of query-service CPU under load.
+
+Gemini's wire shape has less in common with OpenAI's than Anthropic's does, so
+this is a full transport rather than a subclass:
+
+* messages are `Content` objects with a `parts` list and role `"user"` /
+  `"model"` -- there is no assistant role and no system role, the system prompt
+  is a separate `system_instruction` on the config;
+* tool results go back as a `function_response` part, not a distinct message;
+* tool schemas are an OpenAPI subset, so JSON-Schema keywords we emit have to be
+  stripped or the request is rejected;
+* thinking is `thinking_level` / `thinking_budget` on a `ThinkingConfig`.
+
+Targets AI Studio (API key), not Vertex.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from app.agent_loop_lib.core.exceptions import TransportError
+from app.agent_loop_lib.core.messages import (
+    AssistantMessage,
+    Message,
+    MessageRole,
+)
+from app.agent_loop_lib.core.responses import (
+    ModelResponse,
+    StopReason,
+    StructuredResponse,
+    TokenUsage,
+)
+from app.agent_loop_lib.core.streaming import (
+    StreamCompleteEvent,
+    StreamEvent,
+    TextDeltaEvent,
+    ThinkingDeltaEvent,
+    ToolCallDeltaEvent,
+)
+from app.agent_loop_lib.transport.base import LLMTransport
+from app.agent_loop_lib.transport.openai_responses import normalise_tool_call
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from app.agent_loop_lib.core.tool_schema import ToolSchema
+
+logger = logging.getLogger(__name__)
+
+# Gemini validates `parameters` against `google.genai.types.Schema`, which is
+# declared extra="forbid" -- any key outside its field set raises a pydantic
+# ValidationError inside _format_tools, which surfaces as a non-retryable
+# TransportError and fails every tool-bearing request. So this is an ALLOW-list
+# taken from the SDK's own model rather than a deny-list of keywords seen so
+# far: a deny-list silently admits the next unsupported keyword a tool schema
+# grows ($comment, multipleOf, prefixItems, uniqueItems all fail today).
+def _allowed_schema_keys() -> frozenset[str]:
+    """Field names and aliases `types.Schema` accepts, read off the SDK model so
+    an SDK upgrade widens or narrows this automatically."""
+    try:
+        from google.genai import types as genai_types
+    except ImportError:  # pragma: no cover - transport raises on construction
+        return frozenset()
+    fields = genai_types.Schema.model_fields
+    keys = set(fields)
+    keys.update(f.alias for f in fields.values() if f.alias)
+    return frozenset(keys)
+
+
+_FINISH_REASON_MAP = {
+    "STOP": StopReason.END_TURN,
+    "MAX_TOKENS": StopReason.MAX_TOKENS,
+}
+
+# Gemini stops for reasons that are not "the model finished". Mapping these to
+# END_TURN makes a blocked or malformed generation indistinguishable from a
+# normal empty answer, which is how a safety block gets misread as the model
+# having nothing to say.
+_ABNORMAL_FINISH_REASONS = frozenset({
+    "SAFETY", "RECITATION", "PROHIBITED_CONTENT", "SPII", "BLOCKLIST",
+    "MALFORMED_FUNCTION_CALL", "IMAGE_SAFETY", "UNEXPECTED_TOOL_CALL",
+})
+
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504, 529}
+
+
+def sanitize_schema(schema: Any) -> Any:
+    """A JSON Schema into the subset `types.Schema` accepts.
+
+    Recursive because an unsupported keyword at any depth fails the whole
+    declaration, not just its own level.
+
+    `$ref`/`$defs` are dropped rather than inlined, which loses the referenced
+    structure for a schema built from a nested Pydantic model. langchain-google-genai
+    inlines them; matching that is worth doing if a tool ever needs it, but
+    dropping is what keeps the request valid today.
+    """
+    allowed = _allowed_schema_keys()
+
+    if isinstance(schema, list):
+        return [sanitize_schema(v) for v in schema]
+    if not isinstance(schema, dict):
+        return schema
+
+    out: dict[str, Any] = {}
+    for key, value in schema.items():
+        if key not in allowed:
+            continue
+        if key in ("anyOf", "any_of"):
+            out[key] = [sanitize_schema(v) for v in value]
+        elif key == "properties":
+            out[key] = {k: sanitize_schema(v) for k, v in value.items()}
+        elif key == "items":
+            out[key] = sanitize_schema(value)
+        else:
+            out[key] = sanitize_schema(value) if isinstance(value, (dict, list)) else value
+
+    # An object with no properties still needs the key present, or the
+    # declaration is rejected as malformed.
+    if out.get("type") == "object" and "properties" not in out:
+        out["properties"] = {}
+    return out
+
+
+class GeminiTransport(LLMTransport):
+    """Gemini via `google-genai` (AI Studio).
+
+    Install: pip install google-genai
+    """
+
+    DEFAULT_MODEL = "gemini-3-flash-preview"
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = DEFAULT_MODEL,
+        temperature: float | None = None,
+        thinking_level: str | None = None,
+        thinking_budget: int | None = None,
+        max_output_tokens: int | None = None,
+        timeout: float | None = None,
+        model_key: str | None = None,
+    ) -> None:
+        super().__init__()
+        try:
+            from google import genai
+            from google.genai import types as genai_types
+        except ImportError as exc:
+            raise ImportError(
+                "google-genai is required for GeminiTransport. "
+                "Install it with: pip install google-genai"
+            ) from exc
+        self._genai = genai
+        self._types = genai_types
+        self._model = model
+        self._temperature = temperature
+        self._thinking_level = thinking_level
+        self._thinking_budget = thinking_budget
+        self._max_output_tokens = max_output_tokens
+        self._model_key = model_key
+        # Gemini 3 rejects a replayed function_call that has lost its
+        # thought_signature ("Function call is missing a thought_signature in
+        # functionCall parts. This is required for tools to work correctly"),
+        # so the signature has to survive the round trip. It is opaque bytes
+        # with nowhere to live on our provider-neutral `ToolCall`, so it is kept
+        # here, keyed by call id, and re-attached when history is rebuilt. The
+        # transport instance outlives the turn (the registry caches it), which
+        # is the scope this needs.
+        self._thought_signatures: dict[str, bytes] = {}
+        # http_options carries the timeout in milliseconds; LangChain pins
+        # DEFAULT_LLM_TIMEOUT, so a slow turn must fail at the same point.
+        http_options = (
+            genai_types.HttpOptions(timeout=int(timeout * 1000))
+            if isinstance(timeout, (int, float)) else None
+        )
+        self._client = genai.Client(api_key=api_key, http_options=http_options)
+        self.total_input_tokens: int = 0
+        self.total_output_tokens: int = 0
+        self.total_llm_calls: int = 0
+        self.total_cache_read_tokens: int = 0
+        self.total_cache_write_tokens: int = 0
+
+    @staticmethod
+    def _new_call_id() -> str:
+        """A unique id for a call the provider did not identify.
+
+        AI Studio leaves `function_call.id` unset. A positional fallback like
+        `call_{index}` restarts at 0 on every request to the model, so the second
+        turn's id collided with the first's: the signature map overwrote the
+        earlier entry, and the tool-name lookup -- a last-wins dict -- resolved an
+        older tool result to the newer call's name, handing the model a result
+        labelled as a different function.
+        """
+        return f"call_{uuid.uuid4().hex[:16]}"
+
+    @classmethod
+    def from_langchain_model(
+        cls, llm: Any, model_name: str = "", model_key: str | None = None,
+    ) -> "GeminiTransport":
+        """Build from an already-configured `ChatGoogleGenerativeAI`.
+
+        Same contract as the other direct transports: every knob comes off the
+        model the LangChain arm uses. `aimodels` sets `reasoning_effort`, which
+        langchain-google-genai exposes as `thinking_level` (verified on the live
+        deployment: effort "high" -> thinking_level "high"), so reading the
+        attribute is enough here -- unlike Anthropic, where the translation only
+        happens at request-build time.
+        """
+        def _val(name: str) -> str:
+            raw = getattr(llm, name, None)
+            secret = getattr(raw, "get_secret_value", None)
+            return (secret() if callable(secret) else raw) or ""
+
+        api_key = _val("google_api_key") or _val("api_key")
+        if not api_key:
+            raise ValueError(
+                f"{type(llm).__name__} has no google_api_key; the direct Gemini "
+                "transport only supports ChatGoogleGenerativeAI-configured models"
+            )
+
+        timeout = getattr(llm, "timeout", None)
+        return cls(
+            api_key=api_key,
+            model=model_name or getattr(llm, "model", "") or cls.DEFAULT_MODEL,
+            temperature=getattr(llm, "temperature", None),
+            thinking_level=getattr(llm, "thinking_level", None),
+            thinking_budget=getattr(llm, "thinking_budget", None),
+            max_output_tokens=getattr(llm, "max_output_tokens", None)
+            or getattr(llm, "max_tokens", None),
+            timeout=timeout if isinstance(timeout, (int, float)) else None,
+            model_key=model_key,
+        )
+
+    @property
+    def provider(self) -> str:
+        return "gemini"
+
+    @property
+    def model_name(self) -> str:
+        return self._model
+
+    # ------------------------------------------------------------------
+    # Request shaping
+    # ------------------------------------------------------------------
+
+    def _format_contents(self, messages: list[Message]) -> list[Any]:
+        """Framework messages into Gemini `Content` objects.
+
+        Gemini has two roles, `user` and `model`. A tool result is a `user`
+        message carrying a `function_response` part, not a role of its own, and
+        an assistant tool call is a `model` message carrying `function_call`
+        parts -- the history has to round-trip in that shape or the model loses
+        track of what it already called.
+        """
+        types = self._types
+        contents: list[Any] = []
+
+        # Gemini correlates a function_response to its function_call by NAME, and
+        # `ToolMessage` carries only `tool_call_id` -- there is no name on it. So
+        # the name is recovered from the assistant message that made the call.
+        # Sending the id here instead leaves the model unable to see its own tool
+        # result: it answers as if the tool never ran, or not at all.
+        call_names: dict[str, str] = {
+            tc.id: tc.name
+            for msg in messages
+            if msg.role == MessageRole.ASSISTANT
+            for tc in (msg.tool_calls or [])
+            if tc.id
+        }
+
+        # Calls replayed as text because their signature is unknown; their
+        # results have to be replayed as text too.
+        flattened: set[str] = set()
+
+        for msg in messages:
+            if msg.role == MessageRole.TOOL:
+                payload = (msg.content or "") + getattr(msg, "step_footer", "")
+                name = call_names.get(msg.tool_call_id or "")
+                if not name:
+                    meta = getattr(msg, "artifact_meta", None)
+                    name = getattr(meta, "tool_name", "") or "tool"
+                if (msg.tool_call_id or "") in flattened:
+                    # Its call was replayed as text, so a function_response here
+                    # would have no function_call to attach to.
+                    contents.append(types.Content(
+                        role="user",
+                        parts=[types.Part(
+                            text="[previous tool result] " + name + ": " + payload
+                        )],
+                    ))
+                    continue
+                contents.append(types.Content(
+                    role="user",
+                    parts=[types.Part(function_response=types.FunctionResponse(
+                        name=name,
+                        response={"result": payload},
+                    ))],
+                ))
+                continue
+
+            if msg.role == MessageRole.ASSISTANT:
+                parts: list[Any] = []
+                if msg.text:
+                    parts.append(types.Part(text=msg.text))
+                for tc in msg.tool_calls or []:
+                    signature = self._thought_signatures.get(tc.id or "")
+                    if signature:
+                        part = types.Part(function_call=types.FunctionCall(
+                            name=tc.name, args=tc.arguments or {},
+                        ))
+                        part.thought_signature = signature
+                        parts.append(part)
+                        continue
+                    # No signature: this call came from an earlier HTTP request,
+                    # whose transport instance (and its signature map) is gone --
+                    # PipesHubAgentFactory.create builds a fresh TransportRegistry
+                    # per request. Gemini 3 rejects a function_call part without
+                    # one, so the exchange is replayed as plain text instead. The
+                    # model still sees what it called and what came back; it just
+                    # cannot resume the earlier thought.
+                    flattened.add(tc.id or "")
+                    parts.append(types.Part(text=(
+                        "[previous tool call] "
+                        + tc.name
+                        + "("
+                        + json.dumps(tc.arguments or {}, default=str)
+                        + ")"
+                    )))
+                if parts:
+                    contents.append(types.Content(role="model", parts=parts))
+                continue
+
+            content = msg.content
+            if isinstance(content, list):
+                user_parts = self._content_parts(content)
+                if user_parts:
+                    contents.append(types.Content(role="user", parts=user_parts))
+                    continue
+                content = ""
+            contents.append(types.Content(
+                role="user", parts=[types.Part(text=content or "")],
+            ))
+        return contents
+
+    def _content_parts(self, parts: list[Any]) -> list[Any]:
+        """`list[Part]` into Gemini parts, keeping images.
+
+        Gemini takes raw bytes with a mime type (`from_bytes`) or a URI
+        (`from_uri`), not a data: URL, so the base64 has to be decoded here.
+        """
+        import base64
+
+        types = self._types
+        out: list[Any] = []
+        for part in parts:
+            if getattr(part, "type", None) == "image" and getattr(part, "source", None):
+                source = part.source
+                mime = source.media_type or "image/jpeg"
+                if source.type == "base64":
+                    try:
+                        out.append(types.Part.from_bytes(
+                            data=base64.b64decode(source.data), mime_type=mime,
+                        ))
+                    except Exception:
+                        # A malformed attachment must not take the turn down;
+                        # the text of the message is still worth sending.
+                        logger.warning("gemini: dropping undecodable image attachment")
+                    continue
+                out.append(types.Part.from_uri(file_uri=source.data, mime_type=mime))
+                continue
+            text = getattr(part, "text", "")
+            if text:
+                out.append(types.Part(text=text))
+        return out
+
+    def _format_tools(self, tools: list[ToolSchema] | None) -> list[Any] | None:
+        if not tools:
+            return None
+        types = self._types
+        declarations = [
+            types.FunctionDeclaration(
+                name=t.name,
+                description=t.description,
+                parameters=sanitize_schema(
+                    t.input_schema or {"type": "object", "properties": {}}
+                ),
+            )
+            for t in tools
+        ]
+        return [types.Tool(function_declarations=declarations)]
+
+    def _build_config(
+        self, tools: list[ToolSchema] | None, system: str | None,
+        system_blocks: list[str] | None, force_tool: str | None = None,
+    ) -> Any:
+        types = self._types
+        if system_blocks and not system:
+            system = "\n\n".join(b for b in system_blocks if b)
+
+        thinking = None
+        if self._thinking_level or self._thinking_budget:
+            thinking = types.ThinkingConfig(
+                thinking_level=self._thinking_level,
+                thinking_budget=self._thinking_budget,
+            )
+
+        kwargs: dict[str, Any] = {}
+        if system:
+            kwargs["system_instruction"] = system
+        if self._temperature is not None:
+            kwargs["temperature"] = self._temperature
+        if self._max_output_tokens:
+            kwargs["max_output_tokens"] = self._max_output_tokens
+        if thinking is not None:
+            kwargs["thinking_config"] = thinking
+        formatted = self._format_tools(tools)
+        if formatted:
+            kwargs["tools"] = formatted
+            if force_tool:
+                kwargs["tool_config"] = types.ToolConfig(
+                    function_calling_config=types.FunctionCallingConfig(
+                        mode="ANY", allowed_function_names=[force_tool],
+                    )
+                )
+        return types.GenerateContentConfig(**kwargs)
+
+    # ------------------------------------------------------------------
+    # Response parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _candidate_parts(chunk: Any) -> list[Any]:
+        candidates = getattr(chunk, "candidates", None) or []
+        if not candidates:
+            return []
+        content = getattr(candidates[0], "content", None)
+        return list(getattr(content, "parts", None) or [])
+
+    def _record_usage_from(self, response: Any) -> TokenUsage:
+        usage = getattr(response, "usage_metadata", None)
+
+        def _int(name: str) -> int:
+            value = getattr(usage, name, 0) if usage is not None else 0
+            return value if isinstance(value, int) else 0
+
+        # thoughts_token_count is billed output that never appears as text, so
+        # excluding it would under-report what a reasoning turn actually cost.
+        output = _int("candidates_token_count") + _int("thoughts_token_count")
+        return self._record_usage(
+            _int("prompt_token_count"), output, _int("cached_content_token_count"),
+        )
+
+    def _record_usage(
+        self, input_tokens: int, output_tokens: int, cache_read: int,
+    ) -> TokenUsage:
+        self.total_input_tokens += input_tokens
+        self.total_output_tokens += output_tokens
+        self.total_cache_read_tokens += cache_read
+        self.total_llm_calls += 1
+        return TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=0,
+        )
+
+    def _stop_reason(self, chunk: Any, has_tool_calls: bool) -> StopReason:
+        candidates = getattr(chunk, "candidates", None) or []
+        raw = getattr(candidates[0], "finish_reason", None) if candidates else None
+        name = getattr(raw, "name", None) or (str(raw) if raw else None)
+        # Truncation first, then tool calls, matching the OpenAI paths: a reply
+        # cut off mid-call must not be reported as a usable TOOL_USE.
+        if name == "MAX_TOKENS":
+            return StopReason.MAX_TOKENS
+        if name in _ABNORMAL_FINISH_REASONS:
+            # Surfaced rather than silently ended: the caller sees a failed turn
+            # instead of an empty answer it cannot explain.
+            raise TransportError(
+                f"Gemini stopped generating: {name}", retryable=False,
+            )
+        if has_tool_calls:
+            return StopReason.TOOL_USE
+        return _FINISH_REASON_MAP.get(name, StopReason.END_TURN)
+
+    def _wrap_error(self, exc: Exception, context: str) -> TransportError:
+        status = getattr(exc, "code", None) or getattr(exc, "status_code", None)
+        retryable = status in _RETRYABLE_STATUS_CODES if isinstance(status, int) else False
+        if not retryable:
+            text = str(exc).lower()
+            retryable = any(
+                marker in text
+                for marker in ("rate limit", "resource_exhausted", "unavailable",
+                               "deadline", "timeout", "overloaded")
+            )
+        return TransportError(
+            f"Gemini transport error ({context}): {exc}", retryable=retryable,
+        )
+
+    # ------------------------------------------------------------------
+    # LLMTransport interface
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        system: str | None = None,
+        model: str | None = None,
+        thinking_budget: int | None = None,
+        effort: str | None = None,
+        system_blocks: list[str] | None = None,
+        force_tool: str | None = None,
+    ) -> ModelResponse:
+        try:
+            response = await self._client.aio.models.generate_content(
+                model=model or self._model,
+                contents=self._format_contents(messages),
+                config=self._build_config(tools, system, system_blocks, force_tool),
+            )
+        except Exception as exc:
+            raise self._wrap_error(exc, "complete") from exc
+
+        return self._parse_complete(response, model or self._model)
+
+    def _parse_complete(self, response: Any, resolved_model: str) -> ModelResponse:
+        """Parsing sits behind the same error wrapping as the request itself:
+        a malformed `args` payload should surface as a TransportError, not as a
+        raw exception escaping the transport."""
+        text_parts: list[str] = []
+        tool_calls = []
+        for idx, part in enumerate(self._candidate_parts(response)):
+            call = getattr(part, "function_call", None)
+            if call is not None:
+                call_id = getattr(call, "id", None) or self._new_call_id()
+                signature = getattr(part, "thought_signature", None)
+                if signature:
+                    self._thought_signatures[call_id] = signature
+                tool_calls.append(normalise_tool_call(
+                    call_id,
+                    getattr(call, "name", "") or "",
+                    json.dumps(dict(getattr(call, "args", None) or {})),
+                ))
+            elif getattr(part, "text", None) and not getattr(part, "thought", False):
+                text_parts.append(part.text)
+
+        message = AssistantMessage(
+            content="".join(text_parts) or None, tool_calls=tool_calls or None,
+        )
+        stop_reason = self._stop_reason(response, bool(tool_calls))
+        if stop_reason == StopReason.MAX_TOKENS:
+            message.truncated = True
+        return ModelResponse(
+            message=message,
+            usage=self._record_usage_from(response),
+            stop_reason=stop_reason,
+            model=resolved_model,
+        )
+
+    async def complete_structured(
+        self,
+        messages: list[Message],
+        schema: dict[str, Any],
+        system: str | None = None,
+        model: str | None = None,
+        system_blocks: list[str] | None = None,
+    ) -> StructuredResponse:
+        """Structured output via a single forced tool, matching how the other
+        transports do it -- Gemini's native `response_schema` accepts a narrower
+        schema subset than our callers pass."""
+        from app.agent_loop_lib.core.tool_schema import ToolSchema as _ToolSchema
+
+        tool = _ToolSchema(
+            name="respond", description="Respond with the required structure.",
+            input_schema=schema,
+        )
+        response = await self.complete(
+            messages=messages, tools=[tool], system=system, model=model,
+            system_blocks=system_blocks, force_tool="respond",
+        )
+        calls = response.message.tool_calls or []
+        if not calls:
+            # Returning {} would hand the planner, critic and skill extractor an
+            # empty structure with no error -- a silent failure that reads as an
+            # empty result. OpenAITransport raises here for the same reason.
+            raise TransportError(
+                "Gemini returned no structured response: the model answered with "
+                "text instead of calling the forced tool",
+                retryable=False,
+            )
+        return StructuredResponse(
+            data=calls[0].arguments, usage=response.usage, model=response.model,
+        )
+
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        system: str | None = None,
+        model: str | None = None,
+        thinking_budget: int | None = None,
+        effort: str | None = None,
+        system_blocks: list[str] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        resolved_model = model or self._model
+        text_parts: list[str] = []
+        # Gemini sends a whole function_call in one chunk rather than streaming
+        # its arguments, so calls are collected by index and emitted as a single
+        # fragment carrying both name and arguments -- the agent loop reads the
+        # name off the first delta for an index, which still holds.
+        calls: list[tuple[str, str, str]] = []
+        last_chunk: Any = None
+        usage_chunk: Any = None
+
+        try:
+            stream = await self._client.aio.models.generate_content_stream(
+                model=resolved_model,
+                contents=self._format_contents(messages),
+                config=self._build_config(tools, system, system_blocks),
+            )
+            async for chunk in stream:
+                last_chunk = chunk
+                if getattr(chunk, "usage_metadata", None) is not None:
+                    usage_chunk = chunk
+                for part in self._candidate_parts(chunk):
+                    call = getattr(part, "function_call", None)
+                    if call is not None:
+                        index = len(calls)
+                        call_id = getattr(call, "id", None) or self._new_call_id()
+                        name = getattr(call, "name", "") or ""
+                        args = json.dumps(dict(getattr(call, "args", None) or {}))
+                        calls.append((call_id, name, args))
+                        signature = getattr(part, "thought_signature", None)
+                        if signature:
+                            self._thought_signatures[call_id] = signature
+                        yield ToolCallDeltaEvent(
+                            index=index, id=call_id, name=name, arguments_delta=args,
+                        )
+                        continue
+                    text = getattr(part, "text", None)
+                    if not text:
+                        continue
+                    if getattr(part, "thought", False):
+                        yield ThinkingDeltaEvent(delta=text)
+                    else:
+                        text_parts.append(text)
+                        yield TextDeltaEvent(delta=text)
+        except Exception as exc:
+            raise self._wrap_error(exc, "stream") from exc
+
+        tool_calls = [normalise_tool_call(cid, name, args) for cid, name, args in calls]
+        message = AssistantMessage(
+            content="".join(text_parts) or None, tool_calls=tool_calls or None,
+        )
+        stop_reason = self._stop_reason(last_chunk, bool(tool_calls))
+        if stop_reason == StopReason.MAX_TOKENS:
+            message.truncated = True
+        usage = (
+            self._record_usage_from(usage_chunk) if usage_chunk is not None
+            else TokenUsage()
+        )
+        yield StreamCompleteEvent(
+            response=ModelResponse(
+                message=message, usage=usage, stop_reason=stop_reason,
+                model=resolved_model,
+            )
+        )

--- a/backend/python/app/agent_loop_lib/transport/openai.py
+++ b/backend/python/app/agent_loop_lib/transport/openai.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Any
+
+# Private SDK symbol, imported deliberately rather than reimplemented: SSE
+# framing is fiddly (multi-line data, chunk boundaries) and the SDK's decoder is
+# the tested one. test_openai_responses.py pins it, so an SDK upgrade that moves
+# it fails the build instead of the stream.
+from openai._streaming import SSEDecoder
 
 from app.agent_loop_lib.core.exceptions import TransportError
 from app.agent_loop_lib.core.messages import (
@@ -21,20 +29,109 @@ from app.agent_loop_lib.core.streaming import (
     StreamCompleteEvent,
     StreamEvent,
     TextDeltaEvent,
+    ThinkingDeltaEvent,
+    ToolCallDeltaEvent,
 )
 from app.agent_loop_lib.core.tool_schema import ToolSchema
 from app.agent_loop_lib.transport.base import LLMTransport
+from app.agent_loop_lib.transport.openai_responses import (
+    EVT_COMPLETED,
+    EVT_ERROR,
+    EVT_FAILED,
+    EVT_FUNCTION_ARGS_DELTA,
+    EVT_INCOMPLETE,
+    EVT_OUTPUT_ITEM_ADDED,
+    EVT_REASONING_DELTA,
+    EVT_REASONING_SUMMARY_DELTA,
+    EVT_REFUSAL_DELTA,
+    EVT_TEXT_DELTA,
+    RawEvent,
+    format_responses_input,
+    format_responses_tools,
+    normalise_tool_call,
+    parse_responses_output,
+    responses_usage_fields,
+    stop_reason_from_responses,
+)
+from app.agent_loop_lib.transport.provider_conflicts import (
+    is_api_shape_conflict,
+    is_reasoning_mandatory_conflict,
+)
+from app.utils.llm_api_mode_store import LLMApiMode, get_llm_api_mode_store
 
 # Uses `openai` SDK internally.
 # Install: pip install 'agent-loop[openai]'
 
-_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+logger = logging.getLogger(__name__)
+
+_RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504, 529}
+
+# Reasoning values a provider may reject outright when it refuses to let
+# reasoning be disabled. Matches LangChainTransport._reasoning_mandatory_fallback,
+# which bumps off a disabled value rather than clearing the field.
+_DISABLED_REASONING_VALUES = ("none", "off", "disabled", "minimal")
+_REASONING_BUMP_TARGET = "low"
 
 _FINISH_REASON_MAP: dict[str | None, StopReason] = {
     "stop": StopReason.END_TURN,
     "tool_calls": StopReason.TOOL_USE,
     "length": StopReason.MAX_TOKENS,
 }
+
+
+@dataclass
+class RequestDefaults:
+    """Per-request settings taken off the configured LangChain model.
+
+    These are the knobs `aimodels.get_generator_model` sets on the model object
+    (`aimodels.py:1081-1095`) rather than passing per call. `reasoning` and
+    `use_responses_api` travel together: for Azure plus a reasoning model,
+    `_reasoning_effort_kwargs` returns both, and the Responses API is required
+    because Chat Completions rejects reasoning combined with bound tools for the
+    gpt-5.x family.
+    """
+
+    temperature: float | None = None
+    reasoning: dict[str, Any] | None = None
+    reasoning_effort: str | None = None
+    use_responses_api: bool = False
+    model: str = ""
+
+    def _drops_temperature(self) -> bool:
+        """gpt-5 (non-chat) rejects temperature on the Responses API unless
+        reasoning is off.
+
+        langchain_openai applies the same rule before POSTing
+        (`chat_models/base.py`, "Remove temperature parameter for models that
+        don't support it in responses API"), so sending it would make our
+        request differ from the one the LangChain arm issues -- and 400 on the
+        deployment this transport actually targets.
+
+        One deliberate difference: langchain tests the request's `model` field,
+        which on Azure carries the DEPLOYMENT name; this tests the model name.
+        They coincide on deployments named after their model (the case here),
+        and where they don't, testing the model name is the one that matches
+        what the service will accept.
+        """
+        model = self.model or ""
+        return (
+            self.use_responses_api
+            and model.startswith("gpt-5")
+            and "chat" not in model
+            and (self.reasoning or {}).get("effort") != "none"
+        )
+
+    def request_kwargs(self) -> dict[str, Any]:
+        """The subset that goes into a request body."""
+        out: dict[str, Any] = {}
+        if self.temperature is not None and not self._drops_temperature():
+            out["temperature"] = self.temperature
+        if self.use_responses_api:
+            if self.reasoning:
+                out["reasoning"] = dict(self.reasoning)
+        elif self.reasoning_effort:
+            out["reasoning_effort"] = self.reasoning_effort
+        return out
 
 
 class OpenAITransport(LLMTransport):
@@ -51,7 +148,16 @@ class OpenAITransport(LLMTransport):
 
     DEFAULT_MODEL = "gpt-4o"
 
-    def __init__(self, api_key: str, model: str = DEFAULT_MODEL, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str,
+        model: str = DEFAULT_MODEL,
+        base_url: str | None = None,
+        defaults: "RequestDefaults | None" = None,
+        timeout: float | None = None,
+        max_retries: int | None = None,
+        model_key: str | None = None,
+    ) -> None:
         super().__init__()
         try:
             import openai as _openai
@@ -62,9 +168,17 @@ class OpenAITransport(LLMTransport):
             ) from exc
         self._openai = _openai
         self._model = model
+        self._defaults = defaults or RequestDefaults(model=model)
+        self._model_key = model_key
         client_kwargs: dict[str, Any] = {"api_key": api_key}
         if base_url:
             client_kwargs["base_url"] = base_url
+        # Unset, the SDK applies its own (longer) default; LangChain pins
+        # DEFAULT_LLM_TIMEOUT, so a slow turn has to fail at the same point.
+        if timeout is not None:
+            client_kwargs["timeout"] = timeout
+        if max_retries is not None:
+            client_kwargs["max_retries"] = max_retries
         self._client = _openai.AsyncOpenAI(**client_kwargs)
         # Cumulative usage across all calls on this transport instance —
         # diagnostic only; see AnthropicTransport's equivalent fields.
@@ -72,6 +186,60 @@ class OpenAITransport(LLMTransport):
         self.total_output_tokens: int = 0
         self.total_llm_calls: int = 0
         self.total_cache_read_tokens: int = 0
+        self.total_cache_write_tokens: int = 0
+
+
+    @classmethod
+    def from_langchain_model(
+        cls, llm: Any, model_name: str = "", model_key: str | None = None,
+    ) -> "OpenAITransport":
+        """Build from an already-configured `ChatOpenAI`.
+
+        Same contract as `AzureOpenAITransport.from_langchain_model`: read every
+        knob off the model the LangChain path already uses, not just the
+        credentials. `aimodels.get_generator_model` bakes temperature, timeout
+        and the reasoning configuration into the model object, and for a gpt-5
+        model `_reasoning_effort_kwargs` also sets `use_responses_api`, so a
+        transport that copied only the api key would quietly send Chat
+        Completions with no reasoning -- the exact drift this contract exists to
+        prevent.
+        """
+        def _val(name: str) -> str:
+            raw = getattr(llm, name, None)
+            secret = getattr(raw, "get_secret_value", None)
+            return (secret() if callable(secret) else raw) or ""
+
+        api_key = _val("openai_api_key")
+        if not api_key:
+            raise ValueError(
+                f"{type(llm).__name__} has no openai_api_key; the direct OpenAI "
+                "transport only supports ChatOpenAI-configured models"
+            )
+        resolved_model = model_name or getattr(llm, "model_name", "") or cls.DEFAULT_MODEL
+
+        reasoning = getattr(llm, "reasoning", None)
+        defaults = RequestDefaults(
+            temperature=getattr(llm, "temperature", None),
+            reasoning=reasoning if isinstance(reasoning, dict) else None,
+            reasoning_effort=getattr(llm, "reasoning_effort", None),
+            use_responses_api=bool(getattr(llm, "use_responses_api", False)),
+            model=resolved_model,
+        )
+        timeout = getattr(llm, "request_timeout", None)
+        if timeout is None:
+            timeout = getattr(llm, "timeout", None)
+        max_retries = getattr(llm, "max_retries", None)
+        base_url = _val("openai_api_base") or None
+
+        return cls(
+            api_key=api_key,
+            model=resolved_model,
+            base_url=base_url,
+            defaults=defaults,
+            timeout=timeout if isinstance(timeout, (int, float)) else None,
+            max_retries=max_retries if isinstance(max_retries, int) else None,
+            model_key=model_key,
+        )
 
     @property
     def provider(self) -> str:
@@ -108,8 +276,37 @@ class OpenAITransport(LLMTransport):
             }
         content = msg.content
         if isinstance(content, list):
-            content = " ".join(getattr(p, "text", "") for p in content)
+            blocks = self._format_content_blocks(content)
+            # Only send the array form when it carries something a plain string
+            # cannot: an image. Text-only messages stay strings, which is what
+            # every existing test and prompt cache expects.
+            if any(b["type"] != "text" for b in blocks):
+                return {"role": msg.role.value, "content": blocks}
+            content = " ".join(b["text"] for b in blocks)
         return {"role": msg.role.value, "content": content or ""}
+
+    @staticmethod
+    def _format_content_blocks(parts: list[Any]) -> list[dict[str, Any]]:
+        """`list[Part]` into Chat Completions content blocks.
+
+        ImageParts used to be flattened away here by `getattr(p, "text", "")`,
+        which silently dropped every attached image -- the model answered about
+        a picture it never received.
+        """
+        from app.agent_loop_lib.core.messages import image_data_url
+
+        blocks: list[dict[str, Any]] = []
+        for part in parts:
+            if getattr(part, "type", None) == "image" and getattr(part, "source", None):
+                blocks.append({
+                    "type": "image_url",
+                    "image_url": {"url": image_data_url(part.source)},
+                })
+                continue
+            text = getattr(part, "text", "")
+            if text:
+                blocks.append({"type": "text", "text": text})
+        return blocks
 
     def _format_messages(self, messages: list[Message], system: str | None) -> list[dict[str, Any]]:
         formatted: list[dict[str, Any]] = []
@@ -117,6 +314,217 @@ class OpenAITransport(LLMTransport):
             formatted.append({"role": "system", "content": system})
         formatted.extend(self._format_message(m) for m in messages)
         return formatted
+
+    # ------------------------------------------------------------------
+    # Responses API
+    #
+    # A different wire shape, not a variant: `input` instead of `messages`,
+    # flat tools, renamed usage fields, no finish_reason. Reasoning models on
+    # Azure require it, because Chat Completions rejects reasoning combined
+    # with bound tools for the gpt-5.x family.
+    # ------------------------------------------------------------------
+
+    def _wants_responses(self) -> bool:
+        """Whether requests should go to the Responses API.
+
+        Taken from the captured configuration, never re-derived:
+        `aimodels._reasoning_effort_kwargs` has already folded the model-name
+        heuristic and the learned `LLMApiMode` fact into `use_responses_api`.
+        Recomputing it here would be a second source of truth that drifts from
+        the LangChain arm the first time either rule changes. Defaults to False
+        for a transport constructed without a configured model.
+        """
+        return self._defaults.use_responses_api
+
+    def _responses_model_id(self) -> str:
+        """Value for the `model` field on a Responses request."""
+        return self._model
+
+    def _build_responses_kwargs(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None,
+        system: str | None,
+        system_blocks: list[str] | None,
+        stream: bool,
+    ) -> dict[str, Any]:
+        if system_blocks and not system:
+            system = "\n\n".join(b for b in system_blocks if b)
+        kwargs: dict[str, Any] = {
+            "model": self._responses_model_id(),
+            "input": format_responses_input(messages, system),
+            **self._default_request_kwargs(),
+        }
+        formatted_tools = format_responses_tools(tools)
+        if formatted_tools:
+            kwargs["tools"] = formatted_tools
+        if stream:
+            # No stream_options: include_usage is Chat-Completions-only, and
+            # usage always arrives on response.completed.
+            kwargs["stream"] = True
+        return kwargs
+
+    async def _complete_responses(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        system: str | None = None,
+        system_blocks: list[str] | None = None,
+    ) -> ModelResponse:
+        kwargs = self._build_responses_kwargs(messages, tools, system, system_blocks, stream=False)
+        try:
+            response = await self._client.responses.create(**kwargs)
+        except Exception as exc:
+            raise self._wrap_error(exc, "complete") from exc
+
+        message = parse_responses_output(response)
+        usage = self._record_usage(*responses_usage_fields(response))
+        stop_reason = stop_reason_from_responses(response, bool(message.tool_calls))
+        if stop_reason == StopReason.MAX_TOKENS:
+            message.truncated = True
+        return ModelResponse(
+            message=message, usage=usage, stop_reason=stop_reason,
+            model=self._responses_model_id(),
+        )
+
+    async def _raw_response_events(self, kwargs: dict[str, Any]) -> AsyncIterator[Any]:
+        """Responses stream events as `RawEvent`, skipping the SDK's per-event
+        pydantic validation (see `RawEvent` for why -- ~12% of query CPU).
+
+        `with_streaming_response` and `iter_bytes` are public SDK API; only the
+        cast to `ResponseStreamEvent` is bypassed. HTTP, auth, retries and SSE
+        framing all still come from the SDK.
+
+        Two behaviours of `AsyncStream.__stream__` are reproduced deliberately:
+
+        * A non-2xx raises on entering the context manager, before any event is
+          yielded (`_base_client.py`, `_make_status_error_from_response`, after
+          its own retry loop). `AzureOpenAITransport.stream` refuses to retry a
+          request-shape conflict once anything has been emitted, so an error
+          arriving late instead of early would silently disable that recovery.
+        * An event carrying `error` raises rather than ending the stream, or a
+          mid-stream failure would look like a short answer.
+        """
+        decoder = SSEDecoder()
+        async with self._client.responses.with_streaming_response.create(**kwargs) as response:
+            async for sse in decoder.aiter_bytes(response.iter_bytes()):
+                if sse.data.startswith("[DONE]"):
+                    break
+                data = json.loads(sse.data)
+                if isinstance(data, dict) and data.get("error"):
+                    error = data["error"]
+                    message = error.get("message") if isinstance(error, dict) else None
+                    raise TransportError(
+                        "OpenAI API error (stream): "
+                        f"{message or 'An error occurred during streaming'}",
+                        retryable=False,
+                    )
+                yield RawEvent(data)
+
+    async def _stream_responses(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        system: str | None = None,
+        system_blocks: list[str] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        kwargs = self._build_responses_kwargs(messages, tools, system, system_blocks, stream=True)
+        final_response: Any = None
+        # Fallback only. The terminal event carries the fully-formed Response,
+        # so the same parser as _complete_responses builds the final message;
+        # this is used solely when a stream dies before response.completed.
+        partial: dict[int, dict[str, Any]] = {}
+
+        try:
+            async for event in self._raw_response_events(kwargs):
+                etype = getattr(event, "type", "")
+
+                if etype in (EVT_TEXT_DELTA, EVT_REFUSAL_DELTA):
+                    delta = getattr(event, "delta", "") or ""
+                    if delta:
+                        yield TextDeltaEvent(delta=delta)
+
+                elif etype in (EVT_REASONING_DELTA, EVT_REASONING_SUMMARY_DELTA):
+                    delta = getattr(event, "delta", "") or ""
+                    if delta:
+                        yield ThinkingDeltaEvent(delta=delta)
+
+                elif etype == EVT_OUTPUT_ITEM_ADDED:
+                    item = getattr(event, "item", None)
+                    if getattr(item, "type", None) == "function_call":
+                        index = getattr(event, "output_index", 0) or 0
+                        call_id = getattr(item, "call_id", None)
+                        name = getattr(item, "name", None)
+                        partial[index] = {"id": call_id, "name": name, "arguments": ""}
+                        # The opener is where the name arrives, and the agent
+                        # loop reads it off the FIRST delta for an index to
+                        # recognise final_answer. Withholding it until
+                        # arguments arrive is what breaks live streaming.
+                        yield ToolCallDeltaEvent(
+                            index=index, id=call_id, name=name, arguments_delta="",
+                        )
+
+                elif etype == EVT_FUNCTION_ARGS_DELTA:
+                    index = getattr(event, "output_index", 0) or 0
+                    delta = getattr(event, "delta", "") or ""
+                    if delta:
+                        entry = partial.setdefault(
+                            index, {"id": None, "name": None, "arguments": ""}
+                        )
+                        entry["arguments"] += delta
+                        yield ToolCallDeltaEvent(
+                            index=index, id=None, name=None, arguments_delta=delta,
+                        )
+
+                elif etype in (EVT_COMPLETED, EVT_INCOMPLETE):
+                    final_response = getattr(event, "response", None)
+
+                elif etype in (EVT_FAILED, EVT_ERROR):
+                    detail = getattr(getattr(event, "response", None), "error", None)
+                    raise TransportError(
+                        "OpenAI API error (stream): "
+                        f"{detail or getattr(event, 'message', event)}",
+                        retryable=False,
+                    )
+        except TransportError:
+            raise
+        except Exception as exc:
+            raise self._wrap_error(exc, "stream") from exc
+
+        if final_response is not None:
+            message = parse_responses_output(final_response)
+            usage = self._record_usage(*responses_usage_fields(final_response))
+            stop_reason = stop_reason_from_responses(final_response, bool(message.tool_calls))
+        else:
+            # Stream ended without a terminal event; salvage what arrived.
+            salvaged: list[ToolCall] = []
+            for idx, entry in sorted(partial.items()):
+                salvaged.append(
+                    normalise_tool_call(
+                        entry["id"] or f"call_{idx}", entry["name"] or "", entry["arguments"]
+                    )
+                )
+            message = AssistantMessage(content=None, tool_calls=salvaged or None)
+            usage = TokenUsage()
+            stop_reason = StopReason.TOOL_USE if salvaged else StopReason.END_TURN
+
+        if stop_reason == StopReason.MAX_TOKENS:
+            message.truncated = True
+        yield StreamCompleteEvent(
+            response=ModelResponse(
+                message=message, usage=usage, stop_reason=stop_reason,
+                model=self._responses_model_id(),
+            )
+        )
+
+    def _default_request_kwargs(self) -> dict[str, Any]:
+        """Settings applied to every request, on top of the per-call arguments.
+
+        Empty for a transport built without a configured model; populated from
+        `RequestDefaults` when one was captured, so all three request builders
+        pick it up without each having to remember.
+        """
+        return self._defaults.request_kwargs()
 
     def _format_tools(self, tools: list[ToolSchema] | None) -> list[dict] | None:
         """Our internal, provider-agnostic `ToolSchema` into OpenAI's
@@ -138,11 +546,9 @@ class OpenAITransport(LLMTransport):
     def _parse_tool_calls(self, raw_tool_calls: Any) -> list[ToolCall]:
         tool_calls: list[ToolCall] = []
         for tc in raw_tool_calls or []:
-            try:
-                args = json.loads(tc.function.arguments) if tc.function.arguments else {}
-            except (json.JSONDecodeError, ValueError):
-                args = {}
-            tool_calls.append(ToolCall(id=tc.id, name=tc.function.name, arguments=args))
+            tool_calls.append(
+                normalise_tool_call(tc.id, tc.function.name, tc.function.arguments)
+            )
         return tool_calls
 
     def _parse_response(self, choice_message: Any) -> AssistantMessage:
@@ -150,6 +556,42 @@ class OpenAITransport(LLMTransport):
         tool_calls = self._parse_tool_calls(getattr(choice_message, "tool_calls", None))
         text = getattr(choice_message, "content", None)
         return AssistantMessage(content=text, tool_calls=tool_calls or None)
+
+    def _record_usage(
+        self, input_tokens: int, output_tokens: int, cache_read: int, cache_write: int = 0
+    ) -> TokenUsage:
+        """Bump the cumulative counters and build the per-call TokenUsage.
+
+        Shared by both API shapes: the Responses API names every usage field
+        differently, so only the extraction differs, never the accounting.
+        """
+        self.total_input_tokens += input_tokens
+        self.total_output_tokens += output_tokens
+        self.total_llm_calls += 1
+        self.total_cache_read_tokens += cache_read
+        self.total_cache_write_tokens += cache_write
+        return TokenUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_write_tokens=cache_write,
+        )
+
+    @staticmethod
+    def _chat_stop_reason(finish_reason: str | None, has_tool_calls: bool) -> StopReason:
+        """Chat Completions finish_reason -> StopReason, ordered as
+        LangChainTransport orders it (`langchain_transport.py:484,414-423`):
+        truncation first, then tool calls, then the literal mapping.
+
+        Tool calls have to beat a missing/unknown finish_reason, or a provider
+        that omits it turns a turn holding tool calls into END_TURN and the
+        loop stops with the calls unexecuted.
+        """
+        if finish_reason == "length":
+            return StopReason.MAX_TOKENS
+        if has_tool_calls:
+            return StopReason.TOOL_USE
+        return _FINISH_REASON_MAP.get(finish_reason, StopReason.END_TURN)
 
     def _usage_from(self, response: Any) -> TokenUsage:
         usage = getattr(response, "usage", None)
@@ -163,22 +605,16 @@ class OpenAITransport(LLMTransport):
         details = getattr(usage, "prompt_tokens_details", None)
         cached = _int_field(details, "cached_tokens")
 
-        self.total_input_tokens += input_tokens
-        self.total_output_tokens += output_tokens
-        self.total_llm_calls += 1
-        self.total_cache_read_tokens += cached
-
-        return TokenUsage(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cache_read_tokens=cached,
-            cache_write_tokens=0,
-        )
+        return self._record_usage(input_tokens, output_tokens, cached)
 
     def _wrap_error(self, exc: Exception, context: str) -> TransportError:
         status_code = getattr(exc, "status_code", None)
+        # OSError included to match LangChainTransport._is_network_error: a
+        # dropped socket surfaces as a bare OSError often enough that treating
+        # it as fatal here would retry-gap the direct path against that one.
         is_network = isinstance(
-            exc, (self._openai.APIConnectionError, self._openai.APITimeoutError)
+            exc,
+            (self._openai.APIConnectionError, self._openai.APITimeoutError, OSError),
         )
         retryable = is_network or (
             status_code is not None and status_code in _RETRYABLE_STATUS_CODES
@@ -193,7 +629,10 @@ class OpenAITransport(LLMTransport):
     # Public LLMTransport interface
     # ------------------------------------------------------------------
 
-    async def complete(
+    # `complete`/`stream` below wrap these with the one-shot request-shape
+    # retry. Split rather than inlined so the retry can re-run the whole request
+    # without recursing into itself.
+    async def _complete_once(
         self,
         messages: list[Message],
         tools: list[ToolSchema] | None = None,
@@ -203,6 +642,10 @@ class OpenAITransport(LLMTransport):
         effort: str | None = None,
         system_blocks: list[str] | None = None,
     ) -> ModelResponse:
+        if self._wants_responses():
+            return await self._complete_responses(
+                messages, tools=tools, system=system, system_blocks=system_blocks,
+            )
         # OpenAI automatic prefix caching benefits from stable-first ordering
         # alone; join blocks when the caller omitted the already-joined string.
         if system_blocks and not system:
@@ -211,6 +654,7 @@ class OpenAITransport(LLMTransport):
         kwargs: dict[str, Any] = {
             "model": resolved_model,
             "messages": self._format_messages(messages, system),
+            **self._default_request_kwargs(),
         }
         formatted_tools = self._format_tools(tools)
         if formatted_tools:
@@ -230,7 +674,9 @@ class OpenAITransport(LLMTransport):
         usage = self._usage_from(response)
         message = self._parse_response(response.choices[0].message)
         finish_reason = getattr(response.choices[0], "finish_reason", None)
-        stop_reason = _FINISH_REASON_MAP.get(finish_reason, StopReason.END_TURN)
+        stop_reason = self._chat_stop_reason(finish_reason, bool(message.tool_calls))
+        if stop_reason == StopReason.MAX_TOKENS:
+            message.truncated = True
         return ModelResponse(message=message, usage=usage, stop_reason=stop_reason, model=resolved_model)
 
     async def complete_structured(
@@ -256,6 +702,7 @@ class OpenAITransport(LLMTransport):
             "messages": self._format_messages(messages, system),
             "tools": [tool_def],
             "tool_choice": {"type": "function", "function": {"name": "structured_output"}},
+            **self._default_request_kwargs(),
         }
 
         try:
@@ -275,7 +722,7 @@ class OpenAITransport(LLMTransport):
 
         raise TransportError("structured_output tool call not found in response")
 
-    async def stream(
+    async def _stream_once(
         self,
         messages: list[Message],
         tools: list[ToolSchema] | None = None,
@@ -285,6 +732,12 @@ class OpenAITransport(LLMTransport):
         effort: str | None = None,
         system_blocks: list[str] | None = None,
     ) -> AsyncIterator[StreamEvent]:
+        if self._wants_responses():
+            async for event in self._stream_responses(
+                messages, tools=tools, system=system, system_blocks=system_blocks,
+            ):
+                yield event
+            return
         if system_blocks and not system:
             system = "\n\n".join(b for b in system_blocks if b)
         resolved_model = model or self._model
@@ -293,6 +746,7 @@ class OpenAITransport(LLMTransport):
             "messages": self._format_messages(messages, system),
             "stream": True,
             "stream_options": {"include_usage": True},
+            **self._default_request_kwargs(),
         }
         formatted_tools = self._format_tools(tools)
         if formatted_tools:
@@ -319,6 +773,13 @@ class OpenAITransport(LLMTransport):
                 if chunk.choices[0].finish_reason:
                     finish_reason = chunk.choices[0].finish_reason
                 delta = chunk.choices[0].delta
+                # Reasoning text is not a declared field on ChoiceDelta, but the
+                # SDK models allow extras, so providers that emit it (Azure
+                # gpt-5.x) surface it here. Yielded before content so the agent
+                # loop closes its reasoning block on the first text delta.
+                reasoning_delta = getattr(delta, "reasoning_content", None)
+                if reasoning_delta:
+                    yield ThinkingDeltaEvent(delta=reasoning_delta)
                 if delta.content:
                     text_parts.append(delta.content)
                     yield TextDeltaEvent(delta=delta.content)
@@ -330,23 +791,191 @@ class OpenAITransport(LLMTransport):
                         entry["id"] = tc_delta.id
                     if tc_delta.function and tc_delta.function.name:
                         entry["name"] = tc_delta.function.name
+                    args_delta = ""
                     if tc_delta.function and tc_delta.function.arguments:
-                        entry["arguments"] += tc_delta.function.arguments
+                        args_delta = tc_delta.function.arguments
+                        entry["arguments"] += args_delta
+                    # The agent loop decides whether a call is final_answer from
+                    # `name` on the FIRST delta it sees for an index, and streams
+                    # the answer live off that.
+                    #
+                    # Azure opens a tool call with a metadata-only chunk -- name
+                    # and id set, arguments "" -- verified against the live
+                    # service. Skipping empty-argument fragments therefore threw
+                    # the name away and the first delta the loop saw carried
+                    # name=None, so final_answer went unrecognised and the answer
+                    # only appeared once the turn ended.
+                    #
+                    # id/name still carry what THIS fragment carried; providers
+                    # send them once and omit them afterwards.
+                    fragment_name = tc_delta.function.name if tc_delta.function else None
+                    if args_delta or fragment_name or tc_delta.id:
+                        yield ToolCallDeltaEvent(
+                            index=tc_delta.index or 0,
+                            id=tc_delta.id,
+                            name=fragment_name,
+                            arguments_delta=args_delta or "",
+                        )
         except Exception as exc:
             raise self._wrap_error(exc, "stream") from exc
 
         final_tool_calls: list[ToolCall] = []
         for idx, entry in sorted(tool_call_accum.items()):
-            try:
-                args = json.loads(entry["arguments"]) if entry["arguments"] else {}
-            except (json.JSONDecodeError, ValueError):
-                args = {}
             final_tool_calls.append(
-                ToolCall(id=entry["id"] or f"call_{idx}", name=entry["name"] or "", arguments=args)
+                normalise_tool_call(
+                    entry["id"] or f"call_{idx}", entry["name"] or "", entry["arguments"]
+                )
             )
         final_text = "".join(text_parts) or None
         message = AssistantMessage(content=final_text, tool_calls=final_tool_calls or None)
-        stop_reason = _FINISH_REASON_MAP.get(finish_reason, StopReason.END_TURN)
+        stop_reason = self._chat_stop_reason(finish_reason, bool(final_tool_calls))
+        if stop_reason == StopReason.MAX_TOKENS:
+            message.truncated = True
         yield StreamCompleteEvent(
             response=ModelResponse(message=message, usage=usage, stop_reason=stop_reason, model=resolved_model)
         )
+
+    # -- request-shape recovery -------------------------------------------
+    #
+    # LangChainTransport retries once against a differently-configured model
+    # copy. There is no model object here, so the equivalent is retrying the
+    # same call with the offending parameter adjusted.
+
+    def _shape_fallback(self, exc: Exception) -> str | None:
+        """Adjust this transport's request shape after a provider rejection.
+
+        Mirrors `LangChainTransport._api_shape_fallback`: the direction is
+        decided by our own current state rather than by reading more out of the
+        error text. Returns the `LLMApiMode` worth recording if the retry
+        succeeds, or None when the error is not a shape conflict or nothing can
+        be adjusted -- a marker match with no available adjustment means the 400
+        has some other cause and retrying would just repeat it.
+
+        Mutates `self._defaults`, so the retry and every later call on this
+        instance use the working shape. That is the same pinning LangChain does
+        by swapping in the fallback model copy.
+        """
+        d = self._defaults
+        if is_api_shape_conflict(exc):
+            if d.use_responses_api:
+                # The Responses attempt itself was rejected. Keep the tools --
+                # a turn that needs one must still get it -- and drop reasoning.
+                d.use_responses_api = False
+                d.reasoning = None
+                d.reasoning_effort = None
+                return LLMApiMode.NO_REASONING_WITH_TOOLS.value
+            # Reasoning combined with bound tools on Chat Completions: this
+            # deployment wants the Responses API for that combination.
+            effort = d.reasoning_effort or (d.reasoning or {}).get("effort")
+            if not effort:
+                return None
+            d.use_responses_api = True
+            d.reasoning = {"effort": effort}
+            d.reasoning_effort = None
+            return LLMApiMode.RESPONSES.value
+        if is_reasoning_mandatory_conflict(exc):
+            current = (d.reasoning or {}).get("effort") or d.reasoning_effort
+            # Only bump off an explicitly disabled value, like LangChain. Bumping
+            # when nothing was configured would turn reasoning ON for a caller
+            # who never asked for it.
+            if current is None or str(current).lower() not in _DISABLED_REASONING_VALUES:
+                return None
+            if d.use_responses_api:
+                d.reasoning = {"effort": _REASONING_BUMP_TARGET}
+            else:
+                d.reasoning_effort = _REASONING_BUMP_TARGET
+            return LLMApiMode.REASONING_MANDATORY.value
+        return None
+
+    async def _record_api_mode(self, mode: str) -> None:
+        """Persist a learned shape once a retry has actually succeeded, so
+        `aimodels.get_generator_model` builds the model that way from the start
+        on later requests -- and so the LangChain arm learns it too.
+
+        A no-op when the store was never initialised or no `model_key` was
+        threaded through, matching `LangChainTransport._record_api_mode`. The
+        in-request retry above applies either way.
+        """
+        try:
+            store = get_llm_api_mode_store()
+        except Exception:
+            return
+        if store is None or not self._model_key:
+            return
+        try:
+            # keyed on the configured model name, not the deployment
+            await store.record(self._model_key, self._model, mode)
+        except Exception as exc:
+            logger.warning("Could not record learned api mode %s: %s", mode, exc)
+
+    async def complete(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        system: str | None = None,
+        model: str | None = None,
+        thinking_budget: int | None = None,
+        effort: str | None = None,
+        system_blocks: list[str] | None = None,
+    ) -> ModelResponse:
+        try:
+            return await self._complete_once(
+                messages=messages, tools=tools, system=system, model=model,
+                thinking_budget=thinking_budget, effort=effort,
+                system_blocks=system_blocks,
+            )
+        except Exception as exc:
+            mode = self._shape_fallback(exc)
+            if mode is None:
+                raise
+        result = await self._complete_once(
+            messages=messages, tools=tools, system=system, model=model,
+            thinking_budget=thinking_budget, effort=effort,
+            system_blocks=system_blocks,
+        )
+        # Only after the retry actually worked -- recording a guess would make
+        # every later request build the wrong shape from the start.
+        await self._record_api_mode(mode)
+        return result
+
+    async def stream(
+        self,
+        messages: list[Message],
+        tools: list[ToolSchema] | None = None,
+        system: str | None = None,
+        model: str | None = None,
+        thinking_budget: int | None = None,
+        effort: str | None = None,
+        system_blocks: list[str] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream, retrying once on a request-shape conflict.
+
+        The retry only happens if it fires before anything was yielded --
+        re-opening a stream that already emitted deltas would replay them to the
+        client.
+        """
+        emitted = False
+        try:
+            async for event in self._stream_once(
+                messages=messages, tools=tools, system=system, model=model,
+                thinking_budget=thinking_budget, effort=effort,
+                system_blocks=system_blocks,
+            ):
+                emitted = True
+                yield event
+            return
+        except Exception as exc:
+            # Retrying after deltas reached the client would replay them.
+            if emitted:
+                raise
+            mode = self._shape_fallback(exc)
+            if mode is None:
+                raise
+
+        async for event in self._stream_once(
+            messages=messages, tools=tools, system=system, model=model,
+            thinking_budget=thinking_budget, effort=effort,
+            system_blocks=system_blocks,
+        ):
+            yield event
+        await self._record_api_mode(mode)

--- a/backend/python/app/agent_loop_lib/transport/openai_responses.py
+++ b/backend/python/app/agent_loop_lib/transport/openai_responses.py
@@ -1,0 +1,317 @@
+"""Shape helpers for OpenAI's Responses API.
+
+The Responses API is a different wire shape from Chat Completions, not a
+variation on it: messages become `input` items, tools are flat rather than
+nested under `"function"`, usage fields are renamed, and there is no
+`finish_reason` at all. Reasoning models on Azure require it -- Chat Completions
+rejects reasoning combined with bound tools for the gpt-5.x family -- which is
+why `aimodels._reasoning_effort_kwargs` returns `use_responses_api=True` for
+them, and why a transport that only speaks Chat Completions silently ran
+without reasoning.
+
+Everything here is a pure function over plain data so it can be tested without
+a client or a network, and so `OpenAITransport` keeps one place to look for
+"what does the other API shape look like".
+
+Names verified against the installed `openai` SDK (2.45.0).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from app.agent_loop_lib.core.messages import (
+    AssistantMessage,
+    Message,
+    MessageRole,
+    ToolCall,
+)
+from app.agent_loop_lib.core.responses import StopReason
+from app.agent_loop_lib.core.tool_schema import ToolSchema
+
+# Stream event `type` literals we act on. Everything else in the union -- and
+# there are 52 -- is ignored rather than matched, so an event Azure adds later
+# cannot crash the loop.
+EVT_TEXT_DELTA = "response.output_text.delta"
+EVT_REFUSAL_DELTA = "response.refusal.delta"
+EVT_REASONING_DELTA = "response.reasoning_text.delta"
+EVT_REASONING_SUMMARY_DELTA = "response.reasoning_summary_text.delta"
+EVT_OUTPUT_ITEM_ADDED = "response.output_item.added"
+EVT_FUNCTION_ARGS_DELTA = "response.function_call_arguments.delta"
+EVT_COMPLETED = "response.completed"
+EVT_INCOMPLETE = "response.incomplete"
+EVT_FAILED = "response.failed"
+EVT_ERROR = "error"
+
+
+class RawEvent:
+    """Attribute-style read-only view over a decoded SSE payload.
+
+    Exists so the stream can skip the SDK's per-event pydantic validation. The
+    SDK casts every event to `ResponseStreamEvent`, a 53-member discriminated
+    union, which sends `construct_type` down its `is_union` branch and runs a
+    full `TypeAdapter.validate_python` per event -- measured at 56us against
+    1.7us for `json.loads` plus this wrapper, and ~12% of query-service CPU. We
+    read four fields per event, so none of that validation is load-bearing.
+
+    Attribute access, not a model: there is no `.model_dump()`, no field
+    coercion and no defaults. Anything added to the stream loop that needs real
+    SDK model behaviour has to decode the payload itself.
+
+    Missing keys raise `AttributeError` rather than returning None, so
+    `getattr(event, "output_index", 0)` still yields its default -- a
+    None-returning shim would silently defeat every default at the call sites.
+    Nested dicts and lists are wrapped on access, never eagerly: the terminal
+    `response.completed` payload carries the whole Response, and walking it up
+    front would hand back the saving.
+    """
+
+    __slots__ = ("_data",)
+
+    def __init__(self, data: dict[str, Any]) -> None:
+        self._data = data
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            value = self._data[name]
+        except KeyError:
+            raise AttributeError(name) from None
+        return _wrap(value)
+
+    def __repr__(self) -> str:
+        return f"RawEvent({self._data!r})"
+
+
+def _wrap(value: Any) -> Any:
+    if isinstance(value, dict):
+        return RawEvent(value)
+    if isinstance(value, list):
+        return [_wrap(v) for v in value]
+    return value
+
+
+def _responses_content_blocks(parts: list[Any]) -> list[dict[str, Any]]:
+    """`list[Part]` into Responses input blocks.
+
+    The Responses API names these differently from Chat Completions --
+    `input_text` / `input_image`, and `image_url` is a bare string rather than
+    an object -- so the two cannot share one formatter.
+    """
+    from app.agent_loop_lib.core.messages import image_data_url
+
+    blocks: list[dict[str, Any]] = []
+    for part in parts:
+        if getattr(part, "type", None) == "image" and getattr(part, "source", None):
+            blocks.append({
+                "type": "input_image",
+                "image_url": image_data_url(part.source),
+            })
+            continue
+        text = getattr(part, "text", "")
+        if text:
+            blocks.append({"type": "input_text", "text": text})
+    return blocks
+
+
+def format_responses_input(
+    messages: list[Message], system: str | None
+) -> list[dict[str, Any]]:
+    """Our messages into Responses `input` items.
+
+    The system prompt is emitted as a leading `system` item rather than via the
+    separate `instructions` field, so the prompt prefix stays byte-identical to
+    the one the LangChain arm sends and prompt-cache behaviour is comparable.
+
+    A `function_call` must precede its matching `function_call_output`, which
+    our message ordering already guarantees.
+    """
+    items: list[dict[str, Any]] = []
+    if system:
+        items.append({"type": "message", "role": "system", "content": system})
+
+    for msg in messages:
+        if msg.role == MessageRole.TOOL:
+            items.append({
+                "type": "function_call_output",
+                "call_id": msg.tool_call_id,
+                "output": (msg.content or "") + getattr(msg, "step_footer", ""),
+            })
+            continue
+
+        if msg.role == MessageRole.ASSISTANT:
+            text = msg.text
+            if text:
+                items.append({
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [
+                        {"type": "output_text", "text": text, "annotations": []}
+                    ],
+                })
+            for tc in msg.tool_calls or []:
+                items.append({
+                    "type": "function_call",
+                    "name": tc.name,
+                    "arguments": json.dumps(tc.arguments),
+                    "call_id": tc.id,
+                })
+            continue
+
+        content = msg.content
+        if isinstance(content, list):
+            blocks = _responses_content_blocks(content)
+            if any(b["type"] != "input_text" for b in blocks):
+                items.append({
+                    "type": "message", "role": msg.role.value, "content": blocks,
+                })
+                continue
+            content = " ".join(b["text"] for b in blocks)
+        items.append({
+            "type": "message",
+            "role": msg.role.value,
+            "content": content or "",
+        })
+    return items
+
+
+def format_responses_tools(tools: list[ToolSchema] | None) -> list[dict] | None:
+    """Flat tool shape -- `{"type","name","description","parameters"}`.
+
+    Not the Chat Completions form nested under `"function"`; sending that is
+    what produces the `tool_choice.function` rejection already tracked in
+    `provider_conflicts.API_SHAPE_CONFLICT_MARKERS`.
+
+    `strict` is sent explicitly false: our schemas are not guaranteed to satisfy
+    strict mode (which requires `additionalProperties: false` and no optional
+    fields), and a gateway defaulting it to true would start rejecting tools.
+    """
+    if not tools:
+        return None
+    return [
+        {
+            "type": "function",
+            "name": t.name,
+            "description": t.description,
+            "parameters": t.input_schema or {"type": "object", "properties": {}},
+            "strict": False,
+        }
+        for t in tools
+    ]
+
+
+def format_responses_tool_choice(name: str) -> dict[str, Any]:
+    """Force one function. Flat, like the tool definitions."""
+    return {"type": "function", "name": name}
+
+
+def normalise_tool_call(call_id: str, name: str, raw_arguments: str | None) -> ToolCall:
+    """One raw tool call into a `ToolCall`, repaired the way the LangChain path
+    repairs its `invalid_tool_calls`.
+
+    Silently substituting `{}` for unparseable arguments makes a malformed call
+    look like a successful one with no arguments, so the tool runs with nothing
+    instead of the loop being told to correct itself. `_recover_invalid_tool_call`
+    repairs what it can and otherwise attaches the malformed-args sentinels the
+    tool loop already knows how to turn into a corrective message. It also clamps
+    the name, which must not reach history over-long -- history is re-sent every
+    turn.
+
+    Imported lazily: `converters` lives in the app layer and imports this
+    package, so a module-level import would be circular. Falls back to a plain
+    parse when the app layer is absent, keeping agent_loop_lib usable on its own.
+    """
+    try:
+        from app.agents.agent_loop.converters import _recover_invalid_tool_call
+    except Exception:
+        try:
+            args = json.loads(raw_arguments) if raw_arguments else {}
+        except (json.JSONDecodeError, ValueError):
+            args = {}
+        return ToolCall(id=call_id, name=name, arguments=args if isinstance(args, dict) else {})
+
+    try:
+        args = json.loads(raw_arguments) if raw_arguments else {}
+        if isinstance(args, dict):
+            return _recover_invalid_tool_call(
+                {"id": call_id, "name": name, "args": json.dumps(args)}
+            )
+    except (json.JSONDecodeError, ValueError):
+        pass
+    return _recover_invalid_tool_call(
+        {"id": call_id, "name": name, "args": raw_arguments or ""}
+    )
+
+
+def parse_responses_output(response: Any) -> AssistantMessage:
+    """A `Response` into our `AssistantMessage`.
+
+    Walks `output` explicitly rather than using the `output_text` convenience
+    property, which has come and gone across SDK releases. `reasoning` items are
+    skipped: we never request a reasoning summary, so they carry nothing.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[ToolCall] = []
+
+    for item in getattr(response, "output", None) or []:
+        item_type = getattr(item, "type", None)
+        if item_type == "message":
+            for part in getattr(item, "content", None) or []:
+                if getattr(part, "type", None) == "output_text":
+                    text_parts.append(getattr(part, "text", "") or "")
+        elif item_type == "function_call":
+            tool_calls.append(
+                normalise_tool_call(
+                    # call_id is what a later function_call_output must echo;
+                    # `id` is the separate item id and is not interchangeable.
+                    getattr(item, "call_id", None) or getattr(item, "id", "") or "",
+                    getattr(item, "name", "") or "",
+                    getattr(item, "arguments", None),
+                )
+            )
+
+    return AssistantMessage(
+        content="".join(text_parts) or None,
+        tool_calls=tool_calls or None,
+    )
+
+
+def responses_usage_fields(response: Any) -> tuple[int, int, int, int]:
+    """(input, output, cache_read, cache_write) from a `Response`.
+
+    Every field is named differently from Chat Completions -- `input_tokens`
+    rather than `prompt_tokens`, and cached tokens hang off
+    `input_tokens_details` rather than `prompt_tokens_details` -- so reusing the
+    Chat Completions reader here would silently report zeros.
+    """
+    usage = getattr(response, "usage", None)
+
+    def _int(obj: Any, name: str) -> int:
+        value = getattr(obj, name, 0) if obj is not None else 0
+        return value if isinstance(value, int) else 0
+
+    details = getattr(usage, "input_tokens_details", None)
+    return (
+        _int(usage, "input_tokens"),
+        _int(usage, "output_tokens"),
+        _int(details, "cached_tokens"),
+        _int(details, "cache_write_tokens"),
+    )
+
+
+def stop_reason_from_responses(response: Any, has_tool_calls: bool) -> StopReason:
+    """Map a `Response` onto our stop reason.
+
+    Truncation is checked before tool calls, matching
+    `langchain_transport.py:484`: a response cut off mid-arguments leaves
+    unparseable JSON, and reporting TOOL_USE would send the agent loop off to
+    execute a garbage call instead of recovering from the truncation.
+    """
+    reason = getattr(getattr(response, "incomplete_details", None), "reason", None)
+    if reason == "max_output_tokens":
+        return StopReason.MAX_TOKENS
+    if has_tool_calls:
+        return StopReason.TOOL_USE
+    if reason or getattr(response, "status", None) == "incomplete":
+        return StopReason.MAX_TOKENS
+    return StopReason.END_TURN

--- a/backend/python/app/agent_loop_lib/transport/provider_conflicts.py
+++ b/backend/python/app/agent_loop_lib/transport/provider_conflicts.py
@@ -1,0 +1,49 @@
+"""Provider/gateway error signatures that a single retry can recover from.
+
+Shared by every transport so the LangChain and direct-SDK paths cannot drift on
+what counts as recoverable. Matched case-insensitively against ``str(exc)`` --
+deliberately loose rather than a status-code check, because these come from very
+different SDKs (openai, httpx-based gateway clients, ...) with no shared
+exception hierarchy.
+"""
+
+from __future__ import annotations
+
+# Emitted when reasoning + bound function tools cannot both go through the API
+# shape the request used.
+# - "please use /v1/responses instead": Chat Completions rejected the
+#   combination.
+# - "please use /v1/chat/completions instead": the inverse -- a Responses-API
+#   attempt landed on a backend that only supports this on Chat Completions.
+# - "tool_choice.function": Chat-Completions-shaped tool_choice sent to a
+#   Responses-only model/deployment.
+API_SHAPE_CONFLICT_MARKERS = (
+    "please use /v1/responses instead",
+    "please use /v1/chat/completions instead",
+    "tool_choice.function",
+)
+
+# Emitted when a provider/gateway refuses to let reasoning be turned off at all
+# -- observed on some OpenRouter-proxied Gemini models: "Reasoning is mandatory
+# for this endpoint and cannot be disabled."
+REASONING_MANDATORY_CONFLICT_MARKERS = ("reasoning is mandatory",)
+
+
+def is_api_shape_conflict(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in API_SHAPE_CONFLICT_MARKERS)
+
+
+def is_reasoning_mandatory_conflict(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(marker in message for marker in REASONING_MANDATORY_CONFLICT_MARKERS)
+
+
+def wants_responses_api(exc: Exception) -> bool:
+    """True when the error asks for the Responses API specifically.
+
+    The marker names the endpoint the provider wants, so the direct-SDK
+    transport can pick a shape from the error rather than blindly toggling.
+    """
+    message = str(exc).lower()
+    return "please use /v1/responses instead" in message or "tool_choice.function" in message

--- a/backend/python/app/agents/agent_loop/answer_streamer.py
+++ b/backend/python/app/agents/agent_loop/answer_streamer.py
@@ -29,7 +29,7 @@ Citation refs (`[source](refN)`) are resolved progressively via
 `CitationCollector` — the same function `AnswerFinalizer` uses for the
 authoritative `complete` event, so numbered citations appear live as the
 answer streams in. That resolution re-runs over the whole accumulated answer,
-so it is rate-limited (`PIPESHUB_ANSWER_DELTA_INTERVAL_MS`, default 100 ms)
+so it is rate-limited (`PIPESHUB_ANSWER_DELTA_INTERVAL_MS`, default 250 ms)
 rather than run per token, and forced once more at `AGENT_COMPLETE`; raw text
 still streams per token on its own channel. The citation state (`ref_to_url`,
 `final_results`, `web_records`) is snapshotted once per turn at
@@ -61,12 +61,12 @@ logger = logging.getLogger(__name__)
 
 def answer_delta_min_interval() -> float:
     """Seconds between live citation refreshes; 0 restores per-token emits."""
-    raw = os.getenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", "100")
+    raw = os.getenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", "250")
     try:
         value = float(raw)
     except ValueError:
-        logger.warning("Invalid PIPESHUB_ANSWER_DELTA_INTERVAL_MS=%r, falling back to 100", raw)
-        return 0.1
+        logger.warning("Invalid PIPESHUB_ANSWER_DELTA_INTERVAL_MS=%r, falling back to 250", raw)
+        return 0.25
     return max(value, 0.0) / 1000.0
 
 if TYPE_CHECKING:

--- a/backend/python/app/agents/agent_loop/converters.py
+++ b/backend/python/app/agents/agent_loop/converters.py
@@ -464,14 +464,61 @@ async def _unbound_tool_coroutine(**_kwargs: Any) -> Any:  # noqa: ANN401
     )
 
 
+_TOOL_MODEL_CACHE: dict[str, StructuredTool] = {}
+_TOOL_MODEL_CACHE_MAXSIZE = 512
+
+
+def _tool_schema_key(schema: ToolSchema) -> str:
+    """Content key for a tool schema.
+
+    `ToolSchema` is frozen but holds a dict, so it is unhashable, and
+    `ToolRegistry.schemas()` rebuilds these objects every turn — identity would
+    never match. Sorted-key JSON makes two equal schemas collide on purpose and
+    two different ones never.
+    """
+    payload = json.dumps(
+        [schema.name, schema.description, schema.input_schema],
+        sort_keys=True,
+        default=str,
+    )
+    return hashlib.sha256(payload.encode()).hexdigest()
+
+
 def convert_tool_schema_to_langchain(schema: ToolSchema) -> StructuredTool:
+    """Build the LangChain tool object for `schema`, reusing a cached one.
+
+    `create_model()` runs pydantic's full schema generation, and this ran once
+    per tool per LLM call — measured at 8.8% of query-service CPU, rebuilding
+    identical classes (26 tools on 1,820 of 1,842 binds over six hours). The
+    transport's own cache does not cover it: the transport is constructed per
+    request, so it starts empty on every chat.
+
+    Caching the class also lets pydantic's internal schema cache serve the
+    `model_json_schema()` that `convert_to_openai_tool` calls on every send.
+
+    Safe to share: the object carries only a schema — `_unbound_tool_coroutine`
+    raises if anything tries to execute it — and `bind_tools` reads the tools to
+    build a separate list of dicts rather than mutating them.
+    """
+    key = _tool_schema_key(schema)
+    cached = _TOOL_MODEL_CACHE.get(key)
+    if cached is not None:
+        return cached
+
     args_model = _json_schema_to_pydantic_model(f"{schema.name}_Args", schema.input_schema)
-    return StructuredTool.from_function(
+    tool = StructuredTool.from_function(
         name=schema.name,
         description=schema.description,
         args_schema=args_model,
         coroutine=_unbound_tool_coroutine,
     )
+    # Cleared wholesale rather than evicted one at a time: the tool set is
+    # bounded by the registry, so this only fires if schemas are being generated
+    # dynamically, and a rebuild costs the same as the miss it replaces.
+    if len(_TOOL_MODEL_CACHE) >= _TOOL_MODEL_CACHE_MAXSIZE:
+        _TOOL_MODEL_CACHE.clear()
+    _TOOL_MODEL_CACHE[key] = tool
+    return tool
 
 
 def convert_tool_schemas_to_langchain(

--- a/backend/python/app/agents/agent_loop/direct_transport.py
+++ b/backend/python/app/agents/agent_loop/direct_transport.py
@@ -1,0 +1,82 @@
+"""Picks the direct-SDK transport matching a configured LangChain model.
+
+The switch stays binary -- `PIPESHUB_AGENT_TRANSPORT=langchain|direct` -- because
+a deployment chooses *how* it talks to providers, not which provider a given
+request uses. Which provider is a property of the model the request selected, so
+that decision belongs here rather than in an env var: with four models
+configured, an env value naming one provider is meaningless for a request that
+picked another.
+
+Dispatch is on the LangChain model class, which is the discriminator actually
+available at the call site and the same object each `from_langchain_model`
+consumes. `AzureChatOpenAI` and `ChatOpenAI` are siblings under `BaseChatOpenAI`
+rather than parent and child, so isinstance order carries no trap.
+
+Anything without a direct transport falls back to LangChain, so adding a model
+for an unsupported provider degrades to the old path instead of failing.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.agent_loop_lib.transport.base import LLMTransport
+
+logger = logging.getLogger(__name__)
+
+
+def build_direct_transport(
+    llm: Any, model_name: str = "", model_key: str | None = None,
+) -> "LLMTransport | None":
+    """The direct transport for `llm`, or None when there is no direct path.
+
+    Returning None rather than raising is deliberate: the caller falls back to
+    the LangChain transport, so an unsupported provider is slower, never broken.
+    """
+    class_name = type(llm).__name__
+
+    # Imported lazily and individually: each transport imports its provider SDK
+    # at construction, and a deployment that installs only some of them should
+    # not fail to import this module.
+    try:
+        if class_name == "AzureChatOpenAI":
+            from app.agent_loop_lib.transport.azure_openai import AzureOpenAITransport
+            return AzureOpenAITransport.from_langchain_model(
+                llm, model_name=model_name, model_key=model_key,
+            )
+        if class_name in ("ChatOpenAI", "BaseChatOpenAI"):
+            from app.agent_loop_lib.transport.openai import OpenAITransport
+            return OpenAITransport.from_langchain_model(
+                llm, model_name=model_name, model_key=model_key,
+            )
+        if class_name == "ChatAnthropic":
+            from app.agent_loop_lib.transport.anthropic import AnthropicTransport
+            return AnthropicTransport.from_langchain_model(
+                llm, model_name=model_name, model_key=model_key,
+            )
+        if class_name == "ChatGoogleGenerativeAI":
+            from app.agent_loop_lib.transport.gemini import GeminiTransport
+            return GeminiTransport.from_langchain_model(
+                llm, model_name=model_name, model_key=model_key,
+            )
+    except Exception as exc:
+        # A misconfigured model must not take the turn down: the LangChain arm
+        # can still serve it, and the log names the model so the gap is visible.
+        logger.warning(
+            "build_direct_transport: no direct transport for %s (model=%s): %s; "
+            "falling back to LangChain",
+            class_name, model_name or "?", exc,
+        )
+        return None
+
+    logger.info(
+        "build_direct_transport: %s has no direct transport (model=%s); "
+        "using LangChain",
+        class_name, model_name or "?",
+    )
+    return None
+
+
+__all__ = ["build_direct_transport"]

--- a/backend/python/app/agents/agent_loop/factory.py
+++ b/backend/python/app/agents/agent_loop/factory.py
@@ -218,10 +218,18 @@ def _transport_provider() -> str:
     Read per call rather than cached so an arm can be switched by restarting the
     service, without a rebuild.
     """
-    raw = os.getenv("PIPESHUB_AGENT_TRANSPORT", LANGCHAIN_TRANSPORT).strip()
+    raw = os.getenv("PIPESHUB_AGENT_TRANSPORT", LANGCHAIN_TRANSPORT).strip().lower()
     if raw in ("azure_direct", DIRECT_TRANSPORT):
         return DIRECT_TRANSPORT
-    return raw or LANGCHAIN_TRANSPORT
+    if raw and raw != LANGCHAIN_TRANSPORT:
+        # Anything else -- a typo, a stale value, different casing -- would reach
+        # TransportRegistry.resolve and raise RegistryError, failing every turn.
+        # A misconfigured env var should cost the optimisation, not the service.
+        logger.warning(
+            "PIPESHUB_AGENT_TRANSPORT=%r is not a known transport; using %s",
+            raw, LANGCHAIN_TRANSPORT,
+        )
+    return LANGCHAIN_TRANSPORT
 
 # Phase-1 auto-compact (gentle): protects up to 70% of budget in the tail,
 # summarizes only the oldest portion. Phase-2 (aggressive): if still over

--- a/backend/python/app/agents/agent_loop/factory.py
+++ b/backend/python/app/agents/agent_loop/factory.py
@@ -57,33 +57,56 @@ from app.agent_loop_lib.core.messages import (
     ToolMessageMeta,
     UserMessage,
 )
+from app.agent_loop_lib.events.base import CompositeEmitter
 from app.agent_loop_lib.hooks.events import HookEvent
-from app.agent_loop_lib.hooks.middleware.builtin.artifact_compaction import shape_artifact_compaction
-from app.agent_loop_lib.hooks.middleware.builtin.artifact_registration import (
-    shape_artifact_registration,
-)
 from app.agent_loop_lib.hooks.middleware.builtin._message_boundaries import (
     shape_tool_pairing_repair,
+)
+from app.agent_loop_lib.hooks.middleware.builtin.artifact_compaction import (
+    shape_artifact_compaction,
+)
+from app.agent_loop_lib.hooks.middleware.builtin.artifact_registration import (
+    shape_artifact_registration,
 )
 from app.agent_loop_lib.hooks.middleware.builtin.auto_compact import (
     make_llm_summarizer,
     shape_auto_compact,
 )
-from app.agents.agent_loop.artifact_store import build_artifact_store
-from app.agent_loop_lib.hooks.middleware.builtin.budget_reduction import shape_budget_reduction
-from app.agent_loop_lib.hooks.middleware.builtin.deterministic_compact import shape_deterministic_compact
-from app.agent_loop_lib.hooks.middleware.builtin.loop_compaction import shape_loop_compaction
-from app.agent_loop_lib.hooks.middleware.builtin.sliding_window import shape_sliding_window
-from app.agent_loop_lib.hooks.middleware.builtin.synthesis_guard import shape_synthesis_guard
+from app.agent_loop_lib.hooks.middleware.builtin.budget_reduction import (
+    shape_budget_reduction,
+)
+from app.agent_loop_lib.hooks.middleware.builtin.deterministic_compact import (
+    shape_deterministic_compact,
+)
+from app.agent_loop_lib.hooks.middleware.builtin.loop_compaction import (
+    shape_loop_compaction,
+)
+from app.agent_loop_lib.hooks.middleware.builtin.sliding_window import (
+    shape_sliding_window,
+)
+from app.agent_loop_lib.hooks.middleware.builtin.synthesis_guard import (
+    shape_synthesis_guard,
+)
 from app.agent_loop_lib.hooks.middleware.builtin.tool_result_clearing import (
     shape_tool_result_clearing,
 )
-from app.agent_loop_lib.tools.builtin.data.retrieve_artifact import RetrieveArtifactContentTool
-from app.agent_loop_lib.events.base import CompositeEmitter
 from app.agent_loop_lib.hooks.registry import HookRegistry
 from app.agent_loop_lib.runtime.runtime import AgentRuntime
-from app.agent_loop_lib.transport.opik_tracing import resolve_opik_gate, traced_transport_factory
+from app.agent_loop_lib.tools.builtin.data.retrieve_artifact import (
+    RetrieveArtifactContentTool,
+)
+from app.agent_loop_lib.tools.builtin.sandbox.coding_sandbox import CodingSandboxTool
+from app.agent_loop_lib.transport.opik_tracing import (
+    resolve_opik_gate,
+    traced_transport_factory,
+)
 from app.agent_loop_lib.transport.registry import TransportRegistry
+from app.agents.agent_loop.artifact_store import build_artifact_store
+from app.agents.agent_loop.direct_transport import build_direct_transport
+from app.agents.agent_loop.domain_agents import (
+    plan_domain_agents,
+    register_domain_agents,
+)
 from app.agents.agent_loop.hooks import (
     CitationCollector,
     ToolErrorTracker,
@@ -101,8 +124,6 @@ from app.agents.agent_loop.hooks import (
     shape_image_injection,
     stash_tool_call_metadata,
 )
-from app.agent_loop_lib.tools.builtin.sandbox.coding_sandbox import CodingSandboxTool
-from app.agents.agent_loop.domain_agents import plan_domain_agents, register_domain_agents
 from app.agents.agent_loop.langchain_transport import LangChainTransport
 from app.agents.agent_loop.lazy_tools_wiring import (
     CONNECTORS_PARENT,
@@ -122,6 +143,8 @@ from app.agents.agent_loop.loops.orchestrator import (
 from app.agents.agent_loop.loops.plan_execute import PLANNING_TOOL_NAMES, register_planning_tools
 from app.agents.agent_loop.mcp_tool_loader import MCPToolProvider
 from app.agents.agent_loop.prompt_builder import PipesHubPromptBuilder
+from app.agents.agent_loop.protocol.agui_emitter import AGUIEventEmitter
+from app.agents.agent_loop.protocol.transcript_collector import TranscriptCollector
 from app.agents.agent_loop.router import select_loop_and_goal
 from app.agents.agent_loop.sandbox_bridge import (
     build_coding_sandbox_manager,
@@ -137,8 +160,6 @@ from app.agents.agent_loop.skills_wiring import (
     register_skill_tools,
     skills_enabled,
 )
-from app.agents.agent_loop.protocol.agui_emitter import AGUIEventEmitter
-from app.agents.agent_loop.protocol.transcript_collector import TranscriptCollector
 from app.agents.agent_loop.sse_emitter import SSEEventEmitter
 from app.agents.agent_loop.tool_loader import PipesHubToolLoader
 from app.agents.agent_loop.tool_summarizer import PipesHubToolSummarizer
@@ -159,6 +180,7 @@ if TYPE_CHECKING:
     from langchain_core.language_models.chat_models import BaseChatModel
 
     from app.agent_loop_lib.core.types import Goal
+    from app.agent_loop_lib.transport.base import LLMTransport
     from app.agents.actions.internal_tools.intrim_tools import AskUserQuestionItemInput
     from app.agents.agent_loop.context import AgentContext
 
@@ -175,6 +197,31 @@ _DOMAIN_SHARED_NAV_TOOL_NAMES: frozenset[str] = frozenset({
 # tool_system.py / react_agent_node's `recursion_limit`); kept as one named
 # constant here rather than a magic number in `create()`.
 _MAX_TURNS = 15
+
+
+DIRECT_TRANSPORT = "direct"
+LANGCHAIN_TRANSPORT = "langchain"
+
+
+def _transport_provider() -> str:
+    """Which registered transport the agent loop talks through.
+
+    Two values only: "langchain" (default) or "direct", the provider's own SDK,
+    which skips the per-token AIMessageChunk validation LangChain does. It stays
+    a binary switch because a deployment chooses *how* it talks to providers;
+    *which* provider a request uses comes from the model it selected, and
+    `build_direct_transport` resolves that per request.
+
+    "azure_direct" is accepted as a deprecated alias so existing deployments,
+    compose files and load-test scripts keep working across the rename.
+
+    Read per call rather than cached so an arm can be switched by restarting the
+    service, without a rebuild.
+    """
+    raw = os.getenv("PIPESHUB_AGENT_TRANSPORT", LANGCHAIN_TRANSPORT).strip()
+    if raw in ("azure_direct", DIRECT_TRANSPORT):
+        return DIRECT_TRANSPORT
+    return raw or LANGCHAIN_TRANSPORT
 
 # Phase-1 auto-compact (gentle): protects up to 70% of budget in the tail,
 # summarizes only the oldest portion. Phase-2 (aggressive): if still over
@@ -240,6 +287,42 @@ class PipesHubAgentFactory:
                 lambda: LangChainTransport(
                     llm, model_name=model_name, opik_project_name=opik_project_name, model_key=model_key,
                 ),
+                opik_active=opik_active,
+                project_name=opik_project_name,
+            ),
+        )
+        # Same model as "langchain" above, reached through the provider's own
+        # SDK instead. LangChain builds an AIMessageChunk per streamed token and
+        # pydantic validates each one, measured at ~9% of query-service CPU.
+        # Registered rather than substituted: selection is per ModelSpec, so
+        # "langchain" stays the default and this is revertible without a deploy.
+        # The whole configuration comes off `llm` -- not just credentials -- so
+        # both transports issue the same request; `model_key` lets this one
+        # share the learned api-mode store with the LangChain path.
+        #
+        # Which provider is decided from `llm` rather than from the env value:
+        # with several models configured, one env string cannot describe the
+        # provider of whichever model this request chose. A provider with no
+        # direct transport falls back to LangChain rather than failing.
+        #
+        # Wrapped in the same tracing factory: traced_transport_factory works on
+        # any LLMTransport, only build_langchain_opik_callbacks is LangChain-
+        # specific, so leaving this bare simply lost the spans.
+        def _direct_or_langchain() -> "LLMTransport":
+            direct = build_direct_transport(
+                llm, model_name=model_name, model_key=model_key,
+            )
+            if direct is not None:
+                return direct
+            return LangChainTransport(
+                llm, model_name=model_name,
+                opik_project_name=opik_project_name, model_key=model_key,
+            )
+
+        transport_registry.register(
+            DIRECT_TRANSPORT,
+            traced_transport_factory(
+                _direct_or_langchain,
                 opik_active=opik_active,
                 project_name=opik_project_name,
             ),
@@ -499,7 +582,7 @@ class PipesHubAgentFactory:
             # construction is equivalent to having registered it earlier;
             # it just needs `runtime` itself for `run_child()`, which
             # doesn't exist until this line.
-            register_skill_learning(hooks, skill_manager, runtime, provider="langchain", model_name=model_name)
+            register_skill_learning(hooks, skill_manager, runtime, provider=_transport_provider(), model_name=model_name)
 
         # Domain-agent composition, registration half: now that the
         # AgentRuntime exists, actually build each claimed domain's child
@@ -545,7 +628,7 @@ class PipesHubAgentFactory:
             )
             composed_names = register_domain_agents(
                 composition_plan, tool_registry, runtime, context,
-                provider="langchain", model_name=model_name,
+                provider=_transport_provider(), model_name=model_name,
                 lazy_tools=domain_lazy_tools,
                 shared_tool_names=(
                     (DOMAIN_SHARED_SKILL_TOOL_NAMES if skill_manager is not None else frozenset())
@@ -561,7 +644,7 @@ class PipesHubAgentFactory:
             )
             if mode.loop_kind == "orchestrator":
                 runtime.spec_factory = domain_spec_factory(
-                    provider="langchain", model_name=model_name,
+                    provider=_transport_provider(), model_name=model_name,
                     default_tool_names=composed_names, context=context,
                 )
             elif mode.loop_kind == "plan_execute":
@@ -580,7 +663,7 @@ class PipesHubAgentFactory:
             # pool falls back to the flat, uncomposed residual, same as
             # this feature's pre-existing behavior.
             runtime.spec_factory = domain_spec_factory(
-                provider="langchain", model_name=model_name,
+                provider=_transport_provider(), model_name=model_name,
                 default_tool_names=[
                     n for n in tool_registry.names() if n not in COORDINATION_TOOL_NAMES
                 ],
@@ -666,7 +749,7 @@ class PipesHubAgentFactory:
             tool_names=tool_names,
             tool_disclosure=tool_disclosure,
             pinned_toolsets=pinned_toolsets,
-            model=ModelSpec(provider="langchain", model=model_name),
+            model=ModelSpec(provider=_transport_provider(), model=model_name),
             loop=loop,
             max_turns=_MAX_TURNS,
         )

--- a/backend/python/app/agents/agent_loop/langchain_transport.py
+++ b/backend/python/app/agents/agent_loop/langchain_transport.py
@@ -51,6 +51,12 @@ from app.agent_loop_lib.core.streaming import (
 )
 from app.agent_loop_lib.transport.base import LLMTransport
 from app.agent_loop_lib.transport.opik_tracing import build_langchain_opik_callbacks
+from app.agent_loop_lib.transport.provider_conflicts import (
+    API_SHAPE_CONFLICT_MARKERS,
+    REASONING_MANDATORY_CONFLICT_MARKERS,
+    is_api_shape_conflict,
+    is_reasoning_mandatory_conflict,
+)
 from app.agents.agent_loop.converters import (
     convert_assistant_message_from_langchain,
     convert_messages_to_langchain,
@@ -99,27 +105,12 @@ _NETWORK_ERROR_NAME_HINTS = ("connectionerror", "connecttimeout", "readtimeout",
 #   attempt landed on a backend that only supports this on Chat Completions.
 # - "tool_choice.function": Chat-Completions-shaped tool_choice sent to a
 #   Responses-only model/deployment.
-_API_SHAPE_CONFLICT_MARKERS = (
-    "please use /v1/responses instead",
-    "please use /v1/chat/completions instead",
-    "tool_choice.function",
-)
-
-
-def _is_api_shape_conflict(exc: Exception) -> bool:
-    message = str(exc).lower()
-    return any(marker in message for marker in _API_SHAPE_CONFLICT_MARKERS)
-
-
-# Substring a provider/gateway emits when it refuses to let reasoning be
-# turned off at all — observed on some OpenRouter-proxied Gemini models:
-# "Reasoning is mandatory for this endpoint and cannot be disabled."
-_REASONING_MANDATORY_CONFLICT_MARKERS = ("reasoning is mandatory",)
-
-
-def _is_reasoning_mandatory_conflict(exc: Exception) -> bool:
-    message = str(exc).lower()
-    return any(marker in message for marker in _REASONING_MANDATORY_CONFLICT_MARKERS)
+# Markers and predicates live in transport/provider_conflicts.py so the direct
+# SDK transport recovers from exactly the same errors this one does.
+_API_SHAPE_CONFLICT_MARKERS = API_SHAPE_CONFLICT_MARKERS
+_REASONING_MANDATORY_CONFLICT_MARKERS = REASONING_MANDATORY_CONFLICT_MARKERS
+_is_api_shape_conflict = is_api_shape_conflict
+_is_reasoning_mandatory_conflict = is_reasoning_mandatory_conflict
 
 
 def _truncate_raw_for_log(raw: Any, max_len: int = 500) -> str:  # noqa: ANN401
@@ -657,12 +648,23 @@ class LangChainTransport(LLMTransport):
                         if not isinstance(tc_chunk, dict):
                             continue
                         args_delta = tc_chunk.get("args") or ""
-                        if not args_delta:
+                        name = tc_chunk.get("name")
+                        tc_id = tc_chunk.get("id")
+                        # The agent loop reads `name` off the FIRST delta for an
+                        # index to decide whether the call is final_answer, and
+                        # OpenAI/Azure open a tool call with a metadata-only
+                        # fragment (name and id set, args "") -- verified against
+                        # the live deployment. Dropping it meant the first delta
+                        # the loop saw carried name=None, final_answer went
+                        # unrecognised, and the answer only appeared once the
+                        # turn had finished. A fragment carrying nothing at all
+                        # still tells the loop nothing, so it is still skipped.
+                        if not args_delta and not name and not tc_id:
                             continue
                         yield ToolCallDeltaEvent(
                             index=tc_chunk.get("index") or 0,
-                            id=tc_chunk.get("id"),
-                            name=tc_chunk.get("name"),
+                            id=tc_id,
+                            name=name,
                             arguments_delta=args_delta,
                         )
                 break

--- a/backend/python/app/config/constants/arangodb.py
+++ b/backend/python/app/config/constants/arangodb.py
@@ -90,6 +90,22 @@ class Connectors(Enum):
     ATTACHMENTS = "ATTACHMENTS"
 
 
+class PermissionModel(Enum):
+    """How a connector's records derive their per-user visibility.
+
+    ``APP_LEVEL`` means access to the connector app implies access to every
+    record it syncs — the source has no per-record ACLs, so each connector
+    writes one blanket ORG (or single creator-USER) permission. ``RECORD_LEVEL``
+    means the source syncs real per-record ACLs and visibility must be resolved
+    per user. Declared per connector via ``ConnectorBuilder.configure(...)``;
+    ``RECORD_LEVEL`` is the default because assuming per-record ACLs can only
+    under-share, never over-share.
+    """
+
+    APP_LEVEL = "APP_LEVEL"
+    RECORD_LEVEL = "RECORD_LEVEL"
+
+
 class AppGroups(Enum):
     GOOGLE_WORKSPACE = "Google Workspace"
     NOTION = "Notion"

--- a/backend/python/app/connectors/api/router.py
+++ b/backend/python/app/connectors/api/router.py
@@ -93,6 +93,7 @@ from app.connectors.services.kafka_service import KafkaService
 from app.containers.connector import ConnectorAppContainer
 from app.core.signed_url import SignedUrlHandler
 from app.models.entities import Record, RecordType
+from app.services.cache.invalidation_hooks import notify_kb_records_changed
 from app.services.featureflag.config.config import CONFIG
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.utils.api_call import make_api_call
@@ -1862,6 +1863,11 @@ async def delete_record(
                     logger.info(f"✅ Published {event_data['eventType']} event for record {record_id}")
                 except Exception as e:
                     logger.error(f"❌ Failed to publish deletion event: {str(e)}")
+
+            # This route deletes directly, bypassing the processor's cascade
+            # path, so it owns its own cache invalidation.
+            if result.get("isKb") and result.get("connectorId"):
+                await notify_kb_records_changed(result["connectorId"], result.get("orgId"))
 
             logger.info(f"✅ Successfully deleted record {record_id}")
             return {

--- a/backend/python/app/connectors/core/base/data_processor/data_source_entities_processor.py
+++ b/backend/python/app/connectors/core/base/data_processor/data_source_entities_processor.py
@@ -43,6 +43,7 @@ from app.models.entities import (
     WebpageRecord,
 )
 from app.models.permission import EntityType, Permission, PermissionType
+from app.services.cache.invalidation_hooks import notify_kb_records_changed
 from app.services.messaging.messaging_factory import MessagingFactory
 from app.services.messaging.utils import MessagingUtils
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
@@ -1451,6 +1452,10 @@ class DataSourceEntitiesProcessor:
         async with self.data_store_provider.transaction() as tx_store:
             result = await tx_store.delete_records_recursive(record_ids, connector_id)
         await self._publish_delete_events((result or {}).get("eventData"))
+        if (result or {}).get("successfully_deleted"):
+            # No-ops unless connector_id is a KB; connectors invalidate on sync
+            # completion instead, so a mid-sync delete does not thrash the cache.
+            await notify_kb_records_changed(connector_id)
         return result
 
 
@@ -1505,7 +1510,11 @@ class DataSourceEntitiesProcessor:
                         {
                             "eventType": "reindexRecord",
                             "timestamp": get_epoch_timestamp_in_ms(),
-                            "payload": record.to_kafka_record(),
+                            # An explicit reindex must re-run even when the record is
+                            # already COMPLETED; without this the consumer's
+                            # already-indexed guard skips it and reindex silently
+                            # does nothing for a healthy corpus.
+                            "payload": {**record.to_kafka_record(), "forceReindex": True},
                         },
                     )
                     for record in to_publish

--- a/backend/python/app/connectors/core/base/data_processor/data_source_entities_processor.py
+++ b/backend/python/app/connectors/core/base/data_processor/data_source_entities_processor.py
@@ -1451,11 +1451,18 @@ class DataSourceEntitiesProcessor:
             }
         async with self.data_store_provider.transaction() as tx_store:
             result = await tx_store.delete_records_recursive(record_ids, connector_id)
-        await self._publish_delete_events((result or {}).get("eventData"))
         if (result or {}).get("successfully_deleted"):
+            # Before publishing: the transaction has committed, so the records are
+            # already gone, and _publish_delete_events can fail. Invalidating
+            # afterwards would leave the cache serving deleted records until the
+            # TTL expired whenever publication threw. A concurrent read that
+            # repopulates between these two lines reads post-delete state, so
+            # moving this earlier cannot cache anything stale.
+            #
             # No-ops unless connector_id is a KB; connectors invalidate on sync
             # completion instead, so a mid-sync delete does not thrash the cache.
             await notify_kb_records_changed(connector_id)
+        await self._publish_delete_events((result or {}).get("eventData"))
         return result
 
 

--- a/backend/python/app/connectors/core/factory/connector_factory.py
+++ b/backend/python/app/connectors/core/factory/connector_factory.py
@@ -285,7 +285,9 @@ class ConnectorFactory:
         try:
             await connector.run_sync()
         finally:
-            await notify_connector_sync_completed(connector_id)
+            processor = getattr(connector, "data_entities_processor", None)
+            org_id = getattr(processor, "org_id", None) if processor is not None else None
+            await notify_connector_sync_completed(connector_id, org_id)
 
     @classmethod
     async def create_and_start_sync(

--- a/backend/python/app/connectors/core/factory/connector_factory.py
+++ b/backend/python/app/connectors/core/factory/connector_factory.py
@@ -276,6 +276,17 @@ class ConnectorFactory:
 
         return None
 
+    @staticmethod
+    async def _run_sync_and_invalidate(connector: BaseConnector, connector_id: str) -> None:
+        """Run a sync started outside `EventService`, then drop the connector's
+        cached accessible-record map the same way that path does."""
+        from app.services.cache.invalidation_hooks import notify_connector_sync_completed
+
+        try:
+            await connector.run_sync()
+        finally:
+            await notify_connector_sync_completed(connector_id)
+
     @classmethod
     async def create_and_start_sync(
         cls,
@@ -312,7 +323,7 @@ class ConnectorFactory:
                     )
                 else:
                     await sync_task_manager.start_sync(
-                        connector_id, connector.run_sync()
+                        connector_id, cls._run_sync_and_invalidate(connector, connector_id)
                     )
                     logger.info(f"Started sync for {name} {connector_id} connector")
                 return connector

--- a/backend/python/app/connectors/core/registry/connector_builder.py
+++ b/backend/python/app/connectors/core/registry/connector_builder.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any
 
-from app.config.constants.arangodb import ExtensionTypes
+from app.config.constants.arangodb import ExtensionTypes, PermissionModel
 from app.connectors.core.constants import AuthFieldKeys
 from app.connectors.core.registry.auth_builder import (
     AuthBuilder,
@@ -54,6 +54,7 @@ class ConnectorConfigBuilder:
             "hideConnector": False,
             "isAdminAccessRequired": False,
             "personalConnectorType": None,
+            "permissionModel": PermissionModel.RECORD_LEVEL.value,
             "auth": {
                 "supportedAuthTypes": ["OAUTH"],
                 "schemas": {},  # Per-auth-type schemas: {"OAUTH": {"fields": []}, "API_TOKEN": {"fields": []}}
@@ -107,6 +108,21 @@ class ConnectorConfigBuilder:
     def with_icon(self, icon_path: str) -> 'ConnectorConfigBuilder':
         """Set the icon path"""
         self.config["iconPath"] = icon_path
+        return self
+
+    def with_permission_model(self, model: PermissionModel) -> 'ConnectorConfigBuilder':
+        """Declare how this connector's records derive per-user visibility.
+
+        Set ``APP_LEVEL`` only when the source has no per-record ACLs, so every
+        record this connector syncs is visible to everyone who can reach the
+        connector app (these connectors write a single blanket ORG or
+        creator-USER permission per record). Leaving the ``RECORD_LEVEL``
+        default is always safe; declaring ``APP_LEVEL`` wrongly would widen
+        who can see the connector's records.
+        """
+        if not isinstance(model, PermissionModel):
+            raise ValueError(f"permission model must be a PermissionModel, got {type(model).__name__}")
+        self.config["permissionModel"] = model.value
         return self
 
     def with_realtime_support(self, supported: bool = True, connection_type: str = "WEBSOCKET") -> 'ConnectorConfigBuilder':
@@ -342,6 +358,7 @@ class ConnectorBuilder:
         self.connector_scopes: list[ConnectorScope] = []
         self._oauth_configs: dict[str, OAuthConfig] = {}  # Store OAuth configs for auto-registration
         self.connector_info: str | None = None
+        self.permission_model: PermissionModel | None = None
 
     def in_group(self, app_group: str) -> 'ConnectorBuilder':
         """Set the app group"""
@@ -351,6 +368,18 @@ class ConnectorBuilder:
     def with_scopes(self, scopes: list[ConnectorScope]) -> 'ConnectorBuilder':
         """Set the connector scopes"""
         self.connector_scopes = scopes
+        return self
+
+    def with_permission_model(self, model: PermissionModel) -> 'ConnectorBuilder':
+        """Declare how this connector's records derive per-user visibility.
+
+        See `ConnectorConfigBuilder.with_permission_model`. Applied in
+        `build_decorator` so it holds regardless of where it sits in the chain
+        relative to `configure()`.
+        """
+        if not isinstance(model, PermissionModel):
+            raise ValueError(f"permission model must be a PermissionModel, got {type(model).__name__}")
+        self.permission_model = model
         return self
 
     def with_auth(self, auth_builders: list[AuthBuilder]) -> 'ConnectorBuilder':
@@ -442,6 +471,9 @@ class ConnectorBuilder:
         from app.connectors.core.registry.connector_registry import Connector
 
         config = self.config_builder.build()
+
+        if self.permission_model is not None:
+            config["permissionModel"] = self.permission_model.value
 
         # Auto-register all OAuth configs with final connector name
         oauth_registry = get_oauth_config_registry()

--- a/backend/python/app/connectors/core/registry/connector_registry.py
+++ b/backend/python/app/connectors/core/registry/connector_registry.py
@@ -4,7 +4,12 @@ from inspect import isclass
 from typing import Any
 from uuid import uuid4
 
-from app.config.constants.arangodb import CollectionNames, Connectors, ProgressStatus
+from app.config.constants.arangodb import (
+    CollectionNames,
+    Connectors,
+    PermissionModel,
+    ProgressStatus,
+)
 from app.telemetry.event_buffer import record_event
 from app.telemetry.identity import domain_from_email
 from app.connectors.core.registry.connector_builder import ConnectorScope
@@ -209,6 +214,16 @@ class ConnectorRegistry:
 
         except Exception as e:
             self.logger.error(f"Error discovering connectors: {e}")
+
+    @staticmethod
+    def _permission_model_for(metadata: dict[str, Any]) -> str:
+        """The connector's declared permission model, defaulting to RECORD_LEVEL.
+
+        RECORD_LEVEL is the safe default: it resolves visibility per user, so a
+        connector that forgets to declare can only under-share.
+        """
+        config = metadata.get('config') or {}
+        return config.get('permissionModel') or PermissionModel.RECORD_LEVEL.value
 
     def _normalize_connector_name(self, name: str) -> str:
         """
@@ -473,6 +488,9 @@ class ConnectorRegistry:
                 'appGroup': metadata['appGroup'],
                 'authType': auth_type_to_store,  # Store selected auth type (user's choice, not metadata)
                 'scope': scope,
+                # Denormalized off the decorator so the query service can route
+                # permission resolution without importing connector code.
+                'permissionModel': self._permission_model_for(metadata),
                 'isActive': False,
                 'isAgentActive': False,
                 'isConfigured': True,
@@ -593,6 +611,7 @@ class ConnectorRegistry:
 
             # Collect keys of instances that need to be deactivated
             keys_to_deactivate = []
+            stale_permission_models: list[tuple[str, str]] = []
             for document in all_documents:
                 connector_type = document.get('type')
                 is_active = document.get('isActive', False)
@@ -603,6 +622,12 @@ class ConnectorRegistry:
                 if connector_type not in self._connectors and is_active:
                     keys_to_deactivate.append(doc_key)
 
+                registered = self._connectors.get(connector_type)
+                if registered and doc_key:
+                    expected = self._permission_model_for(registered)
+                    if document.get('permissionModel') != expected:
+                        stale_permission_models.append((doc_key, expected))
+
             # Batch deactivate all instances using graph provider
             if keys_to_deactivate:
                 updated_count = await graph_provider.batch_update_connector_status(
@@ -612,6 +637,23 @@ class ConnectorRegistry:
                     is_agent_active=False,
                 )
                 self.logger.info(f"Batch deactivated {updated_count} connector instances")
+
+            # Backfill instances created before the flag existed, and pick up
+            # reclassifications. Best-effort: a failure here only costs the
+            # query service some cache sharing, never correctness.
+            for doc_key, expected in stale_permission_models:
+                try:
+                    await graph_provider.update_node(
+                        doc_key, self._collection_name, {'permissionModel': expected}
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        f"Could not set permissionModel on connector instance {doc_key}: {e}"
+                    )
+            if stale_permission_models:
+                self.logger.info(
+                    f"Backfilled permissionModel on {len(stale_permission_models)} connector instances"
+                )
 
             self.logger.info("Successfully synced registry with database")
             return True

--- a/backend/python/app/connectors/core/registry/connector_registry.py
+++ b/backend/python/app/connectors/core/registry/connector_registry.py
@@ -488,6 +488,7 @@ class ConnectorRegistry:
                 'appGroup': metadata['appGroup'],
                 'authType': auth_type_to_store,  # Store selected auth type (user's choice, not metadata)
                 'scope': scope,
+                'orgId': org_id,
                 # Denormalized off the decorator so the query service can route
                 # permission resolution without importing connector code.
                 'permissionModel': self._permission_model_for(metadata),

--- a/backend/python/app/connectors/services/event_service.py
+++ b/backend/python/app/connectors/services/event_service.py
@@ -325,7 +325,10 @@ class EventService:
                     self.logger.error(f"Error deleting connector sync edges for {connector_id}: {edge_error}")
 
                 # Schedule the background sync task
-                await sync_task_manager.start_sync(connector_id, self._run_sync_and_clear_status(connector, connector_id))
+                await sync_task_manager.start_sync(
+                    connector_id,
+                    self._run_sync_and_clear_status(connector, connector_id, org_id),
+                )
                 self.logger.info(f"Started full sync task for {connector_name} {connector_id}")
 
                 # Clear only when we consumed a persisted pending flag (avoids redundant writes on manual full sync).
@@ -367,12 +370,20 @@ class EventService:
                 self.logger.error(f"❌ Failed to set SYNCING status for connector {connector_id}: {status_err}")
                 # Non-fatal: proceed with sync even if status write failed
 
-            await sync_task_manager.start_sync(connector_id, self._run_sync_and_clear_status(connector, connector_id))
+            await sync_task_manager.start_sync(
+                connector_id,
+                self._run_sync_and_clear_status(connector, connector_id, org_id),
+            )
             self.logger.info(f"Started sync task for {connector_name} {connector_id}")
 
         return True
 
-    async def _run_sync_and_clear_status(self, connector: BaseConnector, connector_id: str) -> None:
+    async def _run_sync_and_clear_status(
+        self,
+        connector: BaseConnector,
+        connector_id: str,
+        org_id: str | None = None,
+    ) -> None:
         """Wrap run_sync() so that status is cleared to null when the task finishes."""
         start = time.monotonic()
         try:
@@ -392,7 +403,7 @@ class EventService:
 
             # The sync may have added or removed records; drop the query
             # service's cached view of this connector so the next search sees them.
-            await notify_connector_sync_completed(connector_id)
+            await notify_connector_sync_completed(connector_id, org_id)
 
     @staticmethod
     def _reindex_task_key(

--- a/backend/python/app/connectors/services/event_service.py
+++ b/backend/python/app/connectors/services/event_service.py
@@ -19,6 +19,7 @@ from app.connectors.core.base.data_store.graph_data_store import GraphDataStore
 from app.connectors.core.factory.connector_factory import ConnectorFactory
 from app.connectors.core.sync.task_manager import reindex_task_manager, sync_task_manager
 from app.containers.connector import ConnectorAppContainer
+from app.services.cache.invalidation_hooks import notify_connector_sync_completed
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
 
@@ -388,6 +389,10 @@ class EventService:
                 self.logger.info(f"✅ Cleared status for connector {connector_id} after sync")
             except Exception as clear_err:
                 self.logger.error(f"❌ Failed to clear status for connector {connector_id}: {clear_err}")
+
+            # The sync may have added or removed records; drop the query
+            # service's cached view of this connector so the next search sees them.
+            await notify_connector_sync_completed(connector_id)
 
     @staticmethod
     def _reindex_task_key(

--- a/backend/python/app/connectors/sources/azure_blob/connector.py
+++ b/backend/python/app/connectors/sources/azure_blob/connector.py
@@ -23,6 +23,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     ProgressStatus,
 )
 from app.config.constants.http_status_code import HttpStatusCode
@@ -288,6 +289,7 @@ class AzureBlobDataSourceEntitiesProcessor(DataSourceEntitiesProcessor):
     .with_description("Sync files and folders from Azure Blob Storage")\
     .with_categories(["Storage"])\
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         AuthBuilder.type(AuthType.CONNECTION_STRING).fields([
             AuthField(

--- a/backend/python/app/connectors/sources/azure_files/connector.py
+++ b/backend/python/app/connectors/sources/azure_files/connector.py
@@ -29,6 +29,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     ProgressStatus,
 )
 from app.config.constants.http_status_code import HttpStatusCode
@@ -234,6 +235,7 @@ class AzureFilesDataSourceEntitiesProcessor(DataSourceEntitiesProcessor):
     .with_description("Sync files and folders from Azure File Shares")\
     .with_categories(["Storage"])\
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         AuthBuilder.type(AuthType.CONNECTION_STRING).fields([
             AuthField(

--- a/backend/python/app/connectors/sources/github/connector.py
+++ b/backend/python/app/connectors/sources/github/connector.py
@@ -20,6 +20,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
 )
 from app.connectors.core.base.connector.connector_service import BaseConnector
 from app.connectors.core.base.data_processor.data_source_entities_processor import (
@@ -109,7 +110,7 @@ class RecordUpdate:
     "Sync content from your Github instance"
 ).with_categories(["Knowledge Management"]).with_scopes(
     [ConnectorScope.PERSONAL.value]
-).with_auth(
+).with_permission_model(PermissionModel.APP_LEVEL).with_auth(
     [
         AuthBuilder.type(AuthType.OAUTH).oauth(
             connector_name="Github",

--- a/backend/python/app/connectors/sources/gitlab/connector.py
+++ b/backend/python/app/connectors/sources/gitlab/connector.py
@@ -92,6 +92,13 @@ _GITLAB_EXECUTOR_MAX_WORKERS = 8
     .with_description("Sync content from your GitLab instance")
     .with_categories(["Knowledge Management"])
     .with_scopes([ConnectorScope.TEAM.value])
+    # No APP_LEVEL here: GitLab syncs real per-project member ACLs
+    # (`projects.py::_transform_restrictions_to_permissions` writes a per-user
+    # permission for every project member), and creator-only is merely the
+    # fallback when member enumeration fails. Declaring APP_LEVEL routes these
+    # users to the connector-wide record scan, which returns every synced
+    # project's records to anyone linked to the app regardless of project
+    # membership. RECORD_LEVEL (the default) is correct.
     .with_auth(
         [
             AuthBuilder.type(AuthType.OAUTH).oauth(

--- a/backend/python/app/connectors/sources/gitlab_personal/connector.py
+++ b/backend/python/app/connectors/sources/gitlab_personal/connector.py
@@ -1,7 +1,7 @@
 from logging import Logger
 
 from app.config.configuration_service import ConfigurationService
-from app.config.constants.arangodb import Connectors, PermissionModel
+from app.config.constants.arangodb import Connectors
 from app.connectors.core.base.connector.connector_service import BaseConnector
 from app.connectors.core.base.data_processor.data_source_entities_processor import (
     DataSourceEntitiesProcessor,
@@ -98,7 +98,12 @@ class GitLabPersonalProjectsSync(ProjectsSync):
     .with_description("Sync content from your personal GitLab account")
     .with_categories(["Knowledge Management"])
     .with_scopes([ConnectorScope.PERSONAL.value])
-    .with_permission_model(PermissionModel.APP_LEVEL)
+    # RECORD_LEVEL (the default) rather than APP_LEVEL: reviewers disagreed on
+    # whether a non-creator can hold a USER_APP_RELATION to a personal instance,
+    # and APP_LEVEL answers with one connector-wide scan that never checks the
+    # per-user ACL. The only cost of being wrong the safe way is losing the cache
+    # shortcut for this connector; the cost of being wrong the other way is one
+    # user reading another's records.
     .with_auth(
         [
             AuthBuilder.type(AuthType.OAUTH).oauth(

--- a/backend/python/app/connectors/sources/gitlab_personal/connector.py
+++ b/backend/python/app/connectors/sources/gitlab_personal/connector.py
@@ -1,7 +1,7 @@
 from logging import Logger
 
 from app.config.configuration_service import ConfigurationService
-from app.config.constants.arangodb import Connectors
+from app.config.constants.arangodb import Connectors, PermissionModel
 from app.connectors.core.base.connector.connector_service import BaseConnector
 from app.connectors.core.base.data_processor.data_source_entities_processor import (
     DataSourceEntitiesProcessor,
@@ -98,6 +98,7 @@ class GitLabPersonalProjectsSync(ProjectsSync):
     .with_description("Sync content from your personal GitLab account")
     .with_categories(["Knowledge Management"])
     .with_scopes([ConnectorScope.PERSONAL.value])
+    .with_permission_model(PermissionModel.APP_LEVEL)
     .with_auth(
         [
             AuthBuilder.type(AuthType.OAUTH).oauth(

--- a/backend/python/app/connectors/sources/google_cloud_storage/connector.py
+++ b/backend/python/app/connectors/sources/google_cloud_storage/connector.py
@@ -24,6 +24,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     ProgressStatus,
 )
 from app.config.constants.http_status_code import HttpStatusCode
@@ -283,6 +284,7 @@ class GCSDataSourceEntitiesProcessor(DataSourceEntitiesProcessor):
     .with_description("Sync files and folders from Google Cloud Storage")\
     .with_categories(["Storage"])\
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         AuthBuilder.type(AuthType.ACCESS_KEY).fields([
             AuthField(

--- a/backend/python/app/connectors/sources/localKB/handlers/kb_service.py
+++ b/backend/python/app/connectors/sources/localKB/handlers/kb_service.py
@@ -13,6 +13,7 @@ from app.config.constants.arangodb import (
 from app.config.constants.service import DefaultEndpoints, config_node_constants
 from app.connectors.services.kafka_service import KafkaService
 from app.models.entities import FileRecord, RecordType
+from app.services.cache.invalidation_hooks import notify_kb_records_changed
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
 
@@ -718,6 +719,10 @@ class KnowledgeBaseService:
                 kb_id, folder_id, name, org_id, parent_folder_id=None
             )
             await self.processor.on_new_records([(folder_record, [])])
+            # Folders are born COMPLETED, so they never pass through the indexing
+            # hook. They carry no virtualRecordId today and so cannot appear in an
+            # accessible-record map — this keeps the KB's entry honest if that changes.
+            await notify_kb_records_changed(kb_id, org_id)
 
             return {
                 "id": folder_id,
@@ -783,6 +788,10 @@ class KnowledgeBaseService:
                 kb_id, folder_id, name, org_id, parent_folder_id=parent_folder_id
             )
             await self.processor.on_new_records([(folder_record, [])])
+            # Folders are born COMPLETED, so they never pass through the indexing
+            # hook. They carry no virtualRecordId today and so cannot appear in an
+            # accessible-record map — this keeps the KB's entry honest if that changes.
+            await notify_kb_records_changed(kb_id, org_id)
 
             return {
                 "id": folder_id,

--- a/backend/python/app/connectors/sources/localKB/handlers/kb_service.py
+++ b/backend/python/app/connectors/sources/localKB/handlers/kb_service.py
@@ -36,6 +36,19 @@ MONGO_USER_GRAPH_KEY_LOOKUP_CHUNK_SIZE = 500
 # path). Note this differs from MimeTypes.FOLDER ("text/directory").
 KB_FOLDER_MIME_TYPE = "application/vnd.folder"
 
+def _mutation_succeeded(result: object) -> bool:
+    """Did a graph-provider permission mutation actually succeed?
+
+    The providers disagree on the return contract: arango's
+    `remove_kb_permission` returns a bare bool, every other path returns a dict
+    carrying `success`. A failure dict is still truthy, so a plain
+    `if result:` reported provider failures to the caller as success.
+    """
+    if isinstance(result, dict):
+        return bool(result.get("success"))
+    return bool(result)
+
+
 class KnowledgeBaseService:
     """Data handler for knowledge base operations."""
 
@@ -1290,6 +1303,11 @@ class KnowledgeBaseService:
 
             if result.get("success"):
                 self.logger.info(f"✅ Permissions created: {result['grantedCount']} granted")
+                # A revoked user keeps reading this KB until the entry
+                # expires otherwise: the cache is only invalidated on
+                # record-set changes, and a permission edit changes no
+                # records. Rare enough that the extra DEL costs nothing.
+                await notify_kb_records_changed(kb_id)
                 return result
             else:
                 self.logger.error(f"❌ Permission creation failed: {result.get('reason')}")
@@ -1491,12 +1509,17 @@ class KnowledgeBaseService:
                 new_role=new_role
             )
 
-            if result:
+            if _mutation_succeeded(result):
                 success_msg = f"✅ Permission updated successfully for {len(valid_user_ids)} users and {len(valid_team_ids)} teams"
                 if skipped_users or skipped_teams:
                     success_msg += f" (skipped {len(skipped_users)} users and {len(skipped_teams)} teams without permissions)"
                 self.logger.info(success_msg)
 
+                # A revoked user keeps reading this KB until the entry
+                # expires otherwise: the cache is only invalidated on
+                # record-set changes, and a permission edit changes no
+                # records. Rare enough that the extra DEL costs nothing.
+                await notify_kb_records_changed(kb_id)
                 return {
                     "success": True,
                     "userIds": valid_user_ids,
@@ -1504,12 +1527,15 @@ class KnowledgeBaseService:
                     "newRole": new_role,
                     "kbId": kb_id,
                 }
-            else:
-                return {
-                    "success": False,
-                    "reason": "Failed to update permission",
-                    "code": 500
-                }
+            # Propagate the provider's own reason when it gave one; the
+            # generic message is only for the bare-bool contract.
+            if isinstance(result, dict):
+                return result
+            return {
+                "success": False,
+                "reason": "Failed to update permission",
+                "code": 500
+            }
 
         except Exception as e:
             self.logger.error(f"❌ Failed to update KB permission: {str(e)}")
@@ -1666,25 +1692,33 @@ class KnowledgeBaseService:
                 team_ids=valid_team_ids
             )
 
-            if result:
+            if _mutation_succeeded(result):
                 success_msg = f"✅ Permission removed successfully for {len(valid_user_ids)} users and {len(valid_team_ids)} teams"
                 if skipped_users or skipped_teams:
                     success_msg += f" (skipped {len(skipped_users)} users and {len(skipped_teams)} teams without permissions)"
                 self.logger.info(success_msg)
 
 
+                # A revoked user keeps reading this KB until the entry
+                # expires otherwise: the cache is only invalidated on
+                # record-set changes, and a permission edit changes no
+                # records. Rare enough that the extra DEL costs nothing.
+                await notify_kb_records_changed(kb_id)
                 return {
                     "success": True,
                     "userIds": valid_user_ids,
                     "teamIds": valid_team_ids,
                     "kbId": kb_id,
                 }
-            else:
-                return {
-                    "success": False,
-                    "reason": "Failed to remove permissions",
-                    "code": 500
-                }
+            # Propagate the provider's own reason when it gave one; the
+            # generic message is only for the bare-bool contract.
+            if isinstance(result, dict):
+                return result
+            return {
+                "success": False,
+                "reason": "Failed to remove permissions",
+                "code": 500
+            }
 
         except Exception as e:
             self.logger.error(f"❌ Failed to remove KB permission: {str(e)}")

--- a/backend/python/app/connectors/sources/local_fs/connector.py
+++ b/backend/python/app/connectors/sources/local_fs/connector.py
@@ -35,6 +35,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     ProgressStatus,
 )
 from app.config.constants.http_status_code import HttpStatusCode
@@ -250,6 +251,7 @@ class LocalFsApp(App):
     )
     .with_categories(["Storage", "Local"])
     .with_scopes([ConnectorScope.PERSONAL.value])
+    .with_permission_model(PermissionModel.APP_LEVEL)
     .configure(
         lambda builder: builder.with_icon(LOCAL_FS_ICON_PATH)
         .with_realtime_support(False)

--- a/backend/python/app/connectors/sources/mariadb/connector.py
+++ b/backend/python/app/connectors/sources/mariadb/connector.py
@@ -20,6 +20,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     RecordRelations,
 )
 from app.connectors.core.constants import IconPaths
@@ -140,6 +141,7 @@ class SyncStats:
     .with_description("Sync databases and tables from MariaDB")\
     .with_categories(["Database"])\
     .with_scopes([ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         AuthBuilder.type(AuthType.BASIC_AUTH).fields([
             AuthField(

--- a/backend/python/app/connectors/sources/minio/connector.py
+++ b/backend/python/app/connectors/sources/minio/connector.py
@@ -10,7 +10,7 @@ from logging import Logger
 from urllib.parse import urlparse
 
 from app.config.configuration_service import ConfigurationService
-from app.config.constants.arangodb import Connectors
+from app.config.constants.arangodb import Connectors, PermissionModel
 from app.connectors.core.constants import IconPaths
 from app.connectors.core.base.data_processor.data_source_entities_processor import (
     DataSourceEntitiesProcessor,
@@ -57,6 +57,7 @@ MinIODataSourceEntitiesProcessor = S3CompatibleDataSourceEntitiesProcessor
     .with_description("Sync files and folders from MinIO S3-compatible storage")\
     .with_categories(["Storage"])\
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         AuthBuilder.type(AuthType.ACCESS_KEY).fields([
             AuthField(

--- a/backend/python/app/connectors/sources/postgres/connector.py
+++ b/backend/python/app/connectors/sources/postgres/connector.py
@@ -20,6 +20,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     RecordRelations,
 )
 from app.connectors.core.constants import IconPaths
@@ -150,6 +151,7 @@ class SyncStats:
     .with_description("Sync schemas and tables from PostgreSQL")\
     .with_categories(["Database"])\
     .with_scopes([ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         # Option 1: Individual connection fields
         AuthBuilder.type(AuthType.BASIC_AUTH).fields([

--- a/backend/python/app/connectors/sources/rss/connector.py
+++ b/backend/python/app/connectors/sources/rss/connector.py
@@ -22,6 +22,7 @@ from app.config.constants.arangodb import (
     ExtensionTypes,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
 )
 from app.connectors.core.constants import IconPaths
 from app.connectors.sources.web.fetch_strategy import fetch_url_with_fallback
@@ -65,6 +66,7 @@ class RSSApp(App):
     .with_description("Subscribe to and sync content from RSS and Atom feeds")
     .with_categories(["Web", "Content"])
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])
+    .with_permission_model(PermissionModel.APP_LEVEL)
     .configure(
         lambda builder: builder.with_icon(IconPaths.connector_icon(Connectors.RSS.value))
         .with_realtime_support(False)

--- a/backend/python/app/connectors/sources/rss/connector.py
+++ b/backend/python/app/connectors/sources/rss/connector.py
@@ -22,7 +22,6 @@ from app.config.constants.arangodb import (
     ExtensionTypes,
     MimeTypes,
     OriginTypes,
-    PermissionModel,
 )
 from app.connectors.core.constants import IconPaths
 from app.connectors.sources.web.fetch_strategy import fetch_url_with_fallback
@@ -66,7 +65,12 @@ class RSSApp(App):
     .with_description("Subscribe to and sync content from RSS and Atom feeds")
     .with_categories(["Web", "Content"])
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])
-    .with_permission_model(PermissionModel.APP_LEVEL)
+    # RECORD_LEVEL (the default) rather than APP_LEVEL: reviewers disagreed on
+    # whether a non-creator can hold a USER_APP_RELATION to a personal instance,
+    # and APP_LEVEL answers with one connector-wide scan that never checks the
+    # per-user ACL. The only cost of being wrong the safe way is losing the cache
+    # shortcut for this connector; the cost of being wrong the other way is one
+    # user reading another's records.
     .configure(
         lambda builder: builder.with_icon(IconPaths.connector_icon(Connectors.RSS.value))
         .with_realtime_support(False)

--- a/backend/python/app/connectors/sources/s3/connector.py
+++ b/backend/python/app/connectors/sources/s3/connector.py
@@ -8,7 +8,7 @@ shared S3CompatibleBaseConnector to handle common functionality.
 from logging import Logger
 
 from app.config.configuration_service import ConfigurationService
-from app.config.constants.arangodb import Connectors
+from app.config.constants.arangodb import Connectors, PermissionModel
 from app.connectors.core.constants import IconPaths
 from app.connectors.core.base.data_processor.data_source_entities_processor import (
     DataSourceEntitiesProcessor,
@@ -59,6 +59,7 @@ S3DataSourceEntitiesProcessor = S3CompatibleDataSourceEntitiesProcessor
     .with_description("Sync files and folders from S3")\
     .with_categories(["Storage"])\
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         AuthBuilder.type(AuthType.ACCESS_KEY).fields([
             AuthField(

--- a/backend/python/app/connectors/sources/snowflake/connector.py
+++ b/backend/python/app/connectors/sources/snowflake/connector.py
@@ -21,6 +21,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     RecordRelations,
 )
 from app.connectors.core.constants import IconPaths
@@ -188,6 +189,7 @@ class SyncStats:
     .with_description("Sync databases, tables, views, stages and files from Snowflake")\
     .with_categories(["Database", "Data Warehouse"])\
     .with_scopes([ConnectorScope.PERSONAL.value, ConnectorScope.TEAM.value])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .with_auth([
         # Option 1: Personal Access Token (PAT) authentication
         AuthBuilder.type(AuthType.ACCESS_KEY).fields([

--- a/backend/python/app/connectors/sources/web/connector.py
+++ b/backend/python/app/connectors/sources/web/connector.py
@@ -26,6 +26,7 @@ from app.config.constants.arangodb import (
     FILE_MIME_TYPES,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
     ProgressStatus,
 )
 from app.config.constants.http_status_code import HttpStatusCode
@@ -171,6 +172,7 @@ class WebApp(App):
     .with_description("Crawl and sync data from web pages")\
     .with_categories(["Web"])\
     .with_scopes([ConnectorScope.PERSONAL, ConnectorScope.TEAM])\
+    .with_permission_model(PermissionModel.APP_LEVEL)\
     .configure(lambda builder: builder
         .with_icon(IconPaths.connector_icon(Connectors.WEB.value))
         .with_realtime_support(False)

--- a/backend/python/app/connectors_main.py
+++ b/backend/python/app/connectors_main.py
@@ -534,6 +534,13 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             pass
     if telemetry.pusher is not None:
         await telemetry.pusher.stop()
+    try:
+        accessible_records_cache = getattr(app.state, "accessible_records_cache", None)
+        if accessible_records_cache is not None:
+            await accessible_records_cache.close()
+            logger.info("✅ Accessible-records cache closed")
+    except Exception as e:
+        logger.error(f"❌ Error closing accessible-records cache: {e}")
     # Shutdown all container resources
     try:
         await shutdown_container_resources(app_container)

--- a/backend/python/app/connectors_main.py
+++ b/backend/python/app/connectors_main.py
@@ -422,6 +422,21 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     app.state.kb_entities_processor = kb_entities_processor
     logger.info("✅ KB entities processor initialized")
 
+    # Sync completion and KB deletes happen here; both drop the query service's
+    # cached accessible-record maps.
+    try:
+        from app.services.cache.accessible_records_cache import AccessibleRecordsCache
+        from app.services.cache.invalidation_hooks import (
+            init_accessible_records_invalidator,
+        )
+        accessible_records_cache = await AccessibleRecordsCache.create(
+            logger, app_container.config_service()
+        )
+        app.state.accessible_records_cache = accessible_records_cache
+        init_accessible_records_invalidator(logger, accessible_records_cache, graph_provider)
+    except Exception as e:
+        logger.warning(f"❌ Failed to register accessible-records invalidator: {e}")
+
     try:
         await telemetry.bind(app_container.config_service(), logger).start()
     except Exception as e:

--- a/backend/python/app/containers/query.py
+++ b/backend/python/app/containers/query.py
@@ -19,11 +19,20 @@ class QueryAppContainer(BaseAppContainer):
     # Override config_service to use the service-specific logger
     config_service = providers.Singleton(ConfigurationService, logger=logger, key_value_store=key_value_store)
 
+    # Caches the accessible-record maps every search resolves; falls back to
+    # live queries when Redis is unavailable or the kill-switch is set.
+    accessible_records_cache = providers.Resource(
+        container_utils.create_accessible_records_cache,
+        logger=logger,
+        config_service=config_service,
+    )
+
     # Graph Database Provider via Factory (HTTP mode - fully async)
     graph_provider = providers.Resource(
         container_utils.create_graph_provider,
         logger=logger,
         config_service=config_service,
+        accessible_records_cache=accessible_records_cache,
     )
 
     vector_db_service =  providers.Resource(

--- a/backend/python/app/containers/utils/utils.py
+++ b/backend/python/app/containers/utils/utils.py
@@ -1,4 +1,5 @@
 from logging import Logger
+from typing import TYPE_CHECKING
 
 from app.config.configuration_service import ConfigurationService
 from app.config.constants.arangodb import ExtensionTypes
@@ -34,6 +35,12 @@ from app.services.vector_db.interface.vector_db import IVectorDBService
 from app.services.vector_db.vector_db_provider_factory import VectorDBProviderFactory
 from app.utils.logger import create_logger
 
+if TYPE_CHECKING:
+    from app.services.cache.accessible_records_cache import (
+        AccessibleRecordsCache,
+        AccessibleRecordsInvalidator,
+    )
+
 
 # Note - Cannot make this a singleton as it is used in the container and DI does not work with static methods
 class ContainerUtils:
@@ -54,12 +61,37 @@ class ContainerUtils:
         self,
         logger: Logger,
         config_service: ConfigurationService,
+        accessible_records_cache: "AccessibleRecordsCache | None" = None,
     ) -> IGraphDBProvider:
         """Async factory to create and connect graph database provider"""
         return await GraphDBProviderFactory.create_provider(
             logger=logger,
             config_service=config_service,
+            accessible_records_cache=accessible_records_cache,
         )
+
+    async def create_accessible_records_cache(
+        self,
+        logger: Logger,
+        config_service: ConfigurationService,
+    ) -> "AccessibleRecordsCache":
+        """Async factory for the accessible-record map cache (never raises)."""
+        from app.services.cache.accessible_records_cache import AccessibleRecordsCache
+
+        return await AccessibleRecordsCache.create(logger, config_service)
+
+    async def create_accessible_records_invalidator(
+        self,
+        logger: Logger,
+        accessible_records_cache: "AccessibleRecordsCache",
+        graph_provider: IGraphDBProvider,
+    ) -> "AccessibleRecordsInvalidator":
+        """Async factory for the invalidation façade used by writer services."""
+        from app.services.cache.accessible_records_cache import (
+            AccessibleRecordsInvalidator,
+        )
+
+        return AccessibleRecordsInvalidator(logger, accessible_records_cache, graph_provider)
 
     async def create_indexing_pipeline(
         self,

--- a/backend/python/app/indexing_main.py
+++ b/backend/python/app/indexing_main.py
@@ -795,6 +795,20 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     set_docling_processor_governor(governor)
     set_pdf_rasterizer_governor(governor)
 
+    # This service flips records to COMPLETED, which is when a KB record first
+    # becomes searchable — the query service's cached map must be dropped then.
+    try:
+        from app.services.cache.accessible_records_cache import AccessibleRecordsCache
+        from app.services.cache.invalidation_hooks import (
+            init_accessible_records_invalidator,
+        )
+        cache = await AccessibleRecordsCache.create(logger, app_container.config_service())
+        app.state.accessible_records_cache = cache
+        init_accessible_records_invalidator(logger, cache, graph_provider)
+    except Exception as e:
+        logger.warning(f"❌ Failed to register accessible-records invalidator: {e}")
+
+
     # Start all message consumers centrally
     try:
         consumers = await start_kafka_consumers(app_container, governor)

--- a/backend/python/app/indexing_main.py
+++ b/backend/python/app/indexing_main.py
@@ -895,6 +895,14 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         logger.error(f"❌ Error during resource governor shutdown: {str(e)}")
     governor.close()
 
+    try:
+        accessible_records_cache = getattr(app.state, "accessible_records_cache", None)
+        if accessible_records_cache is not None:
+            await accessible_records_cache.close()
+            logger.info("✅ Accessible-records cache closed")
+    except Exception as e:
+        logger.error(f"❌ Error closing accessible-records cache: {e}")
+
     # Close configuration service (stops Redis Pub/Sub subscription)
     try:
         config_service = app_container.config_service()

--- a/backend/python/app/models/entities.py
+++ b/backend/python/app/models/entities.py
@@ -2987,6 +2987,7 @@ class AppMetadata(BaseModel):
     updated_at_timestamp: int = Field(description="Epoch timestamp in milliseconds of app update")
     status: str | None = Field(default=None, description="Current sync status")
     is_locked: bool | None = Field(default=None, description="Whether the app is locked")
+    permission_model: str | None = Field(default=None, description="How the connector's records derive per-user visibility (PermissionModel: APP_LEVEL or RECORD_LEVEL)")
 
     @staticmethod
     def from_db_document(doc: dict[str, Any]) -> "AppMetadata":
@@ -3008,6 +3009,7 @@ class AppMetadata(BaseModel):
             updated_at_timestamp=doc.get("updatedAtTimestamp", 0),
             status=doc.get("status"),
             is_locked=doc.get("isLocked"),
+            permission_model=doc.get("permissionModel"),
         )
 
 class MeetingRecord(Record):

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -545,30 +545,38 @@ class RetrievalService:
                             or []
                         )
                 except Exception as e:
-                    # Losing the whole batch would strip webUrl/mimeType from
-                    # every record in it, so degrade to the per-id path the
-                    # batch replaced rather than returning nothing. Matches
-                    # _fetch_docs in chat_helpers.py.
                     self.logger.warning(
                         f"Failed to batch fetch {label}, per-id fallback: {str(e)}"
                     )
-                    per_id = await asyncio.gather(
-                        *[
-                            self.graph_provider.get_document(rid, collection)
-                            for rid in unique_ids
-                        ],
-                        return_exceptions=True,
-                    )
-                    return {
-                        rid: doc
-                        for rid, doc in zip(unique_ids, per_id)
-                        if doc and not isinstance(doc, Exception)
-                    }
+                    nodes = []
+
                 resolved = {}
                 for node in nodes:
                     key = (node or {}).get("id") or (node or {}).get("_key")
                     if key:
                         resolved[key] = node
+
+                # Losing the batch strips webUrl/mimeType from every record in
+                # it, and a result without mimeType is dropped outright by the
+                # required_fields filter below -- the citation disappears from
+                # the answer with no error. The except above cannot catch that:
+                # get_nodes_by_field_in swallows its own errors and returns [],
+                # so a failure looks exactly like "no rows". Recover on which
+                # ids actually came back instead.
+                missing = [rid for rid in unique_ids if rid not in resolved]
+                if missing:
+                    per_id = await asyncio.gather(
+                        *[
+                            self.graph_provider.get_document(rid, collection)
+                            for rid in missing
+                        ],
+                        return_exceptions=True,
+                    )
+                    resolved.update({
+                        rid: doc
+                        for rid, doc in zip(missing, per_id)
+                        if doc and not isinstance(doc, BaseException)
+                    })
                 return resolved
 
             async def fetch_files() -> dict:

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -36,6 +36,7 @@ from app.utils.aimodels import (
     get_generator_model,
 )
 from app.utils.chat_helpers import (
+    GRAPH_BATCH_CHUNK_SIZE,
     get_flattened_results,
     get_record,
 )
@@ -45,6 +46,10 @@ from app.utils.image_utils import get_extension_from_mimetype
 _user_cache: dict[str, tuple] = {}  # {user_id: (user_data, timestamp)}
 USER_CACHE_TTL = 300  # 5 minutes
 MAX_USER_CACHE_SIZE = 1000  # Max number of users to keep in cache
+
+# Applied when a caller passes no limit at all. Matches `search_with_filters`'s
+# own default so the None path and the omitted path retrieve the same amount.
+DEFAULT_SEARCH_LIMIT = 20
 
 # User-facing guidance when the graph/permissions yield no searchable corpus
 ACCESSIBLE_RECORDS_NOT_FOUND_MESSAGE = (
@@ -323,7 +328,7 @@ class RetrievalService:
         user_id: str,
         org_id: str,
         filter_groups: dict[str, list[str]] | None = None,
-        limit: int = 20,
+        limit: int | None = 20,
         virtual_record_ids_from_tool: list[str] | None = None,
         knowledge_search: bool = False,
         time_range: dict[str, int] | None = None,
@@ -334,6 +339,18 @@ class RetrievalService:
             # Get accessible records
             if not self.graph_provider:
                 raise ValueError("GraphProvider is required for permission checking")
+
+            # `None` reaches here from the prefetch path, which forwards the
+            # request's optional `limit` verbatim (chat_modes/bridge.py ->
+            # prefetch.py). A default argument cannot cover that -- an explicit
+            # None overrides it -- and HybridSearchRequest is a plain dataclass,
+            # so the None survived all the way to `req.limit * 2` in
+            # qdrant/utils.py and took the whole search down with a TypeError
+            # that the except below logged as "Filtered search failed",
+            # returning an empty result set. The turn then answered with no
+            # retrieved context and no visible error.
+            if limit is None:
+                limit = DEFAULT_SEARCH_LIMIT
 
             filter_groups = filter_groups or {}
 
@@ -509,39 +526,60 @@ class RetrievalService:
             files_map = {}
             mails_map = {}
 
-            async def fetch_files() -> dict:
-                if not file_record_ids_to_fetch:
+            async def _fetch_by_ids(record_ids: list[str], collection: str, label: str) -> dict:
+                """One query per collection instead of one per chunk.
+
+                The id lists are appended per search result, so a record matched
+                by several chunks was previously fetched once per chunk.
+                """
+                if not record_ids:
                     return {}
+                unique_ids = list(dict.fromkeys(record_ids))
                 try:
-                    file_results = await asyncio.gather(*[
-                        self.graph_provider.get_document(record_id, CollectionNames.FILES.value)
-                        for record_id in file_record_ids_to_fetch
-                    ], return_exceptions=True)
-                    return {
-                        record_id: result
-                        for record_id, result in zip(file_record_ids_to_fetch, file_results)
-                        if result and not isinstance(result, Exception)
-                    }
+                    nodes: list[dict] = []
+                    for start in range(0, len(unique_ids), GRAPH_BATCH_CHUNK_SIZE):
+                        nodes.extend(
+                            await self.graph_provider.get_nodes_by_field_in(
+                                collection, "id", unique_ids[start:start + GRAPH_BATCH_CHUNK_SIZE]
+                            )
+                            or []
+                        )
                 except Exception as e:
-                    self.logger.warning(f"Failed to batch fetch files: {str(e)}")
-                    return {}
+                    # Losing the whole batch would strip webUrl/mimeType from
+                    # every record in it, so degrade to the per-id path the
+                    # batch replaced rather than returning nothing. Matches
+                    # _fetch_docs in chat_helpers.py.
+                    self.logger.warning(
+                        f"Failed to batch fetch {label}, per-id fallback: {str(e)}"
+                    )
+                    per_id = await asyncio.gather(
+                        *[
+                            self.graph_provider.get_document(rid, collection)
+                            for rid in unique_ids
+                        ],
+                        return_exceptions=True,
+                    )
+                    return {
+                        rid: doc
+                        for rid, doc in zip(unique_ids, per_id)
+                        if doc and not isinstance(doc, Exception)
+                    }
+                resolved = {}
+                for node in nodes:
+                    key = (node or {}).get("id") or (node or {}).get("_key")
+                    if key:
+                        resolved[key] = node
+                return resolved
+
+            async def fetch_files() -> dict:
+                return await _fetch_by_ids(
+                    file_record_ids_to_fetch, CollectionNames.FILES.value, "files"
+                )
 
             async def fetch_mails() -> dict:
-                if not mail_record_ids_to_fetch:
-                    return {}
-                try:
-                    mail_results = await asyncio.gather(*[
-                        self.graph_provider.get_document(record_id, CollectionNames.MAILS.value)
-                        for record_id in mail_record_ids_to_fetch
-                    ], return_exceptions=True)
-                    return {
-                        record_id: result
-                        for record_id, result in zip(mail_record_ids_to_fetch, mail_results)
-                        if result and not isinstance(result, Exception)
-                    }
-                except Exception as e:
-                    self.logger.warning(f"Failed to batch fetch mails: {str(e)}")
-                    return {}
+                return await _fetch_by_ids(
+                    mail_record_ids_to_fetch, CollectionNames.MAILS.value, "mails"
+                )
 
             async def fetch_locations() -> dict[str, str]:
                 """Resolve permission-aware Location trails for retrieved records.

--- a/backend/python/app/modules/transformers/blob_storage.py
+++ b/backend/python/app/modules/transformers/blob_storage.py
@@ -1,10 +1,12 @@
 import asyncio
 import json
+import os
 import time
 from typing import Any, Dict, TypedDict
 
 import aiohttp
 import jwt
+import msgspec
 from yarl import URL
 
 from app.config.constants.arangodb import CollectionNames
@@ -19,6 +21,191 @@ from app.modules.transformers.transformer import TransformContext, Transformer
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.utils.request_context import inject_request_headers
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
+
+COMPRESSION_THRESHOLD_BYTES_DEFAULT = 20 * 1024 * 1024
+DOWNLOAD_CONNECTION_LIMIT_DEFAULT = 100
+
+
+def _decode_json(raw: "bytes | str") -> Any:  # noqa: ANN401 - stored records are free-form
+    """Decode a stored-record envelope.
+
+    Records under the compression threshold are stored as plain JSON, so the
+    envelope now carries the whole record and parsing it *is* the record decode.
+    That moved the cost from msgpack (already msgspec, a C decoder) onto the
+    stdlib json module, which measured 12% of query-service CPU. msgspec is
+    ~1.9x faster on a real 48KB record and is already a dependency.
+
+    Accepts str so it can be passed to ``resp.json(loads=...)``; the UTF-8
+    decode aiohttp does first costs ~2us on that record, well inside the win.
+
+    Falls back to the stdlib rather than failing the fetch: a record msgspec
+    rejects is still worth trying to read.
+    """
+    try:
+        return msgspec.json.decode(raw)
+    except Exception:
+        return json.loads(raw) if isinstance(raw, str) else json.loads(raw.decode("utf-8"))
+_COMPRESSION_THRESHOLD_ENV = "PIPESHUB_RECORD_COMPRESSION_THRESHOLD_BYTES"
+
+
+def compression_threshold_bytes() -> int:
+    """Records whose JSON form exceeds this are stored compressed; 0 compresses everything."""
+    raw = os.getenv(_COMPRESSION_THRESHOLD_ENV)
+    if raw is None:
+        return COMPRESSION_THRESHOLD_BYTES_DEFAULT
+    try:
+        return max(int(raw), 0)
+    except ValueError:
+        return COMPRESSION_THRESHOLD_BYTES_DEFAULT
+
+
+_SIGNED_URL_CACHE_ENV = "PIPESHUB_SIGNED_URL_CACHE_SECONDS"
+# storage.controller.ts signs download URLs for 3600s. Cache well inside that so
+# a URL handed out at the end of its cached life still has plenty left to use.
+_SIGNED_URL_CACHE_SECONDS_DEFAULT = 0  # off unless configured
+
+
+def signed_url_cache_seconds() -> int:
+    """TTL for cached storage download URLs; 0 disables the cache.
+
+    Resolving one is a gateway round trip that does a Mongo document lookup, a
+    KV config read and an S3 signing call, and a chat turn does ~120 of them.
+    Off by default so behaviour is unchanged until a deployment opts in.
+    """
+    raw = os.getenv(_SIGNED_URL_CACHE_ENV)
+    if raw is None:
+        return _SIGNED_URL_CACHE_SECONDS_DEFAULT
+    try:
+        return max(min(int(raw), 3000), 0)
+    except ValueError:
+        return _SIGNED_URL_CACHE_SECONDS_DEFAULT
+
+
+# Node closes idle keep-alive connections at 5s (its default; the app never
+# sets server.keepAliveTimeout). Ours must expire first or we reuse a socket the
+# gateway has already closed.
+NODE_KEEPALIVE_MARGIN_SECONDS = 4.0
+
+_shared_sessions: "dict[asyncio.AbstractEventLoop, aiohttp.ClientSession]" = {}
+
+
+def download_connection_limit() -> int:
+    """Max simultaneous connections to the storage API, 0 for unbounded."""
+    raw = os.getenv("PIPESHUB_STORAGE_CONNECTION_LIMIT", "").strip()
+    if raw:
+        try:
+            value = int(raw)
+        except ValueError:
+            pass
+        else:
+            if value >= 0:
+                return value
+    return DOWNLOAD_CONNECTION_LIMIT_DEFAULT
+
+
+def get_shared_session() -> aiohttp.ClientSession:
+    """Process-wide download session, one per running event loop.
+
+    ``BlobStorage`` is constructed ad hoc at ~20 call sites (per request, per
+    tool call), so a per-instance session would build and leak a connection
+    pool per request. Keyed by loop because a session binds to the loop that
+    created it.
+
+    The pool is bounded: record fetches fan out per concurrent turn, and an
+    unbounded pool opened ~1,400 simultaneous sockets to the Node API at 32
+    concurrent users, past its 511-deep listen backlog, so connections were
+    refused and record fetches failed. Queueing above the limit is strictly
+    better than a refused connection.
+    """
+    loop = asyncio.get_running_loop()
+    session = _shared_sessions.get(loop)
+    if session is not None and not session.closed:
+        return session
+
+    if len(_shared_sessions) > 1:
+        for stale_loop in [lp for lp in _shared_sessions if lp.is_closed()]:
+            _shared_sessions.pop(stale_loop, None)
+
+    session = aiohttp.ClientSession(
+        connector=aiohttp.TCPConnector(
+            limit=download_connection_limit(),
+            # Below Node's 5s server.keepAliveTimeout (never overridden, so the
+            # platform default applies). aiohttp's own default is 15s, so an
+            # idle connection sat in our pool for up to 10s after the gateway
+            # had already closed it; reusing one then fails mid-request with
+            # "Server disconnected". That cost 51 record fetches and one failed
+            # tool call in a single day's logs, and became common only once the
+            # session was shared process-wide and connections started living
+            # long enough to go idle.
+            keepalive_timeout=NODE_KEEPALIVE_MARGIN_SECONDS,
+        )
+    )
+    _shared_sessions[loop] = session
+    return session
+
+
+async def close_shared_session() -> None:
+    """Close the pooled session for the running loop; call from service shutdown."""
+    loop = asyncio.get_running_loop()
+    session = _shared_sessions.pop(loop, None)
+    if session is not None and not session.closed:
+        await session.close()
+
+
+# Same reasoning as _shared_sessions: one client per loop, not per BlobStorage.
+# `None` is a cached "unavailable" verdict, so an outage costs one failed
+# connect per loop instead of one per record fetch.
+_shared_redis: "dict[asyncio.AbstractEventLoop, Any]" = {}
+_shared_redis_lock = asyncio.Lock()
+
+
+async def get_shared_redis(config_service: Any, logger: Any) -> Any:  # noqa: ANN401
+    """Process-wide Redis client for the signed-URL cache, one per event loop.
+
+    Returns None when the cache is disabled or Redis is unreachable; callers
+    then use the uncached path, which is what they did before it existed.
+    """
+    if not signed_url_cache_seconds():
+        return None
+    loop = asyncio.get_running_loop()
+    if loop in _shared_redis:
+        return _shared_redis[loop]
+
+    async with _shared_redis_lock:
+        if loop in _shared_redis:
+            return _shared_redis[loop]
+        for stale_loop in [lp for lp in _shared_redis if lp.is_closed()]:
+            _shared_redis.pop(stale_loop, None)
+
+        client = None
+        try:
+            from redis.asyncio import Redis
+
+            cfg = await config_service.get_redis_config()
+            client = Redis(
+                host=cfg.host, port=cfg.port, password=cfg.password,
+                db=cfg.db, decode_responses=True,
+                socket_timeout=2.0, socket_connect_timeout=2.0,
+            )
+            await client.ping()
+        except Exception as e:
+            if client is not None:
+                try:
+                    await client.aclose()
+                except Exception:
+                    pass
+            client = None
+            logger.warning("Signed-URL cache unavailable, disabled: %s", str(e))
+        _shared_redis[loop] = client
+        return client
+
+
+async def close_shared_redis() -> None:
+    """Close the pooled Redis client for the running loop; call from shutdown."""
+    loop = asyncio.get_running_loop()
+    client = _shared_redis.pop(loop, None)
+    if client is not None:
+        await client.aclose()
 
 
 class CustomMetadataEntry(TypedDict):
@@ -50,6 +237,99 @@ class BlobStorage(Transformer):
         self.config_service = config_service
         self.graph_provider = graph_provider
 
+    async def _signed_url_client(self):
+        """Redis client for the signed-URL cache, or None when it is disabled.
+
+        Shared per event loop rather than per instance: BlobStorage is built ad
+        hoc at ~20 call sites (per request, per tool call), so a per-instance
+        client would open and leak a connection pool per request -- the same
+        reason get_shared_session exists. Failures are never fatal; the caller
+        falls back to asking the gateway.
+        """
+        return await get_shared_redis(self.config_service, self.logger)
+
+    async def _record_from_signed_url(
+        self,
+        session: "aiohttp.ClientSession",
+        signed_url: str,
+        file_size_bytes: int | None,
+        virtual_record_id: str,
+    ) -> dict | None:
+        """Download and decode a record from an already-signed storage URL.
+
+        Returns None when the payload carries no record, so the caller can decide
+        whether that is an error or a reason to re-sign.
+        """
+        # Ranged download only pays off on large objects; an unknown size is
+        # assumed large because that is the pre-existing behaviour.
+        MIN_SIZE_FOR_PARALLEL = 3 * 1024 * 1024
+        use_parallel = file_size_bytes is None or file_size_bytes >= MIN_SIZE_FOR_PARALLEL
+
+        async def _single() -> dict:
+            async with session.get(URL(signed_url, encoded=True)) as res:
+                if res.status != HttpStatusCode.SUCCESS.value:
+                    raise Exception(f"Failed to retrieve record: status {res.status}")
+                return await res.json(content_type=None, loads=_decode_json)
+
+        try:
+            if use_parallel:
+                file_bytes = await self._download_with_range_requests(
+                    session, signed_url, chunk_size_mb=2, max_connections=6
+                )
+                data = _decode_json(file_bytes)
+            else:
+                data = await _single()
+        except Exception as e:
+            if not use_parallel:
+                self.logger.error("❌ Failed to retrieve record: %s", str(e))
+                raise
+            self.logger.warning(
+                "⚠️ Parallel download failed: %s. Falling back to single download...", str(e)
+            )
+            try:
+                data = await _single()
+            except Exception as fallback_error:
+                self.logger.error("❌ Fallback download also failed: %s", str(fallback_error))
+                raise Exception(
+                    f"Both parallel and fallback downloads failed: {str(e)}"
+                ) from fallback_error
+
+        if not data.get("record"):
+            return None
+        record = self._process_downloaded_record(data)
+        self.logger.debug(
+            "✅ Successfully retrieved record %s from storage for virtual_record_id: %s",
+            record.get("record_name"), virtual_record_id,
+        )
+        return record
+
+    @staticmethod
+    def _signed_url_key(org_id: str, document_id: str) -> str:
+        # org-scoped: the gateway is called with an org-scoped service token, and
+        # per-user access is enforced before a record reaches this path.
+        return f"sigurl:{org_id}:{document_id}"
+
+    async def _cached_signed_url(self, org_id: str, document_id: str) -> str | None:
+        client = await self._signed_url_client()
+        if client is None:
+            return None
+        try:
+            return await client.get(self._signed_url_key(org_id, document_id))
+        except Exception as e:
+            self.logger.debug("Signed-URL cache read failed: %s", str(e))
+            return None
+
+    async def _store_signed_url(self, org_id: str, document_id: str, url: str) -> None:
+        client = await self._signed_url_client()
+        if client is None or not url:
+            return
+        try:
+            await client.set(
+                self._signed_url_key(org_id, document_id), url, ex=signed_url_cache_seconds()
+            )
+        except Exception as e:
+            self.logger.debug("Signed-URL cache write failed: %s", str(e))
+
     async def _get_auth_and_config(self, org_id: str) -> tuple[dict, str, str]:
         """
         Returns (headers, nodejs_endpoint, storage_type).
@@ -58,18 +338,23 @@ class BlobStorage(Transformer):
             "orgId": org_id,
             "scopes": [TokenScopes.STORAGE_TOKEN.value],
         }
+        # use_cache: these three reads are otherwise an etcd round trip each, on
+        # every record download (~100 per chat turn). The config cache is
+        # invalidated by the etcd watch and Pub/Sub, so reads stay current.
         secret_keys = await self.config_service.get_config(
-            config_node_constants.SECRET_KEYS.value
+            config_node_constants.SECRET_KEYS.value, use_cache=True
         )
         scoped_jwt_secret = secret_keys.get("scopedJwtSecret")
         if not scoped_jwt_secret:
             raise ValueError("Missing scoped JWT secret")
 
         jwt_token = jwt.encode(payload, scoped_jwt_secret, algorithm="HS256")
+        # Headers are rebuilt per call, never cached: inject_request_headers
+        # stamps the caller's request id from a ContextVar.
         headers = inject_request_headers({"Authorization": f"Bearer {jwt_token}"})
 
         endpoints = await self.config_service.get_config(
-            config_node_constants.ENDPOINTS.value
+            config_node_constants.ENDPOINTS.value, use_cache=True
         )
         nodejs_endpoint = endpoints.get("cm", {}).get(
             "endpoint", DefaultEndpoints.NODEJS_ENDPOINT.value
@@ -78,7 +363,7 @@ class BlobStorage(Transformer):
             raise ValueError("Missing CM endpoint configuration")
 
         storage = await self.config_service.get_config(
-            config_node_constants.STORAGE.value
+            config_node_constants.STORAGE.value, use_cache=True
         )
         storage_type = storage.get("storageType")
         if not storage_type:
@@ -108,6 +393,34 @@ class BlobStorage(Transformer):
             or endpoints.get("storage", {}).get("endpoint")
             or DefaultEndpoints.FRONTEND_ENDPOINT.value
         )
+
+    def _maybe_compress_record(self, record: dict, *, label: str = "record") -> tuple[str | None, bool]:
+        """Decide whether a record is worth compressing, and compress it if so.
+
+        Returns ``(compressed_base64_or_None, is_compressed)``.
+
+        Compression is not free on the read side: the blob is base64'd into a
+        JSON envelope, so every reader parses megabytes of base64 before it can
+        even start the zstd+msgpack decode. Below the threshold that costs more
+        than the bytes it saves, so small records are stored as plain JSON —
+        a shape ``_process_downloaded_record`` already accepts.
+        """
+        try:
+            serialized_size = len(json.dumps(record).encode("utf-8"))
+        except (TypeError, ValueError) as e:
+            # Not JSON-serializable, so the uncompressed envelope would fail to
+            # build. msgpack accepts more types — compress regardless of size.
+            self.logger.debug("%s is not JSON-serializable (%s); compressing", label, str(e))
+            serialized_size = None
+
+        if serialized_size is not None and serialized_size <= compression_threshold_bytes():
+            return None, False
+
+        try:
+            return self._compress_record(record), True
+        except Exception as e:
+            self.logger.warning("⚠️ Compression failed, uploading uncompressed: %s", str(e))
+            return None, False
 
     def _compress_record(self, record: dict) -> str:
         """
@@ -630,14 +943,7 @@ class BlobStorage(Transformer):
         try:
             headers, nodejs_endpoint, storage_type = await self._get_auth_and_config(org_id)
 
-            # Compress record for both local and S3 storage
-            try:
-                compressed_record = self._compress_record(record)
-                use_compression = True
-            except Exception as e:
-                self.logger.warning("⚠️ Compression failed, uploading uncompressed: %s", str(e))
-                compressed_record = None
-                use_compression = False
+            compressed_record, use_compression = self._maybe_compress_record(record)
 
             if storage_type == "local":
                 try:
@@ -892,17 +1198,7 @@ class BlobStorage(Transformer):
                     nodes = [doc]
 
             if nodes:
-                doc = nodes[0]
-                record_doc_id = doc.get("record_doc_id") or doc.get("documentId")
-                file_size_bytes = doc.get("fileSizeBytes")
-                record_metadata_doc_id = doc.get("record_metadata_doc_id")
-                result = {
-                    "record_doc_id": record_doc_id,
-                    "fileSizeBytes": file_size_bytes,
-                }
-                if record_metadata_doc_id:
-                    result["record_metadata_doc_id"] = record_metadata_doc_id
-                return result
+                return self._shape_document_lookup(nodes[0])
             else:
                 self.logger.info("No document ID found for virtual record ID: %s", virtual_record_id)
                 return None
@@ -913,100 +1209,195 @@ class BlobStorage(Transformer):
             )
             raise e
 
-    async def get_record_from_storage(self, virtual_record_id: str, org_id: str) -> dict | None:
-            """
-            Retrieve a record's content from blob storage using the virtual_record_id.
-            Returns:
-                str: The content of the record if found, else an empty string.
-            """
-            try:
-                headers, nodejs_endpoint, _ = await self._get_auth_and_config(org_id)
+    @staticmethod
+    def _shape_document_lookup(doc: dict) -> dict:
+        """Project a virtual-record mapping node onto the lookup result shape."""
+        result = {
+            "record_doc_id": doc.get("record_doc_id") or doc.get("documentId"),
+            "fileSizeBytes": doc.get("fileSizeBytes"),
+        }
+        record_metadata_doc_id = doc.get("record_metadata_doc_id")
+        if record_metadata_doc_id:
+            result["record_metadata_doc_id"] = record_metadata_doc_id
+        return result
 
+    VIRTUAL_RECORD_LOOKUP_CHUNK_SIZE = 500
+
+    async def get_document_ids_by_virtual_record_ids(
+        self, virtual_record_ids: list[str]
+    ) -> dict[str, dict]:
+        """Resolve many virtual-record → document mappings with one query per chunk.
+
+        Answering a chat turn fetches ~100 records, each of which otherwise costs
+        its own mapping query.
+
+        The mapping node's key *is* the virtual record id, which is what the
+        per-id path matches on and what carries the index. Batching on a
+        ``virtualRecordId`` property instead matched nothing and fell through to
+        the per-id path for every id, with an unindexed scan added on top.
+
+        Ids the batch does not return still fall back to the per-id path. Ids
+        with no mapping at all are absent from the result rather than
+        present-and-empty, so callers can tell the difference between "not
+        found" and "not looked up".
+        """
+        if not self.graph_provider:
+            self.logger.error("❌ GraphProvider not initialized, cannot resolve virtual record IDs.")
+            raise Exception("GraphProvider not initialized, cannot resolve virtual record IDs.")
+
+        unique_ids = list(dict.fromkeys(vrid for vrid in virtual_record_ids if vrid))
+        if not unique_ids:
+            return {}
+
+        collection_name = CollectionNames.VIRTUAL_RECORD_TO_DOC_ID_MAPPING.value
+        resolved: dict[str, dict] = {}
+
+        chunk_size = self.VIRTUAL_RECORD_LOOKUP_CHUNK_SIZE
+        for start in range(0, len(unique_ids), chunk_size):
+            chunk = unique_ids[start:start + chunk_size]
+            try:
+                nodes = await self.graph_provider.get_nodes_by_field_in(
+                    collection_name, "id", chunk
+                )
+            except Exception as e:
+                # Degrade to the per-id path for this chunk rather than failing the turn.
+                self.logger.warning("Batch virtual-record lookup failed, falling back: %s", str(e))
+                nodes = []
+
+            for node in nodes or []:
+                vrid = node.get("id") or node.get("_key") or node.get("virtualRecordId")
+                if vrid and vrid not in resolved:
+                    resolved[vrid] = self._shape_document_lookup(node)
+
+        # Opt-in only. Nothing in this repo writes a `virtualRecordId` field --
+        # the mapping node's key IS the virtual record id -- and that field is
+        # not indexed, so this query never matches on our data and costs a full
+        # label scan for every id the keyed batch missed (a deleted or missing
+        # mapping is normal). Left available for deployments that dual-write the
+        # field; otherwise ids fall straight through to the per-id path below.
+        missing = [vrid for vrid in unique_ids if vrid not in resolved]
+        if missing and os.getenv("PIPESHUB_VRID_FIELD_LOOKUP", "").lower() in ("1", "true", "yes"):
+            for start in range(0, len(missing), chunk_size):
+                chunk = missing[start:start + chunk_size]
+                try:
+                    nodes = await self.graph_provider.get_nodes_by_field_in(
+                        collection_name, "virtualRecordId", chunk
+                    )
+                except Exception as e:
+                    self.logger.warning(
+                        "Batch virtual-record lookup by field failed, falling back: %s", str(e)
+                    )
+                    continue
+                for node in nodes or []:
+                    vrid = node.get("virtualRecordId")
+                    if vrid and vrid not in resolved:
+                        resolved[vrid] = self._shape_document_lookup(node)
+            missing = [vrid for vrid in unique_ids if vrid not in resolved]
+
+        if missing:
+            fallbacks = await asyncio.gather(
+                *[
+                    self.graph_provider.get_document(vrid, collection_name)
+                    for vrid in missing
+                ],
+                return_exceptions=True,
+            )
+            for vrid, doc in zip(missing, fallbacks):
+                if isinstance(doc, Exception):
+                    self.logger.warning(
+                        "Virtual-record mapping fallback failed for %s: %s", vrid, str(doc)
+                    )
+                    continue
+                if doc:
+                    resolved[vrid] = self._shape_document_lookup(doc)
+
+        return resolved
+
+    async def get_record_from_storage(
+        self,
+        virtual_record_id: str,
+        org_id: str,
+        lookup_result: dict | None = None,
+    ) -> dict | None:
+        """
+        Retrieve a record's content from blob storage using the virtual_record_id.
+
+        Args:
+            lookup_result: pre-resolved virtual-record → document mapping. Callers
+                fetching many records resolve the whole batch in one graph query
+                (see ``get_document_ids_by_virtual_record_ids``) and pass the entry
+                in, which skips the per-record lookup below.
+
+        Returns:
+            str: The content of the record if found, else an empty string.
+        """
+        try:
+            headers, nodejs_endpoint, _ = await self._get_auth_and_config(org_id)
+
+            if lookup_result is None:
                 lookup_result = await self.get_document_id_by_virtual_record_id(virtual_record_id)
 
-                if not lookup_result:
-                    self.logger.info("No document ID found for virtual record ID: %s", virtual_record_id)
-                    return None
+            if not lookup_result:
+                self.logger.info("No document ID found for virtual record ID: %s", virtual_record_id)
+                return None
 
-                document_id = lookup_result.get("record_doc_id")
-                file_size_bytes = lookup_result.get("fileSizeBytes")
+            document_id = lookup_result.get("record_doc_id")
+            file_size_bytes = lookup_result.get("fileSizeBytes")
 
-                if not document_id:
-                    self.logger.debug("No document ID found for virtual record ID: %s", virtual_record_id)
-                    return None
+            if not document_id:
+                self.logger.debug("No document ID found for virtual record ID: %s", virtual_record_id)
+                return None
 
-                download_url = f"{nodejs_endpoint}{Routes.STORAGE_DOWNLOAD.value.format(documentId=document_id)}"
-                async with aiohttp.ClientSession() as session:
-                    async with session.get(download_url, headers=headers) as resp:
-                        if resp.status == HttpStatusCode.SUCCESS.value:
-                            data = await resp.json()
+            download_url = f"{nodejs_endpoint}{Routes.STORAGE_DOWNLOAD.value.format(documentId=document_id)}"
+            session = get_shared_session()
 
-                            if data.get("record"):
-                                record = self._process_downloaded_record(data)
-                                record_name = record.get("record_name")
-                                self.logger.debug("✅ Successfully retrieved record %s from storage for virtual_record_id: %s", record_name, virtual_record_id)
-                                return record
-                            elif data.get("signedUrl"):
-                                signed_url = data.get("signedUrl")
+            # A cached signed URL skips the gateway hop entirely. On any failure
+            # reading it back, fall through to the gateway and re-sign.
+            cached_url = await self._cached_signed_url(org_id, document_id)
+            if cached_url:
+                try:
+                    record = await self._record_from_signed_url(
+                        session, cached_url, file_size_bytes, virtual_record_id
+                    )
+                    if record is not None:
+                        return record
+                except Exception as e:
+                    self.logger.debug(
+                        "Cached signed URL failed for %s, re-signing: %s", document_id, str(e)
+                    )
 
-                                # Determine download strategy based on stored size
-                                if file_size_bytes is None:
-                                    use_parallel = True
-                                else:
-                                    MIN_SIZE_FOR_PARALLEL = 3 * 1024 * 1024
-                                    use_parallel = file_size_bytes >= MIN_SIZE_FOR_PARALLEL
+            async with session.get(download_url, headers=headers) as resp:
+                if resp.status == HttpStatusCode.SUCCESS.value:
+                    data = await resp.json(loads=_decode_json)
 
-                                try:
-                                    if use_parallel:
-                                        file_bytes = await self._download_with_range_requests(
-                                            session,
-                                            signed_url,
-                                            chunk_size_mb=2,
-                                            max_connections=6
-                                        )
-                                        data = json.loads(file_bytes.decode('utf-8'))
-                                    else:
-                                        async with session.get(URL(signed_url, encoded=True)) as res:
-                                            if res.status == HttpStatusCode.SUCCESS.value:
-                                                data = await res.json(content_type=None)
-                                            else:
-                                                raise Exception(f"Failed to retrieve record: status {res.status}")
-                                except Exception as e:
-                                    if use_parallel:
-                                        self.logger.warning("⚠️ Parallel download failed: %s. Falling back to single download...", str(e))
-                                        try:
-                                            async with session.get(URL(signed_url, encoded=True)) as res:
-                                                if res.status == HttpStatusCode.SUCCESS.value:
-                                                    data = await res.json(content_type=None)
-                                                else:
-                                                    raise Exception(f"Fallback download failed with status {res.status}")
-                                        except Exception as fallback_error:
-                                            self.logger.error("❌ Fallback download also failed: %s", str(fallback_error))
-                                            raise Exception(f"Both parallel and fallback downloads failed: {str(e)}") from fallback_error
-                                    else:
-                                        self.logger.error("❌ Failed to retrieve record: %s", str(e))
-                                        raise
+                    if data.get("signedUrl"):
+                        await self._store_signed_url(org_id, document_id, data["signedUrl"])
 
-                                if data.get("record"):
-                                    record = self._process_downloaded_record(data)
-                                    record_name = record.get("record_name")
-                                    self.logger.debug("✅ Successfully retrieved record %s from storage for virtual_record_id: %s", record_name, virtual_record_id)
-                                    return record
-                                else:
-                                    self.logger.error("❌ No record found for virtual_record_id: %s", virtual_record_id)
-                                    raise Exception("No record found for virtual_record_id")
-                            else:
-                                self.logger.error("❌ No record found for virtual_record_id: %s", virtual_record_id)
-                                raise Exception("No record found for virtual_record_id")
-                        else:
-                            self.logger.error("❌ Failed to retrieve record: status %s, virtual_record_id: %s", resp.status, virtual_record_id)
-                            raise Exception("Failed to retrieve record from storage")
-            except Exception as e:
-                self.logger.exception(
-                    "❌ Error retrieving record from storage (virtual_record_id=%s)",
-                    virtual_record_id,
-                )
-                raise e
+                    if data.get("record"):
+                        record = self._process_downloaded_record(data)
+                        record_name = record.get("record_name")
+                        self.logger.debug("✅ Successfully retrieved record %s from storage for virtual_record_id: %s", record_name, virtual_record_id)
+                        return record
+                    elif data.get("signedUrl"):
+                        record = await self._record_from_signed_url(
+                            session, data["signedUrl"], file_size_bytes, virtual_record_id
+                        )
+                        if record is not None:
+                            return record
+                        self.logger.error("❌ No record found for virtual_record_id: %s", virtual_record_id)
+                        raise Exception("No record found for virtual_record_id")
+                    else:
+                        self.logger.error("❌ No record found for virtual_record_id: %s", virtual_record_id)
+                        raise Exception("No record found for virtual_record_id")
+                else:
+                    self.logger.error("❌ Failed to retrieve record: status %s, virtual_record_id: %s", resp.status, virtual_record_id)
+                    raise Exception("Failed to retrieve record from storage")
+        except Exception as e:
+            self.logger.exception(
+                "❌ Error retrieving record from storage (virtual_record_id=%s)",
+                virtual_record_id,
+            )
+            raise e
 
     async def store_virtual_record_mapping(self, virtual_record_id: str, document_id: str, file_size_bytes: int | None = None) -> bool:
         """
@@ -1077,14 +1468,7 @@ class BlobStorage(Transformer):
         try:
             headers, nodejs_endpoint, storage_type = await self._get_auth_and_config(org_id)
 
-            # Compress record for upload
-            try:
-                compressed_record = self._compress_record(record)
-                use_compression = True
-            except Exception as e:
-                self.logger.warning("⚠️ Compression failed, uploading uncompressed: %s", str(e))
-                compressed_record = None
-                use_compression = False
+            compressed_record, use_compression = self._maybe_compress_record(record)
 
             upload_data = {
                 "isCompressed": use_compression,
@@ -1231,13 +1615,9 @@ class BlobStorage(Transformer):
         try:
             headers, nodejs_endpoint, storage_type = await self._get_auth_and_config(org_id)
 
-            try:
-                compressed_metadata = self._compress_record(metadata_dict)
-                use_compression = True
-            except Exception as e:
-                self.logger.warning("⚠️ Metadata compression failed, uploading uncompressed: %s", str(e))
-                compressed_metadata = None
-                use_compression = False
+            compressed_metadata, use_compression = self._maybe_compress_record(
+                metadata_dict, label="metadata"
+            )
 
             upload_data = {
                 "isCompressed": use_compression,
@@ -1800,33 +2180,33 @@ class BlobStorage(Transformer):
 
             download_url = f"{nodejs_endpoint}{Routes.STORAGE_DOWNLOAD.value.format(documentId=metadata_document_id)}"
 
-            async with aiohttp.ClientSession() as session:
-                async with session.get(download_url, headers=headers) as resp:
-                    if resp.status == HttpStatusCode.SUCCESS.value:
-                        data = await resp.json()
-                        if data.get("signedUrl"):
-                            signed_url = data.get("signedUrl")
-                            async with session.get(URL(signed_url, encoded=True)) as signed_resp:
-                                if signed_resp.status == HttpStatusCode.SUCCESS.value:
-                                    data = await signed_resp.json(content_type=None)
-                        # Handle both compressed (from upload_next_version) and uncompressed formats
-                        if data.get("isCompressed"):
-                            record = self._process_downloaded_record(data)
-                        elif isinstance(data, dict) and "record" in data:
-                            record = data.get("record", data)
-                        else:
-                            record = data
-                        self.logger.debug(
-                            "✅ Retrieved reconciliation metadata for virtual_record_id: %s",
-                            virtual_record_id
-                        )
-                        return record
+            session = get_shared_session()
+            async with session.get(download_url, headers=headers) as resp:
+                if resp.status == HttpStatusCode.SUCCESS.value:
+                    data = await resp.json(loads=_decode_json)
+                    if data.get("signedUrl"):
+                        signed_url = data.get("signedUrl")
+                        async with session.get(URL(signed_url, encoded=True)) as signed_resp:
+                            if signed_resp.status == HttpStatusCode.SUCCESS.value:
+                                data = await signed_resp.json(content_type=None)
+                    # Handle both compressed (from upload_next_version) and uncompressed formats
+                    if data.get("isCompressed"):
+                        record = self._process_downloaded_record(data)
+                    elif isinstance(data, dict) and "record" in data:
+                        record = data.get("record", data)
                     else:
-                        self.logger.warning(
-                            "⚠️ Failed to retrieve metadata: status %s, virtual_record_id: %s",
-                            resp.status, virtual_record_id
-                        )
-                        return None
+                        record = data
+                    self.logger.debug(
+                        "✅ Retrieved reconciliation metadata for virtual_record_id: %s",
+                        virtual_record_id
+                    )
+                    return record
+                else:
+                    self.logger.warning(
+                        "⚠️ Failed to retrieve metadata: status %s, virtual_record_id: %s",
+                        resp.status, virtual_record_id
+                    )
+                    return None
 
         except Exception as e:
             self.logger.error("❌ Error retrieving reconciliation metadata: %s", str(e))

--- a/backend/python/app/modules/transformers/blob_storage.py
+++ b/backend/python/app/modules/transformers/blob_storage.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import threading
 import time
 from typing import Any, Dict, TypedDict
 
@@ -156,7 +157,23 @@ async def close_shared_session() -> None:
 # `None` is a cached "unavailable" verdict, so an outage costs one failed
 # connect per loop instead of one per record fetch.
 _shared_redis: "dict[asyncio.AbstractEventLoop, Any]" = {}
-_shared_redis_lock = asyncio.Lock()
+# One lock per loop, not one shared lock: agent action tools run background loops
+# in this process (see agents/actions/*, asyncio.new_event_loop in a thread), and
+# a single asyncio.Lock contended from two loops parks a waiter on one loop that
+# the other's release() never wakes -- a hang, not an error. The threading.Lock
+# only guards creating the per-loop lock, which is not awaited.
+_shared_redis_locks: "dict[asyncio.AbstractEventLoop, asyncio.Lock]" = {}
+_shared_redis_locks_guard = threading.Lock()
+
+
+def _redis_lock_for(loop: "asyncio.AbstractEventLoop") -> asyncio.Lock:
+    with _shared_redis_locks_guard:
+        for stale in [lp for lp in _shared_redis_locks if lp.is_closed()]:
+            _shared_redis_locks.pop(stale, None)
+        lock = _shared_redis_locks.get(loop)
+        if lock is None:
+            lock = _shared_redis_locks[loop] = asyncio.Lock()
+        return lock
 
 
 async def get_shared_redis(config_service: Any, logger: Any) -> Any:  # noqa: ANN401
@@ -171,7 +188,7 @@ async def get_shared_redis(config_service: Any, logger: Any) -> Any:  # noqa: AN
     if loop in _shared_redis:
         return _shared_redis[loop]
 
-    async with _shared_redis_lock:
+    async with _redis_lock_for(loop):
         if loop in _shared_redis:
             return _shared_redis[loop]
         for stale_loop in [lp for lp in _shared_redis if lp.is_closed()]:

--- a/backend/python/app/modules/transformers/sink_orchestrator.py
+++ b/backend/python/app/modules/transformers/sink_orchestrator.py
@@ -16,6 +16,7 @@ from app.modules.transformers.blob_storage import BlobStorage
 from app.modules.transformers.graphdb import GraphDBTransformer
 from app.modules.transformers.transformer import TransformContext, Transformer
 from app.modules.transformers.vectorstore import VectorStore
+from app.services.cache.invalidation_hooks import notify_record_indexed
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.telemetry.modules.activity_metrics import record_service_activity
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
@@ -208,6 +209,15 @@ class SinkOrchestrator(Transformer):
         )
         self.logger.info(
             "✅ indexingStatus=COMPLETED recorded for %s", record.id
+        )
+        # The record is only searchable now, so the accessible-record map that
+        # gates search is stale. KB-only: a connector sync flips thousands of
+        # records here in a burst and invalidates once, at sync completion.
+        await notify_record_indexed(
+            connector_name=record.connector_name,
+            connector_id=record.connector_id,
+            external_record_group_id=record.external_record_group_id,
+            org_id=record.org_id,
         )
 
     # ------------------------------------------------------------------

--- a/backend/python/app/query_main.py
+++ b/backend/python/app/query_main.py
@@ -168,6 +168,17 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         graph_provider = await app_container.graph_provider()
     app.state.graph_provider = graph_provider
 
+    # KB uploads made through chat index in this process, so it invalidates too.
+    try:
+        from app.services.cache.invalidation_hooks import (
+            init_accessible_records_invalidator,
+        )
+        init_accessible_records_invalidator(
+            logger, await app_container.accessible_records_cache(), graph_provider
+        )
+    except Exception as e:
+        logger.warning(f"❌ Failed to register accessible-records invalidator: {e}")
+
     # Start all message consumers centrally
     try:
         consumers = await start_kafka_consumers(app_container)
@@ -295,6 +306,24 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             logger.info("✅ PDF rasterization process pool shut down")
     except Exception as e:
         logger.error(f"❌ Error shutting down PDF rasterization pool: {e}")
+
+    try:
+        from app.modules.transformers.blob_storage import (
+            close_shared_redis,
+            close_shared_session,
+        )
+        await close_shared_session()
+        await close_shared_redis()
+        logger.info("✅ Blob storage session closed")
+    except Exception as e:
+        logger.error(f"❌ Error closing blob storage session: {e}")
+
+    try:
+        accessible_records_cache = await app_container.accessible_records_cache()
+        await accessible_records_cache.close()
+        logger.info("✅ Accessible-records cache closed")
+    except Exception as e:
+        logger.error(f"❌ Error closing accessible-records cache: {e}")
 
 
 # Create FastAPI app with lifespan

--- a/backend/python/app/schema/arango/documents.py
+++ b/backend/python/app/schema/arango/documents.py
@@ -2,6 +2,7 @@ from app.config.constants.arangodb import (
     Connectors,
     ConnectorScopes,
     OriginTypes,
+    PermissionModel,
 )
 from app.models.entities import RecordGroupType, RecordType
 
@@ -161,6 +162,10 @@ app_schema = {
             "updatedAtTimestamp": {"type": "number"},
             "status": {"type": ["string", "null"]},
             "isLocked": {"type": ["boolean", "null"]},
+            "permissionModel": {
+                "type": ["string", "null"],
+                "enum": [m.value for m in PermissionModel] + [None],
+            },
             # KB-specific optional fields
             "orgId": {"type": ["string", "null"]},
             "description": {"type": ["string", "null"]},

--- a/backend/python/app/services/cache/accessible_records_cache.py
+++ b/backend/python/app/services/cache/accessible_records_cache.py
@@ -309,6 +309,13 @@ class AccessibleRecordsInvalidator:
                 return
             org_id = org_id or await self._org_for_app(connector_id)
             if not org_id:
+                # Returning silently here hid a total failure: the cache keeps
+                # serving the pre-sync permission map until the TTL expires.
+                self.logger.warning(
+                    "Skipping accessible-records cache invalidation for connector %s: "
+                    "could not resolve its org",
+                    connector_id,
+                )
                 return
             await self.cache.invalidate_connector(org_id, connector_id)
         except Exception as e:
@@ -380,5 +387,28 @@ class AccessibleRecordsInvalidator:
         return await self.graph_provider.get_document(app_id, CollectionNames.APPS.value)
 
     async def _org_for_app(self, app_id: str) -> str | None:
+        """The org that owns this app.
+
+        Connector apps do not carry `orgId` as a property -- only KB apps do --
+        so the ORG_APP_RELATION edge is the answer for every connector, not a
+        rare fallback. Reading only the property meant every connector-scoped
+        invalidation resolved to None and silently did nothing.
+        """
+        from app.config.constants.arangodb import CollectionNames
+
         app = await self._app_doc(app_id)
-        return (app or {}).get("orgId")
+        org_id = (app or {}).get("orgId")
+        if org_id:
+            return org_id
+
+        edges = await self.graph_provider.get_edges_to_node(
+            f"{CollectionNames.APPS.value}/{app_id}",
+            CollectionNames.ORG_APP_RELATION.value,
+        )
+        for edge in edges or []:
+            # neo4j returns a bare id in `from_id`; arango returns a document
+            # handle in `_from` ("organizations/<key>").
+            raw = str(edge.get("from_id") or edge.get("_from") or "")
+            if raw:
+                return raw.rsplit("/", 1)[-1]
+        return None

--- a/backend/python/app/services/cache/accessible_records_cache.py
+++ b/backend/python/app/services/cache/accessible_records_cache.py
@@ -1,0 +1,384 @@
+"""Redis cache for the `virtualRecordId -> recordId` maps that gate every search.
+
+`get_accessible_virtual_record_ids` recomputes a user's entire accessible
+corpus on every search call — an 8-path permission traversal per connector plus
+a KB traversal, each returning every accessible record. That was ~8% of the
+query service's CPU, repeated once per search per turn even though the answer
+almost never changes between turns.
+
+The maps are cached at the granularity they are computed, not as one merged
+blob, so a single connector's sync only drops that connector's entry:
+
+* KB and app-level connectors produce **user-independent** maps (access to the
+  KB/app implies access to its records), so those entries are shared by every
+  user in the org. Which KBs and apps a given user may reach is still resolved
+  live on every request — only the contents are cached.
+* Record-level connectors sync real per-record ACLs, so their entries are keyed
+  per user. They live in one hash per connector (field = user id) so a single
+  DEL invalidates every user at once, with no SCAN and no set-index.
+
+Every entry carries a TTL. Event-driven invalidation is best-effort by design —
+it must never fail a sync or a delete — so the TTL is the backstop that bounds
+staleness when an invalidation is lost.
+
+Redis is never allowed to break or stall a search: any error falls through to
+the live query and trips a short circuit-breaker so the next requests skip
+Redis entirely instead of paying a timeout each.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING
+
+from redis.asyncio import Redis
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from app.config.configuration_service import ConfigurationService
+    from app.config.constants.arangodb import Connectors
+    from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
+
+__all__ = ["AccessibleRecordsCache", "AccessibleRecordsInvalidator"]
+
+Loader = Callable[[], Awaitable[dict[str, str]]]
+
+_DISABLED_VALUES = {"0", "off", "false", "no"}
+
+
+def _cache_enabled_from_env() -> bool:
+    raw = os.getenv(AccessibleRecordsCache.ENV_ENABLED)
+    return raw is None or raw.strip().lower() not in _DISABLED_VALUES
+
+
+def _ttl_from_env(default: int) -> int:
+    raw = os.getenv(AccessibleRecordsCache.ENV_TTL)
+    if raw is None:
+        return default
+    try:
+        return max(int(raw), 1)
+    except ValueError:
+        return default
+
+
+class AccessibleRecordsCache:
+    """Read-through cache of accessible-record maps, shared across workers."""
+
+    KEY_PREFIX = "pipeshub:accessible_records:v1"
+    ENV_ENABLED = "PIPESHUB_ACCESSIBLE_RECORDS_CACHE"
+    ENV_TTL = "PIPESHUB_ACCESSIBLE_RECORDS_CACHE_TTL"
+    DEFAULT_TTL_SECONDS = 300
+    OP_TIMEOUT_SECONDS = 2.0
+    DOWN_BACKOFF_SECONDS = 30.0
+    MAX_LOCKS = 4096
+
+    def __init__(
+        self,
+        logger: "Logger",
+        redis_client: Redis | None,
+        ttl_seconds: int,
+        enabled: bool,  # noqa: FBT001 - positional keeps the test fakes terse
+    ) -> None:
+        self.logger = logger
+        self._redis = redis_client
+        self._ttl = ttl_seconds
+        self._enabled = enabled and redis_client is not None
+        self._down_until = 0.0
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    @classmethod
+    async def create(
+        cls, logger: "Logger", config_service: "ConfigurationService"
+    ) -> "AccessibleRecordsCache":
+        """Build a cache client. Never raises — a failure yields a disabled cache."""
+        ttl = _ttl_from_env(cls.DEFAULT_TTL_SECONDS)
+        if not _cache_enabled_from_env():
+            logger.info("Accessible-records cache disabled via %s", cls.ENV_ENABLED)
+            return cls(logger, None, ttl, enabled=False)
+
+        try:
+            redis_config = await config_service.get_redis_config()
+            client = Redis(
+                host=redis_config.host,
+                port=redis_config.port,
+                password=redis_config.password,
+                db=redis_config.db,
+                decode_responses=True,
+                socket_timeout=cls.OP_TIMEOUT_SECONDS,
+                socket_connect_timeout=cls.OP_TIMEOUT_SECONDS,
+            )
+            await client.ping()
+        except Exception as e:
+            logger.warning(
+                "Accessible-records cache unavailable (%s); falling back to live queries", str(e)
+            )
+            return cls(logger, None, ttl, enabled=False)
+
+        logger.info("Accessible-records cache ready (ttl=%ss)", ttl)
+        return cls(logger, client, ttl, enabled=True)
+
+    @property
+    def enabled(self) -> bool:
+        """False while disabled, unconfigured, or inside the post-failure backoff."""
+        if not self._enabled:
+            return False
+        return time.monotonic() >= self._down_until
+
+    @property
+    def ttl_seconds(self) -> int:
+        return self._ttl
+
+    async def close(self) -> None:
+        client, self._redis = self._redis, None
+        self._enabled = False
+        if client is not None:
+            try:
+                await client.aclose()
+            except Exception as e:
+                self.logger.debug("Error closing accessible-records cache: %s", str(e))
+
+    # ---- keys ---------------------------------------------------------
+
+    def _kb_key(self, org_id: str, kb_id: str) -> str:
+        return f"{self.KEY_PREFIX}:kb:{org_id}:{kb_id}"
+
+    def _app_connector_key(self, org_id: str, connector_id: str) -> str:
+        return f"{self.KEY_PREFIX}:capp:{org_id}:{connector_id}"
+
+    def _user_connector_key(self, org_id: str, connector_id: str) -> str:
+        return f"{self.KEY_PREFIX}:cusr:{org_id}:{connector_id}"
+
+    # ---- read-through -------------------------------------------------
+
+    async def get_or_compute_kb(
+        self, org_id: str, kb_id: str, loader: Loader
+    ) -> dict[str, str]:
+        return await self._get_or_compute(self._kb_key(org_id, kb_id), None, loader)
+
+    async def get_or_compute_app_connector(
+        self, org_id: str, connector_id: str, loader: Loader
+    ) -> dict[str, str]:
+        return await self._get_or_compute(
+            self._app_connector_key(org_id, connector_id), None, loader
+        )
+
+    async def get_or_compute_user_connector(
+        self, org_id: str, connector_id: str, user_id: str, loader: Loader
+    ) -> dict[str, str]:
+        return await self._get_or_compute(
+            self._user_connector_key(org_id, connector_id), user_id, loader
+        )
+
+    async def _get_or_compute(
+        self, key: str, field: str | None, loader: Loader
+    ) -> dict[str, str]:
+        if not self.enabled:
+            return await loader()
+
+        cached = await self._read(key, field)
+        if cached is not None:
+            return cached
+
+        lock_key = key if field is None else f"{key}#{field}"
+        lock = self._locks.get(lock_key)
+        if lock is None:
+            self._prune_locks()
+            lock = self._locks.setdefault(lock_key, asyncio.Lock())
+
+        async with lock:
+            # Another coroutine may have populated the entry while we queued.
+            cached = await self._read(key, field)
+            if cached is not None:
+                return cached
+
+            value = await loader()
+            await self._write(key, field, value)
+            return value
+
+    async def _read(self, key: str, field: str | None) -> dict[str, str] | None:
+        try:
+            raw = await (
+                self._redis.get(key) if field is None else self._redis.hget(key, field)
+            )
+        except Exception as e:
+            self._mark_down("read", e)
+            return None
+
+        if raw is None:
+            return None
+
+        try:
+            payload = json.loads(raw)
+        except (TypeError, ValueError):
+            return None
+
+        if field is None:
+            return payload if isinstance(payload, dict) else None
+
+        # Hash fields carry their own timestamp: Redis expires whole keys only,
+        # and the key's TTL is refreshed by every other user's write, so a field
+        # would otherwise live forever under steady traffic.
+        if not isinstance(payload, dict):
+            return None
+        written_at = payload.get("t")
+        stored = payload.get("m")
+        if not isinstance(written_at, (int, float)) or not isinstance(stored, dict):
+            return None
+        if time.time() - written_at > self._ttl:
+            return None
+        return stored
+
+    async def _write(self, key: str, field: str | None, value: dict[str, str]) -> None:
+        try:
+            if field is None:
+                await self._redis.set(key, json.dumps(value, separators=(",", ":")), ex=self._ttl)
+            else:
+                envelope = json.dumps({"t": int(time.time()), "m": value}, separators=(",", ":"))
+                await self._redis.hset(key, field, envelope)
+                await self._redis.expire(key, self._ttl)
+        except Exception as e:
+            self._mark_down("write", e)
+
+    # ---- invalidation -------------------------------------------------
+
+    async def invalidate_connector(self, org_id: str, connector_id: str) -> None:
+        """Drop a connector's entry regardless of its permission model."""
+        await self._delete(
+            self._app_connector_key(org_id, connector_id),
+            self._user_connector_key(org_id, connector_id),
+        )
+
+    async def invalidate_kb(self, org_id: str, kb_id: str) -> None:
+        await self._delete(self._kb_key(org_id, kb_id))
+
+    async def _delete(self, *keys: str) -> None:
+        if not self.enabled:
+            return
+        try:
+            await self._redis.delete(*keys)
+        except Exception as e:
+            self._mark_down("delete", e)
+
+    # ---- failure handling ---------------------------------------------
+
+    def _mark_down(self, op: str, error: Exception) -> None:
+        """Skip Redis for a while so a dead server costs one timeout, not one per call."""
+        first = time.monotonic() >= self._down_until
+        self._down_until = time.monotonic() + self.DOWN_BACKOFF_SECONDS
+        if first:
+            self.logger.warning(
+                "Accessible-records cache %s failed (%s); bypassing cache for %ss",
+                op, str(error), self.DOWN_BACKOFF_SECONDS,
+            )
+
+    def _prune_locks(self) -> None:
+        if len(self._locks) < self.MAX_LOCKS:
+            return
+        for lock_key in [k for k, lock in self._locks.items() if not lock.locked()]:
+            self._locks.pop(lock_key, None)
+
+
+class AccessibleRecordsInvalidator:
+    """Invalidation façade for the services that write records.
+
+    Resolves the owning org when the caller does not have it, and swallows every
+    error: dropping a cache entry must never fail a sync, a delete, or the
+    indexing pipeline. The cache TTL covers whatever this misses.
+    """
+
+    def __init__(
+        self,
+        logger: "Logger",
+        cache: AccessibleRecordsCache,
+        graph_provider: "IGraphDBProvider",
+    ) -> None:
+        self.logger = logger
+        self.cache = cache
+        self.graph_provider = graph_provider
+
+    async def on_connector_sync_completed(
+        self, connector_id: str, org_id: str | None = None
+    ) -> None:
+        try:
+            if not connector_id:
+                return
+            org_id = org_id or await self._org_for_app(connector_id)
+            if not org_id:
+                return
+            await self.cache.invalidate_connector(org_id, connector_id)
+        except Exception as e:
+            self.logger.warning(
+                "Could not invalidate accessible-records cache for connector %s: %s",
+                connector_id, str(e),
+            )
+
+    async def on_kb_records_changed(self, kb_id: str, org_id: str | None = None) -> None:
+        """No-op unless `kb_id` really is a KB — the generic delete paths this
+        hangs off also fire for ordinary connectors, which invalidate on sync
+        completion instead."""
+        try:
+            if not kb_id:
+                return
+            app = await self._app_doc(kb_id)
+            if app is None:
+                return
+            from app.config.constants.arangodb import Connectors
+
+            if app.get("type") != Connectors.KNOWLEDGE_BASE.value:
+                return
+            org_id = org_id or app.get("orgId")
+            if not org_id:
+                return
+            await self.cache.invalidate_kb(org_id, kb_id)
+        except Exception as e:
+            self.logger.warning(
+                "Could not invalidate accessible-records cache for KB %s: %s", kb_id, str(e)
+            )
+
+    async def on_record_indexed(
+        self,
+        connector_name: "Connectors | str | None" = None,
+        connector_id: str | None = None,
+        external_record_group_id: str | None = None,
+        org_id: str | None = None,
+    ) -> None:
+        """Invalidate when a KB record becomes searchable.
+
+        Deliberately KB-only. Connector records also flip to COMPLETED here, but
+        a full sync does that thousands of times in a burst; dropping the
+        connector entry per record would leave the cache empty exactly when the
+        graph is busiest. Connectors invalidate once, on sync completion.
+        """
+        try:
+            from app.config.constants.arangodb import Connectors
+
+            name = getattr(connector_name, "value", connector_name)
+            if name != Connectors.KNOWLEDGE_BASE.value:
+                return
+            kb_id = connector_id or external_record_group_id
+            if not kb_id:
+                return
+            if not org_id:
+                app = await self._app_doc(kb_id)
+                org_id = (app or {}).get("orgId")
+            if not org_id:
+                return
+            await self.cache.invalidate_kb(org_id, kb_id)
+        except Exception as e:
+            self.logger.warning(
+                "Could not invalidate accessible-records cache after indexing: %s", str(e)
+            )
+
+    async def _app_doc(self, app_id: str) -> dict | None:
+        from app.config.constants.arangodb import CollectionNames
+
+        return await self.graph_provider.get_document(app_id, CollectionNames.APPS.value)
+
+    async def _org_for_app(self, app_id: str) -> str | None:
+        app = await self._app_doc(app_id)
+        return (app or {}).get("orgId")

--- a/backend/python/app/services/cache/accessible_records_cache.py
+++ b/backend/python/app/services/cache/accessible_records_cache.py
@@ -32,6 +32,7 @@ import asyncio
 import json
 import os
 import time
+import zlib
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
@@ -75,7 +76,12 @@ class AccessibleRecordsCache:
     DEFAULT_TTL_SECONDS = 300
     OP_TIMEOUT_SECONDS = 2.0
     DOWN_BACKOFF_SECONDS = 30.0
-    MAX_LOCKS = 4096
+    # Striped locks, not one per key. A per-key table could only be trimmed of
+    # *unlocked* entries, so under enough concurrent misses on distinct keys it
+    # grew without limit. A fixed stripe array is bounded by construction; two
+    # unrelated keys sharing a stripe just serialise their (already expensive)
+    # miss, which is the point of the lock anyway.
+    LOCK_STRIPES = 1024
 
     def __init__(
         self,
@@ -89,7 +95,9 @@ class AccessibleRecordsCache:
         self._ttl = ttl_seconds
         self._enabled = enabled and redis_client is not None
         self._down_until = 0.0
-        self._locks: dict[str, asyncio.Lock] = {}
+        self._locks: tuple[asyncio.Lock, ...] = tuple(
+            asyncio.Lock() for _ in range(self.LOCK_STRIPES)
+        )
 
     @classmethod
     async def create(
@@ -183,22 +191,32 @@ class AccessibleRecordsCache:
         cached = await self._read(key, field)
         if cached is not None:
             return cached
+        # A failed read has already tripped the breaker. Every further Redis
+        # call in this same request would wait out its own timeout, so one
+        # outage cost three of them (read, re-read, write) on a single search.
+        if not self.enabled:
+            return await loader()
 
         lock_key = key if field is None else f"{key}#{field}"
-        lock = self._locks.get(lock_key)
-        if lock is None:
-            self._prune_locks()
-            lock = self._locks.setdefault(lock_key, asyncio.Lock())
+        lock = self._lock_for(lock_key)
 
         async with lock:
+            if not self.enabled:
+                return await loader()
             # Another coroutine may have populated the entry while we queued.
             cached = await self._read(key, field)
             if cached is not None:
                 return cached
 
             value = await loader()
-            await self._write(key, field, value)
+            if self.enabled:
+                await self._write(key, field, value)
             return value
+
+    def _lock_for(self, lock_key: str) -> asyncio.Lock:
+        """Stripe for this key. crc32 rather than hash() so the mapping is
+        stable across processes and test runs."""
+        return self._locks[zlib.crc32(lock_key.encode()) % len(self._locks)]
 
     async def _read(self, key: str, field: str | None) -> dict[str, str] | None:
         try:
@@ -276,11 +294,6 @@ class AccessibleRecordsCache:
                 op, str(error), self.DOWN_BACKOFF_SECONDS,
             )
 
-    def _prune_locks(self) -> None:
-        if len(self._locks) < self.MAX_LOCKS:
-            return
-        for lock_key in [k for k, lock in self._locks.items() if not lock.locked()]:
-            self._locks.pop(lock_key, None)
 
 
 class AccessibleRecordsInvalidator:

--- a/backend/python/app/services/cache/accessible_records_cache.py
+++ b/backend/python/app/services/cache/accessible_records_cache.py
@@ -406,6 +406,10 @@ class AccessibleRecordsInvalidator:
             CollectionNames.ORG_APP_RELATION.value,
         )
         for edge in edges or []:
+            # A malformed entry must cost only itself: letting .get() raise here
+            # would abort the loop and skip invalidation altogether.
+            if not isinstance(edge, dict):
+                continue
             # neo4j returns a bare id in `from_id`; arango returns a document
             # handle in `_from` ("organizations/<key>").
             raw = str(edge.get("from_id") or edge.get("_from") or "")

--- a/backend/python/app/services/cache/invalidation_hooks.py
+++ b/backend/python/app/services/cache/invalidation_hooks.py
@@ -1,0 +1,102 @@
+"""Process-wide entry points for dropping stale accessible-record cache entries.
+
+The writes that make records appear or disappear are spread across the
+connectors and indexing services — sync completion, KB uploads and deletes, the
+indexing status flip. Threading an invalidator through every one of those call
+chains would mean touching dozens of constructors (``DataSourceEntitiesProcessor``
+alone is built in ~50 places), so services register one invalidator at startup
+and the hook sites call these module functions.
+
+Every function is a no-op when nothing is registered — which is the case for any
+service that never enabled the cache, and during tests — and none of them can
+raise: invalidation is best-effort, and the cache TTL is the backstop.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.config.constants.arangodb import Connectors
+    from app.services.cache.accessible_records_cache import (
+        AccessibleRecordsCache,
+        AccessibleRecordsInvalidator,
+    )
+    from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
+
+__all__ = [
+    "init_accessible_records_invalidator",
+    "get_accessible_records_invalidator",
+    "reset_accessible_records_invalidator",
+    "notify_connector_sync_completed",
+    "notify_kb_records_changed",
+    "notify_record_indexed",
+]
+
+# A holder rather than a bare module global so registration does not need the
+# `global` statement in three places.
+_state: dict[str, "AccessibleRecordsInvalidator | None"] = {"invalidator": None}
+_logger = logging.getLogger(__name__)
+
+
+def init_accessible_records_invalidator(
+    logger: logging.Logger,
+    cache: "AccessibleRecordsCache",
+    graph_provider: "IGraphDBProvider",
+) -> None:
+    """Register the process's invalidator. Safe to call more than once."""
+    from app.services.cache.accessible_records_cache import AccessibleRecordsInvalidator
+
+    _state["invalidator"] = AccessibleRecordsInvalidator(logger, cache, graph_provider)
+
+
+def get_accessible_records_invalidator() -> "AccessibleRecordsInvalidator | None":
+    return _state["invalidator"]
+
+
+def reset_accessible_records_invalidator() -> None:
+    _state["invalidator"] = None
+
+
+async def notify_connector_sync_completed(connector_id: str, org_id: str | None = None) -> None:
+    """A connector finished syncing: its record set may have changed."""
+    invalidator = _state["invalidator"]
+    if invalidator is None:
+        return
+    try:
+        await invalidator.on_connector_sync_completed(connector_id, org_id)
+    except Exception as e:  # pragma: no cover - the invalidator already swallows
+        _logger.warning("accessible-records invalidation failed: %s", str(e))
+
+
+async def notify_kb_records_changed(kb_id: str, org_id: str | None = None) -> None:
+    """Records were added to or removed from a knowledge base."""
+    invalidator = _state["invalidator"]
+    if invalidator is None:
+        return
+    try:
+        await invalidator.on_kb_records_changed(kb_id, org_id)
+    except Exception as e:  # pragma: no cover - the invalidator already swallows
+        _logger.warning("accessible-records invalidation failed: %s", str(e))
+
+
+async def notify_record_indexed(
+    connector_name: "Connectors | str | None" = None,
+    connector_id: str | None = None,
+    external_record_group_id: str | None = None,
+    org_id: str | None = None,
+) -> None:
+    """A record became searchable. KB-only — see `on_record_indexed`."""
+    invalidator = _state["invalidator"]
+    if invalidator is None:
+        return
+    try:
+        await invalidator.on_record_indexed(
+            connector_name=connector_name,
+            connector_id=connector_id,
+            external_record_group_id=external_record_group_id,
+            org_id=org_id,
+        )
+    except Exception as e:  # pragma: no cover - the invalidator already swallows
+        _logger.warning("accessible-records invalidation failed: %s", str(e))

--- a/backend/python/app/services/graph_db/arango/arango_http_provider.py
+++ b/backend/python/app/services/graph_db/arango/arango_http_provider.py
@@ -2843,14 +2843,27 @@ class ArangoHTTPProvider(IGraphDBProvider):
         Returns:
             List[Dict]: Matching nodes
         """
+        # `id` is not a stored attribute here: _translate_node_to_arango moves it
+        # to `_key` on write, so `FILTER doc.id IN ...` matches nothing and the
+        # caller silently gets an empty batch. Callers use the generic `id`
+        # because that is what the Neo4j provider stores, so the translation
+        # belongs here rather than in every call site.
+        filter_field = "_key" if field == "id" else field
+
         if return_fields:
-            return_expr = "{" + ", ".join([f"{f}: doc.{f}" for f in return_fields]) + "}"
+            # `id` has to be projected back out of `_key`, or a caller asking
+            # for it gets null and cannot key results to what it requested.
+            projected = ", ".join(
+                f"id: doc._key" if f == "id" else f"{f}: doc.{f}"
+                for f in return_fields
+            )
+            return_expr = "{" + projected + "}"
         else:
             return_expr = "doc"
 
         query = f"""
         FOR doc IN {collection}
-            FILTER doc.{field} IN @values
+            FILTER doc.{filter_field} IN @values
             RETURN {return_expr}
         """
 

--- a/backend/python/app/services/graph_db/graph_db_provider_factory.py
+++ b/backend/python/app/services/graph_db/graph_db_provider_factory.py
@@ -13,11 +13,15 @@ Design Pattern: Factory Method Pattern
 
 import os
 from logging import Logger
+from typing import TYPE_CHECKING
 
 from app.config.configuration_service import ConfigurationService
 from app.services.graph_db.arango.arango_http_provider import ArangoHTTPProvider
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.services.graph_db.neo4j.neo4j_provider import Neo4jProvider
+
+if TYPE_CHECKING:
+    from app.services.cache.accessible_records_cache import AccessibleRecordsCache
 
 
 class GraphDBProviderFactory:
@@ -40,6 +44,7 @@ class GraphDBProviderFactory:
     async def create_provider(
         logger: Logger,
         config_service: ConfigurationService,
+        accessible_records_cache: "AccessibleRecordsCache | None" = None,
     ) -> IGraphDBProvider:
         """
         Create and initialize a graph database provider.
@@ -92,6 +97,7 @@ class GraphDBProviderFactory:
                 provider = await GraphDBProviderFactory._create_neo4j_provider(
                     logger=logger,
                     config_service=config_service,
+                    accessible_records_cache=accessible_records_cache,
                 )
                 return provider
 
@@ -144,6 +150,7 @@ class GraphDBProviderFactory:
     async def _create_neo4j_provider(
         logger: Logger,
         config_service: ConfigurationService,
+        accessible_records_cache: "AccessibleRecordsCache | None" = None,
     ) -> Neo4jProvider:
         """
         Create and connect a Neo4j provider.
@@ -151,6 +158,7 @@ class GraphDBProviderFactory:
         Args:
             logger: Logger instance
             config_service: Configuration service
+            accessible_records_cache: Optional accessible-record map cache
         Returns:
             Neo4jProvider: Connected Neo4j provider
 
@@ -164,6 +172,7 @@ class GraphDBProviderFactory:
             provider = Neo4jProvider(
                 logger=logger,
                 config_service=config_service,
+                accessible_records_cache=accessible_records_cache,
             )
 
             logger.debug("🔌 Connecting Neo4j provider...")

--- a/backend/python/app/services/graph_db/interface/graph_db_provider.py
+++ b/backend/python/app/services/graph_db/interface/graph_db_provider.py
@@ -7,6 +7,7 @@ abstracting away the specific database implementation (ArangoDB, Neo4j, etc.).
 All methods support optional transaction parameter for atomic operations.
 """
 
+import asyncio
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -917,21 +918,42 @@ class IGraphDBProvider(ABC):
         have not specialised it. Overriding it with a single query is what makes
         it worth calling -- the default still costs one query per record per
         relation type per direction.
+
+        Those queries are issued concurrently. Awaiting them in place would make
+        an unspecialised provider slower than the per-record code this replaced,
+        which gathered the same calls; a caller must not lose latency by moving
+        to the batch API.
         """
-        out: dict[str, dict[str, list[dict[str, Any]]]] = {}
-        for record_id in record_ids:
-            parents: list[dict[str, Any]] = []
-            children: list[dict[str, Any]] = []
-            for relation_type in relation_types:
-                for edges, bucket in (
-                    (await self.get_parent_record_ids_by_relation_type(
-                        record_id, relation_type, transaction), parents),
-                    (await self.get_child_record_ids_by_relation_type(
-                        record_id, relation_type, transaction), children),
-                ):
-                    for edge in edges or []:
-                        bucket.append({**edge, "relationType": relation_type})
-            out[record_id] = {"parents": parents, "children": children}
+        jobs = [
+            (record_id, relation_type, outgoing)
+            for record_id in record_ids
+            for relation_type in relation_types
+            for outgoing in (True, False)
+        ]
+
+        async def fetch(record_id: str, relation_type: str, *, outgoing: bool) -> list[dict[str, Any]]:
+            call = (
+                self.get_parent_record_ids_by_relation_type
+                if outgoing
+                else self.get_child_record_ids_by_relation_type
+            )
+            return await call(record_id, relation_type, transaction)
+
+        results = await asyncio.gather(
+            *[fetch(rid, rel, outgoing=out) for rid, rel, out in jobs],
+            return_exceptions=True,
+        )
+
+        out: dict[str, dict[str, list[dict[str, Any]]]] = {
+            record_id: {"parents": [], "children": []} for record_id in record_ids
+        }
+        for (record_id, relation_type, outgoing), edges in zip(jobs, results):
+            if isinstance(edges, BaseException):
+                # One failing pair must not cost the caller every other edge.
+                continue
+            bucket = out[record_id]["parents" if outgoing else "children"]
+            for edge in edges or []:
+                bucket.append({**edge, "relationType": relation_type})
         return out
 
     @abstractmethod

--- a/backend/python/app/services/graph_db/interface/graph_db_provider.py
+++ b/backend/python/app/services/graph_db/interface/graph_db_provider.py
@@ -900,6 +900,40 @@ class IGraphDBProvider(ABC):
         """
         pass
 
+    async def get_record_relations_batch(
+        self,
+        record_ids: list[str],
+        relation_types: list[str],
+        transaction: Optional[str] = None,
+    ) -> dict[str, dict[str, list[dict[str, Any]]]]:
+        """Edges for many records and relation types at once.
+
+        Returns {record_id: {"parents": [...], "children": [...]}} where the two
+        lists hold what `get_parent_record_ids_by_relation_type` and
+        `get_child_record_ids_by_relation_type` return, each entry additionally
+        carrying `relationType`.
+
+        Concrete by design: this default preserves behaviour for providers that
+        have not specialised it. Overriding it with a single query is what makes
+        it worth calling -- the default still costs one query per record per
+        relation type per direction.
+        """
+        out: dict[str, dict[str, list[dict[str, Any]]]] = {}
+        for record_id in record_ids:
+            parents: list[dict[str, Any]] = []
+            children: list[dict[str, Any]] = []
+            for relation_type in relation_types:
+                for edges, bucket in (
+                    (await self.get_parent_record_ids_by_relation_type(
+                        record_id, relation_type, transaction), parents),
+                    (await self.get_child_record_ids_by_relation_type(
+                        record_id, relation_type, transaction), children),
+                ):
+                    for edge in edges or []:
+                        bucket.append({**edge, "relationType": relation_type})
+            out[record_id] = {"parents": parents, "children": children}
+        return out
+
     @abstractmethod
     async def get_virtual_record_ids_for_record_ids(
         self,

--- a/backend/python/app/services/graph_db/interface/graph_db_provider.py
+++ b/backend/python/app/services/graph_db/interface/graph_db_provider.py
@@ -9,6 +9,7 @@ All methods support optional transaction parameter for atomic operations.
 
 import asyncio
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from typing import TYPE_CHECKING, Any, Optional
 
 from app.models.entities import Person
@@ -953,6 +954,8 @@ class IGraphDBProvider(ABC):
                 continue
             bucket = out[record_id]["parents" if outgoing else "children"]
             for edge in edges or []:
+                if not isinstance(edge, Mapping):
+                    continue
                 bucket.append({**edge, "relationType": relation_type})
         return out
 

--- a/backend/python/app/services/graph_db/neo4j/neo4j_provider.py
+++ b/backend/python/app/services/graph_db/neo4j/neo4j_provider.py
@@ -18,7 +18,7 @@ import unicodedata
 import uuid
 from datetime import datetime, timezone
 from logging import Logger
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from fastapi import Request
 from app.config.configuration_service import ConfigurationService
@@ -30,9 +30,15 @@ from app.config.constants.arangodb import (
     Connectors,
     DepartmentNames,
     OriginTypes,
+    PermissionModel,
     ProgressStatus,
     RecordTypes,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
+
+    from app.services.cache.accessible_records_cache import AccessibleRecordsCache
 from app.config.constants.neo4j import (
     COLLECTION_TO_LABEL,
     EDGE_COLLECTION_TO_RELATIONSHIP,
@@ -95,6 +101,7 @@ class Neo4jProvider(IGraphDBProvider):
         self,
         logger: Logger,
         config_service: ConfigurationService,
+        accessible_records_cache: "AccessibleRecordsCache | None" = None,
     ) -> None:
         """
         Initialize Neo4j provider.
@@ -102,11 +109,14 @@ class Neo4jProvider(IGraphDBProvider):
         Args:
             logger: Logger instance
             config_service: Configuration service for database credentials
+            accessible_records_cache: Optional cache for accessible-record maps.
+                Only the query service passes one; without it every read is live.
         """
         self.logger = logger
         self.config_service = config_service
         self.client: Neo4jClient | None = None
         self.validator = NodeSchemaValidator()
+        self.accessible_records_cache = accessible_records_cache
 
     # ==================== Connection Management ====================
 
@@ -4635,6 +4645,173 @@ class Neo4jProvider(IGraphDBProvider):
             self.logger.error(f"Traceback: {traceback.format_exc()}")
             return {}
 
+    async def _get_accessible_kb_ids(self, user_id: str) -> list[str]:
+        """KB App ids this user can reach, directly or through a team.
+
+        Mirrors the access paths `_get_kb_virtual_ids` resolves inline, so that
+        the per-KB record maps can be cached org-wide while *which* KBs a user
+        may see stays a live check. Raises on failure so callers can fall back
+        to the uncached path rather than silently narrowing the result.
+        """
+        query = """
+        MATCH (userDoc:User {userId: $userId})
+
+        CALL {
+            WITH userDoc
+            OPTIONAL MATCH (userDoc)-[:PERMISSION]->(kb:App {type: "KB"})
+            RETURN collect(DISTINCT kb.id) AS directIds
+        }
+
+        CALL {
+            WITH userDoc
+            OPTIONAL MATCH (userDoc)-[ute:PERMISSION]->(team:Teams)
+            WHERE ute.type = "USER"
+            OPTIONAL MATCH (team)-[tke:PERMISSION]->(kb:App {type: "KB"})
+            WHERE tke.type = "TEAM"
+            RETURN collect(DISTINCT kb.id) AS teamIds
+        }
+
+        WITH directIds + teamIds AS ids
+        UNWIND ids AS kbId
+        WITH kbId WHERE kbId IS NOT NULL
+        RETURN DISTINCT kbId AS kbId
+        """
+        results = await self.client.execute_query(query, parameters={"userId": user_id})
+        return [r.get("kbId") for r in results if r.get("kbId")]
+
+    async def _get_kb_virtual_ids_for_kb(self, kb_id: str) -> dict[str, str]:
+        """Every completed upload in one KB, independent of user.
+
+        Same record predicates as `_get_kb_virtual_ids` — a record only becomes
+        searchable once indexing completes, and KB records are uploads.
+        """
+        query = """
+        MATCH (r:Record)-[:BELONGS_TO]->(kb:App {id: $kbId, type: "KB"})
+        WHERE r.indexingStatus = $completedStatus
+          AND r.origin = $uploadOrigin
+          AND r.virtualRecordId IS NOT NULL
+          AND r.id IS NOT NULL
+        RETURN DISTINCT r.virtualRecordId AS virtualId, r.id AS recordId
+        """
+        results = await self.client.execute_query(
+            query,
+            parameters={
+                "kbId": kb_id,
+                "completedStatus": ProgressStatus.COMPLETED.value,
+                "uploadOrigin": OriginTypes.UPLOAD.value,
+            },
+        )
+
+        virtual_id_to_record_id: dict[str, str] = {}
+        for r in results:
+            vid = r.get("virtualId")
+            rid = r.get("recordId")
+            if vid and rid and vid not in virtual_id_to_record_id:
+                virtual_id_to_record_id[vid] = rid
+        return virtual_id_to_record_id
+
+    async def _get_all_virtual_ids_for_connector(self, connector_id: str) -> dict[str, str]:
+        """Every completed record of an app-level-permission connector.
+
+        These connectors have no per-record ACLs — reaching the connector means
+        reaching its records — so this supersets the per-user 8-path traversal
+        (including its "Anyone" branch) with a single scan. Only valid for
+        connectors declaring `PermissionModel.APP_LEVEL`.
+        """
+        query = """
+        MATCH (r:Record {connectorId: $connectorId})
+        WHERE r.indexingStatus = $completedStatus
+          AND r.virtualRecordId IS NOT NULL
+          AND r.id IS NOT NULL
+        RETURN DISTINCT r.virtualRecordId AS virtualId, r.id AS recordId
+        """
+        results = await self.client.execute_query(
+            query,
+            parameters={
+                "connectorId": connector_id,
+                "completedStatus": ProgressStatus.COMPLETED.value,
+            },
+        )
+
+        virtual_id_to_record_id: dict[str, str] = {}
+        for r in results:
+            vid = r.get("virtualId")
+            rid = r.get("recordId")
+            if vid and rid and vid not in virtual_id_to_record_id:
+                virtual_id_to_record_id[vid] = rid
+        return virtual_id_to_record_id
+
+    async def _get_connector_virtual_ids_cached(
+        self, user_id: str, org_id: str, connector_id: str, permission_model: str | None
+    ) -> dict[str, str]:
+        """One connector's map, through the cache appropriate to its ACL model.
+
+        Only valid for an unfiltered request: the cached maps carry no metadata
+        filter or time range, so the caller must have ruled both out.
+        """
+        try:
+            if permission_model == PermissionModel.APP_LEVEL.value:
+                return await self.accessible_records_cache.get_or_compute_app_connector(
+                    org_id,
+                    connector_id,
+                    lambda: self._get_all_virtual_ids_for_connector(connector_id),
+                )
+            return await self.accessible_records_cache.get_or_compute_user_connector(
+                org_id,
+                connector_id,
+                user_id,
+                lambda: self._get_virtual_ids_for_connector(user_id, org_id, connector_id, None),
+            )
+        except Exception as e:
+            self.logger.warning(
+                f"Cached connector lookup failed for {connector_id}, using live query: {str(e)}"
+            )
+            return await self._get_virtual_ids_for_connector(user_id, org_id, connector_id, None)
+
+    async def _get_kb_virtual_ids_cached(
+        self, user_id: str, org_id: str, kb_ids: list[str] | None
+    ) -> dict[str, str]:
+        """KB half of the accessible map: live access check, cached contents.
+
+        Only valid for an unfiltered request — the cached per-KB maps carry no
+        metadata filter or time range, so the caller must have ruled both out.
+
+        Falls back to the single uncached query on any failure, so a cache or
+        permission-query problem degrades to today's behaviour instead of
+        narrowing what the user can search.
+        """
+        try:
+            accessible = await self._get_accessible_kb_ids(user_id)
+            accessible_set = set(accessible)
+            targets = [kb for kb in kb_ids if kb in accessible_set] if kb_ids else accessible
+
+            if not targets:
+                return {}
+
+            maps = await asyncio.gather(
+                *[
+                    self.accessible_records_cache.get_or_compute_kb(
+                        org_id, kb_id, lambda kb_id=kb_id: self._get_kb_virtual_ids_for_kb(kb_id)
+                    )
+                    for kb_id in targets
+                ],
+                return_exceptions=True,
+            )
+
+            # Iterated in `targets` order so the merge stays first-seen-wins,
+            # matching what the single uncached query returns.
+            merged: dict[str, str] = {}
+            for result in maps:
+                if isinstance(result, Exception):
+                    raise result
+                for vid, rid in result.items():
+                    if vid not in merged:
+                        merged[vid] = rid
+            return merged
+        except Exception as e:
+            self.logger.warning(f"Cached KB lookup failed, using live query: {str(e)}")
+            return await self._get_kb_virtual_ids(user_id, org_id, kb_ids, None)
+
     async def get_accessible_virtual_record_ids(
         self,
         user_id: str,
@@ -4687,6 +4864,7 @@ class Neo4jProvider(IGraphDBProvider):
             # Build ID list and type map to distinguish KB apps from regular connectors
             user_apps_ids = []
             app_type_map: dict[str, str] = {}
+            app_permission_map: dict[str, str | None] = {}
             for app_doc in user_app_docs:
                 if not app_doc:
                     continue
@@ -4695,6 +4873,7 @@ class Neo4jProvider(IGraphDBProvider):
                     continue
                 user_apps_ids.append(app_id)
                 app_type_map[app_id] = app_doc.get('type', '')
+                app_permission_map[app_id] = app_doc.get('permissionModel')
 
             # Separate KB app IDs from regular connector IDs
             kb_app_ids_set = {aid for aid, atype in app_type_map.items() if atype == Connectors.KNOWLEDGE_BASE.value}
@@ -4724,6 +4903,35 @@ class Neo4jProvider(IGraphDBProvider):
                 f"Metadata filters: {list(metadata_filters.keys())}"
             )
 
+            # Metadata filters change what each query returns, so they bypass the
+            # cache entirely rather than needing them in every cache key.
+            # Metadata filters and a time range both narrow what each query
+            # returns, and neither is part of the cache key, so a filtered
+            # request must go to the live path rather than read a map built for
+            # the unfiltered one.
+            use_cache = (
+                self.accessible_records_cache is not None
+                and self.accessible_records_cache.enabled
+                and not metadata_filters
+                and not time_range
+            )
+
+            def connector_task(connector_id: str) -> "Awaitable[dict[str, str]]":
+                if use_cache:
+                    return self._get_connector_virtual_ids_cached(
+                        user_id, org_id, connector_id, app_permission_map.get(connector_id)
+                    )
+                return self._get_virtual_ids_for_connector(
+                    user_id, org_id, connector_id, metadata_filters, time_range=time_range
+                )
+
+            def kb_task(kb_filter: list[str] | None) -> "Awaitable[dict[str, str]]":
+                if use_cache:
+                    return self._get_kb_virtual_ids_cached(user_id, org_id, kb_filter)
+                return self._get_kb_virtual_ids(
+                    user_id, org_id, kb_filter, metadata_filters, time_range=time_range
+                )
+
             # Step 3: Determine tasks based on 4 scenarios
             tasks = []
 
@@ -4738,16 +4946,11 @@ class Neo4jProvider(IGraphDBProvider):
                 ]
                 self.logger.debug(f"Querying {len(connectors_to_query)} filtered connectors")
 
-                for connector_id in connectors_to_query:
-                    tasks.append(self._get_virtual_ids_for_connector(
-                        user_id, org_id, connector_id, metadata_filters, time_range=time_range
-                    ))
+                tasks.extend(connector_task(cid) for cid in connectors_to_query)
 
                 # Query only filtered KBs
                 self.logger.debug(f"Querying {len(kb_ids)} filtered KBs")
-                tasks.append(self._get_kb_virtual_ids(
-                    user_id, org_id, kb_ids, metadata_filters, time_range=time_range
-                ))
+                tasks.append(kb_task(kb_ids))
 
             # Scenario 2: C=false, KB=true (only KB filter)
             elif not has_app_filter and has_kb_filter:
@@ -4755,9 +4958,7 @@ class Neo4jProvider(IGraphDBProvider):
 
                 # Query only filtered KBs (skip connector queries)
                 self.logger.debug(f"Querying {len(kb_ids)} filtered KBs only")
-                tasks.append(self._get_kb_virtual_ids(
-                    user_id, org_id, kb_ids, metadata_filters, time_range=time_range
-                ))
+                tasks.append(kb_task(kb_ids))
 
             # Scenario 3: C=false, KB=false (no filters)
             elif not has_app_filter and not has_kb_filter:
@@ -4765,16 +4966,11 @@ class Neo4jProvider(IGraphDBProvider):
 
                 # Query all regular connector apps
                 self.logger.debug(f"Querying all {len(connector_app_ids_set)} accessible connectors")
-                for connector_id in connector_app_ids_set:
-                    tasks.append(self._get_virtual_ids_for_connector(
-                        user_id, org_id, connector_id, metadata_filters, time_range=time_range
-                    ))
+                tasks.extend(connector_task(cid) for cid in connector_app_ids_set)
 
                 # Query all KBs
                 self.logger.debug("Querying all KBs")
-                tasks.append(self._get_kb_virtual_ids(
-                    user_id, org_id, None, metadata_filters, time_range=time_range
-                ))
+                tasks.append(kb_task(None))
 
             # Scenario 4: C=true, KB=false (only connector filter)
             else:  # has_app_filter and not has_kb_filter
@@ -4788,10 +4984,7 @@ class Neo4jProvider(IGraphDBProvider):
                 ]
                 self.logger.debug(f"Querying {len(connectors_to_query)} filtered connectors only")
 
-                for connector_id in connectors_to_query:
-                    tasks.append(self._get_virtual_ids_for_connector(
-                        user_id, org_id, connector_id, metadata_filters, time_range=time_range
-                    ))
+                tasks.extend(connector_task(cid) for cid in connectors_to_query)
 
             # Step 5: Execute all tasks in parallel
             if not tasks:
@@ -5152,6 +5345,70 @@ class Neo4jProvider(IGraphDBProvider):
                 record_id, str(e),
             )
             return []
+
+    async def get_record_relations_batch(
+        self,
+        record_ids: list[str],
+        relation_types: list[str],
+        transaction: Optional[str] = None,
+    ) -> dict[str, dict[str, list[dict[str, Any]]]]:
+        """Both edge directions for every record, in one query.
+
+        The per-record methods cost one query each per relation type per
+        direction; a turn enriching 30 hits over 2 relation types spent 120
+        round trips here.
+        """
+        out: dict[str, dict[str, list[dict[str, Any]]]] = {
+            record_id: {"parents": [], "children": []} for record_id in record_ids
+        }
+        if not record_ids or not relation_types:
+            return out
+        try:
+            query = """
+            MATCH (a:Record)-[r:RECORD_RELATION]-(b:Record)
+            WHERE a.id IN $record_ids AND r.relationshipType IN $relation_types
+            RETURN a.id AS anchor_id,
+                   b.id AS record_id,
+                   startNode(r).id = a.id AS outgoing,
+                   r.relationshipType AS relationType,
+                   COALESCE(r.parentTableName, '') AS parentTable,
+                   COALESCE(r.childTableName, '') AS childTable,
+                   COALESCE(r.sourceColumn, '') AS sourceColumn,
+                   COALESCE(r.targetColumn, '') AS targetColumn
+            """
+            results = await self.client.execute_query(
+                query,
+                parameters={"record_ids": record_ids, "relation_types": relation_types},
+                txn_id=transaction,
+            )
+            for record in results:
+                anchor = record.get("anchor_id")
+                bucket = out.get(anchor)
+                if bucket is None:
+                    continue
+                # Outgoing means the anchor is the edge's start node, matching
+                # get_parent_record_ids_by_relation_type's direction.
+                outgoing = bool(record.get("outgoing"))
+                edge = {
+                    "record_id": record.get("record_id"),
+                    "relationType": record.get("relationType"),
+                    "sourceColumn": record.get("sourceColumn", ""),
+                    "targetColumn": record.get("targetColumn", ""),
+                }
+                if outgoing:
+                    edge["parentTable"] = record.get("parentTable", "")
+                    bucket["parents"].append(edge)
+                else:
+                    edge["childTable"] = record.get("childTable", "")
+                    bucket["children"].append(edge)
+            return out
+        except Exception as e:
+            self.logger.warning(
+                "Failed to batch record relations for %d records: %s", len(record_ids), str(e),
+            )
+            return await super().get_record_relations_batch(
+                record_ids, relation_types, transaction,
+            )
 
     async def batch_upsert_record_groups(
         self,
@@ -6352,7 +6609,12 @@ class Neo4jProvider(IGraphDBProvider):
                 "success": True,
                 "record_id": record_id,
                 "message": "Record deleted successfully",
-                "eventData": event_data
+                "eventData": event_data,
+                # Lets the caller invalidate the right cache entry without
+                # re-reading the record it just deleted.
+                "connectorId": record.get("connectorId"),
+                "orgId": record.get("orgId"),
+                "isKb": is_kb_record,
             }
 
         except Exception as e:

--- a/backend/python/app/services/messaging/kafka/handlers/record.py
+++ b/backend/python/app/services/messaging/kafka/handlers/record.py
@@ -20,6 +20,7 @@ from app.config.constants.http_status_code import HttpStatusCode
 from app.config.constants.service import DefaultEndpoints, config_node_constants
 from app.events.events import EventProcessor
 from app.exceptions.indexing_exceptions import IndexingError
+from app.services.cache.invalidation_hooks import notify_record_indexed
 from app.services.messaging.config import (
     IndexingEvent,
     PipelineEvent,
@@ -233,7 +234,12 @@ class RecordEventHandler(BaseEventService):
 
             doc = dict(record)
 
-            if (event_type == EventTypes.NEW_RECORD.value or event_type == EventTypes.REINDEX_RECORD.value) and doc.get("indexingStatus") == ProgressStatus.COMPLETED.value:
+            # The guard stops a replayed newRecord from re-running the pipeline over
+            # an indexed corpus. An explicit reindex is the one case that must run
+            # anyway, so it opts out rather than the guard being relaxed for
+            # everyone: without this, reindex reports success while doing nothing.
+            force_reindex = bool(payload.get("forceReindex"))
+            if (not force_reindex) and (event_type == EventTypes.NEW_RECORD.value or event_type == EventTypes.REINDEX_RECORD.value) and doc.get("indexingStatus") == ProgressStatus.COMPLETED.value:
                 self.logger.info(f"🔍 Indexing already done for record {record_id} with virtual_record_id {virtual_record_id}")
                 yield PipelineEvent(event=IndexingEvent.PARSING_COMPLETE, data=PipelineEventData(record_id=record_id))
                 yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=record_id))
@@ -743,6 +749,16 @@ class RecordEventHandler(BaseEventService):
                     virtual_record_id = record.get("virtualRecordId")
                     if indexing_status == ProgressStatus.COMPLETED.value or indexing_status == ProgressStatus.EMPTY.value:
                         await self.event_processor.graph_provider.update_queued_duplicates_status(record_id, indexing_status, virtual_record_id)
+                        if indexing_status == ProgressStatus.COMPLETED.value:
+                            # Duplicates just became searchable too. They can live in
+                            # a different KB than this record, which only the TTL
+                            # covers — the provider returns a count, not the ids.
+                            await notify_record_indexed(
+                                connector_name=record.get("connectorName"),
+                                connector_id=record.get("connectorId"),
+                                external_record_group_id=record.get("externalGroupId"),
+                                org_id=record.get("orgId"),
+                            )
                     elif indexing_status == ProgressStatus.ENABLE_MULTIMODAL_MODELS.value:
                         # Find and trigger indexing for the next queued duplicate
                         self.logger.info(f"🔄 Current record {record_id} has status {indexing_status}, triggering next queued duplicate")

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -3,6 +3,7 @@ import base64
 import hashlib
 import logging
 import re
+import time
 from collections import defaultdict
 from collections.abc import Iterable
 from itertools import groupby
@@ -3803,8 +3804,12 @@ def extract_start_end_text(snippet: str | None) -> tuple[str, str]:
 
     return start_text, end_text.strip()
 
-_FRAGMENT_URL_CACHE: dict[tuple[str, bytes], str] = {}
+# Values are fragment URLs that embed a few URL-encoded snippet words in
+# #:~:text=… — not whole record blocks. Keys are digests of the snippet.
+# TTL + maxsize keep retention bounded across orgs in a long-lived process.
+_FRAGMENT_URL_CACHE: dict[tuple[str, bytes], tuple[str, float]] = {}
 _FRAGMENT_URL_CACHE_MAXSIZE = 8192
+_FRAGMENT_URL_CACHE_TTL_SECONDS = 300.0
 
 
 def generate_text_fragment_url(base_url: str, text_snippet: str) -> str:
@@ -3812,23 +3817,28 @@ def generate_text_fragment_url(base_url: str, text_snippet: str) -> str:
 
     The live citation overlay re-derives every citation's URL on each refresh,
     so the same (base_url, snippet) pair is re-scanned many times per turn.
-    Snippets are keyed by digest rather than by value so the cache cannot pin
-    whole record blocks in memory. Cleared wholesale when full: eviction
-    bookkeeping would cost more than the recompute it saves, and the working
-    set for a turn is far below the bound.
+    Snippets are keyed by digest so the cache does not retain full record text
+    as keys; cached values still hold the short start/end words used in the
+    text-fragment directive. Entries expire after
+    `_FRAGMENT_URL_CACHE_TTL_SECONDS` and the map is cleared wholesale when
+    full — eviction bookkeeping would cost more than the recompute it saves.
     """
     if not isinstance(base_url, str) or not isinstance(text_snippet, str):
         return _build_text_fragment_url(base_url, text_snippet)
 
     key = (base_url, hashlib.sha1(text_snippet.encode("utf-8", "surrogatepass")).digest())
+    now = time.monotonic()
     cached = _FRAGMENT_URL_CACHE.get(key)
     if cached is not None:
-        return cached
+        result, expires_at = cached
+        if expires_at > now:
+            return result
+        _FRAGMENT_URL_CACHE.pop(key, None)
 
     result = _build_text_fragment_url(base_url, text_snippet)
     if len(_FRAGMENT_URL_CACHE) >= _FRAGMENT_URL_CACHE_MAXSIZE:
         _FRAGMENT_URL_CACHE.clear()
-    _FRAGMENT_URL_CACHE[key] = result
+    _FRAGMENT_URL_CACHE[key] = (result, now + _FRAGMENT_URL_CACHE_TTL_SECONDS)
     return result
 
 

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -1,8 +1,10 @@
 import asyncio
 import base64
+import hashlib
 import logging
 import re
 from collections import defaultdict
+from collections.abc import Iterable
 from itertools import groupby
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
@@ -405,6 +407,10 @@ _GRAPH_TO_RECORD_FIELDS: dict[str, str] = {
     "sourceLastModifiedTimestamp": "source_updated_at",
 }
 
+# Matches BlobStorage.VIRTUAL_RECORD_LOOKUP_CHUNK_SIZE: the graph accepts an IN
+# list, but an unbounded one turns one slow query into a timeout.
+GRAPH_BATCH_CHUNK_SIZE = 500
+
 collection_map = {
                     RecordType.TICKET.value: "tickets",
                     RecordType.PROJECT.value: "projects",
@@ -689,6 +695,57 @@ async def _fetch_type_specific_doc(
     except Exception:
         return None
 
+
+async def _fetch_type_specific_docs_batched(
+    graph_provider: IGraphDBProvider,
+    record_ids: Iterable[str],
+    doc_index: dict[str, dict[str, Any]],
+) -> dict[str, dict[str, Any]]:
+    """Resolve type-specific docs for many records, one query per collection.
+
+    Each record otherwise costs its own `get_document`, and a turn enriches every
+    linked record it found. Records whose type has no entry in `collection_map`
+    are skipped rather than queried, matching `_fetch_type_specific_doc`.
+
+    A collection whose query fails is simply absent from the result; the caller
+    falls back to the per-record path for those ids.
+    """
+    by_collection: dict[str, list[str]] = {}
+    for rid in record_ids:
+        collection = collection_map.get((doc_index.get(rid) or {}).get("recordType"))
+        if collection:
+            by_collection.setdefault(collection, []).append(rid)
+    if not by_collection:
+        return {}
+
+    async def _one(collection: str, ids: list[str]) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for start in range(0, len(ids), GRAPH_BATCH_CHUNK_SIZE):
+            out.extend(
+                await graph_provider.get_nodes_by_field_in(
+                    collection, "id", ids[start:start + GRAPH_BATCH_CHUNK_SIZE]
+                )
+                or []
+            )
+        return out
+
+    collections = list(by_collection)
+    results = await asyncio.gather(
+        *[_one(c, by_collection[c]) for c in collections], return_exceptions=True
+    )
+    resolved: dict[str, dict[str, Any]] = {}
+    for collection, result in zip(collections, results):
+        if isinstance(result, Exception):
+            logger.debug(
+                "Linked record context: type-doc batch failed for %s: %s", collection, result
+            )
+            continue
+        for node in result:
+            key = (node or {}).get("id") or (node or {}).get("_key")
+            if key:
+                resolved[key] = node
+    return resolved
+
 def _base_record_context_metadata_from_graph(
     base_graph_doc: dict[str, Any],
     frontend_url: str | None = None,
@@ -728,11 +785,17 @@ async def _build_linked_record_context_metadata(
     vrid: str | None = None,
     blob_store: Any = None,
     org_id: str = "",
+    lookup_result: dict[str, Any] | None = None,
+    type_doc: dict[str, Any] | None = None,
 ) -> str | None:
     """Build linked-record context (metadata + type fields + summary, no blocks).
 
     The base doc is guaranteed present in doc_index by the caller. When the record
     is indexed (has a vrid), the blob supplies the summary; otherwise metadata only.
+
+    `lookup_result` and `type_doc` are pre-resolved by the caller in one batched
+    query each. Both fall back to the per-record path when absent, so a batch
+    miss costs a query rather than losing the field.
     """
     base_doc = doc_index.get(record_id)
     if not base_doc or not isinstance(base_doc, dict):
@@ -741,7 +804,9 @@ async def _build_linked_record_context_metadata(
         blob_record = None
         if vrid and blob_store and org_id:
             try:
-                blob_record = await blob_store.get_record_from_storage(vrid, org_id)
+                blob_record = await blob_store.get_record_from_storage(
+                    vrid, org_id, lookup_result=lookup_result
+                )
             except Exception as e:
                 logger.debug(
                     "Linked record context: blob fetch failed for %s (vrid=%s): %s",
@@ -753,9 +818,11 @@ async def _build_linked_record_context_metadata(
         else:
             record_dict = _build_record_dict_from_graph_base(base_doc)
 
-        type_graph_doc = await _fetch_type_specific_doc(
-            graph_provider, record_id, record_dict.get("record_type")
-        )
+        type_graph_doc = type_doc
+        if type_graph_doc is None:
+            type_graph_doc = await _fetch_type_specific_doc(
+                graph_provider, record_id, record_dict.get("record_type")
+            )
         record_instance = create_record_instance_from_dict(record_dict, type_graph_doc)
         if record_instance:
             return record_instance.to_llm_linked_context(frontend_url)
@@ -777,43 +844,45 @@ def _relation_display_label(relation: RecordRelations, outgoing: bool) -> str:
     return relation.value
 
 
-async def _fetch_edges_for_record(
+async def _fetch_edges_for_records(
     graph_provider: IGraphDBProvider,
-    record_id: str,
-) -> list[tuple[str, str]]:
-    """Return (related_record_id, display_label) pairs from graph edges.
+    record_ids: list[str],
+) -> dict[str, list[tuple[str, str]]]:
+    """Return {record_id: [(related_record_id, display_label), ...]} from graph edges.
 
     Graph API naming is edge-direction based, not familial role:
-      get_parent_record_ids → records this hit points to (_from == hit)
-      get_child_record_ids  → records pointing to this hit (_to == hit)
-    """
-    query_specs = [
-        (outgoing, relation)
-        for relation in RECORD_RELATION_ENRICHMENT_TYPES
-        for outgoing in (True, False)
-    ]
-    tasks = [
-        graph_provider.get_parent_record_ids_by_relation_type(record_id, rel.value)
-        if outgoing
-        else graph_provider.get_child_record_ids_by_relation_type(record_id, rel.value)
-        for outgoing, rel in query_specs
-    ]
+      parents  → records this hit points to (_from == hit)
+      children → records pointing to this hit (_to == hit)
 
-    results = await asyncio.gather(*tasks, return_exceptions=True)
-    edges: list[tuple[str, str]] = []
-    for (outgoing, relation), result in zip(query_specs, results):
-        if isinstance(result, Exception):
-            logger.warning(
-                "Graph context enrichment: edge query failed for %s (%s): %s",
-                record_id, relation.value, result,
-            )
-            continue
-        label = _relation_display_label(relation, outgoing)
-        for edge in result or []:
-            related_id = edge.get("record_id") if isinstance(edge, dict) else None
-            if related_id:
-                edges.append((related_id, label))
-    return edges
+    Batched across records and relation types: the per-record form cost one
+    query per relation type per direction, so a turn enriching every hit spent
+    4x its hit count on round trips.
+    """
+    if not record_ids:
+        return {}
+    by_value = {rel.value: rel for rel in RECORD_RELATION_ENRICHMENT_TYPES}
+    try:
+        relations = await graph_provider.get_record_relations_batch(
+            record_ids, list(by_value),
+        )
+    except Exception as e:
+        logger.warning("Graph context enrichment: batch edge query failed: %s", e)
+        return {}
+
+    out: dict[str, list[tuple[str, str]]] = {}
+    for record_id in record_ids:
+        buckets = relations.get(record_id) or {}
+        edges: list[tuple[str, str]] = []
+        for bucket, outgoing in (("parents", True), ("children", False)):
+            for edge in buckets.get(bucket) or []:
+                if not isinstance(edge, dict):
+                    continue
+                related_id = edge.get("record_id")
+                relation = by_value.get(edge.get("relationType"))
+                if related_id and relation:
+                    edges.append((related_id, _relation_display_label(relation, outgoing)))
+        out[record_id] = edges
+    return out
 
 
 async def resolve_frontend_url(
@@ -908,13 +977,43 @@ async def _resolve_target_metadata(
     """
     ids_needing_docs = [rid for rid in all_target_ids if rid not in doc_index]
 
-    async def _fetch_docs() -> list:
+    async def _fetch_docs() -> dict[str, dict[str, Any]]:
+        """One query per chunk instead of one per record.
+
+        Ids the batch does not return are absent from the result, which is what
+        the caller already did with a `get_document` that returned None. If the
+        batch itself fails, fall back to the per-id path rather than dropping
+        every linked record's metadata.
+        """
         if not ids_needing_docs:
-            return []
-        return await asyncio.gather(
-            *[graph_provider.get_document(rid, CollectionNames.RECORDS.value) for rid in ids_needing_docs],
-            return_exceptions=True,
-        )
+            return {}
+        collection = CollectionNames.RECORDS.value
+        try:
+            nodes: list[dict[str, Any]] = []
+            for start in range(0, len(ids_needing_docs), GRAPH_BATCH_CHUNK_SIZE):
+                nodes.extend(
+                    await graph_provider.get_nodes_by_field_in(
+                        collection, "id", ids_needing_docs[start:start + GRAPH_BATCH_CHUNK_SIZE]
+                    )
+                    or []
+                )
+        except Exception as e:
+            logger.warning("Linked record context: batch doc fetch failed, per-id fallback: %s", e)
+            per_id = await asyncio.gather(
+                *[graph_provider.get_document(rid, collection) for rid in ids_needing_docs],
+                return_exceptions=True,
+            )
+            return {
+                rid: doc
+                for rid, doc in zip(ids_needing_docs, per_id)
+                if not isinstance(doc, Exception) and doc and isinstance(doc, dict)
+            }
+        resolved: dict[str, dict[str, Any]] = {}
+        for node in nodes:
+            key = (node or {}).get("id") or (node or {}).get("_key")
+            if key:
+                resolved[key] = node
+        return resolved
 
     doc_results, vrid_result = await asyncio.gather(
         _fetch_docs(),
@@ -924,8 +1023,8 @@ async def _resolve_target_metadata(
 
     # Populate doc_index from fetched docs
     if ids_needing_docs and not isinstance(doc_results, Exception):
-        for rid, doc in zip(ids_needing_docs, doc_results):
-            if not isinstance(doc, Exception) and doc and isinstance(doc, dict):
+        for rid, doc in doc_results.items():
+            if doc and isinstance(doc, dict):
                 doc_index[rid] = doc
 
     # Build id -> vrid mapping
@@ -942,6 +1041,32 @@ async def _resolve_target_metadata(
 
     context_map: dict[str, str] = {}
     if out_of_context_ids:
+        # Resolve both per-record lookups once for the whole batch. Each linked
+        # record otherwise pays its own virtual-record mapping query inside
+        # get_record_from_storage, plus its own type-specific get_document.
+        blob_lookups: dict[str, dict[str, Any]] = {}
+        vrids_to_resolve = [
+            id_to_vrid[rid] for rid in out_of_context_ids if rid in id_to_vrid
+        ]
+        if blob_store and org_id and vrids_to_resolve:
+            try:
+                resolved_lookups = await blob_store.get_document_ids_by_virtual_record_ids(
+                    vrids_to_resolve
+                )
+                # Anything but a mapping means the pre-resolve did not happen;
+                # passing it through would hand the fetch a bogus lookup instead
+                # of letting it resolve the id itself.
+                if isinstance(resolved_lookups, dict):
+                    blob_lookups = resolved_lookups
+            except Exception as e:
+                logger.warning(
+                    "Linked record context: batch virtual-record lookup failed, "
+                    "resolving per record: %s", e,
+                )
+        type_docs = await _fetch_type_specific_docs_batched(
+            graph_provider, out_of_context_ids, doc_index
+        )
+
         ctx_results = await asyncio.gather(
             *[
                 _build_linked_record_context_metadata(
@@ -949,6 +1074,8 @@ async def _resolve_target_metadata(
                     vrid=id_to_vrid.get(rid),
                     blob_store=blob_store if rid in id_to_vrid else None,
                     org_id=org_id,
+                    lookup_result=blob_lookups.get(id_to_vrid.get(rid) or ""),
+                    type_doc=type_docs.get(rid),
                 )
                 for rid in out_of_context_ids
             ],
@@ -1071,10 +1198,9 @@ async def enrich_records_with_graph_context(
     # Step 2: Fetch edges for relation-eligible hits
     edge_results: list = []
     if relation_eligible:
-        edge_results = await asyncio.gather(
-            *[_fetch_edges_for_record(graph_provider, rid) for _, rid, _ in relation_eligible],
-            return_exceptions=True,
-        )
+        eligible_ids = [rid for _, rid, _ in relation_eligible]
+        edges_by_record = await _fetch_edges_for_records(graph_provider, eligible_ids)
+        edge_results = [edges_by_record.get(rid, []) for rid in eligible_ids]
 
     # Step 3: Build relation buckets from edges
     relation_buckets, all_related_ids = _build_relation_buckets(
@@ -1478,7 +1604,33 @@ async def get_flattened_results(result_set: List[Dict[str, Any]], blob_store: Bl
     except Exception as e:
         logger.warning(f"Failed to fetch frontend URL from config service: {str(e)}")
 
-    await asyncio.gather(*[get_record(virtual_record_id,virtual_record_id_to_result,blob_store,org_id,virtual_to_record_map,graph_provider,frontend_url) for virtual_record_id in records_to_fetch])
+    # One mapping query for the whole batch instead of one (plus a fallback) per
+    # record; each get_record then goes straight to the download.
+    batched_lookups: dict[str, Any] = {}
+    if records_to_fetch:
+        try:
+            batched_lookups = await blob_store.get_document_ids_by_virtual_record_ids(
+                list(records_to_fetch)
+            )
+        except Exception as e:
+            logger.warning("Batch virtual-record lookup failed, resolving per record: %s", str(e))
+
+    # Type-specific metadata (ticket status, mail sender, ...) is one graph query
+    # per record inside get_record. The record type is already known here, so
+    # resolve the whole batch with one query per collection instead.
+    type_docs: dict[str, dict[str, Any]] = {}
+    if records_to_fetch and graph_provider:
+        by_record_id = {
+            gdb["id"]: gdb
+            for vrid in records_to_fetch
+            if isinstance(gdb := (virtual_to_record_map or {}).get(vrid), dict) and gdb.get("id")
+        }
+        if by_record_id:
+            type_docs = await _fetch_type_specific_docs_batched(
+                graph_provider, list(by_record_id), by_record_id
+            )
+
+    await asyncio.gather(*[get_record(virtual_record_id,virtual_record_id_to_result,blob_store,org_id,virtual_to_record_map,graph_provider,frontend_url,batched_lookups.get(virtual_record_id),type_docs) for virtual_record_id in records_to_fetch])
     # Prefetch reconciliation metadata in parallel (records were fully fetched above).
     vrids_needing_recon: set = set[Any]()
 
@@ -2144,9 +2296,9 @@ def extract_bounding_boxes(citation_metadata) -> list[dict[str, float]]:
         except Exception as e:
             raise e
 
-async def get_record(virtual_record_id: str,virtual_record_id_to_result: dict[str, dict[str, Any]],blob_store: BlobStorage,org_id: str,virtual_to_record_map: dict[str, dict[str, Any]]=None,graph_provider: IGraphDBProvider | None = None,frontend_url: str | None = None) -> None:
+async def get_record(virtual_record_id: str,virtual_record_id_to_result: dict[str, dict[str, Any]],blob_store: BlobStorage,org_id: str,virtual_to_record_map: dict[str, dict[str, Any]]=None,graph_provider: IGraphDBProvider | None = None,frontend_url: str | None = None,lookup_result: dict[str, Any] | None = None,type_docs: dict[str, dict[str, Any]] | None = None) -> None:
     try:
-        record = await blob_store.get_record_from_storage(virtual_record_id=virtual_record_id, org_id=org_id)
+        record = await blob_store.get_record_from_storage(virtual_record_id=virtual_record_id, org_id=org_id, lookup_result=lookup_result)
         if record:
             graphDb_record = (virtual_to_record_map or {}).get(virtual_record_id)
             if graphDb_record:
@@ -2174,8 +2326,8 @@ async def get_record(virtual_record_id: str,virtual_record_id_to_result: dict[st
                     record["external_record_id"] = graph_external_id
 
                 # Fetch type-specific metadata and generate formatted string
-                graph_doc = None
-                if graph_provider and record_key:
+                graph_doc = (type_docs or {}).get(record_key)
+                if graph_doc is None and graph_provider and record_key:
                     try:
                         # Determine collection name based on record type
 
@@ -3537,11 +3689,13 @@ def count_tokens(messages: list[Any], message_contents: list[list[dict[str, Any]
 
 FRAGMENT_WORD_COUNT = 4
 
+_FRAGMENT_WORD_PATTERN = re.compile(r"(?:(?<= )|^)[A-Za-z]+(?: [A-Za-z]+)+(?![A-Za-z'-])")
+
 def extract_start_end_text(snippet: str | None) -> tuple[str, str]:
     if not snippet:
         return "", ""
-        
-    PATTERN = re.compile(r"(?:(?<= )|^)[A-Za-z]+(?: [A-Za-z]+)+(?![A-Za-z'-])")
+
+    PATTERN = _FRAGMENT_WORD_PATTERN
 
     # --- Find start_text: first match with at least FRAGMENT_WORD_COUNT words, else longest ---
     all_matches = list(PATTERN.finditer(snippet))
@@ -3588,7 +3742,36 @@ def extract_start_end_text(snippet: str | None) -> tuple[str, str]:
 
     return start_text, end_text.strip()
 
+_FRAGMENT_URL_CACHE: dict[tuple[str, bytes], str] = {}
+_FRAGMENT_URL_CACHE_MAXSIZE = 8192
+
+
 def generate_text_fragment_url(base_url: str, text_snippet: str) -> str:
+    """Memoized wrapper over `_build_text_fragment_url`.
+
+    The live citation overlay re-derives every citation's URL on each refresh,
+    so the same (base_url, snippet) pair is re-scanned many times per turn.
+    Snippets are keyed by digest rather than by value so the cache cannot pin
+    whole record blocks in memory. Cleared wholesale when full: eviction
+    bookkeeping would cost more than the recompute it saves, and the working
+    set for a turn is far below the bound.
+    """
+    if not isinstance(base_url, str) or not isinstance(text_snippet, str):
+        return _build_text_fragment_url(base_url, text_snippet)
+
+    key = (base_url, hashlib.sha1(text_snippet.encode("utf-8", "surrogatepass")).digest())
+    cached = _FRAGMENT_URL_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    result = _build_text_fragment_url(base_url, text_snippet)
+    if len(_FRAGMENT_URL_CACHE) >= _FRAGMENT_URL_CACHE_MAXSIZE:
+        _FRAGMENT_URL_CACHE.clear()
+    _FRAGMENT_URL_CACHE[key] = result
+    return result
+
+
+def _build_text_fragment_url(base_url: str, text_snippet: str) -> str:
     """
     Generate a URL with text fragment for direct navigation to specific text.
 

--- a/backend/python/app/utils/chat_helpers.py
+++ b/backend/python/app/utils/chat_helpers.py
@@ -844,6 +844,48 @@ def _relation_display_label(relation: RecordRelations, outgoing: bool) -> str:
     return relation.value
 
 
+async def _relations_per_record(
+    graph_provider: IGraphDBProvider,
+    record_ids: list[str],
+    relation_types: list[str],
+) -> dict[str, dict[str, list[dict[str, Any]]]]:
+    """Per-record equivalent of `get_record_relations_batch`, used when the
+    batch fails. Concurrent, and a failing pair costs only itself."""
+    async def one(record_id: str, relation_type: str, *, outgoing: bool) -> list[dict[str, Any]]:
+        fetch = (
+            graph_provider.get_parent_record_ids_by_relation_type
+            if outgoing
+            else graph_provider.get_child_record_ids_by_relation_type
+        )
+        return await fetch(record_id, relation_type)
+
+    jobs = [
+        (record_id, relation_type, outgoing)
+        for record_id in record_ids
+        for relation_type in relation_types
+        for outgoing in (True, False)
+    ]
+    results = await asyncio.gather(
+        *[one(rid, rel, outgoing=out) for rid, rel, out in jobs],
+        return_exceptions=True,
+    )
+
+    out: dict[str, dict[str, list[dict[str, Any]]]] = {
+        record_id: {"parents": [], "children": []} for record_id in record_ids
+    }
+    for (record_id, relation_type, outgoing), result in zip(jobs, results):
+        if isinstance(result, BaseException):
+            logger.warning(
+                "Graph context enrichment: %s edges failed for %s: %s",
+                relation_type, record_id, result,
+            )
+            continue
+        bucket = "parents" if outgoing else "children"
+        for edge in result or []:
+            out[record_id][bucket].append({**edge, "relationType": relation_type})
+    return out
+
+
 async def _fetch_edges_for_records(
     graph_provider: IGraphDBProvider,
     record_ids: list[str],
@@ -866,8 +908,14 @@ async def _fetch_edges_for_records(
             record_ids, list(by_value),
         )
     except Exception as e:
-        logger.warning("Graph context enrichment: batch edge query failed: %s", e)
-        return {}
+        # Returning {} here drops linked-record context for every hit in the
+        # turn. The per-record form this replaced used return_exceptions=True
+        # and lost only the failing pair, so fall back to it rather than
+        # degrading the whole turn on one bad batch.
+        logger.warning(
+            "Graph context enrichment: batch edge query failed, per-record fallback: %s", e
+        )
+        relations = await _relations_per_record(graph_provider, record_ids, list(by_value))
 
     out: dict[str, list[tuple[str, str]]] = {}
     for record_id in record_ids:
@@ -999,20 +1047,29 @@ async def _resolve_target_metadata(
                 )
         except Exception as e:
             logger.warning("Linked record context: batch doc fetch failed, per-id fallback: %s", e)
-            per_id = await asyncio.gather(
-                *[graph_provider.get_document(rid, collection) for rid in ids_needing_docs],
-                return_exceptions=True,
-            )
-            return {
-                rid: doc
-                for rid, doc in zip(ids_needing_docs, per_id)
-                if not isinstance(doc, Exception) and doc and isinstance(doc, dict)
-            }
+            nodes = []
+
         resolved: dict[str, dict[str, Any]] = {}
         for node in nodes:
             key = (node or {}).get("id") or (node or {}).get("_key")
             if key:
                 resolved[key] = node
+
+        # Recover on id coverage, not on an exception: get_nodes_by_field_in
+        # catches its own errors and returns [], so a dead database is
+        # indistinguishable from "no rows" and the except above never fires.
+        # Anything the batch did not account for is retried individually.
+        missing = [rid for rid in ids_needing_docs if rid not in resolved]
+        if missing:
+            per_id = await asyncio.gather(
+                *[graph_provider.get_document(rid, collection) for rid in missing],
+                return_exceptions=True,
+            )
+            resolved.update({
+                rid: doc
+                for rid, doc in zip(missing, per_id)
+                if isinstance(doc, dict) and doc
+            })
         return resolved
 
     doc_results, vrid_result = await asyncio.gather(
@@ -1620,10 +1677,14 @@ async def get_flattened_results(result_set: List[Dict[str, Any]], blob_store: Bl
     # resolve the whole batch with one query per collection instead.
     type_docs: dict[str, dict[str, Any]] = {}
     if records_to_fetch and graph_provider:
+        # Records reach here carrying `_key` rather than `id` (the graph write
+        # path moves `id` into `_key`), so keying on `id` alone matched nothing
+        # and the batch silently no-opped back to one query per record.
         by_record_id = {
-            gdb["id"]: gdb
+            key: gdb
             for vrid in records_to_fetch
-            if isinstance(gdb := (virtual_to_record_map or {}).get(vrid), dict) and gdb.get("id")
+            if isinstance(gdb := (virtual_to_record_map or {}).get(vrid), dict)
+            and (key := gdb.get("id") or gdb.get("_key"))
         }
         if by_record_id:
             type_docs = await _fetch_type_specific_docs_batched(

--- a/backend/python/app/utils/fetch_url_tool.py
+++ b/backend/python/app/utils/fetch_url_tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import dataclasses
 import json
 import logging
@@ -115,7 +116,7 @@ def create_fetch_url_tool(
                     the real URL via this mapper.
     """
     @tool("fetch_url", args_schema=FetchUrlArgs)
-    def fetch_url_tool(url: str) -> str:
+    async def fetch_url_tool(url: str) -> str:
         """
         Fetches and extracts main content from a **public** webpage (unauthenticated HTTP GET).
 
@@ -167,7 +168,11 @@ def create_fetch_url_tool(
                 })
 
             try:
-                response = fetch_url(url, verbose=True)
+                # fetch_url is sync (curl_cffi/cloudscraper/requests) and walks a
+                # fallback chain of up to 4 strategies x 3 profiles at 15s each.
+                # Run inline it would stall the event loop -- every concurrent
+                # request -- for the whole chain. image_utils does the same.
+                response = await asyncio.to_thread(fetch_url, url, verbose=True)
             except FetchError as e:
                 logger.warning("Fetch URL rejected or failed for %s: %s", url, e)
                 return json.dumps({

--- a/backend/python/pyproject.toml
+++ b/backend/python/pyproject.toml
@@ -244,6 +244,7 @@ dependencies = [
     "langchain-mistralai==0.2.12",
     "langchain-ollama==1.0.0",
     "langchain-openai==1.4.1",
+    "openai==2.45.0",
     "langchain-qdrant==1.0.0",
     "langchain-voyageai==0.3.0",
     "langchain-xai==1.3.0",

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_anthropic_coverage.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_anthropic_coverage.py
@@ -429,6 +429,29 @@ class TestComplete:
         _, kwargs = transport._client.messages.create.call_args
         assert kwargs["max_tokens"] == 50_000
 
+    async def test_disabled_thinking_still_sends_temperature(self) -> None:
+        transport = _transport(thinking={"type": "disabled"}, temperature=0.4)
+        transport._client.messages.create = AsyncMock(return_value=_response())
+
+        await transport.complete([UserMessage(content="hi")])
+
+        _, kwargs = transport._client.messages.create.call_args
+        assert kwargs["thinking"] == {"type": "disabled"}
+        assert kwargs["temperature"] == 0.4
+
+    async def test_enabled_thinking_suppresses_temperature(self) -> None:
+        transport = _transport(
+            thinking={"type": "enabled", "budget_tokens": 1024},
+            temperature=0.4,
+        )
+        transport._client.messages.create = AsyncMock(return_value=_response())
+
+        await transport.complete([UserMessage(content="hi")])
+
+        _, kwargs = transport._client.messages.create.call_args
+        assert "temperature" not in kwargs
+        assert kwargs["thinking"]["type"] == "enabled"
+
     async def test_tools_get_cache_breakpoint(self) -> None:
         transport = _transport()
         transport._client.messages.create = AsyncMock(return_value=_response())

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_azure_direct_transport.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_azure_direct_transport.py
@@ -1,0 +1,606 @@
+"""Azure direct transport: behaviour must match the LangChain path it replaces.
+
+The point of this transport is to drop LangChain from the streaming path without
+changing what the agent loop sees, so most of these assert equivalence rather
+than correctness in isolation.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from app.agent_loop_lib.core.messages import UserMessage
+from app.agent_loop_lib.core.responses import StopReason
+from app.agent_loop_lib.core.streaming import (
+    StreamCompleteEvent,
+    TextDeltaEvent,
+    ToolCallDeltaEvent,
+)
+from app.agent_loop_lib.transport.azure_openai import (
+    AzureOpenAITransport,
+    RequestDefaults,
+)
+
+# Terminates an SSE body. Streaming Responses requests are served from raw bytes
+# now, so a mock has to produce a well-formed stream rather than a list of
+# already-parsed objects.
+_DONE = b"data: [DONE]\n\n"
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+def _transport() -> AzureOpenAITransport:
+    return AzureOpenAITransport(
+        api_key="k",
+        azure_endpoint="https://example.openai.azure.com",
+        api_version="2024-10-01-preview",
+        deployment="gpt-5-4-mini",
+    )
+
+
+def _chunk(content=None, reasoning=None, tool_calls=None, finish=None):
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    if reasoning is not None:
+        delta.reasoning_content = reasoning
+    return SimpleNamespace(
+        choices=[SimpleNamespace(delta=delta, finish_reason=finish)], usage=None
+    )
+
+
+def _tc(index: int, id=None, name=None, args=None):
+    return SimpleNamespace(
+        index=index, id=id, function=SimpleNamespace(name=name, arguments=args)
+    )
+
+
+def _scripted(chunks: list):
+    class _Stream:
+        def __aiter__(self):
+            async def gen() -> "Iterator":
+                for c in chunks:
+                    yield c
+            return gen()
+    return _Stream()
+
+
+def _wire(transport: AzureOpenAITransport, chunks: list) -> MagicMock:
+    transport._client = MagicMock()
+    transport._client.chat.completions.create = AsyncMock(return_value=_scripted(chunks))
+    return transport._client
+
+
+class TestClientConstruction:
+    def test_uses_the_azure_client_not_the_plain_one(self) -> None:
+        t = _transport()
+        assert type(t._client).__name__ == "AsyncAzureOpenAI"
+        assert t.provider == "azure_direct"
+
+    def test_model_defaults_to_the_deployment(self) -> None:
+        """Azure routes on deployment name, so a public model id would 404."""
+        assert _transport().model_name == "gpt-5-4-mini"
+
+    def test_built_from_the_langchain_model_the_other_transport_uses(self) -> None:
+        llm = MagicMock()
+        llm.azure_endpoint = "https://example.openai.azure.com"
+        llm.deployment_name = "gpt-5-4-mini"
+        llm.openai_api_key = SecretStr("sk-secret")
+        llm.openai_api_version = "2024-10-01-preview"
+
+        t = AzureOpenAITransport.from_langchain_model(llm, model_name="gpt-5.4-mini")
+
+        assert t.provider == "azure_direct"
+        assert t.model_name == "gpt-5.4-mini"
+
+    def test_non_azure_model_is_rejected_loudly(self) -> None:
+        """Silently falling back would hide a misconfiguration behind LangChain."""
+        llm = MagicMock()
+        llm.azure_endpoint = None
+        llm.deployment_name = None
+        llm.openai_api_key = None
+        llm.openai_api_version = None
+        with pytest.raises(ValueError, match="azure_direct only supports"):
+            AzureOpenAITransport.from_langchain_model(llm)
+
+
+class TestStreamEvents:
+    @pytest.mark.asyncio
+    async def test_emits_the_same_event_types_as_the_langchain_path(self) -> None:
+        t = _transport()
+        _wire(t, [
+            _chunk(reasoning="pondering"),
+            _chunk(content="Hello"),
+            _chunk(tool_calls=[_tc(0, id="call_1", name="final_answer", args='{"a"')]),
+            _chunk(tool_calls=[_tc(0, args=':1}')]),
+            _chunk(finish="tool_calls"),
+        ])
+
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        kinds = [type(e).__name__ for e in events]
+
+        assert kinds == [
+            "ThinkingDeltaEvent", "TextDeltaEvent",
+            "ToolCallDeltaEvent", "ToolCallDeltaEvent", "StreamCompleteEvent",
+        ]
+        assert isinstance(events[-1], StreamCompleteEvent)
+
+    @pytest.mark.asyncio
+    async def test_tool_call_fragments_carry_the_index_live_streaming_keys_off(self) -> None:
+        """agent/__init__ keys its final_answer extractor off `index`; without
+        it the answer only reaches the user when the whole turn ends."""
+        t = _transport()
+        _wire(t, [
+            _chunk(tool_calls=[_tc(0, id="c0", name="final_answer", args='{"x"')]),
+            _chunk(tool_calls=[_tc(1, id="c1", name="search", args='{"q"')]),
+            _chunk(tool_calls=[_tc(0, args=':1}')]),
+            _chunk(finish="tool_calls"),
+        ])
+
+        deltas = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        frags = [e for e in deltas if isinstance(e, ToolCallDeltaEvent)]
+
+        assert [f.index for f in frags] == [0, 1, 0]
+        # name/id appear only on the opening fragment of each call, matching what
+        # the LangChain transport passes through; the loop reads name on the
+        # first delta per index only.
+        assert [f.name for f in frags] == ["final_answer", "search", None]
+
+    @pytest.mark.asyncio
+    async def test_fragments_carrying_nothing_at_all_are_skipped(self) -> None:
+        """A fragment with no arguments AND no name/id tells the loop nothing.
+
+        The opening fragment does carry name/id with empty arguments, and that
+        one must survive -- the agent reads `name` off the first delta to spot
+        final_answer.
+        """
+        t = _transport()
+        _wire(t, [
+            _chunk(tool_calls=[_tc(0, id="c0", name="t", args=None)]),
+            _chunk(tool_calls=[_tc(0, args="")]),
+            _chunk(tool_calls=[_tc(0, args="{}")]),
+            _chunk(finish="tool_calls"),
+        ])
+
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        frags = [e for e in events if isinstance(e, ToolCallDeltaEvent)]
+
+        assert [(f.name, f.arguments_delta) for f in frags] == [("t", ""), (None, "{}")]
+
+    @pytest.mark.asyncio
+    async def test_fragments_reassemble_into_the_final_tool_call(self) -> None:
+        t = _transport()
+        _wire(t, [
+            _chunk(tool_calls=[_tc(0, id="c1", name="final_answer", args='{"answer_markdown"')]),
+            _chunk(tool_calls=[_tc(0, args=': "done"}')]),
+            _chunk(finish="tool_calls"),
+        ])
+
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        calls = events[-1].response.message.tool_calls
+
+        assert len(calls) == 1
+        assert calls[0].name == "final_answer"
+        assert calls[0].arguments == {"answer_markdown": "done"}
+
+    @pytest.mark.asyncio
+    async def test_text_only_response_still_terminates_with_one_complete(self) -> None:
+        t = _transport()
+        _wire(t, [_chunk(content="a"), _chunk(content="b"), _chunk(finish="stop")])
+
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert [type(e).__name__ for e in events] == [
+            "TextDeltaEvent", "TextDeltaEvent", "StreamCompleteEvent",
+        ]
+        # content is normalised to parts by AssistantMessage
+        assert "".join(p.text for p in events[-1].response.message.content) == "ab"
+
+
+class TestRequestShapeFallbacks:
+    """Ported from LangChainTransport. These exist because the failures were
+    hit in production, so losing them would be a real regression.
+
+    They drive the retry through the transport's captured configuration rather
+    than a per-call `effort`: LangChain ignores per-call effort because
+    aimodels bakes the reasoning config into the model object, and this
+    transport now matches that.
+    """
+
+    @pytest.mark.asyncio
+    async def test_api_shape_conflict_retries_once_and_switches_endpoint(self) -> None:
+        """Reasoning + tools rejected on Chat Completions means this deployment
+        wants the Responses API for that combination."""
+        t = _transport()
+        t._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        chat_calls: list = []
+        resp_calls: list = []
+
+        async def _chat(**kwargs):
+            chat_calls.append(kwargs)
+            raise RuntimeError("Please use /v1/responses instead")
+
+        # Streaming Responses requests go through with_streaming_response, not
+        # responses.create -- the raw-SSE path skips the SDK's per-event
+        # validation, so this is where the retry now lands.
+        def _resp(**kwargs):
+            resp_calls.append(kwargs)
+            return _FakeStreamingResponse([_DONE])
+
+        t._client = MagicMock()
+        t._client.chat.completions.create = AsyncMock(side_effect=_chat)
+        t._client.responses.with_streaming_response.create = MagicMock(side_effect=_resp)
+
+        [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert len(chat_calls) == 1, "first attempt on Chat Completions"
+        assert chat_calls[0].get("reasoning_effort") == "low"
+        assert len(resp_calls) == 1, "retry must go to the Responses API"
+        assert resp_calls[0].get("reasoning") == {"effort": "low"}
+        assert t._defaults.use_responses_api is True, "the working shape is pinned"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_mandatory_conflict_bumps_off_a_disabled_value(self) -> None:
+        t = _transport()
+        t._defaults = RequestDefaults(reasoning_effort="none", model="gpt-4o")
+        calls: list = []
+
+        async def _create(**kwargs):
+            calls.append(kwargs)
+            if len(calls) == 1:
+                raise RuntimeError("Reasoning is mandatory for this endpoint")
+            return _scripted([_chunk(content="ok"), _chunk(finish="stop")])
+
+        t._client = MagicMock()
+        t._client.chat.completions.create = AsyncMock(side_effect=_create)
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert len(calls) == 2
+        assert calls[1]["reasoning_effort"] == "low"
+        assert isinstance(events[-1], StreamCompleteEvent)
+
+    @pytest.mark.asyncio
+    async def test_unrelated_errors_are_not_retried(self) -> None:
+        t = _transport()
+        t._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        calls: list = []
+
+        async def _create(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("rate limit exceeded")
+
+        t._client = MagicMock()
+        t._client.chat.completions.create = AsyncMock(side_effect=_create)
+        with pytest.raises(Exception, match="rate limit"):
+            [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_retry_once_events_have_been_emitted(self) -> None:
+        """Re-opening a stream mid-flight would replay deltas to the client."""
+        t = _transport()
+        t._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        calls: list = []
+
+        class _Failing:
+            def __aiter__(self):
+                async def gen():
+                    yield _chunk(content="partial")
+                    raise RuntimeError("Please use /v1/responses instead")
+                return gen()
+
+        async def _create(**kwargs):
+            calls.append(kwargs)
+            return _Failing()
+
+        t._client = MagicMock()
+        t._client.chat.completions.create = AsyncMock(side_effect=_create)
+        seen = []
+        with pytest.raises(Exception, match="responses"):
+            async for e in t.stream(messages=[UserMessage(content="hi")]):
+                seen.append(e)
+
+        assert len(calls) == 1
+        assert [type(e).__name__ for e in seen] == ["TextDeltaEvent"]
+
+
+class TestCompleteRetriesLikeStream:
+    """complete() is used for non-streaming turns, planners and auto-compact.
+    Its retry guard tested the returned dict for truthiness, but dropping
+    reasoning_effort leaves an EMPTY dict -- which is exactly the retry case --
+    so it never retried while stream() did."""
+
+    @pytest.mark.asyncio
+    async def test_api_shape_conflict_retries_once(self) -> None:
+        t = _transport()
+        t._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        chat_calls: list = []
+
+        async def _chat(**kwargs):
+            chat_calls.append(kwargs)
+            raise RuntimeError("Please use /v1/responses instead")
+
+        async def _resp(**kwargs):
+            return SimpleNamespace(output=[], usage=None, incomplete_details=None,
+                                   status="completed")
+
+        t._client = MagicMock()
+        t._client.chat.completions.create = AsyncMock(side_effect=_chat)
+        t._client.responses.create = AsyncMock(side_effect=_resp)
+
+        result = await t.complete(messages=[UserMessage(content="hi")])
+
+        assert len(chat_calls) == 1
+        assert t._defaults.use_responses_api is True
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_unrelated_error_still_raises_without_retrying(self) -> None:
+        t = _transport()
+        t._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        calls: list = []
+
+        async def _create(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("rate limit exceeded")
+
+        t._client = MagicMock()
+        t._client.chat.completions.create = AsyncMock(side_effect=_create)
+        with pytest.raises(Exception, match="rate limit"):
+            await t.complete(messages=[UserMessage(content="hi")])
+
+        assert len(calls) == 1
+
+
+class TestToolCallOpeningFragment:
+    """Azure opens a tool call with a metadata-only chunk (name + id, empty
+    arguments) -- verified against the live service. The agent decides whether a
+    call is final_answer from `name` on the first delta it sees, so dropping
+    that chunk meant answers only appeared once the turn ended."""
+
+    @pytest.mark.asyncio
+    async def test_metadata_only_opening_chunk_is_emitted(self) -> None:
+        t = _transport()
+        _wire(t, [
+            _chunk(tool_calls=[_tc(0, id="c1", name="final_answer", args="")]),
+            _chunk(tool_calls=[_tc(0, args='{"answer_markdown": "hi"}')]),
+            _chunk(finish="tool_calls"),
+        ])
+
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        frags = [e for e in events if isinstance(e, ToolCallDeltaEvent)]
+
+        assert frags[0].name == "final_answer", "the agent needs the name on the first delta"
+        assert frags[0].arguments_delta == ""
+        assert events[-1].response.message.tool_calls[0].arguments == {"answer_markdown": "hi"}
+
+    @pytest.mark.asyncio
+    async def test_wholly_empty_fragments_are_still_skipped(self) -> None:
+        t = _transport()
+        _wire(t, [
+            _chunk(tool_calls=[_tc(0, id="c1", name="t", args=None)]),
+            _chunk(tool_calls=[_tc(0, args=None)]),
+            _chunk(tool_calls=[_tc(0, args="{}")]),
+            _chunk(finish="tool_calls"),
+        ])
+
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        frags = [e for e in events if isinstance(e, ToolCallDeltaEvent)]
+
+        # opener carries name/id so it is emitted; the bare empty one is not
+        assert [f.name for f in frags] == ["t", None]
+
+
+class TestConfigurationCapture:
+    """The whole configuration comes off the LangChain model, not just the
+    credentials. Reading only the credentials is what made this transport send
+    Chat Completions with no reasoning while the LangChain arm used the
+    Responses API at effort=high."""
+
+    @staticmethod
+    def _llm(**over):
+        llm = MagicMock()
+        llm.azure_endpoint = "https://e.openai.azure.com"
+        llm.deployment_name = over.get("deployment", "my-deployment")
+        llm.openai_api_key = SecretStr("sk")
+        llm.openai_api_version = "2025-04-01-preview"
+        llm.temperature = over.get("temperature", 1)
+        llm.reasoning = over.get("reasoning", {"effort": "high"})
+        llm.reasoning_effort = over.get("reasoning_effort", None)
+        llm.use_responses_api = over.get("use_responses_api", True)
+        llm.request_timeout = over.get("timeout", 360.0)
+        llm.max_retries = over.get("max_retries", 2)
+        return llm
+
+    def test_reasoning_and_endpoint_are_carried(self) -> None:
+        t = AzureOpenAITransport.from_langchain_model(self._llm(), model_name="gpt-5.4-mini")
+        assert t._wants_responses() is True
+        assert t._default_request_kwargs()["reasoning"] == {"effort": "high"}
+
+    def test_timeout_is_carried_to_the_client(self) -> None:
+        """LangChain pins DEFAULT_LLM_TIMEOUT; unset, the SDK waits far longer."""
+        t = AzureOpenAITransport.from_langchain_model(self._llm(), model_name="m")
+        assert t._client.timeout == 360.0
+
+    def test_temperature_dropped_for_gpt5_reasoning_on_responses(self) -> None:
+        """langchain_openai strips it before POSTing, so sending it would both
+        differ from the LangChain arm and 400 on the deployment."""
+        t = AzureOpenAITransport.from_langchain_model(self._llm(), model_name="gpt-5.4-mini")
+        assert "temperature" not in t._default_request_kwargs()
+
+    def test_temperature_kept_when_reasoning_is_off(self) -> None:
+        t = AzureOpenAITransport.from_langchain_model(
+            self._llm(reasoning={"effort": "none"}), model_name="gpt-5.4-mini",
+        )
+        assert t._default_request_kwargs()["temperature"] == 1
+
+    def test_temperature_kept_for_gpt5_chat(self) -> None:
+        t = AzureOpenAITransport.from_langchain_model(self._llm(), model_name="gpt-5-chat")
+        assert t._default_request_kwargs()["temperature"] == 1
+
+    def test_chat_completions_model_uses_the_other_spelling(self) -> None:
+        t = AzureOpenAITransport.from_langchain_model(
+            self._llm(use_responses_api=False, reasoning=None, reasoning_effort="medium"),
+            model_name="gpt-4o",
+        )
+        assert t._wants_responses() is False
+        assert t._default_request_kwargs()["reasoning_effort"] == "medium"
+
+    def test_responses_requests_carry_the_deployment_not_the_model(self) -> None:
+        """Azure only puts /deployments/{name}/ in the path for Chat
+        Completions, so on Responses the deployment must travel in the body --
+        sending the model name there is a DeploymentNotFound 404."""
+        t = AzureOpenAITransport.from_langchain_model(
+            self._llm(deployment="my-deployment"), model_name="gpt-5.4-mini",
+        )
+        assert t._responses_model_id() == "my-deployment"
+        assert t.model_name == "gpt-5.4-mini"
+
+    @pytest.mark.asyncio
+    async def test_a_reasoning_model_actually_reaches_the_responses_endpoint(self) -> None:
+        """The whole point: this deployment must not silently run without
+        reasoning on Chat Completions."""
+        t = AzureOpenAITransport.from_langchain_model(self._llm(), model_name="gpt-5.4-mini")
+        captured: dict = {}
+
+        def _resp(**kwargs):
+            captured.update(kwargs)
+            return _FakeStreamingResponse([_DONE])
+
+        t._client = MagicMock()
+        t._client.responses.with_streaming_response.create = MagicMock(side_effect=_resp)
+        t._client.chat.completions.create = AsyncMock(
+            side_effect=AssertionError("must not use Chat Completions")
+        )
+
+        [e async for e in t.stream(messages=[UserMessage(content="hi")], system="S")]
+
+        assert captured["model"] == "my-deployment"
+        assert captured["reasoning"] == {"effort": "high"}
+        assert "stream_options" not in captured, "Chat-Completions-only parameter"
+        assert captured["input"][0] == {"type": "message", "role": "system", "content": "S"}
+
+
+def _sse(events: list[dict], chunk_size: int | None = None) -> list[bytes]:
+    """Encode events as an SSE byte stream, optionally split at arbitrary
+    boundaries so the framing is exercised the way the network delivers it."""
+    body = "".join(f"data: {json.dumps(e)}\n\n" for e in events) + "data: [DONE]\n\n"
+    raw = body.encode()
+    if chunk_size is None:
+        return [raw]
+    return [raw[i:i + chunk_size] for i in range(0, len(raw), chunk_size)]
+
+
+class _FakeStreamingResponse:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = chunks
+
+    async def __aenter__(self) -> "_FakeStreamingResponse":
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+    async def iter_bytes(self):
+        for c in self._chunks:
+            yield c
+
+
+def _responses_transport(chunks: list[bytes]) -> AzureOpenAITransport:
+    t = _transport()
+    t._defaults = RequestDefaults(reasoning={"effort": "high"}, use_responses_api=True,
+                                  model="gpt-5.4-mini")
+    t._client = MagicMock()
+    t._client.responses.with_streaming_response.create = MagicMock(
+        return_value=_FakeStreamingResponse(chunks)
+    )
+    return t
+
+
+_STREAM = [
+    {"type": "response.output_text.delta", "delta": "Hel", "output_index": 0},
+    {"type": "response.output_text.delta", "delta": "lo", "output_index": 0},
+    {"type": "response.output_item.added", "output_index": 1,
+     "item": {"type": "function_call", "name": "search", "call_id": "call_1"}},
+    {"type": "response.function_call_arguments.delta", "output_index": 1, "delta": '{"q":'},
+    {"type": "response.function_call_arguments.delta", "output_index": 1, "delta": '"x"}'},
+    {"type": "response.completed", "response": {
+        "output": [{"type": "function_call", "name": "search",
+                    "arguments": '{"q": "x"}', "call_id": "call_1"}],
+        "usage": {"input_tokens": 50, "output_tokens": 9,
+                  "input_tokens_details": {"cached_tokens": 32}},
+        "incomplete_details": None, "status": "completed",
+    }},
+]
+
+
+class TestRawResponsesStream:
+    """The Responses stream is decoded from raw SSE, skipping the SDK's
+    per-event pydantic validation. These assert the events reaching the agent
+    loop are unchanged by that."""
+
+    @pytest.mark.asyncio
+    async def test_full_event_sequence(self) -> None:
+        t = _responses_transport(_sse(_STREAM))
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert [e.delta for e in events if isinstance(e, TextDeltaEvent)] == ["Hel", "lo"]
+        tool_deltas = [e for e in events if isinstance(e, ToolCallDeltaEvent)]
+        # the opener carries the name, which the agent loop reads off the FIRST
+        # delta for an index to recognise final_answer
+        assert (tool_deltas[0].index, tool_deltas[0].name, tool_deltas[0].arguments_delta) == (
+            1, "search", "")
+        assert "".join(d.arguments_delta for d in tool_deltas) == '{"q":"x"}'
+
+        final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
+        assert final.message.tool_calls[0].arguments == {"q": "x"}
+        assert final.message.tool_calls[0].id == "call_1"
+        assert final.stop_reason == StopReason.TOOL_USE
+        assert (final.usage.input_tokens, final.usage.output_tokens) == (50, 9)
+        assert final.usage.cache_read_tokens == 32
+
+    @pytest.mark.asyncio
+    async def test_events_split_across_byte_chunks_still_decode(self) -> None:
+        """The network does not deliver one event per read; a 7-byte chunking
+        puts every boundary mid-event."""
+        t = _responses_transport(_sse(_STREAM, chunk_size=7))
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        assert "".join(e.delta for e in events if isinstance(e, TextDeltaEvent)) == "Hello"
+        final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
+        assert final.message.tool_calls[0].arguments == {"q": "x"}
+
+    @pytest.mark.asyncio
+    async def test_in_stream_error_payload_raises(self) -> None:
+        """Without this the stream would end quietly and the turn would look
+        like a short answer instead of a failure."""
+        chunks = _sse([
+            {"type": "response.output_text.delta", "delta": "par", "output_index": 0},
+            {"error": {"message": "upstream exploded"}},
+        ])
+        t = _responses_transport(chunks)
+        with pytest.raises(Exception, match="upstream exploded"):
+            [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+    @pytest.mark.asyncio
+    async def test_done_sentinel_ends_the_stream(self) -> None:
+        t = _responses_transport(_sse(_STREAM[:2]))
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        assert isinstance(events[-1], StreamCompleteEvent)
+
+    @pytest.mark.asyncio
+    async def test_unknown_event_types_are_ignored(self) -> None:
+        """53 event types exist and we act on 10; one Azure adds later must not
+        crash the loop."""
+        t = _responses_transport(_sse([
+            {"type": "response.audio.delta", "delta": "xx"},
+            {"type": "response.some.future.thing", "whatever": 1},
+            *_STREAM[:2],
+        ]))
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        assert "".join(e.delta for e in events if isinstance(e, TextDeltaEvent)) == "Hello"

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_gemini_transport.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_gemini_transport.py
@@ -439,7 +439,7 @@ class TestStructuredOutput:
         with pytest.raises(Exception, match="no structured response"):
             await t.complete_structured(
                 messages=[UserMessage(content="hi")],
-                schema={"type": "object", "properties": {}},
+                output_schema={"type": "object", "properties": {}},
             )
 
     @pytest.mark.asyncio
@@ -456,8 +456,59 @@ class TestStructuredOutput:
         t._client.aio.models.generate_content = _create
         result = await t.complete_structured(
             messages=[UserMessage(content="hi")],
-            schema={"type": "object", "properties": {"a": {"type": "integer"}}},
+            output_schema={"type": "object", "properties": {"a": {"type": "integer"}}},
         )
         assert result.data == {"a": 1}
         cfg = captured["config"]
         assert cfg.tool_config.function_calling_config.mode.name == "ANY"
+
+
+class TestInterfaceConformance:
+    """Every transport is called through `LLMTransport`, and callers pass by
+    keyword (`models/transport.py` uses `output_schema=`). A renamed parameter
+    is therefore a TypeError at the call site, not a type-checker warning --
+    which is exactly how Gemini's structured output shipped broken while its own
+    tests passed, because they used the wrong name too.
+
+    Covers every implementation, including the tracing decorator, since that is
+    what the factory actually hands to the agent loop.
+    """
+
+    @staticmethod
+    def _implementations() -> list:
+        from app.agent_loop_lib.transport.anthropic import AnthropicTransport
+        from app.agent_loop_lib.transport.azure_openai import AzureOpenAITransport
+        from app.agent_loop_lib.transport.ollama import OllamaTransport
+        from app.agent_loop_lib.transport.openai import OpenAITransport
+        from app.agent_loop_lib.transport.opik_tracing import OpikTracingTransport
+
+        return [
+            GeminiTransport, OpenAITransport, AzureOpenAITransport,
+            AnthropicTransport, OllamaTransport, OpikTracingTransport,
+        ]
+
+    @pytest.mark.parametrize("method", ["complete", "complete_structured", "stream"])
+    def test_every_transport_accepts_the_base_call(self, method: str) -> None:
+        """`bind` rather than a name comparison: it also catches a parameter that
+        became positional-only or a new required argument, neither of which a
+        set-difference on names would see."""
+        import inspect
+
+        from app.agent_loop_lib.transport.base import LLMTransport
+
+        base = inspect.signature(getattr(LLMTransport, method))
+        call_kwargs = {
+            name: object()
+            for name, p in base.parameters.items()
+            if name != "self" and p.kind is not inspect.Parameter.VAR_KEYWORD
+        }
+
+        for transport in self._implementations():
+            signature = inspect.signature(getattr(transport, method))
+            try:
+                signature.bind(object(), **call_kwargs)
+            except TypeError as exc:
+                pytest.fail(
+                    f"{transport.__name__}.{method} cannot accept the base call: "
+                    f"{exc} -- a keyword call through LLMTransport raises TypeError"
+                )

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_gemini_transport.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_gemini_transport.py
@@ -1,0 +1,463 @@
+"""Gemini direct transport.
+
+Gemini's wire shape differs from OpenAI's more than Anthropic's does -- two
+roles, tool results as parts, an OpenAPI-subset schema -- so most of these guard
+the mapping rather than the transport plumbing.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.agent_loop_lib.core.messages import (
+    AssistantMessage,
+    ToolCall,
+    ToolMessage,
+    UserMessage,
+)
+from app.agent_loop_lib.core.responses import StopReason
+from app.agent_loop_lib.core.streaming import (
+    StreamCompleteEvent,
+    TextDeltaEvent,
+    ThinkingDeltaEvent,
+    ToolCallDeltaEvent,
+)
+from app.agent_loop_lib.core.tool_schema import ToolSchema
+from app.agent_loop_lib.transport.gemini import GeminiTransport, sanitize_schema
+
+
+def _transport(**kwargs) -> GeminiTransport:
+    return GeminiTransport(api_key="k", model="gemini-3-flash-preview", **kwargs)
+
+
+def _part(text=None, function_call=None, thought=False):
+    return SimpleNamespace(text=text, function_call=function_call, thought=thought)
+
+
+def _chunk(parts, finish=None, usage=None):
+    return SimpleNamespace(
+        candidates=[SimpleNamespace(
+            content=SimpleNamespace(parts=parts),
+            finish_reason=SimpleNamespace(name=finish) if finish else None,
+        )],
+        usage_metadata=usage,
+    )
+
+
+def _call(name="search", args=None, cid=None):
+    return SimpleNamespace(name=name, args=args or {"q": "x"}, id=cid)
+
+
+def _wire_stream(transport: GeminiTransport, chunks: list) -> None:
+    async def _gen():
+        for c in chunks:
+            yield c
+
+    async def _create(**kwargs):
+        transport._last_kwargs = kwargs
+        return _gen()
+
+    transport._client = MagicMock()
+    transport._client.aio.models.generate_content_stream = _create
+
+
+class TestSchemaSanitizer:
+    """Gemini's `parameters` is an OpenAPI subset; JSON-Schema keywords we emit
+    are rejected outright, failing every tool-bearing request."""
+
+    def test_strips_unsupported_keywords_at_every_depth(self) -> None:
+        out = sanitize_schema({
+            "type": "object",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$comment": "dropped",
+            "multipleOf": 2,
+            "properties": {
+                "nested": {
+                    "type": "object",
+                    "uniqueItems": True,
+                    "properties": {"a": {"type": "string", "pattern": "^a"}},
+                },
+            },
+        })
+        assert "$schema" not in out
+        assert "$comment" not in out, "types.Schema is extra=forbid; this 400s"
+        assert "multipleOf" not in out
+        assert "uniqueItems" not in out["properties"]["nested"]
+        # a real Schema field survives
+        assert out["properties"]["nested"]["properties"]["a"]["pattern"] == "^a"
+
+    def test_object_without_properties_still_gets_the_key(self) -> None:
+        """A bare `{"type": "object"}` is rejected as a malformed declaration."""
+        assert sanitize_schema({"type": "object"})["properties"] == {}
+
+    def test_anyof_is_kept_but_sanitized(self) -> None:
+        out = sanitize_schema(
+            {"anyOf": [{"type": "string"}, {"type": "object", "$comment": "x"}]}
+        )
+        assert len(out["anyOf"]) == 2
+        assert "$comment" not in out["anyOf"][1]
+
+    def test_output_actually_constructs_a_declaration(self) -> None:
+        """The point of the allow-list: asserting keys are absent from a dict
+        proves nothing if genai still rejects the result. types.Schema is
+        extra="forbid", so this is the assertion that matters."""
+        from google.genai import types
+
+        out = sanitize_schema({
+            "type": "object", "$comment": "x", "multipleOf": 2, "title": "T",
+            "properties": {"q": {"type": "string", "uniqueItems": True}},
+            "required": ["q"],
+        })
+        types.FunctionDeclaration(name="f", description="d", parameters=out)
+
+    def test_array_items_are_sanitized(self) -> None:
+        out = sanitize_schema(
+            {"type": "array", "items": {"type": "object", "$ref": "#/x", "properties": {}}}
+        )
+        assert "$ref" not in out["items"]
+
+
+class TestMessageMapping:
+    def test_tool_result_becomes_a_function_response_part(self) -> None:
+        """Gemini has no tool role: a result is a user message carrying a
+        function_response part, or the model loses track of what it called."""
+        t = _transport()
+        contents = t._format_contents([
+            ToolMessage(content="42", tool_call_id="call_1"),
+        ])
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].function_response is not None
+
+    def test_assistant_tool_calls_round_trip_as_model_parts(self) -> None:
+        t = _transport()
+        t._thought_signatures["c1"] = b"sig"
+        contents = t._format_contents([
+            AssistantMessage(
+                content="thinking",
+                tool_calls=[ToolCall(id="c1", name="search", arguments={"q": "x"})],
+            ),
+        ])
+        assert contents[0].role == "model"
+        kinds = [p.function_call is not None for p in contents[0].parts]
+        assert True in kinds, "the tool call must survive into history"
+
+    def test_user_message_maps_to_user_role(self) -> None:
+        t = _transport()
+        contents = t._format_contents([UserMessage(content="hi")])
+        assert contents[0].role == "user"
+        assert contents[0].parts[0].text == "hi"
+
+
+class TestConfig:
+    def test_thinking_config_is_sent_when_captured(self) -> None:
+        cfg = _transport(thinking_level="high")._build_config(None, None, None)
+        assert cfg.thinking_config is not None
+        # The SDK normalises the string aimodels supplies onto its own enum, so
+        # compare on value rather than identity.
+        assert str(cfg.thinking_config.thinking_level.value).lower() == "high"
+
+    def test_no_thinking_config_when_none_configured(self) -> None:
+        assert _transport()._build_config(None, None, None).thinking_config is None
+
+    def test_system_prompt_goes_to_system_instruction(self) -> None:
+        """Gemini has no system role -- it is a separate config field."""
+        cfg = _transport()._build_config(None, "be brief", None)
+        assert cfg.system_instruction == "be brief"
+
+    def test_system_blocks_are_joined_when_no_system(self) -> None:
+        cfg = _transport()._build_config(None, None, ["a", "b"])
+        assert cfg.system_instruction == "a\n\nb"
+
+    def test_tools_become_function_declarations(self) -> None:
+        schema = ToolSchema(
+            name="search", description="d",
+            input_schema={"type": "object", "properties": {}, "additionalProperties": False},
+        )
+        cfg = _transport()._build_config([schema], None, None)
+        decl = cfg.tools[0].function_declarations[0]
+        assert decl.name == "search"
+
+
+class TestStreaming:
+    @pytest.mark.asyncio
+    async def test_text_streams_and_completes(self) -> None:
+        t = _transport()
+        _wire_stream(t, [
+            _chunk([_part(text="Hel")]),
+            _chunk([_part(text="lo")], finish="STOP",
+                   usage=SimpleNamespace(prompt_token_count=10, candidates_token_count=2,
+                                         thoughts_token_count=5,
+                                         cached_content_token_count=3)),
+        ])
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert [e.delta for e in events if isinstance(e, TextDeltaEvent)] == ["Hel", "lo"]
+        final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
+        assert final.message.text == "Hello"
+        assert final.stop_reason == StopReason.END_TURN
+        assert final.usage.input_tokens == 10
+        # thinking tokens are billed output; excluding them under-reports cost
+        assert final.usage.output_tokens == 7
+        assert final.usage.cache_read_tokens == 3
+
+    @pytest.mark.asyncio
+    async def test_tool_call_arrives_as_one_fragment_carrying_the_name(self) -> None:
+        """Gemini sends a whole function_call in a single chunk rather than
+        streaming its arguments. The agent loop reads `name` off the FIRST delta
+        for an index, so that fragment must carry both name and arguments."""
+        t = _transport()
+        _wire_stream(t, [
+            _chunk([_part(function_call=_call(name="final_answer",
+                                              args={"answer_markdown": "hi"}))],
+                   finish="STOP"),
+        ])
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        frags = [e for e in events if isinstance(e, ToolCallDeltaEvent)]
+        assert len(frags) == 1
+        assert frags[0].name == "final_answer"
+        assert json.loads(frags[0].arguments_delta) == {"answer_markdown": "hi"}
+
+        final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
+        assert final.stop_reason == StopReason.TOOL_USE
+        assert final.message.tool_calls[0].arguments == {"answer_markdown": "hi"}
+
+    @pytest.mark.asyncio
+    async def test_thought_parts_become_thinking_not_answer_text(self) -> None:
+        t = _transport()
+        _wire_stream(t, [
+            _chunk([_part(text="pondering", thought=True), _part(text="answer")],
+                   finish="STOP"),
+        ])
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert [e.delta for e in events if isinstance(e, ThinkingDeltaEvent)] == ["pondering"]
+        final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
+        assert final.message.text == "answer", "thoughts must not leak into the answer"
+
+    @pytest.mark.asyncio
+    async def test_truncation_beats_tool_calls(self) -> None:
+        """A reply cut off mid-call must not be reported as a usable TOOL_USE."""
+        t = _transport()
+        _wire_stream(t, [
+            _chunk([_part(function_call=_call())], finish="MAX_TOKENS"),
+        ])
+        events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+        final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
+        assert final.stop_reason == StopReason.MAX_TOKENS
+        assert final.message.truncated is True
+
+    @pytest.mark.asyncio
+    async def test_stream_error_is_wrapped(self) -> None:
+        t = _transport()
+
+        async def _boom(**kwargs):
+            raise RuntimeError("resource_exhausted: quota")
+
+        t._client = MagicMock()
+        t._client.aio.models.generate_content_stream = _boom
+        with pytest.raises(Exception, match="resource_exhausted"):
+            [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+
+class TestConfigCapture:
+    def test_reads_thinking_and_credentials_off_the_langchain_model(self) -> None:
+        llm = SimpleNamespace(
+            google_api_key="secret", model="gemini-3-flash-preview",
+            temperature=0.2, thinking_level="high", thinking_budget=None,
+            max_output_tokens=None, timeout=360.0,
+        )
+        t = GeminiTransport.from_langchain_model(llm, model_name="gemini-3-flash-preview")
+        assert t._thinking_level == "high"
+        assert t._temperature == 0.2
+        assert t.model_name == "gemini-3-flash-preview"
+
+    def test_missing_key_is_rejected_loudly(self) -> None:
+        llm = SimpleNamespace(google_api_key=None, model="x")
+        with pytest.raises(ValueError, match="google_api_key"):
+            GeminiTransport.from_langchain_model(llm)
+
+
+class TestToolResultCorrelation:
+    """Gemini matches a function_response to its function_call by NAME.
+
+    `ToolMessage` carries only `tool_call_id`, so the name has to be recovered
+    from the assistant message that made the call. Sending the id instead leaves
+    the model unable to see its own tool result -- it answers as if the tool
+    never ran, which is exactly how this surfaced: a turn that executed a tool
+    and then returned an empty answer.
+    """
+
+    def test_response_name_comes_from_the_matching_call(self) -> None:
+        t = _transport()
+        t._thought_signatures["call_1"] = b"sig"
+        contents = t._format_contents([
+            UserMessage(content="find x"),
+            AssistantMessage(
+                tool_calls=[ToolCall(id="call_1", name="knowledgegraph__search",
+                                     arguments={"q": "x"})],
+            ),
+            ToolMessage(content="results", tool_call_id="call_1"),
+        ])
+        response_part = contents[-1].parts[0].function_response
+        assert response_part.name == "knowledgegraph__search"
+        assert response_part.name != "call_1", "the id is not a function name"
+
+    def test_unmatched_tool_call_id_does_not_crash(self) -> None:
+        """History can be compacted, dropping the assistant turn that made the
+        call; a missing name must degrade, not raise."""
+        t = _transport()
+        contents = t._format_contents([ToolMessage(content="r", tool_call_id="orphan")])
+        assert contents[0].parts[0].function_response.name == "tool"
+
+
+class TestThoughtSignature:
+    """Gemini 3 rejects a replayed function_call whose thought_signature is
+    missing: "Function call is missing a thought_signature in functionCall
+    parts. This is required for tools to work correctly." It is opaque bytes
+    with nowhere to live on our provider-neutral ToolCall, so the transport
+    keeps it and re-attaches it when history is rebuilt.
+    """
+
+    @pytest.mark.asyncio
+    async def test_signature_is_captured_from_the_stream(self) -> None:
+        t = _transport()
+        part = _part(function_call=_call(name="lookup", cid="call_9"))
+        part.thought_signature = b"sig-bytes"
+        _wire_stream(t, [_chunk([part], finish="STOP")])
+
+        [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+
+        assert t._thought_signatures["call_9"] == b"sig-bytes"
+
+    def test_signature_is_replayed_onto_history(self) -> None:
+        t = _transport()
+        t._thought_signatures["call_9"] = b"sig-bytes"
+        contents = t._format_contents([
+            AssistantMessage(
+                tool_calls=[ToolCall(id="call_9", name="lookup", arguments={"q": "x"})],
+            ),
+        ])
+        assert contents[0].parts[0].thought_signature == b"sig-bytes"
+
+    def test_absent_signature_leaves_the_part_clean(self) -> None:
+        """Turns that never produced one (thinking off) must not send an empty
+        field."""
+        t = _transport()
+        contents = t._format_contents([
+            AssistantMessage(
+                tool_calls=[ToolCall(id="unknown", name="lookup", arguments={})],
+            ),
+        ])
+        assert contents[0].parts[0].thought_signature is None
+
+
+class TestUnsignedHistoryReplay:
+    """A conversation spans several HTTP requests, and the registry -- so the
+    transport and its signature map -- is rebuilt per request
+    (PipesHubAgentFactory.create). Replaying an earlier turn's function_call
+    without its signature is exactly the 400 the signature cache was added to
+    avoid, so those exchanges are replayed as text instead.
+    """
+
+    def test_unsigned_call_is_replayed_as_text_not_a_function_call(self) -> None:
+        t = _transport()
+        contents = t._format_contents([
+            AssistantMessage(
+                tool_calls=[ToolCall(id="old", name="lookup", arguments={"q": "x"})],
+            ),
+        ])
+        parts = contents[0].parts
+        assert all(p.function_call is None for p in parts), (
+            "an unsigned function_call part is rejected by Gemini 3"
+        )
+        assert "lookup" in parts[0].text
+
+    def test_result_of_a_flattened_call_is_also_text(self) -> None:
+        """A function_response with no matching function_call is invalid."""
+        t = _transport()
+        contents = t._format_contents([
+            AssistantMessage(
+                tool_calls=[ToolCall(id="old", name="lookup", arguments={})],
+            ),
+            ToolMessage(content="the result", tool_call_id="old"),
+        ])
+        assert contents[-1].parts[0].function_response is None
+        assert "the result" in contents[-1].parts[0].text
+
+    def test_signed_call_still_uses_the_function_call_path(self) -> None:
+        t = _transport()
+        t._thought_signatures["fresh"] = b"sig"
+        contents = t._format_contents([
+            AssistantMessage(
+                tool_calls=[ToolCall(id="fresh", name="lookup", arguments={})],
+            ),
+            ToolMessage(content="r", tool_call_id="fresh"),
+        ])
+        assert contents[0].parts[0].function_call is not None
+        assert contents[-1].parts[0].function_response is not None
+
+
+class TestCallIdUniqueness:
+    """AI Studio leaves function_call.id unset. A positional fallback restarted
+    at 0 every request, so turn 2 overwrote turn 1's signature and an older tool
+    result resolved to the newer call's name."""
+
+    @pytest.mark.asyncio
+    async def test_ids_do_not_collide_across_turns(self) -> None:
+        t = _transport()
+        seen = []
+        for _ in range(2):
+            part = _part(function_call=_call(name="lookup", cid=None))
+            part.thought_signature = b"sig"
+            _wire_stream(t, [_chunk([part], finish="STOP")])
+            events = [e async for e in t.stream(messages=[UserMessage(content="hi")])]
+            seen.append(next(
+                e for e in events if isinstance(e, ToolCallDeltaEvent)
+            ).id)
+
+        assert seen[0] != seen[1], "a second turn must not reuse the first id"
+        assert len(t._thought_signatures) == 2, "neither signature may be lost"
+
+
+class TestStructuredOutput:
+    @pytest.mark.asyncio
+    async def test_raises_when_the_model_answers_with_text(self) -> None:
+        """Returning {} would hand the planner an empty structure with no
+        error."""
+        t = _transport()
+
+        async def _create(**kwargs):
+            return _chunk([_part(text="I would rather chat")], finish="STOP")
+
+        t._client = MagicMock()
+        t._client.aio.models.generate_content = _create
+        with pytest.raises(Exception, match="no structured response"):
+            await t.complete_structured(
+                messages=[UserMessage(content="hi")],
+                schema={"type": "object", "properties": {}},
+            )
+
+    @pytest.mark.asyncio
+    async def test_forces_the_tool(self) -> None:
+        captured = {}
+
+        async def _create(**kwargs):
+            captured.update(kwargs)
+            return _chunk([_part(function_call=_call(name="respond", args={"a": 1}))],
+                          finish="STOP")
+
+        t = _transport()
+        t._client = MagicMock()
+        t._client.aio.models.generate_content = _create
+        result = await t.complete_structured(
+            messages=[UserMessage(content="hi")],
+            schema={"type": "object", "properties": {"a": {"type": "integer"}}},
+        )
+        assert result.data == {"a": 1}
+        cfg = captured["config"]
+        assert cfg.tool_config.function_calling_config.mode.name == "ANY"

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_image_parts.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_image_parts.py
@@ -1,0 +1,134 @@
+"""Images must reach the provider, on every transport.
+
+`shape_image_injection` (a PRE_MODEL hook) replaces a text placeholder with real
+image data precisely so the model can see an attachment. Every OpenAI-family
+formatter used to reduce `list[Part]` with `" ".join(getattr(p, "text", ""))`,
+and an ImagePart has no `.text` -- so the image became an empty string and the
+model answered about a picture it never received. Anthropic was the only
+transport that carried it.
+"""
+
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from app.agent_loop_lib.core.messages import (
+    ImagePart,
+    ImageSource,
+    TextPart,
+    UserMessage,
+)
+from app.agent_loop_lib.transport.gemini import GeminiTransport
+from app.agent_loop_lib.transport.openai import OpenAITransport
+from app.agent_loop_lib.transport.openai_responses import format_responses_input
+
+PNG = base64.b64encode(b"\x89PNG\r\n\x1a\nfake").decode()
+
+
+def _message_with_image(source: ImageSource) -> UserMessage:
+    return UserMessage(content=[
+        TextPart(text="what is in this image?"),
+        ImagePart(source=source),
+    ])
+
+
+class TestChatCompletions:
+    def test_base64_image_becomes_a_data_url_block(self) -> None:
+        t = OpenAITransport(api_key="k")
+        out = t._format_message(
+            _message_with_image(ImageSource(type="base64", media_type="image/png", data=PNG))
+        )
+        blocks = out["content"]
+        assert isinstance(blocks, list), "an image forces the array content form"
+        image = next(b for b in blocks if b["type"] == "image_url")
+        assert image["image_url"]["url"].startswith("data:image/png;base64,")
+        assert any(b["type"] == "text" for b in blocks), "the question must survive"
+
+    def test_url_image_is_passed_through(self) -> None:
+        t = OpenAITransport(api_key="k")
+        out = t._format_message(
+            _message_with_image(ImageSource(type="url", data="https://x/y.png"))
+        )
+        image = next(b for b in out["content"] if b["type"] == "image_url")
+        assert image["image_url"]["url"] == "https://x/y.png"
+
+    def test_text_only_message_stays_a_plain_string(self) -> None:
+        """Only an image should force the array form -- prompt caching and every
+        existing expectation depend on text staying a string."""
+        t = OpenAITransport(api_key="k")
+        out = t._format_message(UserMessage(content=[TextPart(text="hello")]))
+        assert out["content"] == "hello"
+
+
+class TestResponsesApi:
+    def test_image_becomes_an_input_image_block(self) -> None:
+        items = format_responses_input(
+            [_message_with_image(ImageSource(type="base64", media_type="image/png", data=PNG))],
+            None,
+        )
+        blocks = items[0]["content"]
+        assert isinstance(blocks, list)
+        image = next(b for b in blocks if b["type"] == "input_image")
+        # the Responses API takes a bare string here, unlike Chat Completions
+        assert isinstance(image["image_url"], str)
+        assert image["image_url"].startswith("data:image/png;base64,")
+        assert any(b["type"] == "input_text" for b in blocks)
+
+    def test_text_only_stays_a_string(self) -> None:
+        items = format_responses_input([UserMessage(content=[TextPart(text="hi")])], None)
+        assert items[0]["content"] == "hi"
+
+
+class TestGemini:
+    def test_base64_image_is_decoded_to_bytes(self) -> None:
+        """Gemini takes raw bytes with a mime type, not a data: URL."""
+        t = GeminiTransport(api_key="k")
+        contents = t._format_contents(
+            [_message_with_image(ImageSource(type="base64", media_type="image/png", data=PNG))]
+        )
+        parts = contents[0].parts
+        blob = next(p.inline_data for p in parts if p.inline_data is not None)
+        assert blob.mime_type == "image/png"
+        assert blob.data == base64.b64decode(PNG)
+        assert any(p.text for p in parts), "the question must survive"
+
+    def test_url_image_becomes_file_data(self) -> None:
+        t = GeminiTransport(api_key="k")
+        contents = t._format_contents(
+            [_message_with_image(ImageSource(type="url", media_type="image/png",
+                                             data="https://x/y.png"))]
+        )
+        file_data = next(
+            p.file_data for p in contents[0].parts if p.file_data is not None
+        )
+        assert file_data.file_uri == "https://x/y.png"
+
+    def test_undecodable_image_does_not_take_the_turn_down(self) -> None:
+        t = GeminiTransport(api_key="k")
+        contents = t._format_contents(
+            [_message_with_image(ImageSource(type="base64", media_type="image/png",
+                                             data="!!!not base64!!!"))]
+        )
+        # the text still goes, the bad attachment is dropped
+        assert any(p.text for p in contents[0].parts)
+
+
+@pytest.mark.parametrize("source_type", ["base64", "url"])
+def test_no_transport_silently_drops_an_image(source_type: str) -> None:
+    """The regression this file exists for: an image that reaches none of the
+    provider payloads is invisible -- no error, just a worse answer."""
+    source = (ImageSource(type="base64", media_type="image/png", data=PNG)
+              if source_type == "base64"
+              else ImageSource(type="url", media_type="image/png", data="https://x/y.png"))
+    msg = _message_with_image(source)
+
+    chat = OpenAITransport(api_key="k")._format_message(msg)
+    assert any(b["type"] == "image_url" for b in chat["content"])
+
+    responses = format_responses_input([msg], None)[0]["content"]
+    assert any(b["type"] == "input_image" for b in responses)
+
+    gem = GeminiTransport(api_key="k")._format_contents([msg])[0].parts
+    assert any(p.inline_data is not None or p.file_data is not None for p in gem)

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_openai_coverage.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_openai_coverage.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import openai as openai_sdk
@@ -30,6 +30,7 @@ from app.agent_loop_lib.core.responses import StopReason
 from app.agent_loop_lib.core.streaming import StreamCompleteEvent, TextDeltaEvent
 from app.agent_loop_lib.core.tool_schema import ToolSchema
 from app.agent_loop_lib.transport.openai import OpenAITransport
+from app.agents.agent_loop.converters import MALFORMED_TOOL_CALL_ARGS_KEY
 
 
 def _transport(**kwargs: Any) -> OpenAITransport:
@@ -220,10 +221,27 @@ class TestParseToolCalls:
         result = transport._parse_tool_calls([_raw_tool_call(arguments='{"q": "cats"}')])
         assert result == [ToolCall(id="call_1", name="search", arguments={"q": "cats"})]
 
-    def test_malformed_json_falls_back_to_empty_dict(self) -> None:
+    def test_malformed_json_carries_the_correction_sentinels(self) -> None:
+        """Not `{}`: empty args are indistinguishable from a valid no-argument
+        call, so the tool would run with nothing instead of the loop being told
+        to re-issue it. Same recovery the LangChain arm gets via
+        `converters._recover_invalid_tool_call`."""
         transport = _transport()
         result = transport._parse_tool_calls([_raw_tool_call(arguments="{not json")])
-        assert result[0].arguments == {}
+        assert MALFORMED_TOOL_CALL_ARGS_KEY in result[0].arguments
+        assert result[0].arguments[MALFORMED_TOOL_CALL_ARGS_KEY] == "{not json"
+
+    def test_repairable_json_is_repaired_rather_than_discarded(self) -> None:
+        transport = _transport()
+        result = transport._parse_tool_calls(
+            [_raw_tool_call(arguments='```json\n{"q": "hi",}\n```')]
+        )
+        assert result[0].arguments == {"q": "hi"}
+
+    def test_over_long_name_is_clamped(self) -> None:
+        transport = _transport()
+        result = transport._parse_tool_calls([_raw_tool_call(name="x" * 300, arguments="{}")])
+        assert len(result[0].name) == 128
 
     def test_empty_arguments_string_becomes_empty_dict(self) -> None:
         transport = _transport()
@@ -511,7 +529,7 @@ class TestStream:
         assert tc.name == "search"
         assert tc.arguments == {"q": "cats"}
 
-    async def test_malformed_tool_call_json_becomes_empty_args(self) -> None:
+    async def test_malformed_tool_call_json_carries_the_correction_sentinels(self) -> None:
         transport = _transport()
         chunks = [
             _stream_chunk(tool_calls=[_tc_delta(0, id_="call_1", name="search", arguments="{not json")]),
@@ -519,7 +537,7 @@ class TestStream:
         transport._client.chat.completions.create = AsyncMock(return_value=_AsyncChunkIterator(chunks))
         events = [event async for event in transport.stream([UserMessage(content="x")])]
         final = next(e for e in events if isinstance(e, StreamCompleteEvent)).response
-        assert final.message.tool_calls[0].arguments == {}
+        assert MALFORMED_TOOL_CALL_ARGS_KEY in final.message.tool_calls[0].arguments
 
     async def test_tool_call_missing_id_gets_generated_placeholder(self) -> None:
         transport = _transport()
@@ -580,3 +598,67 @@ class TestStream:
         assert kwargs["reasoning_effort"] == "low"
         assert kwargs["stream"] is True
         assert kwargs["stream_options"] == {"include_usage": True}
+
+
+class TestRequestShapeRecoveryIsNotAzureOnly:
+    """The LangChain arm applies its shape fallback to ANY model exposing
+    use_responses_api -- plain ChatOpenAI, openai_compatible, litellm_proxy,
+    openrouter -- all of which now dispatch to OpenAITransport on the direct
+    arm. While the recovery lived on the Azure subclass, a gpt-5-family
+    "reasoning + bound tools" 400 failed the turn here and never learned.
+    """
+
+    @pytest.mark.asyncio
+    async def test_openai_retries_a_shape_conflict_and_switches_endpoint(self) -> None:
+        from app.agent_loop_lib.transport.openai import RequestDefaults
+
+        transport = _transport()
+        transport._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        chat_calls: list = []
+        resp_calls: list = []
+
+        async def _chat(**kwargs):
+            chat_calls.append(kwargs)
+            raise RuntimeError("Please use /v1/responses instead")
+
+        class _Empty:
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *exc):
+                return None
+
+            async def iter_bytes(self):
+                yield b"data: [DONE]\n\n"
+
+        def _resp(**kwargs):
+            resp_calls.append(kwargs)
+            return _Empty()
+
+        transport._client.chat.completions.create = AsyncMock(side_effect=_chat)
+        transport._client.responses.with_streaming_response.create = MagicMock(
+            side_effect=_resp
+        )
+
+        [e async for e in transport.stream([UserMessage(content="hi")])]
+
+        assert len(chat_calls) == 1, "first attempt on Chat Completions"
+        assert len(resp_calls) == 1, "retry must reach the Responses API"
+        assert transport._defaults.use_responses_api is True, "working shape is pinned"
+
+    @pytest.mark.asyncio
+    async def test_unrelated_errors_still_are_not_retried(self) -> None:
+        from app.agent_loop_lib.transport.openai import RequestDefaults
+
+        transport = _transport()
+        transport._defaults = RequestDefaults(reasoning_effort="low", model="gpt-4o")
+        calls: list = []
+
+        async def _create(**kwargs):
+            calls.append(kwargs)
+            raise RuntimeError("rate limit exceeded")
+
+        transport._client.chat.completions.create = AsyncMock(side_effect=_create)
+        with pytest.raises(Exception, match="rate limit"):
+            [e async for e in transport.stream([UserMessage(content="hi")])]
+        assert len(calls) == 1

--- a/backend/python/tests/unit/agent_loop_lib/transport/test_openai_responses.py
+++ b/backend/python/tests/unit/agent_loop_lib/transport/test_openai_responses.py
@@ -1,0 +1,211 @@
+"""Unit tests for the Responses API helpers (`transport/openai_responses.py`).
+
+These cover the parser the live Azure path actually runs: `azure_direct` against
+a reasoning model sends `/v1/responses`, so `parse_responses_output` -- not the
+Chat Completions parser -- is what turns a real answer into an AssistantMessage.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.agent_loop_lib.core.responses import StopReason
+from app.agent_loop_lib.transport.openai_responses import (
+    RawEvent,
+    format_responses_input,
+    format_responses_tools,
+    normalise_tool_call,
+    parse_responses_output,
+    responses_usage_fields,
+    stop_reason_from_responses,
+)
+from app.agents.agent_loop.converters import MALFORMED_TOOL_CALL_ARGS_KEY
+
+
+def _function_call(name="search", args='{"q": "x"}', call_id="call_1"):
+    return SimpleNamespace(type="function_call", name=name, arguments=args, call_id=call_id, id="item_1")
+
+
+def _text_item(text="hello"):
+    return SimpleNamespace(
+        type="message", content=[SimpleNamespace(type="output_text", text=text)]
+    )
+
+
+class TestParseResponsesOutput:
+    def test_text_and_tool_call_together(self) -> None:
+        response = SimpleNamespace(output=[_text_item("hi"), _function_call()])
+        msg = parse_responses_output(response)
+        assert msg.text == "hi"
+        assert msg.tool_calls[0].name == "search"
+        assert msg.tool_calls[0].arguments == {"q": "x"}
+
+    def test_call_id_is_preferred_over_item_id(self) -> None:
+        """`function_call_output` must echo `call_id`; sending the item id back
+        makes the provider reject the next turn."""
+        msg = parse_responses_output(SimpleNamespace(output=[_function_call()]))
+        assert msg.tool_calls[0].id == "call_1"
+
+    def test_malformed_arguments_carry_the_correction_sentinels(self) -> None:
+        """The regression this file exists for: this parser had its own silent
+        `{}` fallback, so the repair applied everywhere else never reached the
+        endpoint the live deployment actually uses."""
+        msg = parse_responses_output(
+            SimpleNamespace(output=[_function_call(args="{not json")])
+        )
+        assert MALFORMED_TOOL_CALL_ARGS_KEY in msg.tool_calls[0].arguments
+
+    def test_repairable_arguments_are_repaired(self) -> None:
+        msg = parse_responses_output(
+            SimpleNamespace(output=[_function_call(args='```json\n{"q": "hi",}\n```')])
+        )
+        assert msg.tool_calls[0].arguments == {"q": "hi"}
+
+    def test_reasoning_items_are_skipped(self) -> None:
+        response = SimpleNamespace(
+            output=[SimpleNamespace(type="reasoning", summary=[]), _text_item("answer")]
+        )
+        assert parse_responses_output(response).text == "answer"
+
+    def test_empty_output_is_an_empty_message_not_a_crash(self) -> None:
+        msg = parse_responses_output(SimpleNamespace(output=None))
+        assert not msg.text
+        assert msg.tool_calls is None
+
+
+class TestStopReason:
+    def test_truncation_beats_tool_calls(self) -> None:
+        """Arguments cut off mid-JSON are unparseable; reporting TOOL_USE would
+        send the loop off to execute a garbage call."""
+        response = SimpleNamespace(
+            incomplete_details=SimpleNamespace(reason="max_output_tokens"), status="incomplete"
+        )
+        assert stop_reason_from_responses(response, True) == StopReason.MAX_TOKENS
+
+    def test_tool_calls_beat_a_plain_completion(self) -> None:
+        response = SimpleNamespace(incomplete_details=None, status="completed")
+        assert stop_reason_from_responses(response, True) == StopReason.TOOL_USE
+
+    def test_plain_completion_ends_the_turn(self) -> None:
+        response = SimpleNamespace(incomplete_details=None, status="completed")
+        assert stop_reason_from_responses(response, False) == StopReason.END_TURN
+
+
+class TestUsageFields:
+    def test_reads_the_responses_field_names(self) -> None:
+        """Chat Completions names (`prompt_tokens`, `prompt_tokens_details`)
+        would silently report zeros here."""
+        usage = SimpleNamespace(
+            input_tokens=100,
+            output_tokens=20,
+            input_tokens_details=SimpleNamespace(cached_tokens=64, cache_write_tokens=8),
+        )
+        assert responses_usage_fields(SimpleNamespace(usage=usage)) == (100, 20, 64, 8)
+
+    def test_missing_usage_is_zeros(self) -> None:
+        assert responses_usage_fields(SimpleNamespace(usage=None)) == (0, 0, 0, 0)
+
+
+class TestToolFormatting:
+    def test_tools_are_flat_not_nested_under_function(self) -> None:
+        schema = SimpleNamespace(
+            name="search", description="d", input_schema={"type": "object", "properties": {}}
+        )
+        formatted = format_responses_tools([schema])[0]
+        assert formatted["name"] == "search"
+        assert "function" not in formatted, "nested shape is the Chat Completions form"
+        assert formatted["strict"] is False
+
+    def test_no_tools_is_none(self) -> None:
+        assert format_responses_tools(None) is None
+
+
+class TestNormaliseToolCall:
+    def test_over_long_name_is_clamped(self) -> None:
+        call = normalise_tool_call("id", "n" * 300, "{}")
+        assert len(call.name) == 128
+
+    @pytest.mark.parametrize("raw", [None, ""])
+    def test_absent_arguments_are_an_empty_dict(self, raw) -> None:
+        assert normalise_tool_call("id", "search", raw).arguments == {}
+
+
+class TestFormatResponsesInput:
+    def test_system_becomes_a_message_item(self) -> None:
+        """Matches langchain_openai, which appends the system message as an
+        input item rather than using the separate `instructions` field."""
+        items = format_responses_input([], system="be brief")
+        assert items == [{"type": "message", "role": "system", "content": "be brief"}]
+
+
+class TestRawEvent:
+    """The shim that replaces validated SDK models on the stream."""
+
+    def test_missing_key_lets_getattr_default_apply(self) -> None:
+        """The whole point of raising AttributeError instead of returning None:
+        the stream loop is written as `getattr(event, "output_index", 0) or 0`,
+        and a None-returning shim would defeat every one of those defaults."""
+        ev = RawEvent({"type": "response.output_text.delta"})
+        assert getattr(ev, "output_index", 0) == 0
+        assert getattr(ev, "delta", "") == ""
+        with pytest.raises(AttributeError):
+            getattr(ev, "nope")
+
+    def test_index_zero_is_preserved(self) -> None:
+        """`0 or 0` must stay 0 and not be confused with a missing field."""
+        assert getattr(RawEvent({"output_index": 0}), "output_index", 7) == 0
+
+    def test_nested_dicts_and_lists_are_wrapped_on_access(self) -> None:
+        ev = RawEvent({
+            "item": {"type": "function_call", "name": "search", "call_id": "call_1"},
+            "output": [{"type": "message"}, {"type": "function_call"}],
+        })
+        assert ev.item.type == "function_call"
+        assert ev.item.call_id == "call_1"
+        assert [o.type for o in ev.output] == ["message", "function_call"]
+
+    def test_scalars_pass_through(self) -> None:
+        ev = RawEvent({"delta": "hi", "sequence_number": 3, "logprobs": []})
+        assert ev.delta == "hi"
+        assert ev.sequence_number == 3
+        assert ev.logprobs == []
+
+    def test_parsers_accept_the_shim_unchanged(self) -> None:
+        """`parse_responses_output` and friends were written against SDK models;
+        they must work on the shim without modification, since that is what the
+        stream now hands them."""
+        response = RawEvent({
+            "output": [
+                {"type": "message", "content": [{"type": "output_text", "text": "hi"}]},
+                {"type": "function_call", "name": "search",
+                 "arguments": '{"q": "x"}', "call_id": "call_1"},
+            ],
+            "usage": {"input_tokens": 10, "output_tokens": 2,
+                      "input_tokens_details": {"cached_tokens": 4, "cache_write_tokens": 1}},
+            "incomplete_details": None,
+            "status": "completed",
+        })
+        msg = parse_responses_output(response)
+        assert msg.text == "hi"
+        assert msg.tool_calls[0].name == "search"
+        assert msg.tool_calls[0].arguments == {"q": "x"}
+        assert msg.tool_calls[0].id == "call_1"
+        assert responses_usage_fields(response) == (10, 2, 4, 1)
+        assert stop_reason_from_responses(response, True) == StopReason.TOOL_USE
+
+
+class TestSDKDrift:
+    def test_sse_decoder_is_where_we_import_it_from(self) -> None:
+        """`SSEDecoder` is a private SDK symbol. This pin makes an `openai`
+        upgrade that moves or renames it fail the build rather than the
+        stream."""
+        from openai._streaming import SSEDecoder
+
+        assert hasattr(SSEDecoder(), "aiter_bytes")
+
+    def test_streaming_response_helper_is_public_api(self) -> None:
+        from openai.resources.responses import AsyncResponses
+
+        assert hasattr(AsyncResponses, "with_streaming_response")

--- a/backend/python/tests/unit/agents/adapter/test_converters_tool_cache.py
+++ b/backend/python/tests/unit/agents/adapter/test_converters_tool_cache.py
@@ -1,0 +1,133 @@
+"""Tool-schema conversion cache (agents/agent_loop/converters.py).
+
+Building the LangChain tool object runs pydantic's full schema generation, and
+it used to run once per tool per LLM call for output that never varies. These
+guard the two properties that make caching it safe: equal schemas must reuse the
+same object, and the schema handed to the model must not change.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+from app.agent_loop_lib.core.tool_schema import ToolSchema
+from app.agents.agent_loop import converters as conv
+from app.agents.agent_loop.converters import (
+    convert_tool_schema_to_langchain,
+    convert_tool_schemas_to_langchain,
+)
+
+SEARCH_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "query": {"type": "string", "description": "what to look for"},
+        "limit": {"type": "integer", "description": "max results"},
+    },
+    "required": ["query"],
+}
+
+
+def _schema(name: str = "search", description: str = "Search records", **overrides) -> ToolSchema:
+    return ToolSchema(
+        name=name,
+        description=description,
+        input_schema=overrides.get("input_schema", SEARCH_SCHEMA),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache() -> "Iterator[None]":
+    conv._TOOL_MODEL_CACHE.clear()
+    yield
+    conv._TOOL_MODEL_CACHE.clear()
+
+
+class TestCacheIdentity:
+    def test_same_schema_object_is_converted_once(self) -> None:
+        schema = _schema()
+        assert convert_tool_schema_to_langchain(schema) is convert_tool_schema_to_langchain(schema)
+
+    def test_equal_but_distinct_schemas_share_an_entry(self) -> None:
+        """ToolRegistry.schemas() rebuilds ToolSchema objects every turn, so
+        keying on identity rather than content would never hit."""
+        first, second = _schema(), _schema()
+        assert first is not second
+        assert convert_tool_schema_to_langchain(first) is convert_tool_schema_to_langchain(second)
+        assert len(conv._TOOL_MODEL_CACHE) == 1
+
+    def test_property_order_does_not_split_the_entry(self) -> None:
+        reordered = dict(SEARCH_SCHEMA)
+        reordered["properties"] = {
+            "limit": SEARCH_SCHEMA["properties"]["limit"],
+            "query": SEARCH_SCHEMA["properties"]["query"],
+        }
+        a = convert_tool_schema_to_langchain(_schema())
+        b = convert_tool_schema_to_langchain(_schema(input_schema=reordered))
+        assert a is b
+
+
+class TestCacheSeparation:
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"name": "other_tool"},
+            {"description": "a different description"},
+            {"input_schema": {"type": "object", "properties": {"q": {"type": "string"}}}},
+        ],
+    )
+    def test_any_field_change_gets_its_own_entry(self, kwargs: dict) -> None:
+        base = convert_tool_schema_to_langchain(_schema())
+        other = convert_tool_schema_to_langchain(_schema(**kwargs))
+        assert base is not other
+        assert len(conv._TOOL_MODEL_CACHE) == 2
+
+
+class TestOutputUnchanged:
+    def test_cached_tool_exposes_the_same_schema_as_a_fresh_build(self) -> None:
+        """The model must see byte-identical tool JSON; a cache hit that
+        changed the schema would silently alter behaviour."""
+        cached = convert_tool_schema_to_langchain(_schema())
+        conv._TOOL_MODEL_CACHE.clear()
+        fresh = convert_tool_schema_to_langchain(_schema())
+
+        assert cached is not fresh
+        assert cached.name == fresh.name
+        assert cached.description == fresh.description
+        assert cached.args_schema.model_json_schema() == fresh.args_schema.model_json_schema()
+
+    def test_required_and_optional_fields_survive_caching(self) -> None:
+        schema = convert_tool_schema_to_langchain(_schema()).args_schema.model_json_schema()
+        assert schema["properties"]["query"]["description"] == "what to look for"
+        assert "limit" in schema["properties"]
+
+
+class TestListConversion:
+    def test_list_helper_reuses_cached_entries(self) -> None:
+        tools = [_schema(), _schema(name="fetch")]
+        first = convert_tool_schemas_to_langchain(tools)
+        second = convert_tool_schemas_to_langchain([_schema(), _schema(name="fetch")])
+
+        assert [t.name for t in first] == ["search", "fetch"]
+        assert all(a is b for a, b in zip(first, second, strict=True))
+        assert len(conv._TOOL_MODEL_CACHE) == 2
+
+    def test_empty_list_still_returns_empty(self) -> None:
+        assert convert_tool_schemas_to_langchain([]) == []
+        assert convert_tool_schemas_to_langchain(None) == []
+        assert not conv._TOOL_MODEL_CACHE
+
+
+class TestBounding:
+    def test_cache_clears_wholesale_when_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(conv, "_TOOL_MODEL_CACHE_MAXSIZE", 3)
+        for i in range(3):
+            convert_tool_schema_to_langchain(_schema(name=f"tool_{i}"))
+        assert len(conv._TOOL_MODEL_CACHE) == 3
+
+        convert_tool_schema_to_langchain(_schema(name="overflow"))
+        assert len(conv._TOOL_MODEL_CACHE) == 1

--- a/backend/python/tests/unit/agents/adapter/test_direct_transport_dispatch.py
+++ b/backend/python/tests/unit/agents/adapter/test_direct_transport_dispatch.py
@@ -150,3 +150,17 @@ class TestCapturedConfigReachesTheTransport:
         t = build_direct_transport(_gemini(), model_name="gemini-3-flash-preview")
         assert t._thinking_level == "high"
         assert t._temperature == 0.2
+
+    def test_unknown_value_falls_back_instead_of_failing_every_turn(
+        self, monkeypatch
+    ) -> None:
+        """The registry holds only langchain and direct, so an unrecognised value
+        used to reach TransportRegistry.resolve and raise RegistryError -- a typo
+        in a deployment env var took the service down rather than costing it an
+        optimisation."""
+        monkeypatch.setenv("PIPESHUB_AGENT_TRANSPORT", "typo-transport")
+        assert _transport_provider() == LANGCHAIN_TRANSPORT
+
+    def test_case_is_normalised(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_AGENT_TRANSPORT", "DIRECT")
+        assert _transport_provider() == DIRECT_TRANSPORT

--- a/backend/python/tests/unit/agents/adapter/test_direct_transport_dispatch.py
+++ b/backend/python/tests/unit/agents/adapter/test_direct_transport_dispatch.py
@@ -1,0 +1,152 @@
+"""Provider dispatch for the `direct` arm.
+
+The switch is binary (langchain|direct); which provider serves a request comes
+from the model the request selected. These guard that mapping, and that an
+unsupported or misconfigured provider degrades to LangChain instead of failing
+the turn.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import SecretStr
+
+from app.agents.agent_loop.direct_transport import build_direct_transport
+from app.agents.agent_loop.factory import (
+    DIRECT_TRANSPORT,
+    LANGCHAIN_TRANSPORT,
+    _transport_provider,
+)
+
+
+class _Stub:
+    """Named after the LangChain class it stands in for -- the dispatcher keys
+    on the class name, which is the discriminator actually available at the
+    call site."""
+
+    def __init__(self, **attrs) -> None:
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def _named(name: str, **attrs):
+    return type(name, (_Stub,), {})(**attrs)
+
+
+def _azure():
+    return _named(
+        "AzureChatOpenAI",
+        azure_endpoint="https://e.openai.azure.com",
+        deployment_name="dep",
+        openai_api_key=SecretStr("sk-x"),
+        openai_api_version="2024-10-01-preview",
+        temperature=1.0,
+        reasoning={"effort": "high"},
+        use_responses_api=True,
+        request_timeout=360.0,
+    )
+
+
+def _openai():
+    return _named(
+        "ChatOpenAI",
+        openai_api_key=SecretStr("sk-x"),
+        model_name="gpt-5.4-mini",
+        temperature=1.0,
+        reasoning={"effort": "high"},
+        use_responses_api=True,
+        request_timeout=360.0,
+    )
+
+
+def _anthropic():
+    return _named(
+        "ChatAnthropic",
+        anthropic_api_key=SecretStr("sk-ant"),
+        model="claude-sonnet-5",
+        max_tokens=16384,
+        temperature=None,
+        thinking={"type": "adaptive", "display": "summarized"},
+        default_request_timeout=360.0,
+    )
+
+
+def _gemini():
+    return _named(
+        "ChatGoogleGenerativeAI",
+        google_api_key="g-key",
+        model="gemini-3-flash-preview",
+        temperature=0.2,
+        thinking_level="high",
+        thinking_budget=None,
+        timeout=360.0,
+    )
+
+
+class TestDispatch:
+    @pytest.mark.parametrize(
+        ("factory", "expected_provider"),
+        [
+            (_azure, "azure_direct"),
+            (_openai, "openai"),
+            (_anthropic, "anthropic"),
+            (_gemini, "gemini"),
+        ],
+    )
+    def test_each_configured_provider_gets_its_own_transport(
+        self, factory, expected_provider
+    ) -> None:
+        transport = build_direct_transport(factory(), model_name="m", model_key="k")
+        assert transport is not None
+        assert transport.provider == expected_provider
+
+    def test_unknown_provider_falls_back_rather_than_raising(self) -> None:
+        """A model for a provider with no direct transport must degrade to the
+        LangChain path, not fail the turn."""
+        assert build_direct_transport(_named("ChatBedrock"), model_name="m") is None
+
+    def test_misconfigured_model_falls_back_rather_than_raising(self) -> None:
+        """from_langchain_model raises on missing credentials; the dispatcher
+        turns that into a fallback so a bad config is slow, never broken."""
+        broken = _named("ChatAnthropic", anthropic_api_key=None, model="claude-sonnet-5")
+        assert build_direct_transport(broken, model_name="m") is None
+
+
+class TestSwitch:
+    def test_defaults_to_langchain(self, monkeypatch) -> None:
+        monkeypatch.delenv("PIPESHUB_AGENT_TRANSPORT", raising=False)
+        assert _transport_provider() == LANGCHAIN_TRANSPORT
+
+    def test_direct_selects_the_direct_arm(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_AGENT_TRANSPORT", "direct")
+        assert _transport_provider() == DIRECT_TRANSPORT
+
+    def test_azure_direct_is_still_accepted(self, monkeypatch) -> None:
+        """Deployments, compose files and load-test scripts set the old value;
+        the rename must not strand them."""
+        monkeypatch.setenv("PIPESHUB_AGENT_TRANSPORT", "azure_direct")
+        assert _transport_provider() == DIRECT_TRANSPORT
+
+    def test_blank_falls_back_to_langchain(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_AGENT_TRANSPORT", "   ")
+        assert _transport_provider() == LANGCHAIN_TRANSPORT
+
+
+class TestCapturedConfigReachesTheTransport:
+    """The drift this whole contract exists to prevent: a transport that copies
+    credentials but not behaviour silently sends a different request."""
+
+    def test_openai_captures_reasoning_and_endpoint_choice(self) -> None:
+        t = build_direct_transport(_openai(), model_name="gpt-5.4-mini")
+        assert t._defaults.reasoning == {"effort": "high"}
+        assert t._wants_responses() is True
+
+    def test_anthropic_captures_thinking(self) -> None:
+        t = build_direct_transport(_anthropic(), model_name="claude-sonnet-5")
+        assert t._thinking == {"type": "adaptive", "display": "summarized"}
+        assert t._max_tokens == 16384
+
+    def test_gemini_captures_thinking_level(self) -> None:
+        t = build_direct_transport(_gemini(), model_name="gemini-3-flash-preview")
+        assert t._thinking_level == "high"
+        assert t._temperature == 0.2

--- a/backend/python/tests/unit/agents/adapter/test_transport_parity.py
+++ b/backend/python/tests/unit/agents/adapter/test_transport_parity.py
@@ -1,0 +1,288 @@
+"""LangChain vs direct-SDK transport: same input, same events out.
+
+The direct transport exists to remove LangChain from the streaming path without
+changing what the agent loop sees. Individual unit tests check each transport in
+isolation; this one drives both with the same logical response and asserts the
+emitted event stream is equivalent, which is the property that actually matters.
+
+The two SDKs shape their chunks differently, so the fixtures differ by
+construction -- what is compared is the events, not the inputs.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from langchain_core.messages import AIMessageChunk
+
+from app.agent_loop_lib.core.messages import UserMessage
+from app.agent_loop_lib.core.streaming import (
+    StreamCompleteEvent,
+    TextDeltaEvent,
+    ToolCallDeltaEvent,
+)
+from app.agent_loop_lib.transport.azure_openai import AzureOpenAITransport
+from app.agents.agent_loop.langchain_transport import LangChainTransport
+
+_DONE = b"data: [DONE]\n\n"
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class _FakeLangChainModel:
+    def __init__(self, chunks: list[AIMessageChunk]) -> None:
+        self._chunks = chunks
+
+    def bind_tools(self, tools: Any) -> "_FakeLangChainModel":
+        return self
+
+    async def astream(self, messages: list, config: Any = None) -> "AsyncIterator[AIMessageChunk]":
+        for c in self._chunks:
+            yield c
+
+
+def _openai_chunk(content=None, tool_calls=None, finish=None):
+    return SimpleNamespace(
+        choices=[SimpleNamespace(
+            delta=SimpleNamespace(content=content, tool_calls=tool_calls),
+            finish_reason=finish,
+        )],
+        usage=None,
+    )
+
+
+def _openai_tc(index, id=None, name=None, args=None):
+    return SimpleNamespace(index=index, id=id,
+                           function=SimpleNamespace(name=name, arguments=args))
+
+
+def _azure_transport(chunks: list) -> AzureOpenAITransport:
+    t = AzureOpenAITransport(
+        api_key="k", azure_endpoint="https://e.openai.azure.com",
+        api_version="2024-10-01-preview", deployment="dep",
+    )
+
+    class _Stream:
+        def __aiter__(self):
+            async def gen() -> None:
+                for c in chunks:
+                    yield c
+            return gen()
+
+    t._client = MagicMock()
+    t._client.chat.completions.create = AsyncMock(return_value=_Stream())
+    return t
+
+
+async def _events(transport: object) -> list:
+    return [e async for e in transport.stream(messages=[UserMessage(content="hi")])]
+
+
+def _shape(events: list) -> list[tuple]:
+    """Comparable summary: event type plus the fields the agent loop reads."""
+    out = []
+    for e in events:
+        if isinstance(e, TextDeltaEvent):
+            out.append(("text", e.delta))
+        elif isinstance(e, ToolCallDeltaEvent):
+            out.append(("tool_delta", e.index, e.name, e.arguments_delta))
+        elif isinstance(e, StreamCompleteEvent):
+            calls = e.response.message.tool_calls or []
+            out.append(("complete", tuple((c.name, tuple(sorted(c.arguments))) for c in calls)))
+        else:
+            out.append((type(e).__name__,))
+    return out
+
+
+class TestStreamParity:
+    @pytest.mark.asyncio
+    async def test_text_only_response(self) -> None:
+        lc = LangChainTransport(
+            _FakeLangChainModel([AIMessageChunk(content="Hello "), AIMessageChunk(content="world")]),
+            model_name="m",
+        )
+        az = _azure_transport([
+            _openai_chunk(content="Hello "), _openai_chunk(content="world"),
+            _openai_chunk(finish="stop"),
+        ])
+
+        assert _shape(await _events(lc)) == _shape(await _events(az))
+
+    @pytest.mark.asyncio
+    async def test_tool_call_streamed_in_fragments(self) -> None:
+        """The final_answer case: fragments must arrive with matching index,
+        name and payload, because live answer streaming is driven off them."""
+        lc = LangChainTransport(
+            _FakeLangChainModel([
+                AIMessageChunk(content="", tool_call_chunks=[
+                    {"name": "final_answer", "args": '{"answer_markdown"', "id": "c1", "index": 0},
+                ]),
+                AIMessageChunk(content="", tool_call_chunks=[
+                    {"name": None, "args": ': "done"}', "id": None, "index": 0},
+                ]),
+            ]),
+            model_name="m",
+        )
+        az = _azure_transport([
+            _openai_chunk(tool_calls=[_openai_tc(0, id="c1", name="final_answer",
+                                                 args='{"answer_markdown"')]),
+            _openai_chunk(tool_calls=[_openai_tc(0, args=': "done"}')]),
+            _openai_chunk(finish="tool_calls"),
+        ])
+
+        lc_shape, az_shape = _shape(await _events(lc)), _shape(await _events(az))
+
+        # both must stream two fragments for index 0 and assemble one call
+        assert [s for s in lc_shape if s[0] == "tool_delta"] == [
+            s for s in az_shape if s[0] == "tool_delta"
+        ]
+        assert lc_shape[-1] == az_shape[-1] == (
+            "complete", (("final_answer", ("answer_markdown",)),)
+        )
+
+    @pytest.mark.asyncio
+    async def test_both_end_with_exactly_one_complete_event(self) -> None:
+        lc = LangChainTransport(_FakeLangChainModel([AIMessageChunk(content="x")]), model_name="m")
+        az = _azure_transport([_openai_chunk(content="x"), _openai_chunk(finish="stop")])
+
+        for events in (await _events(lc), await _events(az)):
+            completes = [e for e in events if isinstance(e, StreamCompleteEvent)]
+            assert len(completes) == 1
+            assert isinstance(events[-1], StreamCompleteEvent)
+
+
+class _ConfiguredAzureModel:
+    """Stands in for the `AzureChatOpenAI` that `aimodels.get_generator_model`
+    builds for Azure + a reasoning model (`aimodels.py:1077-1095` merged with
+    `_reasoning_effort_kwargs`, `aimodels.py:888-897`).
+
+    Attribute names are langchain_openai's, not the constructor kwargs':
+    `azure_deployment=` lands on `.deployment_name`, `api_key=` on
+    `.openai_api_key`, `timeout=` on `.request_timeout`.
+    """
+
+    def __init__(self, **overrides: Any) -> None:
+        self.azure_endpoint = "https://e.openai.azure.com"
+        self.deployment_name = "dep"
+        self.openai_api_key = "k"
+        self.openai_api_version = "2024-10-01-preview"
+        self.temperature = 1.0
+        self.request_timeout = 360.0
+        self.reasoning = {"effort": "high"}
+        self.use_responses_api = True
+        self.stream_usage = True
+        for key, value in overrides.items():
+            setattr(self, key, value)
+
+
+async def _captured_request(llm: Any, model_name: str = "gpt-4o") -> dict:
+    """The kwargs `azure_direct` would put on the wire for one streamed turn."""
+    transport = AzureOpenAITransport.from_langchain_model(llm, model_name=model_name)
+    captured: dict[str, Any] = {}
+
+    class _Empty:
+        def __aiter__(self):
+            async def gen():
+                return
+                yield
+            return gen()
+
+    class _EmptyStream:
+        """A closed SSE body. Streaming Responses requests are read as raw bytes
+        (the SDK's per-event validation is skipped), so the recorder has to sit
+        on with_streaming_response rather than responses.create."""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return None
+
+        async def iter_bytes(self):
+            yield _DONE
+
+    async def _create(**kwargs):
+        captured.update(kwargs)
+        return _Empty()
+
+    def _create_stream(**kwargs):
+        captured.update(kwargs)
+        return _EmptyStream()
+
+    transport._client = MagicMock()
+    transport._client.responses.create = AsyncMock(side_effect=_create)
+    transport._client.responses.with_streaming_response.create = MagicMock(side_effect=_create_stream)
+    transport._client.chat.completions.create = AsyncMock(side_effect=_create)
+    await _events(transport)
+    return captured
+
+
+class TestRequestParity:
+    """Compares the *outbound request*, not the emitted events.
+
+    `TestStreamParity` above passed throughout the period when `azure_direct`
+    was sending Chat Completions with no reasoning while `langchain` sent
+    Responses at effort=high — both transports turn their own chunks into the
+    same event shapes, so event-level parity cannot see a request-level
+    divergence. These tests read what would actually be POSTed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_reasoning_model_config_reaches_the_request(self) -> None:
+        transport = AzureOpenAITransport.from_langchain_model(
+            _ConfiguredAzureModel(), model_name="gpt-5.4-mini",
+        )
+        assert transport._wants_responses(), "reasoning model must use /v1/responses"
+
+        kwargs = await _captured_request(_ConfiguredAzureModel(), model_name="gpt-5.4-mini")
+        assert kwargs["reasoning"] == {"effort": "high"}
+        assert kwargs["model"] == "dep", "Azure keys the request by DEPLOYMENT, not model name"
+        assert "temperature" not in kwargs, "gpt-5 rejects temperature on the Responses API"
+        assert "stream_options" not in kwargs, "Chat-Completions-only field"
+
+    @pytest.mark.asyncio
+    async def test_non_reasoning_model_keeps_chat_completions_and_temperature(self) -> None:
+        llm = _ConfiguredAzureModel(reasoning=None, use_responses_api=False, temperature=0.3)
+        kwargs = await _captured_request(llm)
+        assert "input" not in kwargs, "must stay on Chat Completions"
+        assert kwargs["temperature"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_carried_onto_the_client(self) -> None:
+        """360s, not the SDK's 600s default: a turn that would hang past the
+        LangChain arm's limit has to fail the same way here."""
+        transport = AzureOpenAITransport.from_langchain_model(_ConfiguredAzureModel())
+        assert transport._client.timeout == 360.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("attribute", "value"),
+        [
+            ("temperature", 0.42),
+            ("reasoning", {"effort": "low"}),
+            ("use_responses_api", False),
+            ("request_timeout", 12.0),
+        ],
+    )
+    async def test_every_configured_knob_changes_the_request(
+        self, attribute: str, value: Any
+    ) -> None:
+        """The drift guard. Each entry is a setting `aimodels` puts on the model
+        rather than passing per call; if `from_langchain_model` stops reading
+        one -- or a new one is added there and not here -- changing it stops
+        changing the request and this fails.
+        """
+        baseline = await _captured_request(_ConfiguredAzureModel())
+        changed = await _captured_request(_ConfiguredAzureModel(**{attribute: value}))
+        if attribute == "request_timeout":
+            base_t = AzureOpenAITransport.from_langchain_model(_ConfiguredAzureModel())
+            new_t = AzureOpenAITransport.from_langchain_model(
+                _ConfiguredAzureModel(request_timeout=value)
+            )
+            assert base_t._client.timeout != new_t._client.timeout
+        else:
+            assert baseline != changed, f"{attribute} is not reaching the request"

--- a/backend/python/tests/unit/connectors/core/registry/test_permission_model.py
+++ b/backend/python/tests/unit/connectors/core/registry/test_permission_model.py
@@ -13,6 +13,12 @@ from app.connectors.core.registry.connector_builder import (
 )
 from app.connectors.core.registry.connector_registry import ConnectorRegistry
 
+# Connectors whose source has no per-record ACLs, so one connector-wide query
+# answers for every user. gitlab, gitlab_personal and rss were removed after
+# review: gitlab syncs per-project member ACLs, and the two personal-scope
+# connectors write creator-only permissions that the APP_LEVEL scan does not
+# re-check. Adding a connector here is a permissions decision, not a
+# performance one.
 APP_LEVEL_CONNECTORS = [
     "app.connectors.sources.s3.connector",
     "app.connectors.sources.minio.connector",
@@ -23,9 +29,6 @@ APP_LEVEL_CONNECTORS = [
     "app.connectors.sources.postgres.connector",
     "app.connectors.sources.mariadb.connector",
     "app.connectors.sources.snowflake.connector",
-    "app.connectors.sources.gitlab.connector",
-    "app.connectors.sources.gitlab_personal.connector",
-    "app.connectors.sources.rss.connector",
     "app.connectors.sources.local_fs.connector",
     "app.connectors.sources.github.connector",
 ]

--- a/backend/python/tests/unit/connectors/core/registry/test_permission_model.py
+++ b/backend/python/tests/unit/connectors/core/registry/test_permission_model.py
@@ -1,0 +1,247 @@
+"""Per-connector permission model: declared in the decorator, denormalized onto
+the App instance doc so the query service can route without importing connectors.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config.constants.arangodb import CollectionNames, Connectors, PermissionModel
+from app.connectors.core.registry.connector_builder import (
+    ConnectorBuilder,
+    ConnectorConfigBuilder,
+)
+from app.connectors.core.registry.connector_registry import ConnectorRegistry
+
+APP_LEVEL_CONNECTORS = [
+    "app.connectors.sources.s3.connector",
+    "app.connectors.sources.minio.connector",
+    "app.connectors.sources.google_cloud_storage.connector",
+    "app.connectors.sources.azure_blob.connector",
+    "app.connectors.sources.azure_files.connector",
+    "app.connectors.sources.web.connector",
+    "app.connectors.sources.postgres.connector",
+    "app.connectors.sources.mariadb.connector",
+    "app.connectors.sources.snowflake.connector",
+    "app.connectors.sources.gitlab.connector",
+    "app.connectors.sources.gitlab_personal.connector",
+    "app.connectors.sources.rss.connector",
+    "app.connectors.sources.local_fs.connector",
+    "app.connectors.sources.github.connector",
+]
+
+
+class TestConfigBuilder:
+    def test_defaults_to_record_level(self) -> None:
+        config = ConnectorConfigBuilder().build()
+        assert config["permissionModel"] == PermissionModel.RECORD_LEVEL.value
+
+    def test_with_permission_model_sets_app_level(self) -> None:
+        config = ConnectorConfigBuilder().with_permission_model(PermissionModel.APP_LEVEL).build()
+        assert config["permissionModel"] == PermissionModel.APP_LEVEL.value
+
+    def test_rejects_raw_strings(self) -> None:
+        with pytest.raises(ValueError, match="PermissionModel"):
+            ConnectorConfigBuilder().with_permission_model("APP_LEVEL")
+
+
+class TestConnectorBuilderPassthrough:
+    def test_survives_a_later_configure_call(self) -> None:
+        """`configure()` swaps the config builder, so the flag is applied at build time."""
+        decorator = (
+            ConnectorBuilder("Example")
+            .with_supported_auth_types("NONE")
+            .with_permission_model(PermissionModel.APP_LEVEL)
+            .configure(lambda c: c.with_icon("/icons/x.svg"))
+            .build_decorator()
+        )
+
+        @decorator
+        class _Example:
+            pass
+
+        config = _Example._connector_metadata["config"]
+        assert config["permissionModel"] == PermissionModel.APP_LEVEL.value
+        assert config["iconPath"] == "/icons/x.svg"
+
+    def test_undeclared_connector_is_record_level(self) -> None:
+        decorator = (
+            ConnectorBuilder("Example2").with_supported_auth_types("NONE").build_decorator()
+        )
+
+        @decorator
+        class _Example2:
+            pass
+
+        assert (
+            _Example2._connector_metadata["config"]["permissionModel"]
+            == PermissionModel.RECORD_LEVEL.value
+        )
+
+    def test_rejects_raw_strings(self) -> None:
+        with pytest.raises(ValueError, match="PermissionModel"):
+            ConnectorBuilder("Example3").with_permission_model("APP_LEVEL")
+
+
+class TestDeclaredConnectors:
+    @pytest.mark.parametrize("module_path", APP_LEVEL_CONNECTORS)
+    def test_declares_app_level(self, module_path) -> None:
+        import importlib
+
+        module = importlib.import_module(module_path)
+        models = {
+            getattr(obj, "_connector_metadata")["config"].get("permissionModel")
+            for obj in vars(module).values()
+            if isinstance(getattr(obj, "_connector_metadata", None), dict)
+        }
+        assert PermissionModel.APP_LEVEL.value in models, f"{module_path} must declare APP_LEVEL"
+
+    @pytest.mark.parametrize(
+        "module_path",
+        [
+            "app.connectors.sources.google.drive.team.connector",
+            "app.connectors.sources.microsoft.sharepoint_online.connector",
+        ],
+    )
+    def test_acl_connectors_stay_record_level(self, module_path) -> None:
+        """Sources with real per-record ACLs must not be cached user-independently."""
+        import importlib
+
+        module = importlib.import_module(module_path)
+        models = {
+            getattr(obj, "_connector_metadata")["config"].get("permissionModel")
+            for obj in vars(module).values()
+            if isinstance(getattr(obj, "_connector_metadata", None), dict)
+        }
+        assert models, f"no connector metadata found in {module_path}"
+        assert models == {PermissionModel.RECORD_LEVEL.value}
+
+
+def _registry() -> ConnectorRegistry:
+    container = MagicMock()
+    container.logger.return_value = MagicMock()
+    return ConnectorRegistry(container)
+
+
+class TestPersistAndBackfill:
+    def test_permission_model_for_reads_config(self) -> None:
+        assert ConnectorRegistry._permission_model_for(
+            {"config": {"permissionModel": PermissionModel.APP_LEVEL.value}}
+        ) == PermissionModel.APP_LEVEL.value
+
+    def test_permission_model_for_defaults_safely(self) -> None:
+        assert ConnectorRegistry._permission_model_for({}) == PermissionModel.RECORD_LEVEL.value
+        assert ConnectorRegistry._permission_model_for({"config": {}}) == PermissionModel.RECORD_LEVEL.value
+
+    @pytest.mark.asyncio
+    async def test_new_instance_carries_the_flag(self) -> None:
+        registry = _registry()
+        graph = MagicMock()
+        graph.get_document = AsyncMock(return_value={"_key": "org-1"})
+        graph.batch_upsert_nodes = AsyncMock(return_value=True)
+        graph.batch_create_edges = AsyncMock(return_value=True)
+        registry._graph_provider = graph
+        registry._check_name_uniqueness = AsyncMock(return_value=True)
+
+        doc = await registry._create_connector_instance(
+            connector_type="S3",
+            instance_name="my-s3",
+            metadata={
+                "appGroup": "S3",
+                "supportedAuthTypes": ["ACCESS_KEY"],
+                "config": {"permissionModel": PermissionModel.APP_LEVEL.value},
+            },
+            scope="team",
+            created_by="user-1",
+            org_id="org-1",
+            selected_auth_type="ACCESS_KEY",
+        )
+
+        assert doc["permissionModel"] == PermissionModel.APP_LEVEL.value
+        upserted = graph.batch_upsert_nodes.await_args.args[0][0]
+        assert upserted["permissionModel"] == PermissionModel.APP_LEVEL.value
+
+    @pytest.mark.asyncio
+    async def test_backfills_missing_and_stale_flags(self) -> None:
+        registry = _registry()
+        registry._connectors = {
+            "S3": {"config": {"permissionModel": PermissionModel.APP_LEVEL.value}},
+            "DRIVE": {"config": {"permissionModel": PermissionModel.RECORD_LEVEL.value}},
+        }
+        graph = MagicMock()
+        graph.get_all_documents = AsyncMock(
+            return_value=[
+                {"_key": "a", "type": "S3", "isActive": True},  # missing flag
+                {
+                    "_key": "b",
+                    "type": "S3",
+                    "isActive": True,
+                    "permissionModel": PermissionModel.RECORD_LEVEL.value,  # stale
+                },
+                {
+                    "_key": "c",
+                    "type": "DRIVE",
+                    "isActive": True,
+                    "permissionModel": PermissionModel.RECORD_LEVEL.value,  # current
+                },
+                {"_key": "kb", "type": Connectors.KNOWLEDGE_BASE.value, "isActive": True},
+            ]
+        )
+        graph.update_node = AsyncMock(return_value=True)
+        graph.batch_update_connector_status = AsyncMock(return_value=0)
+        registry._graph_provider = graph
+
+        assert await registry.sync_with_database() is True
+
+        updated = {
+            call.args[0]: call.args[2]["permissionModel"]
+            for call in graph.update_node.await_args_list
+        }
+        assert updated == {"a": PermissionModel.APP_LEVEL.value, "b": PermissionModel.APP_LEVEL.value}
+
+    @pytest.mark.asyncio
+    async def test_backfill_failure_does_not_fail_sync(self) -> None:
+        registry = _registry()
+        registry._connectors = {"S3": {"config": {"permissionModel": PermissionModel.APP_LEVEL.value}}}
+        graph = MagicMock()
+        graph.get_all_documents = AsyncMock(
+            return_value=[{"_key": "a", "type": "S3", "isActive": True}]
+        )
+        graph.update_node = AsyncMock(side_effect=RuntimeError("graph down"))
+        graph.batch_update_connector_status = AsyncMock(return_value=0)
+        registry._graph_provider = graph
+
+        assert await registry.sync_with_database() is True
+
+    @pytest.mark.asyncio
+    async def test_unregistered_types_are_left_alone(self) -> None:
+        registry = _registry()
+        registry._connectors = {}
+        graph = MagicMock()
+        graph.get_all_documents = AsyncMock(
+            return_value=[{"_key": "a", "type": "RETIRED", "isActive": False}]
+        )
+        graph.update_node = AsyncMock()
+        graph.batch_update_connector_status = AsyncMock(return_value=0)
+        registry._graph_provider = graph
+
+        assert await registry.sync_with_database() is True
+        graph.update_node.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_kb_documents_are_skipped(self) -> None:
+        registry = _registry()
+        registry._connectors = {
+            Connectors.KNOWLEDGE_BASE.value: {"config": {}},
+        }
+        graph = MagicMock()
+        graph.get_all_documents = AsyncMock(
+            return_value=[{"_key": "kb", "type": Connectors.KNOWLEDGE_BASE.value, "isActive": True}]
+        )
+        graph.update_node = AsyncMock()
+        graph.batch_update_connector_status = AsyncMock(return_value=0)
+        registry._graph_provider = graph
+
+        assert await registry.sync_with_database() is True
+        graph.update_node.assert_not_called()
+        assert registry._collection_name == CollectionNames.APPS.value

--- a/backend/python/tests/unit/connectors/core/test_data_source_entities_processor.py
+++ b/backend/python/tests/unit/connectors/core/test_data_source_entities_processor.py
@@ -3778,6 +3778,27 @@ class TestReindexExistingRecords:
         assert [m["eventType"] for _key, m in messages] == ["reindexRecord"]
 
     @pytest.mark.asyncio
+    async def test_reindex_payload_forces_past_the_already_indexed_guard(self):
+        """The consumer skips NEW/REINDEX events for COMPLETED records. An
+        explicit reindex has to opt out or it reports success doing nothing."""
+        proc = _make_processor()
+        tx_store = _make_tx_store()
+        proc.data_store_provider.transaction.return_value = _make_ctx(tx_store)
+
+        record = _make_record()
+        record.id = "rec-1"
+        record.is_internal = False
+        record.indexing_status = ProgressStatus.COMPLETED.value
+
+        await proc.reindex_existing_records([record])
+
+        _topic, messages = proc.messaging_producer.send_messages.await_args.args
+        payload = messages[0][1]["payload"]
+        assert payload["forceReindex"] is True
+        # the rest of the record payload must be untouched
+        assert payload["recordName"] == record.to_kafka_record()["recordName"]
+
+    @pytest.mark.asyncio
     async def test_skips_internal_records(self):
         """Skips internal records during reindex."""
         proc = _make_processor()

--- a/backend/python/tests/unit/connectors/sources/test_rss_connector.py
+++ b/backend/python/tests/unit/connectors/sources/test_rss_connector.py
@@ -669,6 +669,10 @@ class TestFetchAndParseFeed:
     @pytest.mark.asyncio
     async def test_http_error_returns_none(self):
         conn = _make_connector_cov()
+        # Patch `fetch_url_with_fallback`, not `conn.session`. The session is
+        # only that helper's *third* strategy -- curl_cffi and cloudscraper run
+        # first and reach the real network, so a session mock never intercepts
+        # and the test hangs until the suite timeout.
         with _patch_fetch(status=404):
             result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None

--- a/backend/python/tests/unit/connectors/sources/test_rss_connector_coverage.py
+++ b/backend/python/tests/unit/connectors/sources/test_rss_connector_coverage.py
@@ -144,6 +144,10 @@ class TestFetchAndParseFeed:
     @pytest.mark.asyncio
     async def test_http_error_returns_none(self):
         conn = _make_connector()
+        # Patch `fetch_url_with_fallback`, not `conn.session`. The session is
+        # only that helper's *third* strategy -- curl_cffi and cloudscraper run
+        # first and reach the real network, so a session mock never intercepts
+        # and the test hangs until the suite timeout.
         with _patch_fetch(status=404):
             result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None

--- a/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
+++ b/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
@@ -8,7 +8,10 @@ from langchain_core.documents import Document
 from qdrant_client import models
 
 from app.exceptions.fastapi_responses import Status
-from app.modules.retrieval.retrieval_service import ACCESSIBLE_RECORDS_NOT_FOUND_MESSAGE
+from app.modules.retrieval.retrieval_service import (
+    ACCESSIBLE_RECORDS_NOT_FOUND_MESSAGE,
+    DEFAULT_SEARCH_LIMIT,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -573,6 +576,41 @@ class TestSearchWithFilters:
         assert result["message"] == ACCESSIBLE_RECORDS_NOT_FOUND_MESSAGE
 
     @pytest.mark.asyncio
+    async def test_explicit_none_limit_falls_back_to_the_default(
+        self, retrieval_service, mock_graph_provider
+    ):
+        """The prefetch path forwards the request's optional `limit` verbatim, so
+        `None` arrives here explicitly and the default argument cannot cover it.
+        It used to survive into HybridSearchRequest (a plain dataclass, no
+        validation) and blow up on `req.limit * 2`, which the broad except logged
+        as "Filtered search failed" and turned into an empty result set -- the
+        turn then answered with no retrieved context and no visible error.
+        """
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        await retrieval_service.search_with_filters(
+            queries=["test"], user_id="u1", org_id="o1", limit=None
+        )
+
+        passed_limit = retrieval_service._execute_parallel_searches.await_args.args[2]
+        assert passed_limit == DEFAULT_SEARCH_LIMIT
+        assert passed_limit is not None
+
+    @pytest.mark.asyncio
+    async def test_explicit_limit_is_respected(
+        self, retrieval_service, mock_graph_provider
+    ):
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        await retrieval_service.search_with_filters(
+            queries=["test"], user_id="u1", org_id="o1", limit=7
+        )
+
+        assert retrieval_service._execute_parallel_searches.await_args.args[2] == 7
+
+    @pytest.mark.asyncio
     async def test_returns_empty_when_no_search_results(
         self, retrieval_service, mock_graph_provider
     ):
@@ -792,11 +830,12 @@ class TestSearchWithFilters:
                 # mimeType intentionally absent
             }
         ]
-        # get_document returns a file with mimeType and webUrl
-        mock_graph_provider.get_document.return_value = {
+        # the files collection is fetched in one batched query, not per record
+        mock_graph_provider.get_nodes_by_field_in.return_value = [{
+            "id": "rec1",
             "webUrl": "https://example.com/file",
             "mimeType": "application/pdf",
-        }
+        }]
         retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
             {
                 "score": 0.9,
@@ -809,10 +848,10 @@ class TestSearchWithFilters:
             queries=["test"], user_id="u1", org_id="o1"
         )
         assert result["status"] == "success"
-        # The file fetch should have been called with FILES collection
+        # The file fetch should have been one batched call on FILES
         from app.config.constants.arangodb import CollectionNames
-        mock_graph_provider.get_document.assert_called_once_with(
-            "rec1", CollectionNames.FILES.value
+        mock_graph_provider.get_nodes_by_field_in.assert_called_once_with(
+            CollectionNames.FILES.value, "id", ["rec1"]
         )
         sr = result["searchResults"][0]
         assert sr["metadata"]["mimeType"] == "application/pdf"
@@ -836,10 +875,11 @@ class TestSearchWithFilters:
                 # mimeType intentionally absent
             }
         ]
-        mock_graph_provider.get_document.return_value = {
+        mock_graph_provider.get_nodes_by_field_in.return_value = [{
+            "id": "rec1",
             "webUrl": "https://mail.google.com/mail?authuser={user.email}#inbox/123",
             "mimeType": "text/html",
-        }
+        }]
         retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
             {
                 "score": 0.9,
@@ -853,8 +893,8 @@ class TestSearchWithFilters:
         )
         assert result["status"] == "success"
         from app.config.constants.arangodb import CollectionNames
-        mock_graph_provider.get_document.assert_called_once_with(
-            "rec1", CollectionNames.MAILS.value
+        mock_graph_provider.get_nodes_by_field_in.assert_called_once_with(
+            CollectionNames.MAILS.value, "id", ["rec1"]
         )
         sr = result["searchResults"][0]
         # Mail mimeType should default to text/html
@@ -880,10 +920,11 @@ class TestSearchWithFilters:
                 # webUrl intentionally absent
             }
         ]
-        mock_graph_provider.get_document.return_value = {
+        mock_graph_provider.get_nodes_by_field_in.return_value = [{
+            "id": "rec1",
             "webUrl": "https://sharepoint.com/doc",
             "mimeType": "application/pdf",
-        }
+        }]
         retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
             {
                 "score": 0.85,
@@ -917,9 +958,10 @@ class TestSearchWithFilters:
                 # webUrl intentionally absent
             }
         ]
-        mock_graph_provider.get_document.return_value = {
+        mock_graph_provider.get_nodes_by_field_in.return_value = [{
+            "id": "rec1",
             "webUrl": "https://mail.google.com/mail/123",
-        }
+        }]
         retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
             {
                 "score": 0.85,
@@ -965,14 +1007,16 @@ class TestSearchWithFilters:
             },
         ]
 
-        async def mock_get_document(record_id, collection):
+        async def mock_batch(collection, field, values):
             if collection == "files":
-                return {"webUrl": "https://drive.google.com/file", "mimeType": "application/pdf"}
+                return [{"id": "rec1", "webUrl": "https://drive.google.com/file",
+                         "mimeType": "application/pdf"}]
             elif collection == "mails":
-                return {"webUrl": "https://mail.google.com/mail?authuser={user.email}#inbox/456"}
-            return {}
+                return [{"id": "rec2",
+                         "webUrl": "https://mail.google.com/mail?authuser={user.email}#inbox/456"}]
+            return []
 
-        mock_graph_provider.get_document = AsyncMock(side_effect=mock_get_document)
+        mock_graph_provider.get_nodes_by_field_in = AsyncMock(side_effect=mock_batch)
 
         retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
             {
@@ -1211,7 +1255,7 @@ class TestSearchWithFilters:
     async def test_fetch_files_exception_returns_empty_map(
         self, retrieval_service, mock_graph_provider
     ):
-        """When get_document raises for file fetch, it's handled gracefully."""
+        """When the batched file fetch raises, it's handled gracefully."""
         mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
         mock_graph_provider.get_user_by_user_id.return_value = {"email": "u@t.com"}
         mock_graph_provider.get_records_by_record_ids.return_value = [
@@ -1225,8 +1269,7 @@ class TestSearchWithFilters:
                 # no mimeType - triggers file fetch
             }
         ]
-        # get_document raises an exception (returned via gather with return_exceptions=True)
-        mock_graph_provider.get_document = AsyncMock(side_effect=Exception("db error"))
+        mock_graph_provider.get_nodes_by_field_in = AsyncMock(side_effect=Exception("db error"))
         retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
             {
                 "score": 0.9,
@@ -1241,6 +1284,48 @@ class TestSearchWithFilters:
         # Exception results are filtered out; result will lack mimeType so filtered out
         # from complete_results
         assert result["status"] in ("success", "empty_response")
+
+    @pytest.mark.asyncio
+    async def test_record_matched_by_many_chunks_is_fetched_once(
+        self, retrieval_service, mock_graph_provider
+    ):
+        """The fetch list is appended per search result, so a record matched by
+        several chunks used to cost one query per chunk."""
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        mock_graph_provider.get_user_by_user_id.return_value = {"email": "u@t.com"}
+        mock_graph_provider.get_records_by_record_ids.return_value = [
+            {
+                "_key": "rec1",
+                "virtualRecordId": "vr1",
+                "origin": "google_drive",
+                "recordName": "File.bin",
+                "webUrl": "https://example.com/doc",
+                "recordType": "FILE",
+                # no mimeType - triggers the file fetch
+            }
+        ]
+        mock_graph_provider.get_nodes_by_field_in = AsyncMock(return_value=[
+            {"id": "rec1", "webUrl": "https://example.com/f", "mimeType": "application/pdf"}
+        ])
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[
+            {
+                "score": 0.9 - i / 100,
+                "content": f"chunk {i}",
+                "citationType": "vectordb|document",
+                "metadata": {"virtualRecordId": "vr1", "orgId": "o1"},
+            }
+            for i in range(5)
+        ])
+
+        result = await retrieval_service.search_with_filters(
+            queries=["test"], user_id="u1", org_id="o1"
+        )
+
+        assert result["status"] == "success"
+        from app.config.constants.arangodb import CollectionNames
+        mock_graph_provider.get_nodes_by_field_in.assert_called_once_with(
+            CollectionNames.FILES.value, "id", ["rec1"]
+        )
 
     @pytest.mark.asyncio
     async def test_no_returned_virtual_record_ids_returns_404(

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_batch_lookup.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_batch_lookup.py
@@ -1,0 +1,267 @@
+"""Batched virtual-record → document mapping resolution.
+
+The batch must be indistinguishable from calling the per-id path once per id,
+including its per-id fallback for ids the batch does not return.
+
+Mapping nodes are keyed by the virtual record id -- that is the field the
+per-id path matches and the one that carries the index.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config.constants.arangodb import CollectionNames
+from app.modules.transformers.blob_storage import BlobStorage
+
+COLLECTION = CollectionNames.VIRTUAL_RECORD_TO_DOC_ID_MAPPING.value
+
+
+def _make_blob_storage(graph_provider=None) -> BlobStorage:
+    return BlobStorage(
+        logger=MagicMock(),
+        config_service=MagicMock(),
+        graph_provider=graph_provider if graph_provider is not None else MagicMock(),
+    )
+
+
+def _node(vrid: str, doc_id: str, size: int = 100, metadata_id: str | None = None) -> dict:
+    node = {"id": vrid, "record_doc_id": doc_id, "fileSizeBytes": size}
+    if metadata_id:
+        node["record_metadata_doc_id"] = metadata_id
+    return node
+
+
+class TestBatchLookup:
+    @pytest.mark.asyncio
+    async def test_resolves_all_ids_in_one_query(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(
+            return_value=[_node("vr-1", "doc-1"), _node("vr-2", "doc-2", 200)]
+        )
+        graph.get_document = AsyncMock()
+        blob = _make_blob_storage(graph)
+
+        out = await blob.get_document_ids_by_virtual_record_ids(["vr-1", "vr-2"])
+
+        assert out == {
+            "vr-1": {"record_doc_id": "doc-1", "fileSizeBytes": 100},
+            "vr-2": {"record_doc_id": "doc-2", "fileSizeBytes": 200},
+        }
+        graph.get_nodes_by_field_in.assert_awaited_once_with(COLLECTION, "id", ["vr-1", "vr-2"])
+        graph.get_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_shape_matches_the_per_id_path(self) -> None:
+        """Batch and single-id resolution must return identical dicts."""
+        node = _node("vr-1", "doc-1", 42, metadata_id="meta-1")
+
+        graph_batch = MagicMock()
+        graph_batch.get_nodes_by_field_in = AsyncMock(return_value=[node])
+        graph_batch.get_document = AsyncMock()
+
+        graph_single = MagicMock()
+        graph_single.get_nodes_by_filters = AsyncMock(return_value=[node])
+        graph_single.get_document = AsyncMock()
+
+        batched = await _make_blob_storage(graph_batch).get_document_ids_by_virtual_record_ids(["vr-1"])
+        single = await _make_blob_storage(graph_single).get_document_id_by_virtual_record_id("vr-1")
+
+        assert batched["vr-1"] == single
+        assert single["record_metadata_doc_id"] == "meta-1"
+
+    @pytest.mark.asyncio
+    async def test_documentid_alias_is_honoured(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(
+            return_value=[{"id": "vr-1", "documentId": "legacy-doc", "fileSizeBytes": 7}]
+        )
+        graph.get_document = AsyncMock()
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1"])
+
+        assert out["vr-1"]["record_doc_id"] == "legacy-doc"
+
+    @pytest.mark.asyncio
+    async def test_ids_missing_from_batch_fall_back_per_id(self) -> None:
+        """An id with no mapping row at all still costs its per-id query."""
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[_node("vr-1", "doc-1")])
+        graph.get_document = AsyncMock(return_value={"record_doc_id": "doc-2", "fileSizeBytes": 55})
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1", "vr-2"])
+
+        assert out["vr-1"]["record_doc_id"] == "doc-1"
+        assert out["vr-2"]["record_doc_id"] == "doc-2"
+        graph.get_document.assert_awaited_once_with("vr-2", COLLECTION)
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_ids_are_absent_not_empty(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[])
+        graph.get_document = AsyncMock(return_value=None)
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-missing"])
+
+        assert out == {}, "callers must be able to tell 'no mapping' from 'not looked up'"
+
+    @pytest.mark.asyncio
+    async def test_batch_query_failure_degrades_to_per_id(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(side_effect=RuntimeError("bolt down"))
+        graph.get_document = AsyncMock(return_value={"record_doc_id": "doc-1", "fileSizeBytes": 1})
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1"])
+
+        assert out["vr-1"]["record_doc_id"] == "doc-1"
+
+    @pytest.mark.asyncio
+    async def test_one_failed_fallback_does_not_sink_the_batch(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[])
+        graph.get_document = AsyncMock(
+            side_effect=[RuntimeError("boom"), {"record_doc_id": "doc-2", "fileSizeBytes": 2}]
+        )
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1", "vr-2"])
+
+        assert "vr-1" not in out
+        assert out["vr-2"]["record_doc_id"] == "doc-2"
+
+    @pytest.mark.asyncio
+    async def test_duplicates_and_blanks_are_collapsed(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[_node("vr-1", "doc-1")])
+        graph.get_document = AsyncMock()
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(
+            ["vr-1", "vr-1", "", None]
+        )
+
+        assert out == {"vr-1": {"record_doc_id": "doc-1", "fileSizeBytes": 100}}
+        graph.get_nodes_by_field_in.assert_awaited_once_with(COLLECTION, "id", ["vr-1"])
+
+    @pytest.mark.asyncio
+    async def test_empty_input_makes_no_queries(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock()
+        graph.get_document = AsyncMock()
+
+        assert await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids([]) == {}
+        graph.get_nodes_by_field_in.assert_not_called()
+        graph.get_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ids_are_chunked(self) -> None:
+        chunk = BlobStorage.VIRTUAL_RECORD_LOOKUP_CHUNK_SIZE
+        vrids = [f"vr-{i}" for i in range(chunk + 10)]
+
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(
+            side_effect=lambda _c, _f, values: [_node(v, f"doc-{v}") for v in values]
+        )
+        graph.get_document = AsyncMock()
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(vrids)
+
+        assert len(out) == len(vrids)
+        assert graph.get_nodes_by_field_in.await_count == 2
+        assert len(graph.get_nodes_by_field_in.await_args_list[0].args[2]) == chunk
+        assert len(graph.get_nodes_by_field_in.await_args_list[1].args[2]) == 10
+        graph.get_document.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_graph_provider_raises(self) -> None:
+        blob = _make_blob_storage(graph_provider=None)
+        blob.graph_provider = None
+        with pytest.raises(Exception, match="GraphProvider not initialized"):
+            await blob.get_document_ids_by_virtual_record_ids(["vr-1"])
+
+
+class TestBatchKeyField:
+    """The batch matched on a ``virtualRecordId`` property that mapping nodes do
+    not carry, so it returned nothing and every id fell through to the per-id
+    path -- with an unindexed scan added on top. These pin the key field."""
+
+    @pytest.mark.asyncio
+    async def test_batches_on_the_indexed_key_not_a_property(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[])
+        graph.get_document = AsyncMock(return_value=None)
+
+        await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1"])
+
+        field = graph.get_nodes_by_field_in.await_args_list[0].args[1]
+        assert field == "id", "mapping nodes are keyed by virtual record id"
+
+    @pytest.mark.asyncio
+    async def test_nodes_shaped_like_production_resolve_without_any_fallback(self) -> None:
+        """Real rows carry id/documentId/record_metadata_doc_id and no
+        virtualRecordId; every one of these used to miss the batch."""
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[
+            {"id": "vr-1", "documentId": "d1", "fileSizeBytes": 10,
+             "record_metadata_doc_id": "m1"},
+            {"id": "vr-2", "documentId": "d2", "fileSizeBytes": 20,
+             "record_metadata_doc_id": "m2"},
+        ])
+        graph.get_document = AsyncMock()
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(
+            ["vr-1", "vr-2"]
+        )
+
+        graph.get_document.assert_not_called()
+        assert out["vr-1"] == {
+            "record_doc_id": "d1", "fileSizeBytes": 10, "record_metadata_doc_id": "m1",
+        }
+        assert out["vr-2"]["record_doc_id"] == "d2"
+
+    @pytest.mark.asyncio
+    async def test_field_lookup_is_off_by_default(self, monkeypatch) -> None:
+        """The field is unindexed and nothing writes it, so by default a missed
+        id must go straight to the per-id path -- not pay a full label scan."""
+        monkeypatch.delenv("PIPESHUB_VRID_FIELD_LOOKUP", raising=False)
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[])
+        graph.get_document = AsyncMock(return_value={"documentId": "d1", "fileSizeBytes": 3})
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1"])
+
+        fields = [c.args[1] for c in graph.get_nodes_by_field_in.await_args_list]
+        assert fields == ["id"], "only the indexed key should be queried"
+        graph.get_document.assert_awaited_once_with("vr-1", COLLECTION)
+        assert out["vr-1"]["record_doc_id"] == "d1"
+
+    @pytest.mark.asyncio
+    async def test_field_lookup_runs_when_explicitly_enabled(self, monkeypatch) -> None:
+        """Deployments that dual-write the field can opt back in."""
+        monkeypatch.setenv("PIPESHUB_VRID_FIELD_LOOKUP", "true")
+        graph = MagicMock()
+
+        async def _batch(collection, field, values):
+            if field == "id":
+                return []
+            return [{"virtualRecordId": "vr-1", "documentId": "d1", "fileSizeBytes": 3}]
+
+        graph.get_nodes_by_field_in = AsyncMock(side_effect=_batch)
+        graph.get_document = AsyncMock()
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-1"])
+
+        assert [c.args[1] for c in graph.get_nodes_by_field_in.await_args_list] == [
+            "id", "virtualRecordId",
+        ]
+        graph.get_document.assert_not_called()
+        assert out["vr-1"]["record_doc_id"] == "d1"
+
+    @pytest.mark.asyncio
+    async def test_neither_shape_matching_still_falls_back_per_id(self) -> None:
+        graph = MagicMock()
+        graph.get_nodes_by_field_in = AsyncMock(return_value=[])
+        graph.get_document = AsyncMock(return_value={"documentId": "d9", "fileSizeBytes": 1})
+
+        out = await _make_blob_storage(graph).get_document_ids_by_virtual_record_ids(["vr-9"])
+
+        assert out["vr-9"]["record_doc_id"] == "d9"
+        graph.get_document.assert_awaited_once_with("vr-9", COLLECTION)

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_compression_threshold.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_compression_threshold.py
@@ -17,6 +17,11 @@ from app.modules.transformers.blob_storage import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _clear_compression_threshold_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(bs_mod._COMPRESSION_THRESHOLD_ENV, raising=False)
+
+
 def _make_blob_storage() -> BlobStorage:
     return BlobStorage(logger=MagicMock(), config_service=MagicMock(), graph_provider=MagicMock())
 

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_compression_threshold.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_compression_threshold.py
@@ -1,0 +1,149 @@
+"""Only records above the size threshold are compressed.
+
+Small records are stored as plain JSON so readers skip the base64 + zstd +
+msgpack decode; the read path must accept both shapes unchanged.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.modules.transformers import blob_storage as bs_mod
+from app.modules.transformers.blob_storage import (
+    COMPRESSION_THRESHOLD_BYTES_DEFAULT,
+    BlobStorage,
+    compression_threshold_bytes,
+)
+
+
+def _make_blob_storage() -> BlobStorage:
+    return BlobStorage(logger=MagicMock(), config_service=MagicMock(), graph_provider=MagicMock())
+
+
+def _record_of_json_size(target_bytes: int) -> dict:
+    """A record whose json.dumps length is at least `target_bytes`."""
+    record = {"id": "rec-1", "blob": "x" * target_bytes}
+    assert len(json.dumps(record).encode("utf-8")) >= target_bytes
+    return record
+
+
+class TestThresholdConfig:
+    def test_default_is_20mb(self) -> None:
+        assert COMPRESSION_THRESHOLD_BYTES_DEFAULT == 20 * 1024 * 1024
+        assert compression_threshold_bytes() == 20 * 1024 * 1024
+
+    def test_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "1024")
+        assert compression_threshold_bytes() == 1024
+
+    def test_zero_env_compresses_everything(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "0")
+        assert compression_threshold_bytes() == 0
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "twenty-megs")
+        assert compression_threshold_bytes() == COMPRESSION_THRESHOLD_BYTES_DEFAULT
+
+    def test_negative_env_is_clamped(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "-5")
+        assert compression_threshold_bytes() == 0
+
+
+class TestMaybeCompress:
+    def test_small_record_is_not_compressed(self) -> None:
+        payload, is_compressed = _make_blob_storage()._maybe_compress_record({"key": "value"})
+        assert is_compressed is False
+        assert payload is None
+
+    def test_record_above_threshold_is_compressed(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "1024")
+        payload, is_compressed = _make_blob_storage()._maybe_compress_record(
+            _record_of_json_size(4096)
+        )
+        assert is_compressed is True
+        assert isinstance(payload, str) and payload
+
+    def test_boundary_is_exclusive(self, monkeypatch) -> None:
+        """Exactly at the threshold stays uncompressed; one byte over compresses."""
+        blob = _make_blob_storage()
+        record = {"blob": "x" * 500}
+        exact_size = len(json.dumps(record).encode("utf-8"))
+
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, str(exact_size))
+        assert blob._maybe_compress_record(record)[1] is False
+
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, str(exact_size - 1))
+        assert blob._maybe_compress_record(record)[1] is True
+
+    def test_non_json_serializable_record_is_compressed(self, monkeypatch) -> None:
+        """The uncompressed envelope is json.dumps'd, so it could not carry this."""
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, str(10 * 1024 * 1024))
+        payload, is_compressed = _make_blob_storage()._maybe_compress_record(
+            {"when": {1, 2, 3}}  # a set: msgpack encodes it, json.dumps does not
+        )
+        assert is_compressed is True
+        assert isinstance(payload, str)
+
+    def test_compression_failure_falls_back_to_uncompressed(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "10")
+        blob = _make_blob_storage()
+        blob._compress_record = MagicMock(side_effect=RuntimeError("zstd exploded"))
+
+        payload, is_compressed = blob._maybe_compress_record(_record_of_json_size(1024))
+
+        assert is_compressed is False
+        assert payload is None
+        blob.logger.warning.assert_called()
+
+
+class TestRoundTripBothShapes:
+    """`_process_downloaded_record` must read what the writer now produces."""
+
+    def test_uncompressed_envelope_round_trips(self) -> None:
+        blob = _make_blob_storage()
+        record = {"id": "rec-1", "record_name": "small.txt", "blocks": [1, 2, 3]}
+
+        payload, is_compressed = blob._maybe_compress_record(record)
+        envelope = {
+            "isCompressed": is_compressed,
+            "record": payload if is_compressed else record,
+            "virtualRecordId": "vr-1",
+        }
+        # The envelope must survive the JSON hop it takes through storage.
+        envelope = json.loads(json.dumps(envelope))
+
+        assert blob._process_downloaded_record(envelope) == record
+
+    def test_compressed_envelope_round_trips(self, monkeypatch) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, "16")
+        blob = _make_blob_storage()
+        record = {"id": "rec-1", "record_name": "big.txt", "body": "y" * 4096}
+
+        payload, is_compressed = blob._maybe_compress_record(record)
+        assert is_compressed is True
+
+        envelope = json.loads(
+            json.dumps({"isCompressed": True, "record": payload, "virtualRecordId": "vr-1"})
+        )
+
+        assert blob._process_downloaded_record(envelope) == record
+
+    @pytest.mark.parametrize("threshold", ["0", "999999999"])
+    def test_writer_and_reader_agree_at_any_threshold(self, monkeypatch, threshold) -> None:
+        monkeypatch.setenv(bs_mod._COMPRESSION_THRESHOLD_ENV, threshold)
+        blob = _make_blob_storage()
+        record = {"id": "rec-1", "text": "hello world", "n": 42, "nested": {"a": [1, 2]}}
+
+        payload, is_compressed = blob._maybe_compress_record(record)
+        envelope = json.loads(
+            json.dumps(
+                {
+                    "isCompressed": is_compressed,
+                    "record": payload if is_compressed else record,
+                    "virtualRecordId": "vr-1",
+                }
+            )
+        )
+
+        assert blob._process_downloaded_record(envelope) == record

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_extended.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_extended.py
@@ -138,9 +138,10 @@ class TestSaveRecordPayloadFields:
         assert file_call.args[0] == "file"
         payload_bytes = file_call.args[1]
         payload = json.loads(payload_bytes.decode("utf-8"))
-        assert payload["isCompressed"] is True
+        # Below the compression threshold, so the record is stored as plain JSON.
+        assert payload["isCompressed"] is False
+        assert payload["record"] == {"key": "value"}
         assert payload["virtualRecordId"] == "vr-1"
-        assert "record" in payload
 
         fields = {
             call.args[0]: call

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_extended.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_extended.py
@@ -95,8 +95,11 @@ class TestSaveRecordPayloadFields:
     """Assert payload and metadata fields for save_record_to_storage."""
 
     @pytest.mark.asyncio
-    async def test_local_upload_uses_virtual_record_id_fields_and_payload(self):
+    async def test_local_upload_uses_virtual_record_id_fields_and_payload(self, monkeypatch):
         """Local branch should use virtual_record_id in form metadata and payload."""
+        monkeypatch.setenv(
+            "PIPESHUB_RECORD_COMPRESSION_THRESHOLD_BYTES", str(10 * 1024 * 1024)
+        )
         bs = _make_blob_storage()
         bs.config_service.get_config = AsyncMock(
             side_effect=[

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_shared_session.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_shared_session.py
@@ -1,0 +1,309 @@
+"""Shared download session + cached config reads (blob_storage).
+
+Guards the two properties that make the shared session safe: the session is
+reused rather than rebuilt per record, and the per-request trace id is still
+stamped fresh on every call (it must never be cached alongside the token).
+"""
+
+import contextlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.modules.transformers import blob_storage as bs_mod
+from app.modules.transformers.blob_storage import (
+    DOWNLOAD_CONNECTION_LIMIT_DEFAULT,
+    BlobStorage,
+    close_shared_session,
+    download_connection_limit,
+    get_shared_session,
+)
+from app.utils.request_context import HEADER_REQUEST_ID, reset_context, set_context
+
+
+def _make_blob_storage() -> BlobStorage:
+    logger = MagicMock()
+    config_service = MagicMock()
+    config_service.get_config = AsyncMock(
+        side_effect=[
+            {"scopedJwtSecret": "secret-value-for-tests"},
+            {"cm": {"endpoint": "http://localhost:3001"}},
+            {"storageType": "local"},
+        ]
+    )
+    return BlobStorage(logger=logger, config_service=config_service, graph_provider=MagicMock())
+
+
+@pytest.fixture(autouse=True)
+def _clear_sessions():
+    bs_mod._shared_sessions.clear()
+    yield
+    bs_mod._shared_sessions.clear()
+
+
+class TestConnectionLimit:
+    """An unbounded pool overran the storage API's listen backlog under load."""
+
+    @pytest.mark.asyncio
+    async def test_pool_is_bounded_by_default(self) -> None:
+        fake = MagicMock()
+        fake.closed = False
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=fake), patch.object(
+            bs_mod.aiohttp, "TCPConnector"
+        ) as connector:
+            get_shared_session()
+
+        assert connector.call_args.kwargs["limit"] == DOWNLOAD_CONNECTION_LIMIT_DEFAULT
+        assert DOWNLOAD_CONNECTION_LIMIT_DEFAULT > 0, "0 means unbounded"
+
+    def test_env_overrides_the_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PIPESHUB_STORAGE_CONNECTION_LIMIT", "250")
+        assert download_connection_limit() == 250
+
+    def test_env_can_restore_unbounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PIPESHUB_STORAGE_CONNECTION_LIMIT", "0")
+        assert download_connection_limit() == 0
+
+    @pytest.mark.parametrize("bad", ["", "  ", "abc", "-5"])
+    def test_unusable_values_fall_back_to_the_default(
+        self, bad: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("PIPESHUB_STORAGE_CONNECTION_LIMIT", bad)
+        assert download_connection_limit() == DOWNLOAD_CONNECTION_LIMIT_DEFAULT
+
+
+class TestSharedSession:
+    @pytest.mark.asyncio
+    async def test_same_session_returned_within_a_loop(self) -> None:
+        fake = MagicMock()
+        fake.closed = False
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=fake) as ctor:
+            first = get_shared_session()
+            second = get_shared_session()
+
+        assert first is second
+        assert ctor.call_count == 1, "session must be built once per loop, not per call"
+
+    @pytest.mark.asyncio
+    async def test_closed_session_is_replaced(self) -> None:
+        stale = MagicMock()
+        stale.closed = True
+        fresh = MagicMock()
+        fresh.closed = False
+
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=stale):
+            get_shared_session()
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=fresh):
+            replacement = get_shared_session()
+
+        assert replacement is fresh
+
+    @pytest.mark.asyncio
+    async def test_close_shared_session_closes_and_forgets(self) -> None:
+        fake = MagicMock()
+        fake.closed = False
+        fake.close = AsyncMock()
+
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=fake):
+            get_shared_session()
+
+        await close_shared_session()
+
+        fake.close.assert_awaited_once()
+        assert not bs_mod._shared_sessions
+
+    @pytest.mark.asyncio
+    async def test_close_is_safe_when_nothing_open(self) -> None:
+        await close_shared_session()  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_download_does_not_close_the_shared_session(self) -> None:
+        """The old code closed its session per record; the shared one must survive."""
+        blob = _make_blob_storage()
+        blob.get_document_id_by_virtual_record_id = AsyncMock(
+            return_value={"record_doc_id": "doc-1", "fileSizeBytes": 10}
+        )
+
+        record = {"id": "rec-1"}
+        resp = AsyncMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={"record": record})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.closed = False
+        session.get = MagicMock(return_value=resp)
+        session.close = AsyncMock()
+
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=session):
+            out = await blob.get_record_from_storage("vr-1", "org-1")
+
+        assert out == record
+        session.close.assert_not_called()
+        assert bs_mod._shared_sessions, "session should stay pooled for the next record"
+
+
+class TestAuthAndConfigCaching:
+    @pytest.mark.asyncio
+    async def test_config_reads_use_the_invalidated_cache(self) -> None:
+        blob = _make_blob_storage()
+        await blob._get_auth_and_config("org-1")
+
+        assert blob.config_service.get_config.await_count == 3
+        for call in blob.config_service.get_config.await_args_list:
+            assert call.kwargs.get("use_cache") is True, (
+                "each read is otherwise an etcd round trip per record download"
+            )
+
+    @pytest.mark.asyncio
+    async def test_request_id_is_stamped_per_call_not_cached(self) -> None:
+        """The trace id comes from a ContextVar; caching headers would leak it."""
+        blob = _make_blob_storage()
+
+        token = set_context("request-aaa")
+        try:
+            headers_a, _, _ = await blob._get_auth_and_config("org-1")
+        finally:
+            reset_context(token)
+
+        blob.config_service.get_config = AsyncMock(
+            side_effect=[
+                {"scopedJwtSecret": "secret-value-for-tests"},
+                {"cm": {"endpoint": "http://localhost:3001"}},
+                {"storageType": "local"},
+            ]
+        )
+
+        token = set_context("request-bbb")
+        try:
+            headers_b, _, _ = await blob._get_auth_and_config("org-1")
+        finally:
+            reset_context(token)
+
+        assert headers_a[HEADER_REQUEST_ID] == "request-aaa"
+        assert headers_b[HEADER_REQUEST_ID] == "request-bbb"
+        # Same org ⇒ same scoped token, but distinct header dicts.
+        assert headers_a["Authorization"] == headers_b["Authorization"]
+        assert headers_a is not headers_b
+
+
+class TestLookupPassthrough:
+    @pytest.mark.asyncio
+    async def test_pre_resolved_lookup_skips_the_per_record_query(self) -> None:
+        blob = _make_blob_storage()
+        blob.get_document_id_by_virtual_record_id = AsyncMock()
+
+        record = {"id": "rec-1"}
+        resp = AsyncMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={"record": record})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.closed = False
+        session.get = MagicMock(return_value=resp)
+
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=session):
+            out = await blob.get_record_from_storage(
+                "vr-1", "org-1", lookup_result={"record_doc_id": "doc-1", "fileSizeBytes": 5}
+            )
+
+        assert out == record
+        blob.get_document_id_by_virtual_record_id.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_omitted_lookup_still_queries(self) -> None:
+        blob = _make_blob_storage()
+        blob.get_document_id_by_virtual_record_id = AsyncMock(
+            return_value={"record_doc_id": "doc-1", "fileSizeBytes": 5}
+        )
+
+        record = {"id": "rec-1"}
+        resp = AsyncMock()
+        resp.status = 200
+        resp.json = AsyncMock(return_value={"record": record})
+        resp.__aenter__ = AsyncMock(return_value=resp)
+        resp.__aexit__ = AsyncMock(return_value=False)
+
+        session = MagicMock()
+        session.closed = False
+        session.get = MagicMock(return_value=resp)
+
+        with patch.object(bs_mod.aiohttp, "ClientSession", return_value=session):
+            out = await blob.get_record_from_storage("vr-1", "org-1")
+
+        assert out == record
+        blob.get_document_id_by_virtual_record_id.assert_awaited_once_with("vr-1")
+
+    @pytest.mark.asyncio
+    async def test_empty_pre_resolved_lookup_returns_none(self) -> None:
+        blob = _make_blob_storage()
+        blob.get_document_id_by_virtual_record_id = AsyncMock()
+
+        out = await blob.get_record_from_storage("vr-1", "org-1", lookup_result={})
+
+        assert out is None
+        # An empty dict is a resolved "not found", so it must still short-circuit
+        # rather than fall back to the per-record query.
+        blob.get_document_id_by_virtual_record_id.assert_not_called()
+
+
+class TestEnvelopeDecoding:
+    """Records under the compression threshold are plain JSON, so the envelope
+    parse IS the record decode -- it moved from msgpack (msgspec) to JSON."""
+
+    def test_decodes_bytes_without_a_utf8_round_trip(self) -> None:
+        raw = b'{"isCompressed": false, "record": {"record_name": "n"}, "virtualRecordId": "v"}'
+        assert bs_mod._decode_json(raw) == {
+            "isCompressed": False,
+            "record": {"record_name": "n"},
+            "virtualRecordId": "v",
+        }
+
+    def test_matches_stdlib_json_exactly(self) -> None:
+        import json as _json
+
+        raw = _json.dumps(
+            {"isCompressed": False, "record": {"a": [1, 2.5, None, True], "b": "ünïcode"}}
+        ).encode()
+        assert bs_mod._decode_json(raw) == _json.loads(raw.decode("utf-8"))
+
+    def test_falls_back_to_stdlib_when_msgspec_rejects(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A record msgspec cannot parse is still worth trying to read."""
+        def _boom(_raw) -> None:
+            raise ValueError("nope")
+
+        monkeypatch.setattr(bs_mod.msgspec.json, "decode", _boom)
+        assert bs_mod._decode_json(b'{"record": {"x": 1}}') == {"record": {"x": 1}}
+
+
+class TestKeepAliveTimeout:
+    """The shared session must drop idle connections before Node does.
+
+    Node never sets `server.keepAliveTimeout`, so its 5s default applies, while
+    aiohttp's connector default is 15s. Reusing a connection in that gap fails
+    with "Server disconnected" -- 51 record fetches and one failed tool call in
+    one day of logs, and only common once the session became process-wide and
+    connections lived long enough to go idle.
+    """
+
+    @pytest.mark.asyncio
+    async def test_connector_expires_before_the_gateway_does(self) -> None:
+        from app.modules.transformers.blob_storage import (
+            NODE_KEEPALIVE_MARGIN_SECONDS,
+            close_shared_redis,
+            get_shared_session,
+        )
+
+        session = get_shared_session()
+        try:
+            assert session.connector._keepalive_timeout == NODE_KEEPALIVE_MARGIN_SECONDS
+            assert NODE_KEEPALIVE_MARGIN_SECONDS < 5, (
+                "must be under Node's 5s default or the race returns"
+            )
+        finally:
+            await session.close()
+            with contextlib.suppress(Exception):
+                await close_shared_redis()

--- a/backend/python/tests/unit/modules/transformers/test_blob_storage_shared_session.py
+++ b/backend/python/tests/unit/modules/transformers/test_blob_storage_shared_session.py
@@ -41,6 +41,11 @@ def _clear_sessions():
     bs_mod._shared_sessions.clear()
 
 
+@pytest.fixture(autouse=True)
+def _clear_connection_limit_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("PIPESHUB_STORAGE_CONNECTION_LIMIT", raising=False)
+
+
 class TestConnectionLimit:
     """An unbounded pool overran the storage API's listen backlog under load."""
 

--- a/backend/python/tests/unit/modules/transformers/test_signed_url_cache.py
+++ b/backend/python/tests/unit/modules/transformers/test_signed_url_cache.py
@@ -1,0 +1,186 @@
+"""Caching the storage download URL.
+
+Resolving one is a gateway round trip that does a Mongo document lookup, a KV
+config read and an S3 signing call, and a chat turn does ~120 of them. The URLs
+are signed for 3600s, so caching them well inside that window removes almost all
+of those hops. These pin the behaviour that makes it safe: off by default, keyed
+per org, and never fatal when Redis or a stale URL misbehaves.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import asyncio
+
+import pytest
+
+from app.modules.transformers import blob_storage as bs
+from app.modules.transformers.blob_storage import BlobStorage, signed_url_cache_seconds
+
+
+@pytest.fixture(autouse=True)
+def _reset_shared_redis():
+    """The client is cached per event loop at module scope; clear it between
+    tests so one test's verdict does not leak into the next."""
+    bs._shared_redis.clear()
+    yield
+    bs._shared_redis.clear()
+
+
+def _blob() -> BlobStorage:
+    return BlobStorage(logger=MagicMock(), config_service=MagicMock(), graph_provider=MagicMock())
+
+
+class TestTTLConfig:
+    def test_disabled_by_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", raising=False)
+        assert signed_url_cache_seconds() == 0
+
+    def test_reads_the_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "1800")
+        assert signed_url_cache_seconds() == 1800
+
+    def test_clamped_below_the_signed_url_lifetime(self, monkeypatch) -> None:
+        """URLs are signed for 3600s; handing out one about to expire is worse
+        than not caching."""
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "99999")
+        assert signed_url_cache_seconds() == 3000
+
+    def test_garbage_falls_back_to_disabled(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "soon")
+        assert signed_url_cache_seconds() == 0
+
+
+class TestKeying:
+    def test_key_is_scoped_per_org(self) -> None:
+        """A document id alone would share a URL across tenants."""
+        a = BlobStorage._signed_url_key("org-a", "doc-1")
+        b = BlobStorage._signed_url_key("org-b", "doc-1")
+        assert a != b
+        assert "org-a" in a and "doc-1" in a
+
+
+class TestCacheDisabled:
+    @pytest.mark.asyncio
+    async def test_no_redis_client_when_ttl_is_zero(self, monkeypatch) -> None:
+        monkeypatch.delenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", raising=False)
+        assert await _blob()._signed_url_client() is None
+
+    @pytest.mark.asyncio
+    async def test_reads_and_writes_are_noops_when_disabled(self, monkeypatch) -> None:
+        monkeypatch.delenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", raising=False)
+        b = _blob()
+        assert await b._cached_signed_url("org", "doc") is None
+        await b._store_signed_url("org", "doc", "https://s3/x")  # must not raise
+
+
+class TestFailureIsNeverFatal:
+    @pytest.mark.asyncio
+    async def test_redis_read_failure_reports_a_miss(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        b = _blob()
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=RuntimeError("redis down"))
+        bs._shared_redis[asyncio.get_running_loop()] = client
+
+        assert await b._cached_signed_url("org", "doc") is None
+
+    @pytest.mark.asyncio
+    async def test_redis_write_failure_is_swallowed(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        b = _blob()
+        client = MagicMock()
+        client.set = AsyncMock(side_effect=RuntimeError("redis down"))
+        bs._shared_redis[asyncio.get_running_loop()] = client
+
+        await b._store_signed_url("org", "doc", "https://s3/x")  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_client_construction_failure_disables_quietly(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        b = _blob()
+        b.config_service.get_redis_config = AsyncMock(side_effect=RuntimeError("no config"))
+        assert await b._signed_url_client() is None
+
+    @pytest.mark.asyncio
+    async def test_ttl_is_passed_to_redis(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "900")
+        b = _blob()
+        client = MagicMock()
+        client.set = AsyncMock()
+        bs._shared_redis[asyncio.get_running_loop()] = client
+
+        await b._store_signed_url("org", "doc", "https://s3/x")
+
+        assert client.set.await_args.kwargs["ex"] == 900
+
+
+class TestClientConstruction:
+    """RedisConfig is an object, not a dict — subscripting it silently disabled
+    the cache on the first deployment."""
+
+    @pytest.mark.asyncio
+    async def test_builds_the_client_from_redis_config_attributes(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        b = _blob()
+        cfg = MagicMock(host="r", port=6379, password="pw", db=0)
+        b.config_service.get_redis_config = AsyncMock(return_value=cfg)
+
+        with patch("redis.asyncio.Redis") as R:
+            R.return_value.ping = AsyncMock()
+            client = await b._signed_url_client()
+
+        assert client is not None
+        kw = R.call_args.kwargs
+        assert (kw["host"], kw["port"], kw["password"], kw["db"]) == ("r", 6379, "pw", 0)
+
+    @pytest.mark.asyncio
+    async def test_unreachable_redis_disables_rather_than_raising(self, monkeypatch) -> None:
+        """Redis needs auth here; a failed ping must not break record fetches."""
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        b = _blob()
+        b.config_service.get_redis_config = AsyncMock(
+            return_value=MagicMock(host="r", port=6379, password=None, db=0)
+        )
+
+        with patch("redis.asyncio.Redis") as R:
+            R.return_value.ping = AsyncMock(side_effect=RuntimeError("NOAUTH"))
+            assert await b._signed_url_client() is None
+
+
+class TestClientIsSharedNotPerInstance:
+    """BlobStorage is constructed ad hoc at ~20 call sites, several of them per
+    request and per tool call. A per-instance client opened and leaked a Redis
+    connection pool per request -- the same trap get_shared_session documents."""
+
+    @pytest.mark.asyncio
+    async def test_many_instances_share_one_client(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        cfg = MagicMock(host="r", port=6379, password=None, db=0)
+
+        with patch("redis.asyncio.Redis") as R:
+            R.return_value.ping = AsyncMock()
+            clients = []
+            for _ in range(5):
+                b = _blob()
+                b.config_service.get_redis_config = AsyncMock(return_value=cfg)
+                clients.append(await b._signed_url_client())
+
+        assert R.call_count == 1, "one pool for the process, not one per instance"
+        assert all(c is clients[0] for c in clients)
+
+    @pytest.mark.asyncio
+    async def test_unreachable_redis_is_only_attempted_once(self, monkeypatch) -> None:
+        """An outage must not cost a 2s connect per record fetch."""
+        monkeypatch.setenv("PIPESHUB_SIGNED_URL_CACHE_SECONDS", "600")
+        cfg = MagicMock(host="r", port=6379, password=None, db=0)
+
+        with patch("redis.asyncio.Redis") as R:
+            R.return_value.ping = AsyncMock(side_effect=RuntimeError("down"))
+            R.return_value.aclose = AsyncMock()
+            for _ in range(4):
+                b = _blob()
+                b.config_service.get_redis_config = AsyncMock(return_value=cfg)
+                assert await b._signed_url_client() is None
+
+        assert R.call_count == 1, "the failure verdict must be cached"
+        R.return_value.aclose.assert_awaited()

--- a/backend/python/tests/unit/services/cache/test_accessible_records_cache.py
+++ b/backend/python/tests/unit/services/cache/test_accessible_records_cache.py
@@ -248,12 +248,107 @@ class TestSingleFlight:
         )
         assert set(started) == {"a", "b"}
 
-    async def test_lock_table_is_bounded(self) -> None:
+    async def test_lock_table_never_grows(self) -> None:
+        """The stripe array is fixed at construction, so no key count grows it."""
         cache = _cache(FakeRedis())
-        cache.MAX_LOCKS = 8
-        for i in range(40):
+        before = len(cache._locks)
+        for i in range(400):
             await cache.get_or_compute_kb(ORG, f"kb-{i}", _loader({}))
-        assert len(cache._locks) <= cache.MAX_LOCKS
+        assert len(cache._locks) == before == cache.LOCK_STRIPES
+
+    async def test_lock_table_bounded_while_every_lock_is_held(self) -> None:
+        """The case the old per-key table failed.
+
+        Trimming could only remove *unlocked* entries, so with every lock held
+        a new distinct key was inserted anyway and the table grew past its
+        bound. Striping cannot: the array is allocated once.
+        """
+        cache = _cache(FakeRedis())
+        held = list(cache._locks)
+        for lock in held:
+            await lock.acquire()
+        try:
+            assert len(cache._locks) == cache.LOCK_STRIPES
+            # Distinct keys that would each have wanted their own lock.
+            for i in range(50):
+                cache._lock_for(f"brand-new-key-{i}")
+            assert len(cache._locks) == cache.LOCK_STRIPES
+        finally:
+            for lock in held:
+                lock.release()
+
+    async def test_same_key_maps_to_one_stripe_and_is_stable(self) -> None:
+        cache = _cache(FakeRedis())
+        assert cache._lock_for("kb:x") is cache._lock_for("kb:x")
+        # Stable across instances: crc32, not the per-process hash seed.
+        other = _cache(FakeRedis())
+        assert cache._locks.index(cache._lock_for("kb:x")) == other._locks.index(
+            other._lock_for("kb:x")
+        )
+
+
+class TestOutageCost:
+    """One Redis outage must cost one timeout per call, not three.
+
+    `enabled` is only consulted on entry, so a failed first read used to leave
+    the method free to issue a second read and a write -- three waits of
+    OP_TIMEOUT_SECONDS each on a single search.
+    """
+
+    class DeadRedis:
+        def __init__(self) -> None:
+            self.ops: list[str] = []
+
+        async def _fail(self, name: str) -> None:
+            self.ops.append(name)
+            raise ConnectionError("connection refused")
+
+        async def get(self, *a, **k) -> None:
+            await self._fail("get")
+
+        async def set(self, *a, **k) -> None:
+            await self._fail("set")
+
+        async def hget(self, *a, **k) -> None:
+            await self._fail("hget")
+
+        async def hset(self, *a, **k) -> None:
+            await self._fail("hset")
+
+        async def expire(self, *a, **k) -> None:
+            await self._fail("expire")
+
+        async def delete(self, *a, **k) -> None:
+            await self._fail("delete")
+
+    async def test_one_redis_op_per_call_when_down(self) -> None:
+        dead = self.DeadRedis()
+        cache = _cache(dead)
+        result = await cache.get_or_compute_kb(ORG, "kb-1", _loader({"v": "r"}))
+
+        assert result == {"v": "r"}, "caller must still get correct data"
+        assert dead.ops == ["get"], (
+            f"expected a single Redis attempt, got {dead.ops} — a failed read "
+            f"must short-circuit instead of re-reading and writing"
+        )
+
+    async def test_breaker_still_skips_redis_on_later_calls(self) -> None:
+        dead = self.DeadRedis()
+        cache = _cache(dead)
+        await cache.get_or_compute_kb(ORG, "kb-1", _loader({"v": "r"}))
+        before = len(dead.ops)
+        for _ in range(5):
+            await cache.get_or_compute_kb(ORG, "kb-1", _loader({"v": "r"}))
+        assert len(dead.ops) == before, "backoff should skip Redis entirely"
+
+    async def test_write_is_skipped_when_the_locked_read_trips_the_breaker(self) -> None:
+        """Healthy on entry, dead by the time the loader returns."""
+        dead = self.DeadRedis()
+        cache = _cache(dead)
+        assert cache.enabled
+        result = await cache.get_or_compute_kb(ORG, "kb-2", _loader({"a": "b"}))
+        assert result == {"a": "b"}
+        assert "set" not in dead.ops, f"write attempted after breaker tripped: {dead.ops}"
 
 
 class TestKillSwitch:

--- a/backend/python/tests/unit/services/cache/test_accessible_records_cache.py
+++ b/backend/python/tests/unit/services/cache/test_accessible_records_cache.py
@@ -1,0 +1,397 @@
+"""AccessibleRecordsCache: key schema, read-through, single-flight, TTL and the
+guarantee that a broken Redis can never fail or stall a search."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.cache.accessible_records_cache import AccessibleRecordsCache
+
+ORG = "org-1"
+KB = "kb-1"
+CONNECTOR = "conn-1"
+USER = "user-1"
+
+
+class FakeRedis:
+    """In-memory stand-in for the handful of commands the cache uses."""
+
+    def __init__(self) -> None:
+        self.strings: dict[str, str] = {}
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.expires: dict[str, int] = {}
+        self.calls: list[tuple] = []
+
+    async def get(self, key):
+        self.calls.append(("get", key))
+        return self.strings.get(key)
+
+    async def set(self, key, value, ex=None):
+        self.calls.append(("set", key, ex))
+        self.strings[key] = value
+        if ex is not None:
+            self.expires[key] = ex
+        return True
+
+    async def hget(self, key, field):
+        self.calls.append(("hget", key, field))
+        return self.hashes.get(key, {}).get(field)
+
+    async def hset(self, key, field, value):
+        self.calls.append(("hset", key, field))
+        self.hashes.setdefault(key, {})[field] = value
+        return 1
+
+    async def expire(self, key, ttl):
+        self.calls.append(("expire", key, ttl))
+        self.expires[key] = ttl
+        return True
+
+    async def delete(self, *keys):
+        self.calls.append(("delete", *keys))
+        removed = 0
+        for key in keys:
+            removed += 1 if self.strings.pop(key, None) is not None else 0
+            removed += 1 if self.hashes.pop(key, None) is not None else 0
+            self.expires.pop(key, None)
+        return removed
+
+    async def ping(self):
+        return True
+
+    async def aclose(self):
+        return None
+
+
+class BrokenRedis(FakeRedis):
+    async def get(self, key):
+        raise ConnectionError("redis down")
+
+    async def set(self, key, value, ex=None):
+        raise ConnectionError("redis down")
+
+    async def hget(self, key, field):
+        raise ConnectionError("redis down")
+
+    async def hset(self, key, field, value):
+        raise ConnectionError("redis down")
+
+    async def delete(self, *keys):
+        raise ConnectionError("redis down")
+
+
+def _cache(redis=None, ttl=300, enabled=True) -> AccessibleRecordsCache:
+    return AccessibleRecordsCache(MagicMock(), redis if redis is not None else FakeRedis(), ttl, enabled)
+
+
+def _loader(value, counter=None):
+    async def load():
+        if counter is not None:
+            counter.append(1)
+        return value
+    return load
+
+
+class TestKeySchema:
+    def test_keys_are_namespaced_and_org_scoped(self) -> None:
+        cache = _cache()
+        assert cache._kb_key(ORG, KB) == f"pipeshub:accessible_records:v1:kb:{ORG}:{KB}"
+        assert cache._app_connector_key(ORG, CONNECTOR) == f"pipeshub:accessible_records:v1:capp:{ORG}:{CONNECTOR}"
+        assert cache._user_connector_key(ORG, CONNECTOR) == f"pipeshub:accessible_records:v1:cusr:{ORG}:{CONNECTOR}"
+
+    def test_key_classes_do_not_collide(self) -> None:
+        cache = _cache()
+        keys = {
+            cache._kb_key(ORG, "x"),
+            cache._app_connector_key(ORG, "x"),
+            cache._user_connector_key(ORG, "x"),
+        }
+        assert len(keys) == 3
+
+    def test_orgs_are_isolated(self) -> None:
+        cache = _cache()
+        assert cache._kb_key("org-a", KB) != cache._kb_key("org-b", KB)
+
+
+class TestReadThrough:
+    async def test_miss_then_hit(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        calls: list = []
+        value = {"vr-1": "rec-1"}
+
+        assert await cache.get_or_compute_kb(ORG, KB, _loader(value, calls)) == value
+        assert await cache.get_or_compute_kb(ORG, KB, _loader(value, calls)) == value
+        assert len(calls) == 1, "second call must be served from Redis"
+
+    async def test_value_is_stored_with_ttl(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis, ttl=123)
+        await cache.get_or_compute_kb(ORG, KB, _loader({"vr-1": "rec-1"}))
+        assert redis.expires[cache._kb_key(ORG, KB)] == 123
+
+    async def test_empty_map_is_cached(self) -> None:
+        """A user with no access must not re-run the traversal on every search."""
+        redis = FakeRedis()
+        cache = _cache(redis)
+        calls: list = []
+
+        assert await cache.get_or_compute_kb(ORG, KB, _loader({}, calls)) == {}
+        assert await cache.get_or_compute_kb(ORG, KB, _loader({}, calls)) == {}
+        assert len(calls) == 1
+
+    async def test_app_connector_entry_is_user_independent(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        calls: list = []
+        value = {"vr-1": "rec-1"}
+
+        await cache.get_or_compute_app_connector(ORG, CONNECTOR, _loader(value, calls))
+        await cache.get_or_compute_app_connector(ORG, CONNECTOR, _loader(value, calls))
+        assert len(calls) == 1
+
+    async def test_user_connector_entries_are_per_user(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        a = {"vr-a": "rec-a"}
+        b = {"vr-b": "rec-b"}
+
+        assert await cache.get_or_compute_user_connector(ORG, CONNECTOR, "user-a", _loader(a)) == a
+        assert await cache.get_or_compute_user_connector(ORG, CONNECTOR, "user-b", _loader(b)) == b
+        # One hash, one field per user.
+        assert set(redis.hashes[cache._user_connector_key(ORG, CONNECTOR)]) == {"user-a", "user-b"}
+
+    async def test_corrupt_payload_is_treated_as_a_miss(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        redis.strings[cache._kb_key(ORG, KB)] = "not-json"
+
+        assert await cache.get_or_compute_kb(ORG, KB, _loader({"vr-1": "rec-1"})) == {"vr-1": "rec-1"}
+
+
+class TestHashFreshness:
+    async def test_stale_field_is_recomputed(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis, ttl=60)
+        key = cache._user_connector_key(ORG, CONNECTOR)
+        redis.hashes[key] = {
+            USER: json.dumps({"t": int(time.time()) - 3600, "m": {"old": "value"}})
+        }
+
+        out = await cache.get_or_compute_user_connector(ORG, CONNECTOR, USER, _loader({"new": "value"}))
+
+        assert out == {"new": "value"}
+
+    async def test_fresh_field_is_served(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis, ttl=60)
+        key = cache._user_connector_key(ORG, CONNECTOR)
+        redis.hashes[key] = {USER: json.dumps({"t": int(time.time()), "m": {"cached": "hit"}})}
+        calls: list = []
+
+        out = await cache.get_or_compute_user_connector(ORG, CONNECTOR, USER, _loader({}, calls))
+
+        assert out == {"cached": "hit"}
+        assert not calls
+
+    async def test_envelope_without_timestamp_is_a_miss(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        redis.hashes[cache._user_connector_key(ORG, CONNECTOR)] = {USER: json.dumps({"m": {"a": "b"}})}
+
+        assert await cache.get_or_compute_user_connector(ORG, CONNECTOR, USER, _loader({"x": "y"})) == {"x": "y"}
+
+    async def test_write_refreshes_the_hash_key_ttl(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis, ttl=77)
+        await cache.get_or_compute_user_connector(ORG, CONNECTOR, USER, _loader({"a": "b"}))
+        assert redis.expires[cache._user_connector_key(ORG, CONNECTOR)] == 77
+
+
+class TestSingleFlight:
+    async def test_concurrent_misses_run_the_loader_once(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        calls: list = []
+
+        async def slow_loader():
+            calls.append(1)
+            await asyncio.sleep(0.02)
+            return {"vr-1": "rec-1"}
+
+        results = await asyncio.gather(
+            *[cache.get_or_compute_kb(ORG, KB, slow_loader) for _ in range(10)]
+        )
+
+        assert all(r == {"vr-1": "rec-1"} for r in results)
+        assert len(calls) == 1
+
+    async def test_distinct_keys_are_not_serialized(self) -> None:
+        cache = _cache(FakeRedis())
+        started: list = []
+
+        def make(key_id):
+            async def load():
+                started.append(key_id)
+                await asyncio.sleep(0.02)
+                return {key_id: "rec"}
+            return load
+
+        await asyncio.gather(
+            cache.get_or_compute_kb(ORG, "kb-a", make("a")),
+            cache.get_or_compute_kb(ORG, "kb-b", make("b")),
+        )
+        assert set(started) == {"a", "b"}
+
+    async def test_lock_table_is_bounded(self) -> None:
+        cache = _cache(FakeRedis())
+        cache.MAX_LOCKS = 8
+        for i in range(40):
+            await cache.get_or_compute_kb(ORG, f"kb-{i}", _loader({}))
+        assert len(cache._locks) <= cache.MAX_LOCKS
+
+
+class TestKillSwitch:
+    async def test_disabled_cache_always_calls_the_loader(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis, enabled=False)
+        calls: list = []
+
+        await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"}, calls))
+        await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"}, calls))
+
+        assert len(calls) == 2
+        assert not redis.calls, "a disabled cache must not touch Redis at all"
+
+    async def test_create_honours_the_env_kill_switch(self, monkeypatch) -> None:
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_ENABLED, "off")
+        config = MagicMock()
+        config.get_redis_config = AsyncMock()
+
+        cache = await AccessibleRecordsCache.create(MagicMock(), config)
+
+        assert cache.enabled is False
+        config.get_redis_config.assert_not_called()
+
+    async def test_create_survives_an_unreachable_redis(self, monkeypatch) -> None:
+        monkeypatch.delenv(AccessibleRecordsCache.ENV_ENABLED, raising=False)
+        config = MagicMock()
+        config.get_redis_config = AsyncMock(side_effect=RuntimeError("no redis config"))
+
+        cache = await AccessibleRecordsCache.create(MagicMock(), config)
+
+        assert cache.enabled is False
+        assert await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"})) == {"a": "b"}
+
+    async def test_ttl_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_ENABLED, "off")
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_TTL, "45")
+        cache = await AccessibleRecordsCache.create(MagicMock(), MagicMock())
+        assert cache.ttl_seconds == 45
+
+    async def test_invalid_ttl_env_falls_back(self, monkeypatch) -> None:
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_ENABLED, "off")
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_TTL, "soon")
+        cache = await AccessibleRecordsCache.create(MagicMock(), MagicMock())
+        assert cache.ttl_seconds == AccessibleRecordsCache.DEFAULT_TTL_SECONDS
+
+
+class TestRedisDown:
+    async def test_read_failure_falls_through_to_the_loader(self) -> None:
+        cache = _cache(BrokenRedis())
+        assert await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"})) == {"a": "b"}
+
+    async def test_failure_trips_the_backoff(self) -> None:
+        redis = BrokenRedis()
+        cache = _cache(redis)
+
+        await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"}))
+        assert cache.enabled is False
+
+        redis.calls.clear()
+        assert await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"})) == {"a": "b"}
+        assert not redis.calls, "while down, Redis must not be contacted at all"
+
+    async def test_backoff_expires(self) -> None:
+        cache = _cache(BrokenRedis())
+        await cache.get_or_compute_kb(ORG, KB, _loader({"a": "b"}))
+        assert cache.enabled is False
+
+        cache._down_until = 0.0
+        assert cache.enabled is True
+
+    async def test_invalidation_failure_is_swallowed(self) -> None:
+        cache = _cache(BrokenRedis())
+        await cache.invalidate_kb(ORG, KB)
+        await cache.invalidate_connector(ORG, CONNECTOR)
+
+    async def test_loader_exceptions_propagate_unchanged(self) -> None:
+        cache = _cache(FakeRedis())
+
+        async def failing():
+            raise RuntimeError("graph exploded")
+
+        with pytest.raises(RuntimeError, match="graph exploded"):
+            await cache.get_or_compute_kb(ORG, KB, failing)
+
+
+class TestInvalidation:
+    async def test_invalidate_kb_drops_only_that_kb(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        await cache.get_or_compute_kb(ORG, "kb-a", _loader({"a": "1"}))
+        await cache.get_or_compute_kb(ORG, "kb-b", _loader({"b": "2"}))
+
+        await cache.invalidate_kb(ORG, "kb-a")
+
+        assert cache._kb_key(ORG, "kb-a") not in redis.strings
+        assert cache._kb_key(ORG, "kb-b") in redis.strings
+
+    async def test_invalidate_connector_drops_both_shapes(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        await cache.get_or_compute_app_connector(ORG, CONNECTOR, _loader({"a": "1"}))
+        await cache.get_or_compute_user_connector(ORG, CONNECTOR, USER, _loader({"b": "2"}))
+
+        await cache.invalidate_connector(ORG, CONNECTOR)
+
+        assert cache._app_connector_key(ORG, CONNECTOR) not in redis.strings
+        assert cache._user_connector_key(ORG, CONNECTOR) not in redis.hashes
+
+    async def test_one_delete_clears_every_user_of_a_connector(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis)
+        for i in range(5):
+            await cache.get_or_compute_user_connector(ORG, CONNECTOR, f"user-{i}", _loader({"a": "1"}))
+
+        await cache.invalidate_connector(ORG, CONNECTOR)
+
+        assert cache._user_connector_key(ORG, CONNECTOR) not in redis.hashes
+
+    async def test_invalidation_is_a_noop_when_disabled(self) -> None:
+        redis = FakeRedis()
+        cache = _cache(redis, enabled=False)
+        await cache.invalidate_kb(ORG, KB)
+        assert not redis.calls
+
+
+class TestClose:
+    async def test_close_disables_and_releases(self) -> None:
+        redis = FakeRedis()
+        redis.aclose = AsyncMock()
+        cache = _cache(redis)
+
+        await cache.close()
+
+        assert cache.enabled is False
+        redis.aclose.assert_awaited_once()
+
+    async def test_close_is_idempotent(self) -> None:
+        cache = _cache(FakeRedis())
+        await cache.close()
+        await cache.close()

--- a/backend/python/tests/unit/services/cache/test_accessible_records_invalidator.py
+++ b/backend/python/tests/unit/services/cache/test_accessible_records_invalidator.py
@@ -1,0 +1,158 @@
+"""AccessibleRecordsInvalidator: resolves the org, guards the KB-only policy, and
+never lets a cache problem fail the caller's real work."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config.constants.arangodb import CollectionNames, Connectors
+from app.services.cache.accessible_records_cache import AccessibleRecordsInvalidator
+
+ORG = "org-1"
+
+
+def _make(app_doc=None, get_document_error=None):
+    cache = MagicMock()
+    cache.invalidate_connector = AsyncMock()
+    cache.invalidate_kb = AsyncMock()
+
+    graph = MagicMock()
+    if get_document_error is not None:
+        graph.get_document = AsyncMock(side_effect=get_document_error)
+    else:
+        graph.get_document = AsyncMock(return_value=app_doc)
+
+    return AccessibleRecordsInvalidator(MagicMock(), cache, graph), cache, graph
+
+
+class TestConnectorSyncCompleted:
+    async def test_resolves_org_from_the_app_doc(self) -> None:
+        inv, cache, graph = _make(app_doc={"orgId": ORG, "type": "S3"})
+
+        await inv.on_connector_sync_completed("conn-1")
+
+        graph.get_document.assert_awaited_once_with("conn-1", CollectionNames.APPS.value)
+        cache.invalidate_connector.assert_awaited_once_with(ORG, "conn-1")
+
+    async def test_supplied_org_skips_the_lookup(self) -> None:
+        inv, cache, graph = _make()
+
+        await inv.on_connector_sync_completed("conn-1", org_id=ORG)
+
+        graph.get_document.assert_not_called()
+        cache.invalidate_connector.assert_awaited_once_with(ORG, "conn-1")
+
+    async def test_unknown_app_is_a_noop(self) -> None:
+        inv, cache, _ = _make(app_doc=None)
+        await inv.on_connector_sync_completed("conn-1")
+        cache.invalidate_connector.assert_not_called()
+
+    async def test_blank_connector_id_is_a_noop(self) -> None:
+        inv, cache, graph = _make()
+        await inv.on_connector_sync_completed("")
+        graph.get_document.assert_not_called()
+        cache.invalidate_connector.assert_not_called()
+
+    async def test_graph_failure_is_swallowed(self) -> None:
+        inv, cache, _ = _make(get_document_error=RuntimeError("graph down"))
+        await inv.on_connector_sync_completed("conn-1")
+        cache.invalidate_connector.assert_not_called()
+
+    async def test_cache_failure_is_swallowed(self) -> None:
+        inv, cache, _ = _make(app_doc={"orgId": ORG})
+        cache.invalidate_connector = AsyncMock(side_effect=RuntimeError("redis down"))
+        await inv.on_connector_sync_completed("conn-1")  # must not raise
+
+
+class TestKbRecordsChanged:
+    async def test_invalidates_a_kb(self) -> None:
+        inv, cache, _ = _make(app_doc={"orgId": ORG, "type": Connectors.KNOWLEDGE_BASE.value})
+
+        await inv.on_kb_records_changed("kb-1")
+
+        cache.invalidate_kb.assert_awaited_once_with(ORG, "kb-1")
+
+    async def test_non_kb_app_is_a_noop(self) -> None:
+        """The cascade-delete hook also fires for ordinary connectors."""
+        inv, cache, _ = _make(app_doc={"orgId": ORG, "type": "DRIVE"})
+
+        await inv.on_kb_records_changed("conn-1")
+
+        cache.invalidate_kb.assert_not_called()
+
+    async def test_missing_app_doc_is_a_noop(self) -> None:
+        inv, cache, _ = _make(app_doc=None)
+        await inv.on_kb_records_changed("kb-1")
+        cache.invalidate_kb.assert_not_called()
+
+    async def test_app_without_org_is_a_noop(self) -> None:
+        inv, cache, _ = _make(app_doc={"type": Connectors.KNOWLEDGE_BASE.value})
+        await inv.on_kb_records_changed("kb-1")
+        cache.invalidate_kb.assert_not_called()
+
+    async def test_supplied_org_still_checks_the_type(self) -> None:
+        inv, cache, _ = _make(app_doc={"orgId": ORG, "type": "SLACK"})
+        await inv.on_kb_records_changed("conn-1", org_id=ORG)
+        cache.invalidate_kb.assert_not_called()
+
+    async def test_graph_failure_is_swallowed(self) -> None:
+        inv, cache, _ = _make(get_document_error=RuntimeError("graph down"))
+        await inv.on_kb_records_changed("kb-1")
+        cache.invalidate_kb.assert_not_called()
+
+
+class TestRecordIndexed:
+    async def test_kb_record_invalidates(self) -> None:
+        inv, cache, _ = _make(app_doc={"orgId": ORG, "type": Connectors.KNOWLEDGE_BASE.value})
+
+        await inv.on_record_indexed(
+            connector_name=Connectors.KNOWLEDGE_BASE, connector_id="kb-1", org_id=ORG
+        )
+
+        cache.invalidate_kb.assert_awaited_once_with(ORG, "kb-1")
+
+    async def test_accepts_the_enum_or_its_value(self) -> None:
+        inv, cache, _ = _make()
+        await inv.on_record_indexed(connector_name="KB", connector_id="kb-1", org_id=ORG)
+        cache.invalidate_kb.assert_awaited_once_with(ORG, "kb-1")
+
+    async def test_connector_records_are_ignored(self) -> None:
+        """A full sync flips thousands of records COMPLETED; invalidating per
+        record would empty the cache exactly when the graph is busiest."""
+        inv, cache, graph = _make()
+
+        await inv.on_record_indexed(connector_name="DRIVE", connector_id="conn-1", org_id=ORG)
+
+        cache.invalidate_kb.assert_not_called()
+        cache.invalidate_connector.assert_not_called()
+        graph.get_document.assert_not_called()
+
+    async def test_falls_back_to_the_record_group_id(self) -> None:
+        inv, cache, _ = _make()
+        await inv.on_record_indexed(
+            connector_name="KB", connector_id=None, external_record_group_id="kb-9", org_id=ORG
+        )
+        cache.invalidate_kb.assert_awaited_once_with(ORG, "kb-9")
+
+    async def test_resolves_org_when_missing(self) -> None:
+        inv, cache, graph = _make(app_doc={"orgId": ORG})
+        await inv.on_record_indexed(connector_name="KB", connector_id="kb-1")
+        graph.get_document.assert_awaited_once_with("kb-1", CollectionNames.APPS.value)
+        cache.invalidate_kb.assert_awaited_once_with(ORG, "kb-1")
+
+    async def test_no_kb_id_is_a_noop(self) -> None:
+        inv, cache, _ = _make()
+        await inv.on_record_indexed(connector_name="KB", connector_id=None)
+        cache.invalidate_kb.assert_not_called()
+
+    async def test_missing_connector_name_is_a_noop(self) -> None:
+        inv, cache, _ = _make()
+        await inv.on_record_indexed(connector_id="kb-1", org_id=ORG)
+        cache.invalidate_kb.assert_not_called()
+
+    async def test_failures_are_swallowed(self) -> None:
+        inv, cache, _ = _make(app_doc={"orgId": ORG})
+        cache.invalidate_kb = AsyncMock(side_effect=RuntimeError("redis down"))
+        await inv.on_record_indexed(connector_name="KB", connector_id="kb-1", org_id=ORG)

--- a/backend/python/tests/unit/services/cache/test_accessible_records_invalidator.py
+++ b/backend/python/tests/unit/services/cache/test_accessible_records_invalidator.py
@@ -13,7 +13,7 @@ from app.services.cache.accessible_records_cache import AccessibleRecordsInvalid
 ORG = "org-1"
 
 
-def _make(app_doc=None, get_document_error=None):
+def _make(app_doc=None, get_document_error=None, org_edges=None):
     cache = MagicMock()
     cache.invalidate_connector = AsyncMock()
     cache.invalidate_kb = AsyncMock()
@@ -23,6 +23,7 @@ def _make(app_doc=None, get_document_error=None):
         graph.get_document = AsyncMock(side_effect=get_document_error)
     else:
         graph.get_document = AsyncMock(return_value=app_doc)
+    graph.get_edges_to_node = AsyncMock(return_value=org_edges or [])
 
     return AccessibleRecordsInvalidator(MagicMock(), cache, graph), cache, graph
 
@@ -34,6 +35,31 @@ class TestConnectorSyncCompleted:
         await inv.on_connector_sync_completed("conn-1")
 
         graph.get_document.assert_awaited_once_with("conn-1", CollectionNames.APPS.value)
+        graph.get_edges_to_node.assert_not_called()
+        cache.invalidate_connector.assert_awaited_once_with(ORG, "conn-1")
+
+    async def test_resolves_org_from_org_app_relation_when_property_missing(self) -> None:
+        inv, cache, graph = _make(
+            app_doc={"type": "S3"},
+            org_edges=[{"from_id": ORG}],
+        )
+
+        await inv.on_connector_sync_completed("conn-1")
+
+        graph.get_edges_to_node.assert_awaited_once_with(
+            f"{CollectionNames.APPS.value}/conn-1",
+            CollectionNames.ORG_APP_RELATION.value,
+        )
+        cache.invalidate_connector.assert_awaited_once_with(ORG, "conn-1")
+
+    async def test_resolves_org_from_arango_edge_shape(self) -> None:
+        inv, cache, _ = _make(
+            app_doc={"type": "S3"},
+            org_edges=[{"_from": f"organizations/{ORG}"}],
+        )
+
+        await inv.on_connector_sync_completed("conn-1")
+
         cache.invalidate_connector.assert_awaited_once_with(ORG, "conn-1")
 
     async def test_supplied_org_skips_the_lookup(self) -> None:

--- a/backend/python/tests/unit/services/cache/test_cache_env_contract.py
+++ b/backend/python/tests/unit/services/cache/test_cache_env_contract.py
@@ -1,0 +1,66 @@
+"""The env knobs the load-test A/B depends on.
+
+Each of these is read at process start, so a run that sets them and sees no
+change would be a silent wasted experiment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.agents.agent_loop.answer_streamer import answer_delta_min_interval
+from app.modules.transformers.blob_storage import (
+    COMPRESSION_THRESHOLD_BYTES_DEFAULT,
+    compression_threshold_bytes,
+)
+from app.services.cache.accessible_records_cache import AccessibleRecordsCache
+
+
+class TestAccessibleRecordsCacheSwitch:
+    @pytest.mark.parametrize("value", ["off", "OFF", "false", "0", "no"])
+    def test_disabling_values(self, monkeypatch, value) -> None:
+        from app.services.cache.accessible_records_cache import _cache_enabled_from_env
+
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_ENABLED, value)
+        assert _cache_enabled_from_env() is False
+
+    @pytest.mark.parametrize("value", ["on", "1", "true", "yes"])
+    def test_enabling_values(self, monkeypatch, value) -> None:
+        from app.services.cache.accessible_records_cache import _cache_enabled_from_env
+
+        monkeypatch.setenv(AccessibleRecordsCache.ENV_ENABLED, value)
+        assert _cache_enabled_from_env() is True
+
+    def test_default_is_on(self, monkeypatch) -> None:
+        from app.services.cache.accessible_records_cache import _cache_enabled_from_env
+
+        monkeypatch.delenv(AccessibleRecordsCache.ENV_ENABLED, raising=False)
+        assert _cache_enabled_from_env() is True
+
+
+class TestAnswerDeltaInterval:
+    def test_default_is_250ms(self, monkeypatch) -> None:
+        monkeypatch.delenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", raising=False)
+        assert answer_delta_min_interval() == 0.25
+
+    def test_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", "100")
+        assert answer_delta_min_interval() == 0.1
+
+    def test_zero_restores_per_token_emits(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", "0")
+        assert answer_delta_min_interval() == 0.0
+
+    def test_garbage_falls_back_to_the_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_ANSWER_DELTA_INTERVAL_MS", "fast")
+        assert answer_delta_min_interval() == 0.25
+
+
+class TestCompressionThreshold:
+    def test_default(self, monkeypatch) -> None:
+        monkeypatch.delenv("PIPESHUB_RECORD_COMPRESSION_THRESHOLD_BYTES", raising=False)
+        assert compression_threshold_bytes() == COMPRESSION_THRESHOLD_BYTES_DEFAULT
+
+    def test_env_override(self, monkeypatch) -> None:
+        monkeypatch.setenv("PIPESHUB_RECORD_COMPRESSION_THRESHOLD_BYTES", "1048576")
+        assert compression_threshold_bytes() == 1048576

--- a/backend/python/tests/unit/services/cache/test_invalidation_hooks.py
+++ b/backend/python/tests/unit/services/cache/test_invalidation_hooks.py
@@ -98,7 +98,7 @@ class TestSyncCompletionSite:
             ):
                 await service._run_sync_and_clear_status(connector, "conn-1")
 
-        notify.assert_awaited_once_with("conn-1")
+        notify.assert_awaited_once_with("conn-1", None)
 
     async def test_fires_even_when_the_sync_raises(self) -> None:
         service = EventService(MagicMock(), MagicMock(), MagicMock())
@@ -111,19 +111,20 @@ class TestSyncCompletionSite:
             "app.connectors.services.event_service.notify_connector_sync_completed", new=notify
         ):
             with pytest.raises(RuntimeError, match="sync failed"):
-                await service._run_sync_and_clear_status(connector, "conn-1")
+                await service._run_sync_and_clear_status(connector, "conn-1", "org-1")
 
-        notify.assert_awaited_once_with("conn-1")
+        notify.assert_awaited_once_with("conn-1", "org-1")
 
     async def test_boot_resume_path_also_fires(self) -> None:
         connector = MagicMock()
         connector.run_sync = AsyncMock()
+        connector.data_entities_processor = MagicMock(org_id="org-1")
         invalidator = _register()
 
         await ConnectorFactory._run_sync_and_invalidate(connector, "conn-1")
 
         connector.run_sync.assert_awaited_once()
-        invalidator.on_connector_sync_completed.assert_awaited_once_with("conn-1", None)
+        invalidator.on_connector_sync_completed.assert_awaited_once_with("conn-1", "org-1")
 
 
 class TestCascadeDeleteSite:

--- a/backend/python/tests/unit/services/cache/test_invalidation_hooks.py
+++ b/backend/python/tests/unit/services/cache/test_invalidation_hooks.py
@@ -1,0 +1,238 @@
+"""The module-level invalidation hooks and the call sites that fire them.
+
+Two properties matter: the hooks are inert until a service registers an
+invalidator (so nothing changes for services that never enable the cache), and
+each write path that makes records appear or disappear actually calls one.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.config.constants.arangodb import Connectors
+from app.connectors.core.base.data_processor.data_source_entities_processor import (
+    DataSourceEntitiesProcessor,
+)
+from app.connectors.core.factory.connector_factory import ConnectorFactory
+from app.connectors.services.event_service import EventService
+from app.modules.transformers.sink_orchestrator import SinkOrchestrator
+from app.services.cache import invalidation_hooks as hooks
+from app.services.graph_db.neo4j.neo4j_provider import Neo4jProvider
+
+_PROCESSOR_MODULE = (
+    "app.connectors.core.base.data_processor.data_source_entities_processor"
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks():
+    hooks.reset_accessible_records_invalidator()
+    yield
+    hooks.reset_accessible_records_invalidator()
+
+
+def _register() -> MagicMock:
+    invalidator = MagicMock()
+    invalidator.on_connector_sync_completed = AsyncMock()
+    invalidator.on_kb_records_changed = AsyncMock()
+    invalidator.on_record_indexed = AsyncMock()
+    hooks._state["invalidator"] = invalidator
+    return invalidator
+
+
+class TestRegistration:
+    async def test_hooks_are_inert_before_registration(self) -> None:
+        assert hooks.get_accessible_records_invalidator() is None
+        await hooks.notify_connector_sync_completed("conn-1")
+        await hooks.notify_kb_records_changed("kb-1")
+        await hooks.notify_record_indexed(connector_name="KB", connector_id="kb-1")
+
+    def test_init_builds_an_invalidator(self) -> None:
+        hooks.init_accessible_records_invalidator(MagicMock(), MagicMock(), MagicMock())
+        assert hooks.get_accessible_records_invalidator() is not None
+
+    def test_init_is_idempotent(self) -> None:
+        hooks.init_accessible_records_invalidator(MagicMock(), MagicMock(), MagicMock())
+        first = hooks.get_accessible_records_invalidator()
+        hooks.init_accessible_records_invalidator(MagicMock(), MagicMock(), MagicMock())
+        assert hooks.get_accessible_records_invalidator() is not first
+
+    async def test_hooks_forward_after_registration(self) -> None:
+        invalidator = _register()
+
+        await hooks.notify_connector_sync_completed("conn-1", "org-1")
+        await hooks.notify_kb_records_changed("kb-1", "org-1")
+        await hooks.notify_record_indexed(connector_name="KB", connector_id="kb-1", org_id="org-1")
+
+        invalidator.on_connector_sync_completed.assert_awaited_once_with("conn-1", "org-1")
+        invalidator.on_kb_records_changed.assert_awaited_once_with("kb-1", "org-1")
+        invalidator.on_record_indexed.assert_awaited_once()
+
+    async def test_a_raising_invalidator_cannot_break_the_caller(self) -> None:
+        invalidator = _register()
+        invalidator.on_connector_sync_completed = AsyncMock(side_effect=RuntimeError("boom"))
+        invalidator.on_kb_records_changed = AsyncMock(side_effect=RuntimeError("boom"))
+        invalidator.on_record_indexed = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await hooks.notify_connector_sync_completed("conn-1")
+        await hooks.notify_kb_records_changed("kb-1")
+        await hooks.notify_record_indexed(connector_name="KB", connector_id="kb-1")
+
+
+class TestSyncCompletionSite:
+    async def test_fires_after_a_successful_sync(self) -> None:
+        service = EventService(MagicMock(), MagicMock(), MagicMock())
+        service._update_app_status = AsyncMock()
+        connector = MagicMock()
+        connector.run_sync = AsyncMock()
+
+        with patch.object(
+            hooks, "notify_connector_sync_completed", new=AsyncMock()
+        ) as notify:
+            # The module imported the symbol directly, so patch it there too.
+            with patch(
+                "app.connectors.services.event_service.notify_connector_sync_completed",
+                new=notify,
+            ):
+                await service._run_sync_and_clear_status(connector, "conn-1")
+
+        notify.assert_awaited_once_with("conn-1")
+
+    async def test_fires_even_when_the_sync_raises(self) -> None:
+        service = EventService(MagicMock(), MagicMock(), MagicMock())
+        service._update_app_status = AsyncMock()
+        connector = MagicMock()
+        connector.run_sync = AsyncMock(side_effect=RuntimeError("sync failed"))
+
+        notify = AsyncMock()
+        with patch(
+            "app.connectors.services.event_service.notify_connector_sync_completed", new=notify
+        ):
+            with pytest.raises(RuntimeError, match="sync failed"):
+                await service._run_sync_and_clear_status(connector, "conn-1")
+
+        notify.assert_awaited_once_with("conn-1")
+
+    async def test_boot_resume_path_also_fires(self) -> None:
+        connector = MagicMock()
+        connector.run_sync = AsyncMock()
+        invalidator = _register()
+
+        await ConnectorFactory._run_sync_and_invalidate(connector, "conn-1")
+
+        connector.run_sync.assert_awaited_once()
+        invalidator.on_connector_sync_completed.assert_awaited_once_with("conn-1", None)
+
+
+class TestCascadeDeleteSite:
+    def _processor(self, result):
+        processor = DataSourceEntitiesProcessor.__new__(DataSourceEntitiesProcessor)
+        processor.logger = MagicMock()
+        processor._publish_delete_events = AsyncMock()
+
+        tx_store = MagicMock()
+        tx_store.delete_records_recursive = AsyncMock(return_value=result)
+        transaction = MagicMock()
+        transaction.__aenter__ = AsyncMock(return_value=tx_store)
+        transaction.__aexit__ = AsyncMock(return_value=False)
+        processor.data_store_provider = MagicMock()
+        processor.data_store_provider.transaction = MagicMock(return_value=transaction)
+        return processor
+
+    async def test_fires_when_records_were_deleted(self) -> None:
+        processor = self._processor({"successfully_deleted": 2, "eventData": None})
+        notify = AsyncMock()
+
+        with patch(
+            f"{_PROCESSOR_MODULE}.notify_kb_records_changed",
+            new=notify,
+        ):
+            await processor.on_records_deleted_cascade(["rec-1", "rec-2"], "kb-1")
+
+        notify.assert_awaited_once_with("kb-1")
+
+    async def test_silent_when_nothing_was_deleted(self) -> None:
+        processor = self._processor({"successfully_deleted": 0, "eventData": None})
+        notify = AsyncMock()
+
+        with patch(
+            f"{_PROCESSOR_MODULE}.notify_kb_records_changed",
+            new=notify,
+        ):
+            await processor.on_records_deleted_cascade(["rec-1"], "kb-1")
+
+        notify.assert_not_called()
+
+    async def test_empty_request_short_circuits(self) -> None:
+        processor = self._processor({"successfully_deleted": 0})
+        notify = AsyncMock()
+
+        with patch(
+            f"{_PROCESSOR_MODULE}.notify_kb_records_changed",
+            new=notify,
+        ):
+            result = await processor.on_records_deleted_cascade([], "kb-1")
+
+        assert result["total_requested"] == 0
+        notify.assert_not_called()
+
+
+class TestIndexingCompletionSite:
+    async def test_fires_when_a_record_becomes_searchable(self) -> None:
+        orchestrator = SinkOrchestrator.__new__(SinkOrchestrator)
+        orchestrator.logger = MagicMock()
+        orchestrator.graph_provider = MagicMock()
+        orchestrator.graph_provider.batch_upsert_nodes = AsyncMock()
+
+        record = MagicMock()
+        record.id = "rec-1"
+        record.virtual_record_id = "vr-1"
+        record.connector_name = Connectors.KNOWLEDGE_BASE
+        record.connector_id = "kb-1"
+        record.external_record_group_id = None
+        record.org_id = "org-1"
+        ctx = MagicMock()
+        ctx.record = record
+
+        notify = AsyncMock()
+        with patch(
+            "app.modules.transformers.sink_orchestrator.notify_record_indexed", new=notify
+        ):
+            await orchestrator._update_indexing_status(ctx)
+
+        orchestrator.graph_provider.batch_upsert_nodes.assert_awaited_once()
+        notify.assert_awaited_once_with(
+            connector_name=Connectors.KNOWLEDGE_BASE,
+            connector_id="kb-1",
+            external_record_group_id=None,
+            org_id="org-1",
+        )
+
+
+class TestDeleteRecordResultShape:
+    async def test_success_result_carries_the_invalidation_fields(self) -> None:
+        """The HTTP delete route reads these to invalidate without a re-read."""
+        provider = Neo4jProvider(MagicMock(), MagicMock())
+        provider.client = MagicMock()
+        provider.get_document = AsyncMock(
+            return_value={
+                "id": "rec-1",
+                "connectorId": "conn-1",
+                "orgId": "org-1",
+                "connectorName": "DRIVE",
+                "origin": "CONNECTOR",
+                "virtualRecordId": "vr-1",
+            }
+        )
+        provider.delete_nodes_and_edges = AsyncMock()
+        provider.execute_query = AsyncMock(return_value=[])
+        provider.client.execute_query = AsyncMock(return_value=[])
+
+        result = await provider.delete_record(record_id="rec-1", user_id="user-1")
+
+        assert result["success"] is True
+        assert result["connectorId"] == "conn-1"
+        assert result["orgId"] == "org-1"
+        assert result["isKb"] is False

--- a/backend/python/tests/unit/services/cache/test_invalidation_hooks.py
+++ b/backend/python/tests/unit/services/cache/test_invalidation_hooks.py
@@ -53,7 +53,7 @@ class TestRegistration:
         hooks.init_accessible_records_invalidator(MagicMock(), MagicMock(), MagicMock())
         assert hooks.get_accessible_records_invalidator() is not None
 
-    def test_init_is_idempotent(self) -> None:
+    def test_init_replaces_existing_invalidator(self) -> None:
         hooks.init_accessible_records_invalidator(MagicMock(), MagicMock(), MagicMock())
         first = hooks.get_accessible_records_invalidator()
         hooks.init_accessible_records_invalidator(MagicMock(), MagicMock(), MagicMock())

--- a/backend/python/tests/unit/services/graph_db/test_accessible_records_provider_routing.py
+++ b/backend/python/tests/unit/services/graph_db/test_accessible_records_provider_routing.py
@@ -1,0 +1,396 @@
+"""`get_accessible_virtual_record_ids` with the cache wired in.
+
+The cache must not change *what* the method returns — only how often the graph
+is asked. These tests pin the four-scenario branching, the first-seen-wins merge
+order, the metadata-filter bypass, and the permission-model routing.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config.constants.arangodb import Connectors, PermissionModel
+from app.services.cache.accessible_records_cache import AccessibleRecordsCache
+from app.services.graph_db.neo4j.neo4j_provider import Neo4jProvider
+
+ORG = "org-1"
+USER = "user-1"
+
+
+class RecordingCache(AccessibleRecordsCache):
+    """Real cache semantics over a dict, with a log of which entry class was used."""
+
+    def __init__(self, enabled: bool = True) -> None:
+        super().__init__(MagicMock(), None, ttl_seconds=300, enabled=False)
+        self._enabled = enabled
+        self.store: dict[str, dict] = {}
+        self.routes: list[tuple[str, str]] = []
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    async def get_or_compute_kb(self, org_id, kb_id, loader):
+        self.routes.append(("kb", kb_id))
+        key = f"kb:{org_id}:{kb_id}"
+        if key not in self.store:
+            self.store[key] = await loader()
+        return self.store[key]
+
+    async def get_or_compute_app_connector(self, org_id, connector_id, loader):
+        self.routes.append(("capp", connector_id))
+        key = f"capp:{org_id}:{connector_id}"
+        if key not in self.store:
+            self.store[key] = await loader()
+        return self.store[key]
+
+    async def get_or_compute_user_connector(self, org_id, connector_id, user_id, loader):
+        self.routes.append(("cusr", connector_id))
+        key = f"cusr:{org_id}:{connector_id}:{user_id}"
+        if key not in self.store:
+            self.store[key] = await loader()
+        return self.store[key]
+
+
+def _provider(cache=None, apps=None) -> Neo4jProvider:
+    provider = Neo4jProvider(MagicMock(), MagicMock(), accessible_records_cache=cache)
+    provider.client = MagicMock()
+    provider.get_user_by_user_id = AsyncMock(return_value={"id": "user-key-1"})
+    provider.get_user_apps = AsyncMock(return_value=apps if apps is not None else [])
+
+    # Every underlying query is stubbed; tests assert on which ones ran.
+    provider._get_virtual_ids_for_connector = AsyncMock(return_value={})
+    provider._get_kb_virtual_ids = AsyncMock(return_value={})
+    provider._get_all_virtual_ids_for_connector = AsyncMock(return_value={})
+    provider._get_kb_virtual_ids_for_kb = AsyncMock(return_value={})
+    provider._get_accessible_kb_ids = AsyncMock(return_value=[])
+    return provider
+
+
+def _app(app_id: str, app_type: str, permission_model: str | None = None) -> dict:
+    doc = {"id": app_id, "type": app_type}
+    if permission_model is not None:
+        doc["permissionModel"] = permission_model
+    return doc
+
+
+APP_LEVEL_CONNECTOR = _app("conn-app", "S3", PermissionModel.APP_LEVEL.value)
+RECORD_LEVEL_CONNECTOR = _app("conn-rec", "DRIVE", PermissionModel.RECORD_LEVEL.value)
+KB_APP = _app("kb-1", Connectors.KNOWLEDGE_BASE.value)
+
+
+class TestCacheDisabledParity:
+    """With no cache (connectors/indexing services) nothing may change."""
+
+    async def test_no_cache_uses_the_live_queries(self) -> None:
+        provider = _provider(cache=None, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        provider._get_virtual_ids_for_connector.assert_awaited_once()
+        provider._get_kb_virtual_ids.assert_awaited_once()
+        provider._get_all_virtual_ids_for_connector.assert_not_called()
+        provider._get_kb_virtual_ids_for_kb.assert_not_called()
+
+    async def test_disabled_cache_uses_the_live_queries(self) -> None:
+        provider = _provider(cache=RecordingCache(enabled=False), apps=[APP_LEVEL_CONNECTOR, KB_APP])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        provider._get_virtual_ids_for_connector.assert_awaited_once()
+        provider._get_kb_virtual_ids.assert_awaited_once()
+
+
+class TestPermissionModelRouting:
+    async def test_app_level_connector_uses_the_shared_entry(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert cache.routes == [("capp", "conn-app")]
+        provider._get_all_virtual_ids_for_connector.assert_awaited_once_with("conn-app")
+        provider._get_virtual_ids_for_connector.assert_not_called()
+
+    async def test_record_level_connector_uses_the_per_user_entry(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[RECORD_LEVEL_CONNECTOR])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert cache.routes == [("cusr", "conn-rec")]
+        provider._get_virtual_ids_for_connector.assert_awaited_once_with(
+            USER, ORG, "conn-rec", None
+        )
+        provider._get_all_virtual_ids_for_connector.assert_not_called()
+
+    async def test_missing_flag_defaults_to_per_user(self) -> None:
+        """An instance predating the flag must not be shared across users."""
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[_app("conn-old", "SLACK")])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert cache.routes == [("cusr", "conn-old")]
+
+    async def test_two_users_share_an_app_level_entry(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR])
+        provider._get_all_virtual_ids_for_connector = AsyncMock(return_value={"vr-1": "rec-1"})
+
+        first = await provider.get_accessible_virtual_record_ids("user-a", ORG)
+        second = await provider.get_accessible_virtual_record_ids("user-b", ORG)
+
+        assert first == second == {"vr-1": "rec-1"}
+        assert provider._get_all_virtual_ids_for_connector.await_count == 1
+
+    async def test_two_users_do_not_share_a_record_level_entry(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[RECORD_LEVEL_CONNECTOR])
+        provider._get_virtual_ids_for_connector = AsyncMock(
+            side_effect=[{"vr-a": "rec-a"}, {"vr-b": "rec-b"}]
+        )
+
+        first = await provider.get_accessible_virtual_record_ids("user-a", ORG)
+        second = await provider.get_accessible_virtual_record_ids("user-b", ORG)
+
+        assert first == {"vr-a": "rec-a"}
+        assert second == {"vr-b": "rec-b"}
+
+
+class TestMetadataFilterBypass:
+    async def test_metadata_filters_take_the_live_path(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+
+        await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"departments": ["eng"]}
+        )
+
+        assert cache.routes == []
+        provider._get_virtual_ids_for_connector.assert_awaited_once_with(
+            USER, ORG, "conn-app", {"departments": ["eng"]}, time_range=None
+        )
+        provider._get_kb_virtual_ids.assert_awaited_once_with(
+            USER, ORG, None, {"departments": ["eng"]}, time_range=None
+        )
+
+    async def test_time_range_takes_the_live_path(self) -> None:
+        """A time range narrows the result set and is not in the cache key, so
+        serving a cached map would return records outside the window."""
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+        window = {"source_created_after_ms": 1700000000000}
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG, time_range=window)
+
+        assert cache.routes == []
+        provider._get_virtual_ids_for_connector.assert_awaited_once_with(
+            USER, ORG, "conn-app", {}, time_range=window
+        )
+        provider._get_kb_virtual_ids.assert_awaited_once_with(
+            USER, ORG, None, {}, time_range=window
+        )
+
+    async def test_time_range_bypasses_even_with_kb_and_apps_filters(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+        window = {"source_updated_before_ms": 1800000000000}
+
+        await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"apps": ["conn-app"], "kb": ["kb-1"]}, time_range=window
+        )
+
+        assert cache.routes == [], "a time-filtered request must not read cached maps"
+
+    async def test_kb_and_apps_filters_still_use_the_cache(self) -> None:
+        """kb/apps select which entries to read; they are not metadata filters."""
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+
+        await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"apps": ["conn-app"], "kb": ["kb-1"]}
+        )
+
+        assert ("capp", "conn-app") in cache.routes
+        assert ("kb", "kb-1") in cache.routes
+
+
+class TestScenarioBranching:
+    async def test_scenario_1_both_filters(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, RECORD_LEVEL_CONNECTOR, KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+
+        await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"apps": ["conn-app"], "kb": ["kb-1"]}
+        )
+
+        assert cache.routes == [("capp", "conn-app"), ("kb", "kb-1")]
+
+    async def test_scenario_2_kb_filter_only_skips_connectors(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG, filters={"kb": ["kb-1"]})
+
+        assert cache.routes == [("kb", "kb-1")]
+
+    async def test_scenario_3_no_filters_queries_everything(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, RECORD_LEVEL_CONNECTOR, KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        kinds = {kind for kind, _ in cache.routes}
+        assert kinds == {"capp", "cusr", "kb"}
+
+    async def test_scenario_4_app_filter_only_skips_kb_entirely(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+
+        await provider.get_accessible_virtual_record_ids(USER, ORG, filters={"apps": ["conn-app"]})
+
+        assert cache.routes == [("capp", "conn-app")]
+        provider._get_accessible_kb_ids.assert_not_called()
+
+    async def test_filtered_apps_outside_the_users_access_are_dropped(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR])
+
+        await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"apps": ["conn-app", "conn-not-mine"]}
+        )
+
+        assert cache.routes == [("capp", "conn-app")]
+
+
+class TestMergeOrder:
+    async def test_connector_wins_over_kb_for_a_shared_vid(self) -> None:
+        """Connector tasks are appended before the KB task, and first seen wins."""
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR, KB_APP])
+        provider._get_all_virtual_ids_for_connector = AsyncMock(return_value={"vr-1": "from-connector"})
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+        provider._get_kb_virtual_ids_for_kb = AsyncMock(return_value={"vr-1": "from-kb"})
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert out == {"vr-1": "from-connector"}
+
+    async def test_earlier_filtered_connector_wins(self) -> None:
+        cache = RecordingCache()
+        apps = [
+            _app("conn-a", "S3", PermissionModel.APP_LEVEL.value),
+            _app("conn-b", "S3", PermissionModel.APP_LEVEL.value),
+        ]
+        provider = _provider(cache, apps=apps)
+        provider._get_all_virtual_ids_for_connector = AsyncMock(
+            side_effect=lambda cid: {"vr-1": f"rec-from-{cid}"}
+        )
+
+        out = await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"apps": ["conn-a", "conn-b"]}
+        )
+
+        assert out == {"vr-1": "rec-from-conn-a"}
+
+    async def test_kb_union_is_first_seen_wins_in_target_order(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1", "kb-2"])
+        provider._get_kb_virtual_ids_for_kb = AsyncMock(
+            side_effect=lambda kb_id: {"vr-1": f"rec-{kb_id}"}
+        )
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert out == {"vr-1": "rec-kb-1"}
+
+
+class TestKbAccessResolution:
+    async def test_kb_filter_is_intersected_with_live_access(self) -> None:
+        """A user must not read a KB entry they cannot reach."""
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+
+        await provider.get_accessible_virtual_record_ids(
+            USER, ORG, filters={"kb": ["kb-1", "kb-forbidden"]}
+        )
+
+        assert cache.routes == [("kb", "kb-1")]
+
+    async def test_no_kb_access_reads_nothing(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=[])
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG, filters={"kb": ["kb-1"]})
+
+        assert out == {}
+        assert cache.routes == []
+
+    async def test_access_query_failure_falls_back_to_the_live_path(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(side_effect=RuntimeError("bolt down"))
+        provider._get_kb_virtual_ids = AsyncMock(return_value={"vr-1": "rec-1"})
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert out == {"vr-1": "rec-1"}
+        provider._get_kb_virtual_ids.assert_awaited_once_with(USER, ORG, None, None)
+
+    async def test_per_kb_failure_falls_back_to_the_live_path(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[KB_APP])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+        provider._get_kb_virtual_ids_for_kb = AsyncMock(side_effect=RuntimeError("bolt down"))
+        provider._get_kb_virtual_ids = AsyncMock(return_value={"vr-live": "rec-live"})
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert out == {"vr-live": "rec-live"}
+
+
+class TestConnectorFallback:
+    async def test_cache_error_falls_back_to_the_live_connector_query(self) -> None:
+        cache = RecordingCache()
+
+        async def boom(*args, **kwargs):
+            raise RuntimeError("redis exploded")
+
+        cache.get_or_compute_app_connector = boom
+        provider = _provider(cache, apps=[APP_LEVEL_CONNECTOR])
+        provider._get_virtual_ids_for_connector = AsyncMock(return_value={"vr-1": "rec-1"})
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert out == {"vr-1": "rec-1"}
+        provider._get_virtual_ids_for_connector.assert_awaited_once_with(
+            USER, ORG, "conn-app", None
+        )
+
+
+class TestUnchangedPreconditions:
+    async def test_unknown_user_returns_empty(self) -> None:
+        provider = _provider(RecordingCache())
+        provider.get_user_by_user_id = AsyncMock(return_value=None)
+
+        assert await provider.get_accessible_virtual_record_ids(USER, ORG) == {}
+
+    async def test_user_with_no_apps_still_checks_kb(self) -> None:
+        cache = RecordingCache()
+        provider = _provider(cache, apps=[])
+        provider._get_accessible_kb_ids = AsyncMock(return_value=["kb-1"])
+        provider._get_kb_virtual_ids_for_kb = AsyncMock(return_value={"vr-1": "rec-1"})
+
+        out = await provider.get_accessible_virtual_record_ids(USER, ORG)
+
+        assert out == {"vr-1": "rec-1"}

--- a/backend/python/tests/unit/services/graph_db/test_arango_field_in_id.py
+++ b/backend/python/tests/unit/services/graph_db/test_arango_field_in_id.py
@@ -1,0 +1,56 @@
+"""`get_nodes_by_field_in(collection, "id", ...)` must match on ArangoDB.
+
+ArangoDB is the DEFAULT datastore (`DATA_STORE` defaults to "arangodb"), and
+`_translate_node_to_arango` moves `id` into `_key` on write -- so `id` is not a
+stored attribute and `FILTER doc.id IN [...]` matched nothing. Every batched
+lookup added for throughput (blob_storage, retrieval_service, chat_helpers)
+passes field="id", so on the default backend they silently returned empty
+batches: citations lost their links and linked-record context disappeared, with
+no error anywhere.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.graph_db.arango.arango_http_provider import ArangoHTTPProvider
+
+
+def _provider() -> ArangoHTTPProvider:
+    p = ArangoHTTPProvider.__new__(ArangoHTTPProvider)
+    p.logger = MagicMock()
+    p.http_client = MagicMock()
+    p.http_client.execute_aql = AsyncMock(return_value=[])
+    return p
+
+
+def _aql(provider: ArangoHTTPProvider) -> str:
+    return provider.http_client.execute_aql.await_args.args[0]
+
+
+class TestIdIsTranslatedToKey:
+    @pytest.mark.asyncio
+    async def test_id_filters_on_key(self) -> None:
+        p = _provider()
+        await p.get_nodes_by_field_in("records", "id", ["a", "b"])
+        query = _aql(p)
+        assert "FILTER doc._key IN @values" in query
+        assert "doc.id IN" not in query, "`id` is not stored; this matches nothing"
+
+    @pytest.mark.asyncio
+    async def test_other_fields_are_untouched(self) -> None:
+        p = _provider()
+        await p.get_nodes_by_field_in("records", "virtualRecordId", ["v1"])
+        assert "FILTER doc.virtualRecordId IN @values" in _aql(p)
+
+    @pytest.mark.asyncio
+    async def test_projected_id_comes_from_key(self) -> None:
+        """A caller asking for `id` back must get it, or it cannot key the
+        results to the ids it requested."""
+        p = _provider()
+        await p.get_nodes_by_field_in("records", "id", ["a"], return_fields=["id", "webUrl"])
+        query = _aql(p)
+        assert "id: doc._key" in query
+        assert "webUrl: doc.webUrl" in query

--- a/backend/python/tests/unit/services/graph_db/test_graph_db_factory.py
+++ b/backend/python/tests/unit/services/graph_db/test_graph_db_factory.py
@@ -192,6 +192,7 @@ class TestGraphDBProviderFactoryCreateProvider:
         mock_create_neo4j.assert_awaited_once_with(
             logger=mock_logger,
             config_service=config,
+            accessible_records_cache=None,
         )
 
     @pytest.mark.asyncio
@@ -284,7 +285,9 @@ class TestGraphDBProviderFactoryCreateNeo4jProvider:
             config_service=config,
         )
         assert result is mock_instance
-        MockProvider.assert_called_once_with(logger=mock_logger, config_service=config)
+        MockProvider.assert_called_once_with(
+            logger=mock_logger, config_service=config, accessible_records_cache=None
+        )
         mock_instance.connect.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/backend/python/tests/unit/services/graph_db/test_neo4j_record_relations_batch.py
+++ b/backend/python/tests/unit/services/graph_db/test_neo4j_record_relations_batch.py
@@ -112,3 +112,23 @@ class TestFailure:
             {"record_id": "p1", "relationType": "PARENT_CHILD"}
         ]
         assert p.get_parent_record_ids_by_relation_type.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_default_batch_skips_non_mapping_rows(self) -> None:
+        from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
+
+        p = _provider([])
+        p.get_parent_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "p1"}, "bad-row", None]
+        )
+        p.get_child_record_ids_by_relation_type = AsyncMock(return_value=[42])
+
+        # Call the interface default, not Neo4j's specialised batch query.
+        out = await IGraphDBProvider.get_record_relations_batch(
+            p, ["a"], ["PARENT_CHILD"]
+        )
+
+        assert out["a"]["parents"] == [
+            {"record_id": "p1", "relationType": "PARENT_CHILD"}
+        ]
+        assert out["a"]["children"] == []

--- a/backend/python/tests/unit/services/graph_db/test_neo4j_record_relations_batch.py
+++ b/backend/python/tests/unit/services/graph_db/test_neo4j_record_relations_batch.py
@@ -1,0 +1,114 @@
+"""One Cypher query for every record's edges, in both directions.
+
+The per-record methods cost a query each per relation type per direction, so a
+turn enriching its search hits spent 4x its hit count on round trips. What
+matters here is that the batched form still splits parents from children
+correctly -- getting that backwards mislabels every relation shown to the model.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.graph_db.neo4j.neo4j_provider import Neo4jProvider
+
+
+def _provider(rows: list[dict] | Exception) -> Neo4jProvider:
+    p = Neo4jProvider(logger=MagicMock(), config_service=MagicMock())
+    p.client = AsyncMock()
+    if isinstance(rows, Exception):
+        p.client.execute_query = AsyncMock(side_effect=rows)
+    else:
+        p.client.execute_query = AsyncMock(return_value=rows)
+    return p
+
+
+def _row(anchor: str, other: str, outgoing: bool, rel: str = "PARENT_CHILD") -> dict:
+    return {
+        "anchor_id": anchor, "record_id": other, "outgoing": outgoing,
+        "relationType": rel, "parentTable": "", "childTable": "",
+        "sourceColumn": "", "targetColumn": "",
+    }
+
+
+class TestBatchShape:
+    @pytest.mark.asyncio
+    async def test_all_records_cost_a_single_query(self) -> None:
+        p = _provider([])
+        await p.get_record_relations_batch(["a", "b", "c"], ["PARENT_CHILD", "ATTACHMENT"])
+        assert p.client.execute_query.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_ids_and_relations_are_bound_as_parameters(self) -> None:
+        p = _provider([])
+        await p.get_record_relations_batch(["a", "b"], ["PARENT_CHILD"])
+        params = p.client.execute_query.call_args.kwargs["parameters"]
+        assert params == {"record_ids": ["a", "b"], "relation_types": ["PARENT_CHILD"]}
+
+    @pytest.mark.asyncio
+    async def test_every_requested_record_is_present_even_with_no_edges(self) -> None:
+        """Callers index the result by record id; a missing key would KeyError."""
+        p = _provider([])
+        out = await p.get_record_relations_batch(["a", "b"], ["PARENT_CHILD"])
+        assert out == {
+            "a": {"parents": [], "children": []},
+            "b": {"parents": [], "children": []},
+        }
+
+    @pytest.mark.asyncio
+    async def test_empty_input_issues_no_query(self) -> None:
+        p = _provider([])
+        assert await p.get_record_relations_batch([], ["PARENT_CHILD"]) == {}
+        assert await p.get_record_relations_batch(["a"], []) == {
+            "a": {"parents": [], "children": []}
+        }
+        assert p.client.execute_query.await_count == 0
+
+
+class TestDirection:
+    @pytest.mark.asyncio
+    async def test_outgoing_edges_become_parents_incoming_become_children(self) -> None:
+        p = _provider([_row("a", "out", True), _row("a", "in", False)])
+        out = await p.get_record_relations_batch(["a"], ["PARENT_CHILD"])
+        assert [e["record_id"] for e in out["a"]["parents"]] == ["out"]
+        assert [e["record_id"] for e in out["a"]["children"]] == ["in"]
+
+    @pytest.mark.asyncio
+    async def test_each_endpoint_of_a_shared_edge_is_anchored_separately(self) -> None:
+        """When both ends are in the batch Neo4j returns the edge once per
+        anchor; each must land in the opposite bucket."""
+        p = _provider([_row("a", "b", True), _row("b", "a", False)])
+        out = await p.get_record_relations_batch(["a", "b"], ["PARENT_CHILD"])
+        assert out["a"]["parents"][0]["record_id"] == "b"
+        assert out["b"]["children"][0]["record_id"] == "a"
+
+    @pytest.mark.asyncio
+    async def test_relation_type_is_carried_so_callers_can_label_edges(self) -> None:
+        p = _provider([_row("a", "x", True, rel="ATTACHMENT")])
+        out = await p.get_record_relations_batch(["a"], ["ATTACHMENT"])
+        assert out["a"]["parents"][0]["relationType"] == "ATTACHMENT"
+
+    @pytest.mark.asyncio
+    async def test_rows_for_unrequested_anchors_are_ignored(self) -> None:
+        p = _provider([_row("zzz", "x", True)])
+        out = await p.get_record_relations_batch(["a"], ["PARENT_CHILD"])
+        assert out == {"a": {"parents": [], "children": []}}
+
+
+class TestFailure:
+    @pytest.mark.asyncio
+    async def test_query_failure_falls_back_to_the_per_record_path(self) -> None:
+        """Losing relation context silently would strip metadata from answers,
+        so a failed batch retries the way it worked before."""
+        p = _provider(RuntimeError("boom"))
+        p.get_parent_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "p1"}]
+        )
+        p.get_child_record_ids_by_relation_type = AsyncMock(return_value=[])
+
+        out = await p.get_record_relations_batch(["a"], ["PARENT_CHILD"])
+
+        assert out["a"]["parents"] == [
+            {"record_id": "p1", "relationType": "PARENT_CHILD"}
+        ]
+        assert p.get_parent_record_ids_by_relation_type.await_count == 1

--- a/backend/python/tests/unit/utils/test_chat_helpers.py
+++ b/backend/python/tests/unit/utils/test_chat_helpers.py
@@ -5060,6 +5060,23 @@ class TestEnrichRecordsWithGraphContext:
         gp.get_parent_record_ids_by_relation_type = AsyncMock(side_effect=_parent)
         gp.get_child_record_ids_by_relation_type = AsyncMock(side_effect=_child)
 
+        async def _relations_batch(record_ids, relation_types, transaction=None):
+            return {
+                rid: {
+                    "parents": [
+                        {**e, "relationType": rt}
+                        for rt in relation_types for e in outgoing_by_type.get(rt, [])
+                    ],
+                    "children": [
+                        {**e, "relationType": rt}
+                        for rt in relation_types for e in incoming_by_type.get(rt, [])
+                    ],
+                }
+                for rid in record_ids
+            }
+
+        gp.get_record_relations_batch = AsyncMock(side_effect=_relations_batch)
+
         async def _get_document(record_id, collection=None, *args, **kwargs):
             if record_id in docs_by_id:
                 return docs_by_id[record_id]
@@ -5074,6 +5091,16 @@ class TestEnrichRecordsWithGraphContext:
             }
 
         gp.get_document = AsyncMock(side_effect=_get_document)
+
+        # The enrichment path resolves base and type-specific docs one query per
+        # collection rather than one per record. Delegate through the attribute
+        # so tests that override `get_document` after construction stay
+        # authoritative for both call shapes.
+        async def _get_nodes_by_field_in(collection, field_name, field_values, *args, **kwargs):
+            docs = [await gp.get_document(rid, collection) for rid in field_values]
+            return [d for d in docs if isinstance(d, dict) and (d.get("id") or d.get("_key"))]
+
+        gp.get_nodes_by_field_in = AsyncMock(side_effect=_get_nodes_by_field_in)
         gp.get_virtual_record_ids_for_record_ids = AsyncMock(return_value=vrid_map or {})
         return gp
 
@@ -5304,7 +5331,12 @@ class TestEnrichRecordsWithGraphContext:
         rel = flattened[0]["parent_node_relation"]
         assert rel["record_id"] == "rec-issue-1"
         assert "This ticket tracks the login bug fix." in rel["context_metadata"]
-        blob_store.get_record_from_storage.assert_awaited_once_with("vr-parent-1", "org-1")
+        # lookup_result is pre-resolved in one batched call by the caller; the
+        # fetch resolves the id itself only when the batch had no entry.
+        blob_store.get_record_from_storage.assert_awaited_once()
+        args, kwargs = blob_store.get_record_from_storage.await_args
+        assert args == ("vr-parent-1", "org-1")
+        assert set(kwargs) <= {"lookup_result"}
 
     @pytest.mark.asyncio
     async def test_falls_back_to_graph_when_not_indexed(self):
@@ -5405,15 +5437,19 @@ class TestEnrichRecordsWithGraphContext:
         assert "record_relations" not in rec
 
     @pytest.mark.asyncio
-    async def test_queries_both_relation_types(self):
+    async def test_queries_both_relation_types_in_one_batch(self):
         rec = self._ticket_record()
         vr_map = {"vr-ticket": rec}
         gp = self._make_graph_provider()
         await enrich_records_with_graph_context(
             vr_map, graph_provider=gp, flattened_results=[],
         )
-        assert gp.get_parent_record_ids_by_relation_type.await_count == 2
-        assert gp.get_child_record_ids_by_relation_type.await_count == 2
+        gp.get_record_relations_batch.assert_awaited_once()
+        from app.utils.chat_helpers import RECORD_RELATION_ENRICHMENT_TYPES
+        requested = set(gp.get_record_relations_batch.await_args.args[1])
+        assert requested == {rel.value for rel in RECORD_RELATION_ENRICHMENT_TYPES}
+        assert gp.get_parent_record_ids_by_relation_type.await_count == 0
+        assert gp.get_child_record_ids_by_relation_type.await_count == 0
 
     @pytest.mark.asyncio
     async def test_stores_minimal_related_records(self):

--- a/backend/python/tests/unit/utils/test_fetch_url_tool.py
+++ b/backend/python/tests/unit/utils/test_fetch_url_tool.py
@@ -141,13 +141,15 @@ class TestResolveTinyRefUrl:
 
         assert result == "https://ref99.xyz"
 
-    def test_tiny_ref_with_no_mapper_returns_original(self) -> None:
+    @pytest.mark.asyncio
+    async def test_tiny_ref_with_no_mapper_returns_original(self) -> None:
         with patch("app.utils.fetch_url_tool.extract_tiny_ref", return_value="ref1"):
             result = _resolve_tiny_ref_url("https://ref1.xyz", None)
 
         assert result == "https://ref1.xyz"
 
-    def test_resolved_url_also_has_fragment_stripped(self) -> None:
+    @pytest.mark.asyncio
+    async def test_resolved_url_also_has_fragment_stripped(self) -> None:
         mock_mapper = MagicMock()
         mock_mapper.ref_to_url = {"ref1": "https://real.com/page#:~:text=hello"}
 
@@ -163,40 +165,46 @@ class TestResolveTinyRefUrl:
 
 
 class TestCreateFetchUrlTool:
-    def test_creates_tool_without_mapper(self) -> None:
+    @pytest.mark.asyncio
+    async def test_creates_tool_without_mapper(self) -> None:
         tool = create_fetch_url_tool()
         assert tool.name == "fetch_url"
 
-    def test_creates_tool_with_mapper(self) -> None:
+    @pytest.mark.asyncio
+    async def test_creates_tool_with_mapper(self) -> None:
         mock_mapper = MagicMock()
         tool = create_fetch_url_tool(ref_mapper=mock_mapper)
         assert tool.name == "fetch_url"
 
-    def test_invalid_scheme_returns_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_invalid_scheme_returns_error(self) -> None:
         tool = create_fetch_url_tool()
-        result = tool.invoke({"url": "ftp://example.com/file"})
+        result = await tool.ainvoke({"url": "ftp://example.com/file"})
         import json
         data = json.loads(result)
         assert data["ok"] is False
         assert "scheme" in data["error"].lower() or "Invalid" in data["error"]
 
-    def test_no_netloc_returns_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_no_netloc_returns_error(self) -> None:
         tool = create_fetch_url_tool()
-        result = tool.invoke({"url": "https://"})
+        result = await tool.ainvoke({"url": "https://"})
         import json
         data = json.loads(result)
         assert data["ok"] is False
 
-    def test_unresolved_tiny_ref_returns_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_unresolved_tiny_ref_returns_error(self) -> None:
         tool = create_fetch_url_tool()
         with patch("app.utils.fetch_url_tool.extract_tiny_ref", return_value="ref1"), \
              patch("app.utils.fetch_url_tool._resolve_tiny_ref_url", return_value="https://ref1.xyz"):
-            result = tool.invoke({"url": "https://ref1.xyz"})
+            result = await tool.ainvoke({"url": "https://ref1.xyz"})
         import json
         data = json.loads(result)
         assert data["ok"] is False
 
-    def test_fetch_url_success_with_blocks(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fetch_url_success_with_blocks(self) -> None:
         mock_resp = FetchResult(
             status_code=200,
             text="<html><body><p>Hello world</p></body></html>",
@@ -213,7 +221,7 @@ class TestCreateFetchUrlTool:
              patch("app.utils.fetch_url_tool.html_to_blocks", return_value=[mock_block]), \
              patch("dataclasses.asdict", return_value=mock_block_dict):
             tool = create_fetch_url_tool()
-            result = tool.invoke({"url": "https://example.com"})
+            result = await tool.ainvoke({"url": "https://example.com"})
 
         import json
         data = json.loads(result)
@@ -221,7 +229,8 @@ class TestCreateFetchUrlTool:
         assert data["url"] == "https://example.com"
         assert len(data["blocks"]) == 1
 
-    def test_fetch_url_non_200_response(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fetch_url_non_200_response(self) -> None:
         mock_resp = FetchResult(
             status_code=403,
             text="Forbidden",
@@ -233,14 +242,15 @@ class TestCreateFetchUrlTool:
 
         with patch("app.utils.fetch_url_tool.fetch_url", return_value=mock_resp):
             tool = create_fetch_url_tool()
-            result = tool.invoke({"url": "https://example.com/secret"})
+            result = await tool.ainvoke({"url": "https://example.com/secret"})
 
         import json
         data = json.loads(result)
         assert data["ok"] is False
         assert "403" in data["error"]
 
-    def test_fetch_url_empty_blocks_returns_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fetch_url_empty_blocks_returns_error(self) -> None:
         mock_resp = FetchResult(
             status_code=200,
             text="<html></html>",
@@ -253,24 +263,26 @@ class TestCreateFetchUrlTool:
         with patch("app.utils.fetch_url_tool.fetch_url", return_value=mock_resp), \
              patch("app.utils.fetch_url_tool.html_to_blocks", return_value=[]):
             tool = create_fetch_url_tool()
-            result = tool.invoke({"url": "https://example.com"})
+            result = await tool.ainvoke({"url": "https://example.com"})
 
         import json
         data = json.loads(result)
         assert data["ok"] is False
         assert "No readable content" in data["error"]
 
-    def test_fetch_url_exception_returns_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fetch_url_exception_returns_error(self) -> None:
         with patch("app.utils.fetch_url_tool.fetch_url", side_effect=RuntimeError("network failure")):
             tool = create_fetch_url_tool()
-            result = tool.invoke({"url": "https://example.com"})
+            result = await tool.ainvoke({"url": "https://example.com"})
 
         import json
         data = json.loads(result)
         assert data["ok"] is False
         assert "network failure" in data["error"]
 
-    def test_fetch_url_with_ref_mapper_resolves_url(self) -> None:
+    @pytest.mark.asyncio
+    async def test_fetch_url_with_ref_mapper_resolves_url(self) -> None:
         mock_mapper = MagicMock()
         mock_mapper.ref_to_url = {}
 
@@ -289,7 +301,7 @@ class TestCreateFetchUrlTool:
              patch("app.utils.fetch_url_tool.html_to_blocks", return_value=[mock_block]), \
              patch("dataclasses.asdict", return_value={"type": "paragraph", "content": "content"}):
             tool = create_fetch_url_tool(ref_mapper=mock_mapper)
-            result = tool.invoke({"url": "https://real.com/page"})
+            result = await tool.ainvoke({"url": "https://real.com/page"})
 
         import json
         data = json.loads(result)

--- a/backend/python/tests/unit/utils/test_linked_record_batching.py
+++ b/backend/python/tests/unit/utils/test_linked_record_batching.py
@@ -1,0 +1,291 @@
+"""Batched lookups on the linked-record enrichment path.
+
+Enriching a search hit's related records used to cost three calls per record: a
+blob fetch (which repeated its own virtual-record mapping query), a base graph
+doc, and a type-specific graph doc. These guard that batching them is
+indistinguishable from the per-record path, including when a batch misses or
+fails outright.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config.constants.arangodb import CollectionNames
+from app.utils import chat_helpers as ch
+
+RECORDS = CollectionNames.RECORDS.value
+
+
+def _graph_provider(nodes_by_collection: dict | None = None) -> MagicMock:
+    """Graph provider whose batch call answers from a collection → nodes map."""
+    nodes_by_collection = nodes_by_collection or {}
+    provider = MagicMock()
+
+    async def _batch(collection, field, values, **_kw) -> list[dict]:
+        return [n for n in nodes_by_collection.get(collection, []) if n["id"] in values]
+
+    provider.get_nodes_by_field_in = AsyncMock(side_effect=_batch)
+    provider.get_document = AsyncMock(return_value=None)
+    provider.get_virtual_record_ids_for_record_ids = AsyncMock(return_value={})
+    return provider
+
+
+class TestBaseDocBatching:
+    @pytest.mark.asyncio
+    async def test_one_query_replaces_one_per_record(self) -> None:
+        ids = [f"r{i}" for i in range(5)]
+        provider = _graph_provider({RECORDS: [{"id": i, "recordName": i} for i in ids]})
+        doc_index: dict = {}
+
+        await ch._resolve_target_metadata(
+            set(ids), doc_index, provider, set(ids), None, None, "org",
+        )
+
+        assert provider.get_nodes_by_field_in.await_count == 1
+        assert provider.get_document.await_count == 0
+        assert set(doc_index) == set(ids)
+
+    @pytest.mark.asyncio
+    async def test_ids_missing_from_the_batch_are_simply_absent(self) -> None:
+        """Matches today's behaviour when get_document returned None."""
+        provider = _graph_provider({RECORDS: [{"id": "r1", "recordName": "r1"}]})
+        doc_index: dict = {}
+
+        await ch._resolve_target_metadata(
+            {"r1", "r2"}, doc_index, provider, {"r1", "r2"}, None, None, "org",
+        )
+
+        assert "r1" in doc_index
+        assert "r2" not in doc_index
+
+    @pytest.mark.asyncio
+    async def test_batch_failure_falls_back_to_per_id(self) -> None:
+        provider = _graph_provider()
+        provider.get_nodes_by_field_in = AsyncMock(side_effect=RuntimeError("graph down"))
+        provider.get_document = AsyncMock(return_value={"id": "r1", "recordName": "fallback"})
+        doc_index: dict = {}
+
+        await ch._resolve_target_metadata(
+            {"r1"}, doc_index, provider, {"r1"}, None, None, "org",
+        )
+
+        assert provider.get_document.await_count == 1
+        assert doc_index["r1"]["recordName"] == "fallback"
+
+
+class TestTypeDocBatching:
+    @pytest.mark.asyncio
+    async def test_grouped_by_collection_not_per_record(self) -> None:
+        doc_index = {
+            "t1": {"id": "t1", "recordType": "TICKET"},
+            "t2": {"id": "t2", "recordType": "TICKET"},
+            "f1": {"id": "f1", "recordType": "FILE"},
+        }
+        provider = _graph_provider({
+            "tickets": [{"id": "t1", "status": "open"}, {"id": "t2", "status": "done"}],
+            "files": [{"id": "f1", "extension": "pdf"}],
+        })
+
+        resolved = await ch._fetch_type_specific_docs_batched(
+            provider, list(doc_index), doc_index,
+        )
+
+        # one query per collection, two collections
+        assert provider.get_nodes_by_field_in.await_count == 2
+        assert resolved["t1"]["status"] == "open"
+        assert resolved["f1"]["extension"] == "pdf"
+
+    @pytest.mark.asyncio
+    async def test_unmapped_record_types_are_never_queried(self) -> None:
+        """CONFLUENCE_PAGE/WEBPAGE/DATASOURCE have no collection_map entry and
+        took the `if not collection: return None` branch before batching."""
+        doc_index = {
+            "c1": {"id": "c1", "recordType": "CONFLUENCE_PAGE"},
+            "w1": {"id": "w1", "recordType": "WEBPAGE"},
+        }
+        provider = _graph_provider()
+
+        resolved = await ch._fetch_type_specific_docs_batched(
+            provider, list(doc_index), doc_index,
+        )
+
+        assert provider.get_nodes_by_field_in.await_count == 0
+        assert resolved == {}
+
+    @pytest.mark.asyncio
+    async def test_failing_collection_does_not_lose_the_others(self) -> None:
+        doc_index = {
+            "t1": {"id": "t1", "recordType": "TICKET"},
+            "f1": {"id": "f1", "recordType": "FILE"},
+        }
+        provider = _graph_provider()
+
+        async def _batch(collection, field, values, **_kw) -> list[dict]:
+            if collection == "tickets":
+                raise RuntimeError("tickets unavailable")
+            return [{"id": "f1", "extension": "pdf"}]
+
+        provider.get_nodes_by_field_in = AsyncMock(side_effect=_batch)
+
+        resolved = await ch._fetch_type_specific_docs_batched(
+            provider, list(doc_index), doc_index,
+        )
+
+        assert "t1" not in resolved
+        assert resolved["f1"]["extension"] == "pdf"
+
+
+class TestBlobLookupPassthrough:
+    @pytest.mark.asyncio
+    async def test_prefetched_lookup_is_forwarded_to_the_blob_fetch(self) -> None:
+        """Without this the fetch repeats the mapping query the caller batched."""
+        blob_store = MagicMock()
+        blob_store.get_record_from_storage = AsyncMock(return_value={"summary": "s"})
+        doc_index = {"r1": {"id": "r1", "recordType": "FILE", "recordName": "n"}}
+
+        await ch._build_linked_record_context_metadata(
+            "r1", _graph_provider(), doc_index, None,
+            vrid="v1", blob_store=blob_store, org_id="org",
+            lookup_result={"_key": "doc-1"},
+        )
+
+        assert blob_store.get_record_from_storage.await_args.kwargs["lookup_result"] == {
+            "_key": "doc-1"
+        }
+
+    @pytest.mark.asyncio
+    async def test_type_doc_when_supplied_skips_the_per_record_query(self) -> None:
+        provider = _graph_provider()
+        blob_store = MagicMock()
+        blob_store.get_record_from_storage = AsyncMock(return_value=None)
+        doc_index = {"t1": {"id": "t1", "recordType": "TICKET", "recordName": "n"}}
+
+        await ch._build_linked_record_context_metadata(
+            "t1", provider, doc_index, None,
+            vrid="v1", blob_store=blob_store, org_id="org",
+            type_doc={"id": "t1", "status": "open"},
+        )
+
+        assert provider.get_document.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_type_doc_still_falls_back_to_the_query(self) -> None:
+        provider = _graph_provider()
+        provider.get_document = AsyncMock(return_value={"id": "t1", "status": "open"})
+        blob_store = MagicMock()
+        blob_store.get_record_from_storage = AsyncMock(return_value=None)
+        doc_index = {"t1": {"id": "t1", "recordType": "TICKET", "recordName": "n"}}
+
+        await ch._build_linked_record_context_metadata(
+            "t1", provider, doc_index, None,
+            vrid="v1", blob_store=blob_store, org_id="org",
+            type_doc=None,
+        )
+
+        assert provider.get_document.await_count == 1
+
+
+class TestMainRecordPathTypeDocs:
+    """The main record path resolved type-specific metadata per record too."""
+
+    @pytest.mark.asyncio
+    async def test_supplied_type_docs_skip_the_per_record_query(self) -> None:
+        provider = _graph_provider()
+        blob_store = MagicMock()
+        blob_store.get_record_from_storage = AsyncMock(
+            return_value={"record_name": "n", "summary": "s"}
+        )
+        vtr = {"v1": {"id": "t1", "recordType": "TICKET", "recordName": "n"}}
+
+        await ch.get_record(
+            "v1", {}, blob_store, "org", vtr, provider, None, None,
+            {"t1": {"id": "t1", "status": "open"}},
+        )
+
+        assert provider.get_document.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_missing_type_doc_falls_back_to_the_query(self) -> None:
+        provider = _graph_provider()
+        provider.get_document = AsyncMock(return_value={"id": "t1", "status": "open"})
+        blob_store = MagicMock()
+        blob_store.get_record_from_storage = AsyncMock(
+            return_value={"record_name": "n", "summary": "s"}
+        )
+        vtr = {"v1": {"id": "t1", "recordType": "TICKET", "recordName": "n"}}
+
+        await ch.get_record("v1", {}, blob_store, "org", vtr, provider, None, None, {})
+
+        assert provider.get_document.await_count == 1
+
+
+class TestEdgeBatching:
+    """Record-relation edges were four queries per hit (2 relation types x 2
+    directions). These pin the batched form to the same output."""
+
+    @staticmethod
+    def _provider_with_edges(batch_result: dict) -> MagicMock:
+        provider = _graph_provider()
+        provider.get_record_relations_batch = AsyncMock(return_value=batch_result)
+        provider.get_parent_record_ids_by_relation_type = AsyncMock(return_value=[])
+        provider.get_child_record_ids_by_relation_type = AsyncMock(return_value=[])
+        return provider
+
+    @pytest.mark.asyncio
+    async def test_one_query_covers_every_record_and_direction(self) -> None:
+        provider = self._provider_with_edges({
+            "r1": {
+                "parents": [{"record_id": "p1", "relationType": "PARENT_CHILD"}],
+                "children": [{"record_id": "c1", "relationType": "ATTACHMENT"}],
+            },
+            "r2": {"parents": [], "children": []},
+        })
+
+        out = await ch._fetch_edges_for_records(provider, ["r1", "r2"])
+
+        assert provider.get_record_relations_batch.await_count == 1
+        assert provider.get_parent_record_ids_by_relation_type.await_count == 0
+        assert provider.get_child_record_ids_by_relation_type.await_count == 0
+        assert out["r2"] == []
+        # incoming ATTACHMENT reads as PARENT, outgoing PARENT_CHILD as CHILD
+        assert sorted(out["r1"]) == [("c1", "PARENT"), ("p1", "CHILD")]
+
+    @pytest.mark.asyncio
+    async def test_direction_drives_the_label_not_the_relation_name(self) -> None:
+        """PARENT_CHILD outgoing means the hit points at its child; incoming
+        means the hit has a parent. Swapping these mislabels the context."""
+        provider = self._provider_with_edges({
+            "r1": {
+                "parents": [{"record_id": "out", "relationType": "PARENT_CHILD"}],
+                "children": [{"record_id": "in", "relationType": "PARENT_CHILD"}],
+            },
+        })
+
+        out = dict(await ch._fetch_edges_for_records(provider, ["r1"]))["r1"]
+
+        assert dict((rid, label) for rid, label in out) == {"out": "CHILD", "in": "PARENT"}
+
+    @pytest.mark.asyncio
+    async def test_unknown_relation_types_are_dropped(self) -> None:
+        provider = self._provider_with_edges({
+            "r1": {
+                "parents": [{"record_id": "p1", "relationType": "SOMETHING_ELSE"}],
+                "children": [],
+            },
+        })
+
+        assert await ch._fetch_edges_for_records(provider, ["r1"]) == {"r1": []}
+
+    @pytest.mark.asyncio
+    async def test_no_records_issues_no_query(self) -> None:
+        provider = self._provider_with_edges({})
+        assert await ch._fetch_edges_for_records(provider, []) == {}
+        assert provider.get_record_relations_batch.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_batch_failure_degrades_to_no_edges_not_an_exception(self) -> None:
+        provider = self._provider_with_edges({})
+        provider.get_record_relations_batch = AsyncMock(side_effect=RuntimeError("boom"))
+
+        assert await ch._fetch_edges_for_records(provider, ["r1"]) == {}

--- a/backend/python/tests/unit/utils/test_linked_record_batching.py
+++ b/backend/python/tests/unit/utils/test_linked_record_batching.py
@@ -284,8 +284,34 @@ class TestEdgeBatching:
         assert provider.get_record_relations_batch.await_count == 0
 
     @pytest.mark.asyncio
-    async def test_batch_failure_degrades_to_no_edges_not_an_exception(self) -> None:
+    async def test_batch_failure_falls_back_per_record_rather_than_dropping_all(
+        self,
+    ) -> None:
+        """A failed batch must not cost the whole turn its linked-record context.
+
+        Returning {} here silently stripped enrichment from every hit; the
+        per-record form this replaced lost only the failing pair.
+        """
         provider = self._provider_with_edges({})
         provider.get_record_relations_batch = AsyncMock(side_effect=RuntimeError("boom"))
+        provider.get_parent_record_ids_by_relation_type = AsyncMock(
+            return_value=[{"record_id": "p1", "recordName": "Parent One"}]
+        )
 
-        assert await ch._fetch_edges_for_records(provider, ["r1"]) == {}
+        edges = await ch._fetch_edges_for_records(provider, ["r1"])
+
+        assert provider.get_parent_record_ids_by_relation_type.await_count > 0
+        assert edges.get("r1"), "per-record fallback produced no edges"
+
+    @pytest.mark.asyncio
+    async def test_batch_failure_never_raises(self) -> None:
+        provider = self._provider_with_edges({})
+        provider.get_record_relations_batch = AsyncMock(side_effect=RuntimeError("boom"))
+        provider.get_parent_record_ids_by_relation_type = AsyncMock(
+            side_effect=RuntimeError("also down")
+        )
+        provider.get_child_record_ids_by_relation_type = AsyncMock(
+            side_effect=RuntimeError("also down")
+        )
+
+        assert await ch._fetch_edges_for_records(provider, ["r1"]) == {"r1": []}

--- a/backend/python/tests/unit/utils/test_text_fragment_url_cache.py
+++ b/backend/python/tests/unit/utils/test_text_fragment_url_cache.py
@@ -1,0 +1,104 @@
+"""Memoized `generate_text_fragment_url` must be indistinguishable from the raw builder."""
+
+import pytest
+
+from app.utils import chat_helpers
+from app.utils.chat_helpers import (
+    _build_text_fragment_url,
+    _FRAGMENT_URL_CACHE,
+    generate_text_fragment_url,
+)
+
+BASE = "https://example.com/doc/1"
+
+SNIPPETS = [
+    "The quick brown fox jumps over the lazy dog",
+    "  leading and trailing whitespace  ",
+    "trailing punctuation should be stripped!!!",
+    "single",
+    "",
+    "   ",
+    "!!!???",
+    "Ünïcodé wörds thät need éncoding here",
+    "emoji 🎉 mixed with words that follow after",
+    "a" * 5000 + " long tail words here",
+    "one two",
+    "line one\nline two continues here\nline three",
+    "Hyphenated-words and don't contractions appear",
+]
+
+BASES = [
+    BASE,
+    "https://example.com/doc/1#section",
+    "https://example.com/doc/1#:~:text=already,fragment",
+    "",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    _FRAGMENT_URL_CACHE.clear()
+    yield
+    _FRAGMENT_URL_CACHE.clear()
+
+
+@pytest.mark.parametrize("base", BASES)
+@pytest.mark.parametrize("snippet", SNIPPETS)
+def test_memoized_output_matches_uncached(base, snippet) -> None:
+    expected = _build_text_fragment_url(base, snippet)
+    assert generate_text_fragment_url(base, snippet) == expected
+    # second call is served from the cache and must be identical
+    assert generate_text_fragment_url(base, snippet) == expected
+
+
+def test_cache_actually_serves_repeat_calls(monkeypatch) -> None:
+    calls = []
+    real = chat_helpers._build_text_fragment_url
+
+    def counting(base_url, text_snippet):
+        calls.append((base_url, text_snippet))
+        return real(base_url, text_snippet)
+
+    monkeypatch.setattr(chat_helpers, "_build_text_fragment_url", counting)
+
+    snippet = "the quick brown fox jumps over"
+    first = chat_helpers.generate_text_fragment_url(BASE, snippet)
+    second = chat_helpers.generate_text_fragment_url(BASE, snippet)
+
+    assert first == second
+    assert len(calls) == 1, "repeat call should hit the cache"
+
+
+def test_distinct_snippets_do_not_collide() -> None:
+    a = generate_text_fragment_url(BASE, "alpha beta gamma delta")
+    b = generate_text_fragment_url(BASE, "epsilon zeta eta theta")
+    assert a != b
+    assert a == _build_text_fragment_url(BASE, "alpha beta gamma delta")
+    assert b == _build_text_fragment_url(BASE, "epsilon zeta eta theta")
+
+
+def test_distinct_base_urls_do_not_collide() -> None:
+    snippet = "shared snippet text here"
+    a = generate_text_fragment_url("https://a.example/x", snippet)
+    b = generate_text_fragment_url("https://b.example/x", snippet)
+    assert a != b
+    assert a.startswith("https://a.example/x")
+    assert b.startswith("https://b.example/x")
+
+
+def test_cache_is_bounded() -> None:
+    maxsize = chat_helpers._FRAGMENT_URL_CACHE_MAXSIZE
+    for i in range(maxsize + 50):
+        generate_text_fragment_url(BASE, f"unique snippet number {i} here")
+    assert len(_FRAGMENT_URL_CACHE) <= maxsize
+
+
+def test_non_string_inputs_bypass_cache_and_preserve_behaviour() -> None:
+    # None snippet: builder short-circuits to base_url, and nothing is cached.
+    assert generate_text_fragment_url(BASE, None) == _build_text_fragment_url(BASE, None)
+    assert not _FRAGMENT_URL_CACHE
+
+    # Non-str base_url raises out of the builder today (the membership test is
+    # outside its try block); the wrapper must not mask that.
+    with pytest.raises(TypeError):
+        generate_text_fragment_url(123, "some snippet words here")

--- a/backend/python/tests/unit/utils/test_text_fragment_url_cache.py
+++ b/backend/python/tests/unit/utils/test_text_fragment_url_cache.py
@@ -93,6 +93,29 @@ def test_cache_is_bounded() -> None:
     assert len(_FRAGMENT_URL_CACHE) <= maxsize
 
 
+def test_cache_entries_expire(monkeypatch) -> None:
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(chat_helpers.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(chat_helpers, "_FRAGMENT_URL_CACHE_TTL_SECONDS", 10.0)
+
+    snippet = "the quick brown fox jumps over"
+    first = generate_text_fragment_url(BASE, snippet)
+    assert len(_FRAGMENT_URL_CACHE) == 1
+
+    clock["t"] += 11.0
+    calls = []
+    real = chat_helpers._build_text_fragment_url
+
+    def counting(base_url, text_snippet):
+        calls.append(1)
+        return real(base_url, text_snippet)
+
+    monkeypatch.setattr(chat_helpers, "_build_text_fragment_url", counting)
+    second = generate_text_fragment_url(BASE, snippet)
+    assert second == first
+    assert len(calls) == 1
+
+
 def test_non_string_inputs_bypass_cache_and_preserve_behaviour() -> None:
     # None snippet: builder short-circuits to base_url, and nothing is cached.
     assert generate_text_fragment_url(BASE, None) == _build_text_fragment_url(BASE, None)

--- a/integration-tests/connectors/azure_blob/azure_blob_integration_test.py
+++ b/integration-tests/connectors/azure_blob/azure_blob_integration_test.py
@@ -31,6 +31,11 @@ if str(_ROOT) not in sys.path:
 
 from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
 from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from app.config.constants.arangodb import PermissionModel  # noqa: E402
+from helper.assertions import (  # noqa: E402
+    assert_app_level_permissions,
+    assert_permission_model,
+)
 from helper.graph_provider_utils import (  # noqa: E402
     async_wait_for_stable_record_count,
     wait_until_graph_condition,
@@ -86,8 +91,13 @@ class TestAzureBlobConnector:
                 connector_id, [known_name]
             )
 
-        perm_count = await graph_provider.count_permission_edges(connector_id)
-        logger.info("Permission edges: %d (connector %s)", perm_count, connector_id)
+        await assert_permission_model(
+            graph_provider, connector_id, PermissionModel.APP_LEVEL.value,
+            context="TC-SYNC-001",
+        )
+        await assert_app_level_permissions(
+            graph_provider, connector_id, full_count, context="TC-SYNC-001",
+        )
 
         summary = await graph_provider.graph_summary(connector_id)
         logger.info("Graph summary after full sync: %s (connector %s)", summary, connector_id)

--- a/integration-tests/connectors/azure_files/azure_files_integration_test.py
+++ b/integration-tests/connectors/azure_files/azure_files_integration_test.py
@@ -31,6 +31,11 @@ if str(_ROOT) not in sys.path:
 
 from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
 from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from app.config.constants.arangodb import PermissionModel  # noqa: E402
+from helper.assertions import (  # noqa: E402
+    assert_app_level_permissions,
+    assert_permission_model,
+)
 from helper.graph_provider_utils import (  # noqa: E402
     async_wait_for_stable_record_count,
     wait_until_graph_condition,
@@ -88,8 +93,13 @@ class TestAzureFilesConnector:
                 connector_id, [known_name]
             )
 
-        perm_count = await graph_provider.count_permission_edges(connector_id)
-        logger.info("Permission edges: %d (connector %s)", perm_count, connector_id)
+        await assert_permission_model(
+            graph_provider, connector_id, PermissionModel.APP_LEVEL.value,
+            context="TC-SYNC-001",
+        )
+        await assert_app_level_permissions(
+            graph_provider, connector_id, full_count, context="TC-SYNC-001",
+        )
 
         summary = await graph_provider.graph_summary(connector_id)
         logger.info("Graph summary after full sync: %s (connector %s)", summary, connector_id)

--- a/integration-tests/connectors/confluence/confluence_integration_test.py
+++ b/integration-tests/connectors/confluence/confluence_integration_test.py
@@ -42,7 +42,12 @@ from app.models.entities import (  # type: ignore[import-not-found]  # noqa: E40
 from app.sources.external.confluence.confluence import (  # type: ignore[import-not-found]  # noqa: E402
     ConfluenceDataSource,
 )
-from helper.assertions import ConnectorAssertions, RecordAssertion  # noqa: E402
+from app.config.constants.arangodb import PermissionModel  # noqa: E402
+from helper.assertions import (  # noqa: E402
+    ConnectorAssertions,
+    RecordAssertion,
+    assert_permission_model,
+)
 from connectors.confluence.confluence_v1_test_utils import (  # noqa: E402
     FOLDER_MIME_TYPE,
     assert_api_content_matches_graph,
@@ -165,7 +170,23 @@ class TestConfluenceValidation:
         """TC-CF-008: Verify record relationships (parent/child, permissions)."""
         connector_id = confluence_connector["connector_id"]
 
+        await assert_permission_model(
+            graph_provider, connector_id, PermissionModel.RECORD_LEVEL.value,
+            context="TC-CF-008",
+        )
+
+        # RECORD_LEVEL means visibility is resolved per user, so records must be
+        # reachable through *some* ACL -- granted directly or inherited from a
+        # parent. Deliberately not asserting direct edges alone: Confluence
+        # attaches most access at the space, and jira (TC-JIRA-*) is inherit-only
+        # entirely, so a direct-edge count is the wrong invariant here.
         perm_count = await graph_provider.count_permission_edges(connector_id)
+        inherit_count = await graph_provider.count_inherit_permissions_edges(connector_id)
+        assert perm_count > 0 or inherit_count > 0, (
+            "[TC-CF-008] Connector is declared RECORD_LEVEL but its records carry "
+            "neither direct nor inherited permission edges, so per-user visibility "
+            "cannot be resolved for them."
+        )
 
         record_group_edges = await graph_provider.count_record_group_edges(connector_id)
         assert record_group_edges > 0, "Should have Record->RecordGroup BELONGS_TO edges"

--- a/integration-tests/connectors/gcs/gcs_integration_test.py
+++ b/integration-tests/connectors/gcs/gcs_integration_test.py
@@ -31,6 +31,11 @@ if str(_ROOT) not in sys.path:
 
 from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
 from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from app.config.constants.arangodb import PermissionModel  # noqa: E402
+from helper.assertions import (  # noqa: E402
+    assert_app_level_permissions,
+    assert_permission_model,
+)
 from helper.graph_provider_utils import (  # noqa: E402
     async_wait_for_stable_record_count,
     wait_until_graph_condition,
@@ -94,8 +99,13 @@ class TestGCSConnector:
                 connector_id, [known_name]
             )
 
-        perm_count = await graph_provider.count_permission_edges(connector_id)
-        logger.info("Permission edges: %d (connector %s)", perm_count, connector_id)
+        await assert_permission_model(
+            graph_provider, connector_id, PermissionModel.APP_LEVEL.value,
+            context="TC-SYNC-001",
+        )
+        await assert_app_level_permissions(
+            graph_provider, connector_id, full_count, context="TC-SYNC-001",
+        )
 
         summary = await graph_provider.graph_summary(connector_id)
         logger.info("Graph summary after full sync: %s (connector %s)", summary, connector_id)

--- a/integration-tests/connectors/jira/jira_expected.py
+++ b/integration-tests/connectors/jira/jira_expected.py
@@ -9,6 +9,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
 )
 from app.connectors.utils.value_mapper import ValueMapper
 from app.models.entities import (
@@ -44,6 +45,7 @@ class JiraExpected:
             scope="team",
             created_at_timestamp=0,
             updated_at_timestamp=0,
+            permission_model=PermissionModel.RECORD_LEVEL.value,
         )
 
     @staticmethod

--- a/integration-tests/connectors/linear/linear_expected.py
+++ b/integration-tests/connectors/linear/linear_expected.py
@@ -11,6 +11,7 @@ from app.config.constants.arangodb import (
     Connectors,
     MimeTypes,
     OriginTypes,
+    PermissionModel,
 )
 from app.connectors.sources.linear.connector import PLACEHOLDER_REVISION_PREFIX
 from app.connectors.utils.value_mapper import ValueMapper
@@ -52,6 +53,7 @@ class LinearExpected:
             scope="team",
             created_at_timestamp=0,
             updated_at_timestamp=0,
+            permission_model=PermissionModel.RECORD_LEVEL.value,
         )
 
     @staticmethod

--- a/integration-tests/connectors/s3/s3_integration_test.py
+++ b/integration-tests/connectors/s3/s3_integration_test.py
@@ -31,6 +31,11 @@ if str(_ROOT) not in sys.path:
 
 from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
 from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from app.config.constants.arangodb import PermissionModel  # noqa: E402
+from helper.assertions import (  # noqa: E402
+    assert_app_level_permissions,
+    assert_permission_model,
+)
 from helper.graph_provider_utils import (  # noqa: E402
     async_wait_for_stable_record_count,
     wait_until_graph_condition,
@@ -88,8 +93,13 @@ class TestS3Connector:
                 connector_id, [known_name]
             )
 
-        perm_count = await graph_provider.count_permission_edges(connector_id)
-        logger.info("Permission edges: %d (connector %s)", perm_count, connector_id)
+        await assert_permission_model(
+            graph_provider, connector_id, PermissionModel.APP_LEVEL.value,
+            context="TC-SYNC-001",
+        )
+        await assert_app_level_permissions(
+            graph_provider, connector_id, full_count, context="TC-SYNC-001",
+        )
 
         summary = await graph_provider.graph_summary(connector_id)
         logger.info("Graph summary after full sync: %s (connector %s)", summary, connector_id)

--- a/integration-tests/helper/assertions.py
+++ b/integration-tests/helper/assertions.py
@@ -472,17 +472,21 @@ async def assert_app_level_permissions(
     *,
     context: str = "",
 ) -> None:
-    """APP_LEVEL connectors write a blanket grant, not one grant per record.
+    """APP_LEVEL connectors grant access through the app, not per user.
 
-    The source has no per-record ACLs, so reaching the app means reaching every
-    record it synced. If permission edges instead scale with the record count,
-    the connector is really writing per-record ACLs and the declared model is
-    wrong -- which matters, because the APP_LEVEL read path never consults them.
+    Deliberately *not* asserting that permission edges stay below the record
+    count. A blanket grant is often materialised once per record: S3 writes 53
+    edges for 53 records, and all 53 originate from a single Organization node
+    with type ORG -- a blanket grant by any reasonable reading, which a
+    count-based heuristic would fail. What actually matters is that no
+    *per-user* ACL is written, and an edge count cannot show that. So this only
+    asserts the connector grants access at all; the model itself is checked by
+    `assert_permission_model`.
     """
     label = f"[{context}] " if context else ""
     perm_count = await graph_provider.count_permission_edges(connector_id)
-    assert perm_count < max(record_count, 1), (
-        f"{label}Connector {connector_id} is declared APP_LEVEL but has "
-        f"{perm_count} permission edge(s) for {record_count} record(s) — that is "
-        f"per-record ACLs, which the APP_LEVEL read path ignores."
-    )
+    if record_count > 0:
+        assert perm_count > 0, (
+            f"{label}Connector {connector_id} synced {record_count} record(s) but has "
+            f"no permission edges at all — nothing grants access to them."
+        )

--- a/integration-tests/helper/assertions.py
+++ b/integration-tests/helper/assertions.py
@@ -438,3 +438,51 @@ class ConnectorAssertions:
             property_name, validated_count, connector_id
         )
         return validated_count
+
+
+async def assert_permission_model(
+    graph_provider: "GraphProviderProtocol",
+    connector_id: str,
+    expected: str,
+    *,
+    context: str = "",
+) -> None:
+    """The app document records the permission model the connector declared.
+
+    Worth asserting on its own: the model decides whether per-user visibility is
+    resolved per record or answered once for the whole connector, so a value
+    that silently fails to persist changes who can read what -- and nothing
+    else in these suites would notice.
+    """
+    label = f"[{context}] " if context else ""
+    app = await graph_provider.get_app_metadata_by_connector_id(connector_id)
+    assert app is not None, f"{label}No app document for connector {connector_id}"
+    actual = getattr(app, "permission_model", None)
+    assert actual == expected, (
+        f"{label}Connector {connector_id} declares permissionModel={expected!r} in "
+        f"code but its app document holds {actual!r}. A declared model that does "
+        f"not reach the database is not in force."
+    )
+
+
+async def assert_app_level_permissions(
+    graph_provider: "GraphProviderProtocol",
+    connector_id: str,
+    record_count: int,
+    *,
+    context: str = "",
+) -> None:
+    """APP_LEVEL connectors write a blanket grant, not one grant per record.
+
+    The source has no per-record ACLs, so reaching the app means reaching every
+    record it synced. If permission edges instead scale with the record count,
+    the connector is really writing per-record ACLs and the declared model is
+    wrong -- which matters, because the APP_LEVEL read path never consults them.
+    """
+    label = f"[{context}] " if context else ""
+    perm_count = await graph_provider.count_permission_edges(connector_id)
+    assert perm_count < max(record_count, 1), (
+        f"{label}Connector {connector_id} is declared APP_LEVEL but has "
+        f"{perm_count} permission edge(s) for {record_count} record(s) — that is "
+        f"per-record ACLs, which the APP_LEVEL read path ignores."
+    )

--- a/integration-tests/helper/second_user.py
+++ b/integration-tests/helper/second_user.py
@@ -1,0 +1,342 @@
+"""A logged-in non-admin identity, for tests that ask "can *this* user see it?".
+
+Every other suite runs as the org admin, who can reach everything, so no test
+could distinguish "permission enforced" from "permission ignored". These tests
+need a second person.
+
+Deliberately *not* built on ``PIPESHUB_TEST_NON_ADMIN_EMAIL`` /
+``PIPESHUB_TEST_NON_ADMIN_PASSWORD``: those are commented out in every env
+template, so the one suite that reads them skips on every run. A fixture that
+silently does nothing is worse than no fixture.
+
+Deliberately *not* built on ``second_user_auth.second_pipeshub_client`` either:
+that routes through an OAuth app whose scope list is fixed at creation, and
+search is not in it. Logging in returns the same token the UI uses, which
+carries the user's real permissions -- which is precisely what is under test.
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import os
+import subprocess
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterator
+
+import bcrypt
+import pytest
+import requests
+from pymongo import MongoClient
+
+from config import MONGO_DB_NAME, MONGO_URI, TEST_USER_PASSWORD
+from pipeshub_client import PipeshubClient
+
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+logger = logging.getLogger("second-user")
+
+MONGO_CONTAINER = os.getenv("PIPESHUB_MONGO_CONTAINER", "mongodb")
+GRAPH_USER_POLL_TIMEOUT_SEC = 60.0
+GRAPH_USER_POLL_INTERVAL_SEC = 2.0
+
+
+@dataclass
+class SecondUser:
+    """A real, logged-in, non-admin user.
+
+    ``graph_id`` is the id the permission APIs expect, and is not the Mongo
+    ``user_id`` that created the account -- granting against the wrong one
+    silently grants nothing.
+    """
+
+    user_id: str
+    graph_id: str
+    email: str
+    token: str
+    base_url: str
+    timeout: int
+
+    @property
+    def headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
+
+    def search(self, query: str, kb_id: str, limit: int = 5) -> requests.Response:
+        """Search as this user, scoped to one knowledge base."""
+        return requests.post(
+            f"{self.base_url}/api/v1/search",
+            headers=self.headers,
+            json={"query": query, "filters": {"kb": [kb_id]}, "limit": limit},
+            timeout=self.timeout,
+        )
+
+
+def search_result_count(resp: requests.Response) -> int:
+    """Number of hits in a search response, tolerating either envelope."""
+    body = resp.json()
+    search_response = body.get("searchResponse") or body
+    return len(search_response.get("searchResults") or [])
+
+
+# A KB-filtered search by a user with no access to that KB answers 404 (the KB
+# is not resolvable for them) rather than an empty 200 -- verified against a
+# live deployment. 403 is accepted too so an authorization change upstream
+# reads as still-denied rather than as a failure of these tests.
+NO_ACCESS_STATUSES = (403, 404)
+
+
+def describe_search(resp: requests.Response) -> str:
+    if resp.status_code == 200:
+        return f"http=200 hits={search_result_count(resp)}"
+    return f"http={resp.status_code} body={resp.text[:200]}"
+
+
+def has_no_access(resp: requests.Response) -> bool:
+    """True when this search proves the user cannot reach the KB's records.
+
+    Either the KB did not resolve for them at all, or it did and returned
+    nothing.
+    """
+    if resp.status_code in NO_ACCESS_STATUSES:
+        return True
+    return resp.status_code == 200 and search_result_count(resp) == 0
+
+
+def _create_user(client: PipeshubClient, email: str) -> dict[str, Any]:
+    """`POST /users` creates the account with no credentials and sends no mail,
+    so this works on a stack with no SMTP -- unlike the invite route."""
+    resp = requests.post(
+        f"{client.base_url}/api/v1/users",
+        headers=client._headers(),
+        json={"fullName": f"IT Second User {uuid.uuid4().hex[:8]}", "email": email},
+        timeout=client.timeout_seconds,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"createUser failed for {email}: HTTP {resp.status_code}: {resp.text[:300]}"
+        )
+    return resp.json()
+
+
+def _credential_document(org_id: str, user_id: str, hashed: str) -> dict[str, Any]:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return {
+        # Both ids are declared String in userCredentials.schema.ts.
+        "userId": str(user_id),
+        "orgId": str(org_id),
+        "hashedPassword": hashed,
+        "ipAddress": "127.0.0.1",
+        "wrongCredentialCount": 0,
+        "isBlocked": False,
+        "forceNewPasswordGeneration": False,
+        "isDeleted": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def _seed_password_direct(org_id: str, user_id: str, hashed: str) -> None:
+    client = MongoClient(MONGO_URI, serverSelectionTimeoutMS=10000)
+    try:
+        collection = client[MONGO_DB_NAME].userCredentials
+        # delete_many first: a re-run against a database that still holds a row
+        # for this user would leave duplicates, and which one login picks up is
+        # not defined.
+        collection.delete_many({"userId": str(user_id), "orgId": str(org_id)})
+        collection.insert_one(_credential_document(org_id, user_id, hashed))
+    finally:
+        client.close()
+
+
+def _seed_password_via_docker(org_id: str, user_id: str, hashed: str) -> None:
+    """Fallback for stacks that do not publish 27017.
+
+    The integration compose publishes Mongo, so the direct client is the normal
+    path. The shipped compose does not, and running these tests against an
+    ordinary deployment is worth supporting -- same approach as
+    `loadtest/seed_users.py`.
+    """
+    script = (
+        f'db = db.getSiblingDB("{MONGO_DB_NAME}");'
+        f'db.userCredentials.deleteMany({{userId:"{user_id}",orgId:"{org_id}"}});'
+        f'db.userCredentials.insertOne({{userId:"{user_id}",orgId:"{org_id}",'
+        f'hashedPassword:"{hashed}",ipAddress:"127.0.0.1",wrongCredentialCount:0,'
+        f"isBlocked:false,forceNewPasswordGeneration:false,isDeleted:false,"
+        f"createdAt:new Date(),updatedAt:new Date()}});"
+    )
+    uri = MONGO_URI.replace("/?", f"/{MONGO_DB_NAME}?")
+    errors = []
+    for prefix in (["docker"], ["sudo", "-n", "docker"]):
+        try:
+            result = subprocess.run(
+                [*prefix, "exec", "-i", MONGO_CONTAINER, "mongosh", "--quiet",
+                 uri, "--eval", script],
+                capture_output=True, text=True, timeout=60,
+            )
+            if result.returncode == 0:
+                return
+            errors.append(f"{' '.join(prefix)}: {(result.stderr or result.stdout)[:200]}")
+        except Exception as e:  # noqa: BLE001 - try the next invocation
+            errors.append(f"{' '.join(prefix)}: {e}")
+    raise RuntimeError("mongosh via docker exec failed:\n  " + "\n  ".join(errors))
+
+
+def _seed_password(org_id: str, user_id: str) -> None:
+    """Give the new account a password so it can log in.
+
+    `POST /users` creates an account with no credentials, and the invite route
+    needs SMTP, so the credential row is written directly.
+    """
+    hashed = bcrypt.hashpw(TEST_USER_PASSWORD.encode(), bcrypt.gensalt()).decode()
+    try:
+        _seed_password_direct(org_id, user_id, hashed)
+    except Exception as direct_error:  # noqa: BLE001 - fall back, then report both
+        logger.info("Direct Mongo seed failed (%s); trying docker exec", direct_error)
+        try:
+            _seed_password_via_docker(org_id, user_id, hashed)
+        except Exception as docker_error:
+            raise RuntimeError(
+                f"Could not seed a password for {user_id}.\n"
+                f"  direct: {direct_error}\n"
+                f"  docker: {docker_error}"
+            ) from docker_error
+
+
+def _delete_credentials(org_id: str, user_id: str) -> None:
+    try:
+        client = MongoClient(MONGO_URI, serverSelectionTimeoutMS=10000)
+        try:
+            client[MONGO_DB_NAME].userCredentials.delete_many(
+                {"userId": str(user_id), "orgId": str(org_id)}
+            )
+        finally:
+            client.close()
+    except Exception:  # noqa: BLE001 - teardown must not fail the run
+        logger.warning("Could not clean up credentials for user %s", user_id)
+
+
+def _login(base_url: str, email: str, timeout: int) -> str:
+    init_resp = requests.post(
+        f"{base_url}/api/v1/userAccount/initAuth",
+        json={"email": email},
+        timeout=timeout,
+    )
+    if init_resp.status_code >= 400:
+        raise RuntimeError(
+            f"initAuth failed for {email}: HTTP {init_resp.status_code}: {init_resp.text[:200]}"
+        )
+    session_token = init_resp.headers.get("x-session-token")
+    if not session_token:
+        raise RuntimeError("initAuth returned no x-session-token")
+
+    auth_resp = requests.post(
+        f"{base_url}/api/v1/userAccount/authenticate",
+        headers={"x-session-token": session_token},
+        json={
+            "method": "password",
+            "credentials": {"password": TEST_USER_PASSWORD},
+            "email": email,
+        },
+        timeout=timeout,
+    )
+    if auth_resp.status_code >= 400:
+        raise RuntimeError(
+            f"authenticate failed for {email}: "
+            f"HTTP {auth_resp.status_code}: {auth_resp.text[:200]}"
+        )
+    return str(auth_resp.json()["accessToken"])
+
+
+def _wait_for_graph_user(client: PipeshubClient, email: str) -> dict[str, Any]:
+    """The account reaches the graph over Kafka, not in the create call.
+
+    A permission granted before it lands comes back ``grantedCount: 0`` and the
+    test then measures nothing.
+    """
+    # Imported here, not at module scope: this module reaches
+    # helper.graph_provider, which needs the backend `app` package on sys.path,
+    # and only conftest puts it there.
+    from messaging.test_e2e_record_pipeline import poll_until  # noqa: PLC0415
+
+    email_lower = email.lower()
+    search_term = email.split("@", 1)[0]
+
+    def _found() -> dict[str, Any] | None:
+        resp = requests.get(
+            f"{client.base_url}/api/v1/users/graph/list",
+            headers=client._headers(),
+            params={"search": search_term, "limit": "50"},
+            timeout=client.timeout_seconds,
+        )
+        if resp.status_code != 200:
+            return None
+        for user in resp.json().get("users") or []:
+            if str(user.get("email") or "").lower() == email_lower:
+                return user
+        return None
+
+    return poll_until(
+        _found,
+        timeout=GRAPH_USER_POLL_TIMEOUT_SEC,
+        interval=GRAPH_USER_POLL_INTERVAL_SEC,
+        description=f"graph user for {email!r}",
+    )
+
+
+def create_second_user(client: PipeshubClient) -> SecondUser:
+    """Create, credential and log in a non-admin user. Caller deletes it."""
+    email = f"it-second-{uuid.uuid4().hex[:10]}@test-pipeshub.com"
+    user = _create_user(client, email)
+    user_id = str(user.get("_id") or user.get("id") or "")
+    org_id = str(user.get("orgId") or client.org_id or "")
+    if not user_id or not org_id:
+        raise RuntimeError(f"createUser response missing _id/orgId: {sorted(user)}")
+
+    _seed_password(org_id, user_id)
+    graph_user = _wait_for_graph_user(client, email)
+    graph_id = str(graph_user.get("id") or "")
+    if not graph_id:
+        raise RuntimeError(f"graph user for {email} has no id: {graph_user}")
+
+    token = _login(client.base_url, email, client.timeout_seconds)
+    logger.info("Second user ready: %s (graph id %s)", email, graph_id)
+    return SecondUser(
+        user_id=user_id,
+        graph_id=graph_id,
+        email=email,
+        token=token,
+        base_url=client.base_url,
+        timeout=client.timeout_seconds,
+    )
+
+
+def delete_second_user(client: PipeshubClient, user: SecondUser) -> None:
+    _delete_credentials(client.org_id, user.user_id)
+    try:
+        requests.delete(
+            f"{client.base_url}/api/v1/users/{user.user_id}",
+            headers=client._headers(),
+            timeout=client.timeout_seconds,
+        )
+    except Exception:  # noqa: BLE001 - teardown must not fail the run
+        logger.warning("Could not delete test user %s", user.user_id)
+
+
+@pytest.fixture(scope="session")
+def second_user(pipeshub_client: PipeshubClient) -> Iterator[SecondUser]:
+    """Session-scoped: creating a user costs a Kafka round trip to the graph."""
+    client = pipeshub_client
+    client._ensure_access_token()
+    user = create_second_user(client)
+    try:
+        yield user
+    finally:
+        delete_second_user(client, user)

--- a/integration-tests/helper/second_user.py
+++ b/integration-tests/helper/second_user.py
@@ -32,12 +32,16 @@ import pytest
 import requests
 from pymongo import MongoClient
 
-from config import MONGO_DB_NAME, MONGO_URI, TEST_USER_PASSWORD
-from pipeshub_client import PipeshubClient
-
+# Path setup precedes the local imports below: `config` and `pipeshub_client`
+# live in this directory, and importing this module should not depend on a
+# caller having configured sys.path first.
 _ROOT = Path(__file__).resolve().parents[1]
-if str(_ROOT) not in sys.path:
-    sys.path.insert(0, str(_ROOT))
+for _p in (_ROOT, _ROOT / "helper"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from config import MONGO_DB_NAME, MONGO_URI, TEST_USER_PASSWORD  # noqa: E402
+from pipeshub_client import PipeshubClient  # noqa: E402
 
 logger = logging.getLogger("second-user")
 

--- a/integration-tests/response-validation/enterprise-search/conftest.py
+++ b/integration-tests/response-validation/enterprise-search/conftest.py
@@ -29,6 +29,7 @@ from helper.agui_sse import (
     run_finished_result,
 )
 from helper.clients.kb_client import KBClient
+from helper.second_user import second_user  # noqa: F401 - fixture
 from helper.clients.agents_client import AgentsClient
 from helper.clients.conversations_client import (
     AgentConversationsClient,

--- a/integration-tests/response-validation/enterprise-search/conversations/integration_test_retrieval_integrity.py
+++ b/integration-tests/response-validation/enterprise-search/conversations/integration_test_retrieval_integrity.py
@@ -99,7 +99,8 @@ def _record_ids(citations: list[dict[str, Any]]) -> list[str]:
         record_id = None
         if isinstance(metadata, dict):
             record_id = metadata.get("recordId")
-        record_id = record_id or block.get("recordId") if isinstance(block, dict) else record_id
+        if not record_id and isinstance(block, dict):
+            record_id = block.get("recordId")
         if record_id and str(record_id) not in ids:
             ids.append(str(record_id))
     return ids
@@ -154,6 +155,7 @@ class TestRetrievalIntegrity:
             self.conversations, self.stream_timeout, filters={"kb": [self.kb_id]}
         )
         assert finished, "stream ended without RUN_FINISHED"
+        assert conversation_id, "stream never reported a conversation id"
 
         resp = self.conversations.get_conversation(
             conversation_id, timeout=self.stream_timeout

--- a/integration-tests/response-validation/enterprise-search/conversations/integration_test_retrieval_integrity.py
+++ b/integration-tests/response-validation/enterprise-search/conversations/integration_test_retrieval_integrity.py
@@ -1,0 +1,202 @@
+"""Did the turn actually retrieve anything, and does what it cited still exist?
+
+Both cover failures that leave a *successful-looking* answer behind, which is
+why the existing conversation tests cannot see them: the stream reaches
+RUN_FINISHED, the answer is non-empty, the schema matches -- and the model
+simply answered with no source material.
+
+* Retrieval silently returning nothing. An explicit ``limit: null`` used to
+  survive as ``None`` all the way to ``req.limit * 2`` in the vector store,
+  where the ``TypeError`` was caught and logged as "Filtered search failed" and
+  turned into an empty result set. Guarded now in `retrieval_service.py`; this
+  is what keeps it guarded.
+* Citations pointing at records that cannot be fetched, which is the failure
+  mode a batched graph/storage lookup introduces if it drops or mismatches
+  rows.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[3]
+_RV_HELPER = _ROOT / "response-validation" / "helper"
+for _p in (_ROOT, _RV_HELPER):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from helper.agui_sse import (  # noqa: E402
+    is_conversation_created,
+    is_root_error,
+    is_root_finished,
+    iter_sse_envelopes,
+)
+from helper.clients.conversations_client import ConversationsClient  # noqa: E402
+from helper.clients.kb_client import KBClient  # noqa: E402
+from helper.pipeshub_client import PipeshubClient  # noqa: E402
+
+# Answerable only from the Asana PDF in `session_kb`, so a turn that retrieves
+# nothing cannot bluff its way to a citation.
+GROUNDED_QUERY = "every year asana undertakes which exercise?"
+
+pytestmark = pytest.mark.xdist_group("retrieval-integrity")
+
+
+def _stream_and_collect(
+    conversations: ConversationsClient, timeout: int, **body: Any
+) -> tuple[str, bool]:
+    """Run one turn to completion. Returns (conversation_id, saw_run_finished)."""
+    conversation_id = ""
+    finished = False
+    with conversations.stream_conversation(
+        query=GROUNDED_QUERY, chatMode="internal_search", timeout=timeout, **body
+    ) as resp:
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        for envelope in iter_sse_envelopes(resp):
+            payload = json.loads(envelope["data"])
+            event = envelope["event"]
+
+            if is_conversation_created(payload):
+                value = payload.get("value") or payload
+                conversation_id = str(
+                    value.get("conversationId") or value.get("_id") or conversation_id
+                )
+            if is_root_error(event, payload):
+                raise AssertionError(f"stream emitted RUN_ERROR: {payload!r}")
+            if is_root_finished(event, payload):
+                finished = True
+                break
+    return conversation_id, finished
+
+
+def _bot_citations(conversation: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every citation attached to a bot message in the conversation."""
+    convo = conversation.get("conversation") or conversation
+    citations: list[dict[str, Any]] = []
+    for message in convo.get("messages") or []:
+        for citation in message.get("citations") or []:
+            if isinstance(citation, dict):
+                citations.append(citation)
+    return citations
+
+
+def _record_ids(citations: list[dict[str, Any]]) -> list[str]:
+    """Record ids the citations point at, where the payload exposes one.
+
+    Citations are returned either as bare references or already populated, so
+    look in both shapes rather than assuming one.
+    """
+    ids: list[str] = []
+    for citation in citations:
+        block = citation.get("citationData") or citation.get("citation") or citation
+        metadata = block.get("metadata") if isinstance(block, dict) else None
+        record_id = None
+        if isinstance(metadata, dict):
+            record_id = metadata.get("recordId")
+        record_id = record_id or block.get("recordId") if isinstance(block, dict) else record_id
+        if record_id and str(record_id) not in ids:
+            ids.append(str(record_id))
+    return ids
+
+
+@pytest.mark.integration
+class TestRetrievalIntegrity:
+
+    @pytest.fixture(autouse=True)
+    def _setup(
+        self,
+        conversations_client: ConversationsClient,
+        pipeshub_client: PipeshubClient,
+        session_kb: dict,
+    ) -> None:
+        self.conversations = conversations_client
+        self.client = pipeshub_client
+        self.kb_client = KBClient(pipeshub_client)
+        self.kb_id = session_kb["kb_id"]
+        self.record_id = session_kb["record_id"]
+        timeout = int(os.getenv("PIPESHUB_TEST_TIMEOUT", "60"))
+        override = os.getenv("PIPESHUB_TEST_STREAM_TIMEOUT", "").strip()
+        self.stream_timeout = int(override) if override else max(timeout, 120)
+
+    def test_grounded_turn_cites_its_sources(self) -> None:
+        """A question answerable only from the KB comes back with citations."""
+        conversation_id, finished = _stream_and_collect(
+            self.conversations, self.stream_timeout, filters={"kb": [self.kb_id]}
+        )
+        assert finished, "stream ended without RUN_FINISHED"
+        assert conversation_id, "stream never reported a conversation id"
+
+        resp = self.conversations.get_conversation(
+            conversation_id, timeout=self.stream_timeout
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        citations = _bot_citations(resp.json())
+        assert citations, (
+            "The answer carried no citations at all. The question is answerable "
+            "only from the knowledge base, so a turn with no sources means "
+            "retrieval returned nothing and the model answered unaided."
+        )
+
+    def test_cited_records_are_retrievable(self) -> None:
+        """Everything the answer cites can still be fetched.
+
+        Guards the batched graph and storage lookups: dropping or mismatching a
+        row there produces citations that point at nothing, which no
+        schema-shape assertion would catch.
+        """
+        conversation_id, finished = _stream_and_collect(
+            self.conversations, self.stream_timeout, filters={"kb": [self.kb_id]}
+        )
+        assert finished, "stream ended without RUN_FINISHED"
+
+        resp = self.conversations.get_conversation(
+            conversation_id, timeout=self.stream_timeout
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        citations = _bot_citations(resp.json())
+        assert citations, "no citations to check — see test_grounded_turn_cites_its_sources"
+
+        record_ids = _record_ids(citations)
+        if not record_ids:
+            pytest.skip(
+                "Citations in this deployment do not expose a recordId; nothing to resolve"
+            )
+        for record_id in record_ids:
+            record = self.kb_client.get_record(record_id)
+            body = record.get("record") or record
+            assert body.get("id") or body.get("_key"), (
+                f"Cited record {record_id} could not be fetched: {record!r}"
+            )
+
+    def test_explicit_null_limit_still_retrieves(self) -> None:
+        """`limit: null` must not quietly disable retrieval.
+
+        `ChatQuery.limit` defaults to 50, so *omitting* it is safe -- only an
+        explicit null reaches the code path that broke. It failed silently: the
+        turn still finished and still answered, just with nothing retrieved, so
+        the only way to see it is to check that sources came back.
+        """
+        conversation_id, finished = _stream_and_collect(
+            self.conversations,
+            self.stream_timeout,
+            filters={"kb": [self.kb_id]},
+            limit=None,
+        )
+        assert finished, "stream with limit=null ended without RUN_FINISHED"
+        assert conversation_id, "stream with limit=null never reported a conversation id"
+
+        resp = self.conversations.get_conversation(
+            conversation_id, timeout=self.stream_timeout
+        )
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        assert _bot_citations(resp.json()), (
+            "A turn sent with limit=null produced no citations, while the same "
+            "question cites sources normally — retrieval silently returned an "
+            "empty result set instead of falling back to the default limit."
+        )

--- a/integration-tests/response-validation/enterprise-search/search/integration_test_record_visibility.py
+++ b/integration-tests/response-validation/enterprise-search/search/integration_test_record_visibility.py
@@ -1,0 +1,265 @@
+"""What a *given user* can actually retrieve, and how fast that reacts to change.
+
+Every other suite runs as the org admin, who can reach everything, so none of
+them can tell "permission enforced" from "permission ignored". These do.
+
+Written as assertions about the invariant -- a user without access retrieves
+nothing -- rather than about any cache. That holds on every graph store, so the
+tests stay honest whichever one is configured, and they start covering new
+caching layers for free as those arrive.
+
+Retrieval is a ranked, embedding-driven search, so the assertions are chosen to
+not depend on ranking:
+
+* the "can see it" direction asserts *some* hit came back, and fails **setup**
+  loudly if the corpus cannot be found at all, so it can never pass vacuously;
+* the "cannot see it" direction asserts **zero** hits, which is decided by the
+  accessible-id filter alone -- an empty id set excludes everything no matter
+  how the embeddings rank.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+import requests
+
+_ROOT = Path(__file__).resolve().parents[3]
+_RV_HELPER = _ROOT / "response-validation" / "helper"
+for _p in (_ROOT, _RV_HELPER):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from helper.clients.kb_client import KBClient  # noqa: E402
+from helper.pipeshub_client import PipeshubClient  # noqa: E402
+from helper.second_user import (  # noqa: E402
+    SecondUser,
+    describe_search,
+    has_no_access,
+    search_result_count,
+)
+from messaging.test_e2e_record_pipeline import (  # noqa: E402
+    TERMINAL_STATUSES,
+    _extract_kb_id,
+    _extract_record_id,
+    _get_record_status,
+    poll_until,
+)
+
+# Same readiness budget the session KB uses for the identical PDF.
+INDEX_TIMEOUT_SEC = 180
+INDEX_POLL_INTERVAL_SEC = 3
+
+# The same question the rest of this suite searches for; it has answers in the
+# Asana PDF that `session_kb` uploads and waits to be indexed.
+SEARCH_QUERY = "every year asana undertakes which exercise?"
+
+# These grant and revoke on the shared session KB, so they must not interleave
+# with each other. Granting a *second* user changes nothing for the admin, so
+# the rest of the suite is unaffected.
+pytestmark = pytest.mark.xdist_group("record-visibility")
+
+
+def _permissions_url(base_url: str, kb_id: str) -> str:
+    return f"{base_url}/api/v1/knowledgeBase/{kb_id}/permissions"
+
+
+def _grant_reader(client: PipeshubClient, kb_id: str, user: SecondUser) -> None:
+    resp = requests.post(
+        _permissions_url(client.base_url, kb_id),
+        headers=client._headers(),
+        json={"userIds": [user.user_id], "teamIds": [], "role": "READER"},
+        timeout=client.timeout_seconds,
+    )
+    assert resp.status_code == 201, f"grant failed: {resp.status_code}: {resp.text}"
+    granted = (resp.json().get("permissionResult") or {}).get("grantedCount") or 0
+    # grantedCount 0 means the grant silently did nothing -- usually the user has
+    # not reached the graph yet. Everything after this would then be measuring
+    # the wrong thing.
+    assert int(granted) >= 1, f"grant reported grantedCount=0: {resp.text}"
+
+
+def _revoke(client: PipeshubClient, kb_id: str, user: SecondUser) -> requests.Response:
+    return requests.delete(
+        _permissions_url(client.base_url, kb_id),
+        headers=client._headers(),
+        json={"userIds": [user.user_id], "teamIds": []},
+        timeout=client.timeout_seconds,
+    )
+
+
+@pytest.fixture
+def granted_reader(
+    pipeshub_client: PipeshubClient,
+    session_kb: dict[str, str],
+    second_user: SecondUser,
+) -> Iterator[SecondUser]:
+    """Second user holding READER on the session KB, revoked on teardown."""
+    _grant_reader(pipeshub_client, session_kb["kb_id"], second_user)
+    try:
+        yield second_user
+    finally:
+        _revoke(pipeshub_client, session_kb["kb_id"], second_user)
+
+
+@pytest.mark.integration
+class TestRecordVisibility:
+    """Grant and revoke must take effect on the next request, not eventually."""
+
+    def test_granted_user_can_retrieve_kb_records(
+        self,
+        pipeshub_client: PipeshubClient,
+        session_kb: dict[str, str],
+        granted_reader: SecondUser,
+    ) -> None:
+        """A user just given READER retrieves the KB's content immediately."""
+        kb_id = session_kb["kb_id"]
+
+        resp = granted_reader.search(SEARCH_QUERY, kb_id)
+        assert resp.status_code == 200, f"{resp.status_code}: {resp.text}"
+        assert search_result_count(resp) > 0, (
+            "Second user holds READER on this KB but retrieved nothing. Either the "
+            "grant did not take effect, or a stale empty accessible-record set was "
+            f"served. Response: {resp.text[:400]}"
+        )
+
+    def test_revoked_user_cannot_retrieve_kb_records(
+        self,
+        pipeshub_client: PipeshubClient,
+        session_kb: dict[str, str],
+        granted_reader: SecondUser,
+    ) -> None:
+        """Revoking access stops retrieval on the very next request.
+
+        The regression this exists for: a user's accessible-record set was
+        cached and only invalidated when records changed, never when
+        *permissions* changed -- so a revoked user kept reading the KB until the
+        entry aged out, minutes later.
+        """
+        kb_id = session_kb["kb_id"]
+
+        before = granted_reader.search(SEARCH_QUERY, kb_id)
+        assert before.status_code == 200, f"{before.status_code}: {before.text}"
+        # Precondition, not the assertion under test. If the corpus cannot be
+        # retrieved even *with* permission then the "0 results" check below
+        # would pass for the wrong reason, so fail here instead.
+        assert search_result_count(before) > 0, (
+            "Precondition failed: the granted user retrieved nothing before "
+            "revocation, so this test cannot prove revocation did anything. "
+            f"Response: {before.text[:400]}"
+        )
+
+        revoke_resp = _revoke(pipeshub_client, kb_id, granted_reader)
+        assert revoke_resp.status_code == 200, (
+            f"revoke failed: {revoke_resp.status_code}: {revoke_resp.text}"
+        )
+
+        after = granted_reader.search(SEARCH_QUERY, kb_id)
+        assert has_no_access(after), (
+            "Revoked user could still reach this KB's records. Access was removed "
+            "before this request was made, so the search should have been refused "
+            f"or come back empty. Got {describe_search(after)}"
+        )
+
+    def test_user_without_permission_cannot_retrieve_kb_records(
+        self,
+        session_kb: dict[str, str],
+        second_user: SecondUser,
+    ) -> None:
+        """A user never granted anything retrieves nothing -- the baseline the
+        other two are measured against."""
+        resp = second_user.search(SEARCH_QUERY, session_kb["kb_id"])
+        assert has_no_access(resp), (
+            "A user with no permission on this KB could reach its records: "
+            f"{describe_search(resp)}"
+        )
+
+
+@pytest.mark.integration
+class TestDeletedRecordVisibility:
+    """A deleted record stops being retrievable straight away."""
+
+    def test_deleted_record_disappears_from_retrieval(
+        self,
+        pipeshub_client: PipeshubClient,
+        asana_pdf_blob: dict,
+    ) -> None:
+        """Upload, find it, delete it, and it is gone from the next search.
+
+        Runs as the admin: this is about the record leaving the retrievable set,
+        not about permissions. Builds its own KB rather than using `session_kb`,
+        because deleting that one's only record would strand every other test in
+        the suite.
+        """
+        kb_client = KBClient(pipeshub_client)
+        kb_id, record_id = _kb_with_indexed_pdf(kb_client, asana_pdf_blob)
+        try:
+            search = _admin_search(pipeshub_client, SEARCH_QUERY, kb_id)
+            assert search.status_code == 200, f"{search.status_code}: {search.text}"
+            assert search_result_count(search) > 0, (
+                "Precondition failed: freshly indexed record was not retrievable, "
+                f"so its deletion proves nothing. Response: {search.text[:400]}"
+            )
+
+            delete_resp = kb_client.delete_record(record_id)
+            assert delete_resp is not None, "delete_record returned nothing"
+
+            after = _admin_search(pipeshub_client, SEARCH_QUERY, kb_id)
+            assert after.status_code == 200, f"{after.status_code}: {after.text}"
+            assert search_result_count(after) == 0, (
+                "A deleted record was still retrievable. "
+                f"Response: {after.text[:400]}"
+            )
+        finally:
+            try:
+                kb_client.delete_kb(kb_id)
+            except Exception:  # noqa: BLE001 - teardown must not fail the run
+                pass
+
+
+def _admin_search(
+    client: PipeshubClient, query: str, kb_id: str, limit: int = 5
+) -> requests.Response:
+    return requests.post(
+        f"{client.base_url}/api/v1/search",
+        headers=client._headers(),
+        json={"query": query, "filters": {"kb": [kb_id]}, "limit": limit},
+        timeout=client.timeout_seconds,
+    )
+
+
+def _kb_with_indexed_pdf(
+    kb_client: KBClient, blob: dict
+) -> tuple[str, str]:
+    """A private KB holding the same PDF, waited until it is really searchable.
+
+    Waiting on the record *document* is not enough -- it exists well before it
+    is indexed, and a search in that window comes back empty for reasons that
+    have nothing to do with what is under test. Reuses the same readiness gate
+    and terminal-status set as `session_kb`.
+    """
+    kb_resp = kb_client.create_kb(name="record-visibility-it-kb")
+    kb_id = _extract_kb_id(kb_resp)
+    assert kb_id, f"KB create returned no id: {kb_resp}"
+
+    upload_resp = kb_client.upload_file(
+        kb_id, blob["originalname"], blob["buffer"], mimetype=blob["mimetype"]
+    )
+    record_id = _extract_record_id(upload_resp)
+    assert record_id, f"Upload returned no record id: {upload_resp}"
+
+    poll_until(
+        lambda: _get_record_status(kb_client.get_record(record_id)) in TERMINAL_STATUSES,
+        timeout=INDEX_TIMEOUT_SEC,
+        interval=INDEX_POLL_INTERVAL_SEC,
+        description=f"record {record_id} to finish indexing",
+    )
+    status = _get_record_status(kb_client.get_record(record_id))
+    assert status == "COMPLETED", (
+        f"PDF reached terminal status {status!r}, expected COMPLETED — "
+        "there would be nothing to retrieve, so the deletion check is meaningless."
+    )
+    return kb_id, record_id

--- a/integration-tests/response-validation/enterprise-search/search/integration_test_record_visibility.py
+++ b/integration-tests/response-validation/enterprise-search/search/integration_test_record_visibility.py
@@ -208,10 +208,13 @@ class TestDeletedRecordVisibility:
             assert delete_resp is not None, "delete_record returned nothing"
 
             after = _admin_search(pipeshub_client, SEARCH_QUERY, kb_id)
-            assert after.status_code == 200, f"{after.status_code}: {after.text}"
-            assert search_result_count(after) == 0, (
+            # Deleting the KB's only record leaves nothing searchable, and the
+            # service reports that as 404 ("No documents are available for you
+            # to search yet") rather than an empty 200. Both mean the record is
+            # gone; demanding 200 asserted an implementation detail instead.
+            assert has_no_access(after), (
                 "A deleted record was still retrievable. "
-                f"Response: {after.text[:400]}"
+                f"Got {describe_search(after)}"
             )
         finally:
             try:

--- a/integration-tests/response-validation/knowledgebase/integration_test_permissions_crud.py
+++ b/integration-tests/response-validation/knowledgebase/integration_test_permissions_crud.py
@@ -70,6 +70,10 @@ def _list_permissions(
     return list(resp.json().get("permissions") or [])
 
 
+# Sentinel: the KB lists a permission for this user but reports no role.
+_ROLE_PRESENT_BUT_UNSET = "<present-without-role>"
+
+
 def _granted_role(
     base_url: str,
     headers: dict[str, str],
@@ -90,8 +94,11 @@ def _granted_role(
         if entry.get("type") != "USER":
             continue
         if str(entry.get("id") or "") == graph_user_id:
+            # A surviving row with a null role is NOT the same as no row: the
+            # delete test asserts the permission is gone, and collapsing both
+            # to None would let a still-present permission pass it.
             role = entry.get("role")
-            return str(role) if role is not None else None
+            return str(role) if role is not None else _ROLE_PRESENT_BUT_UNSET
     return None
 
 

--- a/integration-tests/response-validation/knowledgebase/integration_test_permissions_crud.py
+++ b/integration-tests/response-validation/knowledgebase/integration_test_permissions_crud.py
@@ -60,6 +60,41 @@ def _granted_count(create_body: dict[str, object]) -> int:
     return int(count) if count is not None else 0
 
 
+def _list_permissions(
+    base_url: str, headers: dict[str, str], kb_id: str, *, timeout: int
+) -> list[dict[str, object]]:
+    resp = requests.get(
+        _permissions_url(base_url, kb_id), headers=headers, timeout=timeout
+    )
+    assert resp.status_code == 200, f"listKBPermissions failed: {resp.text}"
+    return list(resp.json().get("permissions") or [])
+
+
+def _granted_role(
+    base_url: str,
+    headers: dict[str, str],
+    kb_id: str,
+    graph_user_id: str,
+    *,
+    timeout: int,
+) -> str | None:
+    """The role this KB *actually* records for a user, or None if absent.
+
+    The mutation endpoints answer with the role that was requested, so asserting
+    on their response only proves the request was echoed. A provider write can
+    fail and still be reported as success (a failure dict is truthy), which the
+    response-shape assertions cannot see. Reading the state back is what makes
+    these tests able to fail.
+    """
+    for entry in _list_permissions(base_url, headers, kb_id, timeout=timeout):
+        if entry.get("type") != "USER":
+            continue
+        if str(entry.get("id") or "") == graph_user_id:
+            role = entry.get("role")
+            return str(role) if role is not None else None
+    return None
+
+
 def _remove_permission(
     base_url: str,
     headers: dict[str, str],
@@ -106,6 +141,7 @@ class TestKBPermissionCreate:
         kb_id = str(six_kb_records["kb_id"])
         grantee = four_new_users[0]
         grantee_id = _user_id(grantee)
+        grantee_graph_id = _graph_user_id(grantee)
 
         resp = requests.post(
             _permissions_url(self.base_url, kb_id),
@@ -124,6 +160,14 @@ class TestKBPermissionCreate:
             assert _granted_count(body) >= 1, (
                 "Permission create returned grantedCount=0 — grantee Mongo userId "
                 "not found in graph yet"
+            )
+
+            assert _granted_role(
+                self.base_url, self.headers, kb_id, grantee_graph_id,
+                timeout=self.client.timeout_seconds,
+            ) == "READER", (
+                "createKBPermission reported success but the knowledge base does "
+                "not list the grantee with that role."
             )
         finally:
             _remove_permission(
@@ -411,6 +455,14 @@ class TestKBPermissionUpdate:
             assert grantee_graph_id in body["userIds"]
             assert body.get("teamIds") == []
             assert body["newRole"] == "WRITER"
+
+            assert _granted_role(
+                self.base_url, self.headers, kb_id, grantee_graph_id,
+                timeout=self.client.timeout_seconds,
+            ) == "WRITER", (
+                "updateKBPermissions reported success but the knowledge base still "
+                "records a different role for this user."
+            )
         finally:
             _remove_permission(
                 self.base_url,
@@ -618,6 +670,14 @@ class TestKBPermissionDelete:
             assert body["kbId"] == kb_id
             assert grantee_graph_id in body["userIds"]
             assert body.get("teamIds") == []
+
+            assert _granted_role(
+                self.base_url, self.headers, kb_id, grantee_graph_id,
+                timeout=self.client.timeout_seconds,
+            ) is None, (
+                "deleteKBPermissions reported success but the knowledge base still "
+                "lists a permission for this user."
+            )
         finally:
             _remove_permission(
                 self.base_url,

--- a/integration-tests/validation/schemas/app_metadata.yaml
+++ b/integration-tests/validation/schemas/app_metadata.yaml
@@ -34,6 +34,9 @@ fields:
   name:
     required: true
     type: string
+  permission_model:
+    required: false
+    type: string
   scope:
     required: true
     type: string

--- a/loadtest/.env.example
+++ b/loadtest/.env.example
@@ -22,9 +22,12 @@ PIPESHUB_PASSWORD=
 # Single-identity fallback. Bearer JWT: browser devtools -> any API request ->
 # Authorization header. Usually valid ~24h; perftest.sh probes it and aborts if
 # it is not accepted. Ignored when PIPESHUB_USERS/PIPESHUB_EMAILS is set.
+# Precedence: PIPESHUB_TOKEN (if set) wins over TOKEN. Locust and perftest.sh
+# both accept either name; .env uses TOKEN so one value works for both harnesses.
 # No credential is needed for `./perftest.sh <label> 0 <seconds>`, which only
 # collects from a run someone else is driving.
 TOKEN=
+# PIPESHUB_TOKEN=
 
 # ── Deployment ───────────────────────────────────────────────────────────
 # auto    Detected for you: a RUNNING container named PIPESHUB_CONTAINER wins,

--- a/loadtest/.env.example
+++ b/loadtest/.env.example
@@ -1,13 +1,29 @@
 # Copy to `.env` and edit:  cp .env.example .env
 # `.env` is gitignored. Real environment variables override anything set here.
-# Every value below is optional except TOKEN — the defaults describe the
+# Everything below is optional except a credential — the defaults describe the
 # standard Docker deployment.
 
-# ── Required ─────────────────────────────────────────────────────────────
-# Bearer JWT. Browser devtools -> any API request -> Authorization header.
-# Usually valid ~24h; perftest.sh probes it and aborts if it is not accepted.
-# Needed only when generating load: `./perftest.sh <label> 0 <seconds>` collects
-# from a run someone else is driving and neither sends requests nor asks for it.
+# ── Required: one of these ───────────────────────────────────────────────
+# Preferred. Each simulated user drives one of these real accounts, so anything
+# the backend caches per user is measured honestly — a single shared identity
+# makes a per-user cache look like it always hits. Tokens are fetched by
+# password login at test start, so they never go stale mid-run.
+#
+# Provision them on a local stack with:
+#     PIPESHUB_ADMIN_EMAIL=... PIPESHUB_ADMIN_PASSWORD=... ./seed_users.py --count 8
+#
+# and paste the line it prints:
+PIPESHUB_USERS=
+
+# Same thing when every account shares a password.
+PIPESHUB_EMAILS=
+PIPESHUB_PASSWORD=
+
+# Single-identity fallback. Bearer JWT: browser devtools -> any API request ->
+# Authorization header. Usually valid ~24h; perftest.sh probes it and aborts if
+# it is not accepted. Ignored when PIPESHUB_USERS/PIPESHUB_EMAILS is set.
+# No credential is needed for `./perftest.sh <label> 0 <seconds>`, which only
+# collects from a run someone else is driving.
 TOKEN=
 
 # ── Deployment ───────────────────────────────────────────────────────────

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -15,15 +15,37 @@ On the machine running PipesHub:
 
 ```bash
 cd loadtest
-cp .env.example .env                  # then put your TOKEN in it
+cp .env.example .env                  # then put a credential in it
 pip3 install --user py-spy            # optional, for the CPU flame graph
 
 ./instrument.sh on                    # docker only; adds phase + backend timing
 ./perftest.sh baseline 8 300          # label, users, seconds
 ```
 
-`TOKEN` is a bearer JWT — browser devtools, any API request, the
-`Authorization` header. Everything else in `.env` has a working default.
+Everything else in `.env` has a working default.
+
+### Credentials
+
+Two options, and which you pick changes what the numbers mean:
+
+- **`PIPESHUB_USERS`** (`email:password,…`) — each simulated user drives a real
+  account. Required for anything the backend caches per user: with one shared
+  identity a per-user cache looks like it always hits, so an A/B of one would
+  measure a hit rate no deployment ever sees. Tokens come from password login
+  at test start, so they cannot expire mid-run.
+- **`TOKEN`** — a single bearer JWT from browser devtools. Fine for absolute
+  throughput on a stateless path; misleading for per-user caches.
+
+Provision accounts on a local stack (creates users, sets passwords, verifies
+each login, and prints the `PIPESHUB_USERS` line to paste in):
+
+```bash
+PIPESHUB_ADMIN_EMAIL=admin@example.com PIPESHUB_ADMIN_PASSWORD='...' \
+    ./seed_users.py --count 8
+```
+
+Seeded users only see what the org shares with them — give them access to the
+knowledge bases the run is meant to search, or they will answer from nothing.
 
 That writes `results/baseline/`, printing the report to the terminal too:
 
@@ -180,7 +202,9 @@ PIPESHUB_MODE=docker ./perftest.sh baseline 8 300
 
 | variable | default | what it does |
 |---|---|---|
-| `TOKEN` | — | bearer JWT; required unless `users` is 0 |
+| `PIPESHUB_USERS` | — | `email:password,…`; one real account per simulated user |
+| `PIPESHUB_EMAILS` / `PIPESHUB_PASSWORD` | — | same, when the accounts share a password |
+| `TOKEN` | — | single-identity bearer JWT; used only if the two above are unset. One of the three is required unless `users` is 0 |
 | `PIPESHUB_MODE` | `auto` | `auto` / `docker` / `native` |
 | `PIPESHUB_HOST` | `http://localhost:3000` | API gateway the load hits — the Node backend, not the frontend |
 | `PIPESHUB_CONTAINER` | `pipeshub-ai` | docker mode only |
@@ -190,6 +214,7 @@ PIPESHUB_MODE=docker ./perftest.sh baseline 8 300
 | `PIPESHUB_QUERY_FILE` | `queries.txt` | the query set users rotate through |
 | `PIPESHUB_QUERY` | — | force a single query instead of the file |
 | `PIPESHUB_THINK_TIME` | `3` | seconds between a user's turns |
+| `PIPESHUB_TURN_MAX_SECONDS` | `300` | per-turn curl timeout. Raise it when turns outlast it — a cut SSE stream still reports HTTP 200, so truncation shows only as `curl_exit=28` and a missing completion marker |
 
 `perftest.sh` probes the token before starting and aborts if it is not
 accepted — an expired token turns every request into a 401, which otherwise
@@ -228,6 +253,9 @@ elsewhere and use this only to collect:
 | `restart_query.sh` | restart only the query process, leaving the container up |
 | `locustfile_play.py` | optional locust scenario, if you prefer locust's latency percentiles |
 | `queries.txt` | the query set users draw from — **edit this for your corpus** |
+| `PERFORMANCE.md` | measured results: before/after across the worker/user matrix |
+| `PROFILE.md` | where CPU goes, and what to optimise next |
+| `baseline/` | the raw evidence — flame graphs, memory graphs, profiles, matrix data |
 | `aggregate.py` | rolls many runs' `summary.json` into one table + `matrix.csv` |
 | `_common.sh` | sourced by the rest: finds docker (with/without sudo), finds Python, checks the container is up |
 | `instr/` | the probes copied into the container, plus the report aggregators |

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -33,8 +33,9 @@ Two options, and which you pick changes what the numbers mean:
   identity a per-user cache looks like it always hits, so an A/B of one would
   measure a hit rate no deployment ever sees. Tokens come from password login
   at test start, so they cannot expire mid-run.
-- **`TOKEN`** — a single bearer JWT from browser devtools. Fine for absolute
-  throughput on a stateless path; misleading for per-user caches.
+- **`TOKEN` / `PIPESHUB_TOKEN`** — a single bearer JWT from browser devtools.
+  Fine for absolute throughput on a stateless path; misleading for per-user
+  caches. `PIPESHUB_TOKEN` wins when both are set; `.env` documents `TOKEN`.
 
 Provision accounts on a local stack (creates users, sets passwords, verifies
 each login, and prints the `PIPESHUB_USERS` line to paste in):
@@ -204,7 +205,7 @@ PIPESHUB_MODE=docker ./perftest.sh baseline 8 300
 |---|---|---|
 | `PIPESHUB_USERS` | — | `email:password,…`; one real account per simulated user |
 | `PIPESHUB_EMAILS` / `PIPESHUB_PASSWORD` | — | same, when the accounts share a password |
-| `TOKEN` | — | single-identity bearer JWT; used only if the two above are unset. One of the three is required unless `users` is 0 |
+| `TOKEN` / `PIPESHUB_TOKEN` | — | single-identity bearer JWT; used only if the two above are unset. `PIPESHUB_TOKEN` overrides `TOKEN`. One of these is required unless `users` is 0 |
 | `PIPESHUB_MODE` | `auto` | `auto` / `docker` / `native` |
 | `PIPESHUB_HOST` | `http://localhost:3000` | API gateway the load hits — the Node backend, not the frontend |
 | `PIPESHUB_CONTAINER` | `pipeshub-ai` | docker mode only |

--- a/loadtest/host_sampler.sh
+++ b/loadtest/host_sampler.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# host_sampler.sh <outfile> <seconds> [interval]
+#
+# Total host CPU and the load generator's own share of it. resource_sampler.sh
+# covers containers and query workers but not the curl driver, which runs on the
+# host and shares the same 8 cores. Without this, a run where the generator
+# starves the service is indistinguishable from one where the workers saturate --
+# and at 256+ users that is the difference between "we found the ceiling" and
+# "we measured our own test harness".
+set -uo pipefail
+OUT=${1:?usage: host_sampler.sh <outfile> <seconds> [interval]}
+SECS=${2:?}
+INT=${3:-5}
+
+echo "ts,host_cpu_pct,gen_cpu_pct,gen_procs,runq" > "$OUT"
+
+read_cpu() {  # busy and total jiffies from /proc/stat
+    awk '/^cpu /{idle=$5+$6; total=0; for(i=2;i<=NF;i++) total+=$i; print total-idle, total}' /proc/stat
+}
+# aggregate utime+stime of every curl the harness has running
+read_gen() {
+    local tot=0 n=0 pid
+    for pid in $(pgrep -x curl 2>/dev/null); do
+        if read -r _ _ _ _ _ _ _ _ _ _ _ _ _ ut st _ < /proc/"$pid"/stat 2>/dev/null; then
+            tot=$(( tot + ut + st )); n=$(( n + 1 ))
+        fi
+    done
+    echo "$tot $n"
+}
+
+HZ=$(getconf CLK_TCK)
+read -r pb pt < <(read_cpu)
+read -r gb gn < <(read_gen)
+end=$(( $(date +%s) + SECS ))
+while [ "$(date +%s)" -lt "$end" ]; do
+    sleep "$INT"
+    read -r cb ct < <(read_cpu)
+    read -r gc gn < <(read_gen)
+    dt=$(( ct - pt ))
+    [ "$dt" -le 0 ] && { pb=$cb; pt=$ct; gb=$gc; continue; }
+    host=$(awk -v a=$(( cb - pb )) -v b="$dt" 'BEGIN{printf "%.1f", a*100/b}')
+    # curl pids churn between samples, so a negative delta just means the
+    # previous set exited; clamp rather than report nonsense.
+    gd=$(( gc - gb )); [ "$gd" -lt 0 ] && gd=0
+    gen=$(awk -v j="$gd" -v hz="$HZ" -v i="$INT" 'BEGIN{printf "%.1f", j*100/(hz*i)}')
+    runq=$(awk '{print $1}' /proc/loadavg)
+    echo "$(date +%s),$host,$gen,$gn,$runq" >> "$OUT"
+    pb=$cb; pt=$ct; gb=$gc
+done

--- a/loadtest/instr/agg_resources.py
+++ b/loadtest/instr/agg_resources.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Summarise resources.csv into the run report.
+
+CPU is reported as percent of one core, so 400% means four cores' worth. The
+whole point of sampling continuously is that a single spot reading is not
+trustworthy here -- two readings of the same run disagreed 20x -- so this prints
+the distribution (p50/p95/max), not just a mean.
+
+Reads the CSV written by resource_sampler.sh; prints nothing if it is absent so
+runs without the sampler still report normally.
+"""
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+
+
+def pct(vals: list[float], q: float) -> float:
+    if not vals:
+        return 0.0
+    s = sorted(vals)
+    i = min(int(q * (len(s) - 1) + 0.5), len(s) - 1)
+    return s[i]
+
+
+def main() -> int:
+    path = sys.argv[1] if len(sys.argv) > 1 else "resources.csv"
+    cores = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+
+    cpu: dict[tuple[str, str], list[float]] = defaultdict(list)
+    rss: dict[tuple[str, str], list[float]] = defaultdict(list)
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            next(fh, None)
+            for line in fh:
+                parts = line.strip().split(",")
+                if len(parts) != 5:
+                    continue
+                _, scope, name, c, m = parts
+                try:
+                    cpu[(scope, name)].append(float(c))
+                    rss[(scope, name)].append(float(m))
+                except ValueError:
+                    continue
+    except FileNotFoundError:
+        return 0
+    if not cpu:
+        return 0
+
+    # workers roll up into one line as well as appearing individually
+    worker_series: list[list[float]] = [
+        v for (scope, name), v in cpu.items() if scope == "process" and name.startswith("query_worker")
+    ]
+    if worker_series:
+        n = min(len(v) for v in worker_series)
+        cpu[("process", "QUERY WORKERS TOTAL")] = [
+            sum(v[i] for v in worker_series) for i in range(n)
+        ]
+        rss[("process", "QUERY WORKERS TOTAL")] = [
+            sum(rss[k][i] for k in rss if k[0] == "process" and k[1].startswith("query_worker"))
+            for i in range(n)
+        ]
+
+    def rows(scope: str) -> list[tuple]:
+        out = []
+        for (s, name), vals in cpu.items():
+            if s != scope:
+                continue
+            out.append((name, len(vals), sum(vals) / len(vals), pct(vals, 0.5),
+                        pct(vals, 0.95), max(vals), max(rss[(s, name)] or [0])))
+        return sorted(out, key=lambda r: -r[2])
+
+    hdr = "  %-26s %5s %8s %8s %8s %8s %10s" % (
+        "name", "n", "mean%", "p50%", "p95%", "max%", "peak RSS MB")
+    for scope, title in (("process", "PER-PROCESS (inside the app container)"),
+                         ("container", "PER-CONTAINER")):
+        rs = rows(scope)
+        if not rs:
+            continue
+        print("  -- %s --" % title)
+        print(hdr)
+        for name, n, mean, p50, p95, mx, peak in rs:
+            print("  %-26s %5d %8.1f %8.1f %8.1f %8.1f %10.0f" % (name, n, mean, p50, p95, mx, peak))
+        print()
+
+    host = cpu.get(("host", "loadavg"), [])
+    if host:
+        line = "  host load: mean %.2f  p50 %.2f  p95 %.2f  max %.2f" % (
+            sum(host) / len(host), pct(host, 0.5), pct(host, 0.95), max(host))
+        if cores:
+            line += "   (%d cores)" % cores
+        print(line)
+
+    # total CPU actually consumed across containers, vs what the box has
+    ctotal = [v for (s, _), v in cpu.items() if s == "container"]
+    if ctotal and cores:
+        n = min(len(v) for v in ctotal)
+        summed = [sum(v[i] for v in ctotal) for i in range(n)]
+        print("  all containers: mean %.0f%% of %d00%% available (p95 %.0f%%)" % (
+            sum(summed) / len(summed), cores, pct(summed, 0.95)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loadtest/instrument.sh
+++ b/loadtest/instrument.sh
@@ -27,7 +27,11 @@ if [ "$PIPESHUB_MODE" != "docker" ]; then
     exit 1
 fi
 
-in_container() { $DOCKER exec "$CONTAINER" "$@"; }
+# -i is required: the heredocs below pipe a script into `python3 -`, and without
+# stdin attached docker exec hands python an immediate EOF. It then executes
+# nothing, prints nothing and exits 0 — so `on` reported success while the probe
+# was never wired, and `off` never removed it.
+in_container() { $DOCKER exec -i "$CONTAINER" "$@"; }
 
 case "$ACTION" in
   on)
@@ -49,18 +53,28 @@ case "$ACTION" in
 p = "/app/python/app/utils/runtime_threads.py"
 src = open(p).read()
 line = "    from app.utils import backend_timing as _backend_timing  # noqa: F401"
+block = "try:\n" + line + "\nexcept Exception:\n    pass\n"
 if "backend_timing" in src:
     print("   already wired")
 else:
-    marker = "import"
     lines = src.splitlines(keepends=True)
     for i, ln in enumerate(lines):
         if ln.startswith("def ") or ln.startswith("class "):
-            lines.insert(i, "try:\n" + line + "\nexcept Exception:\n    pass\n\n")
+            lines.insert(i, block + "\n")
             break
+    else:
+        # runtime_threads.py is pure module-level setup with no def/class to
+        # insert before. The loop used to fall through, write the file back
+        # byte-identical and still print "wired" — so the probe never loaded
+        # and every run reported "no BACKENDAGG lines" as if uninstrumented.
+        if lines and not lines[-1].endswith("\n"):
+            lines.append("\n")
+        lines.append("\n" + block)
     out = "".join(lines)
     compile(out, p, "exec")
     open(p, "w").write(out)
+    if "backend_timing" not in open(p).read():
+        raise SystemExit("!! backend probe wiring failed — backend latency unavailable")
     print("   wired")
 PY
     bash "$HERE/restart_query.sh"

--- a/loadtest/locustfile_play.py
+++ b/loadtest/locustfile_play.py
@@ -13,6 +13,7 @@ Usage:
     export PIPESHUB_USERS='a@example.com:Pass1!,b@example.com:Pass2!'
     # or a single one
     export PIPESHUB_TOKEN='<bearer token from browser devtools>'
+    # PIPESHUB_TOKEN wins; TOKEN is the documented .env fallback (same as perftest.sh)
     locust -f locustfile.py --headless -u 10 -r 2 -t 10m -H http://localhost:3000
 
     # ramp to find the knee
@@ -43,7 +44,8 @@ from pipeshub_auth import AuthError, credentials_from_env, resolve_tokens  # noq
 # Config
 # --------------------------------------------------------------------------
 
-TOKEN = os.environ.get("PIPESHUB_TOKEN", "")
+# Prefer PIPESHUB_TOKEN; fall back to TOKEN so loadtest/.env matches perftest.sh.
+TOKEN = os.environ.get("PIPESHUB_TOKEN") or os.environ.get("TOKEN") or ""
 AGENT_KEY = os.environ.get("PIPESHUB_AGENT_KEY", "")
 
 # Tokens the simulated users draw from, resolved once at test_start. One shared
@@ -122,12 +124,13 @@ def _resolve_identities(environment, **_kwargs) -> None:
 
     if TOKEN:
         TOKENS = [TOKEN]
-        print("[loadtest] using the single PIPESHUB_TOKEN identity")
+        which = "PIPESHUB_TOKEN" if os.environ.get("PIPESHUB_TOKEN") else "TOKEN"
+        print(f"[loadtest] using the single {which} identity")
         return
 
     raise SystemExit(
         "No credentials. Set PIPESHUB_USERS='email:password,...' (see seed_users.py), "
-        "or PIPESHUB_EMAILS + PIPESHUB_PASSWORD, or PIPESHUB_TOKEN for a single user."
+        "or PIPESHUB_EMAILS + PIPESHUB_PASSWORD, or PIPESHUB_TOKEN / TOKEN for a single user."
     )
 
 

--- a/loadtest/locustfile_play.py
+++ b/loadtest/locustfile_play.py
@@ -9,6 +9,9 @@ Run against a resource-pinned Docker stack (see docker-compose.loadtest.yml).
 Numbers from an unpinned stack are not reproducible.
 
 Usage:
+    # Many identities (required to A/B anything cached per user — see seed_users.py)
+    export PIPESHUB_USERS='a@example.com:Pass1!,b@example.com:Pass2!'
+    # or a single one
     export PIPESHUB_TOKEN='<bearer token from browser devtools>'
     locust -f locustfile.py --headless -u 10 -r 2 -t 10m -H http://localhost:3000
 
@@ -24,12 +27,17 @@ Scenario classes (name them on the CLI to pin the mix):
 
 from __future__ import annotations
 
+import itertools
 import json
 import os
+import sys
 from pathlib import Path
 import time
 
 from locust import HttpUser, LoadTestShape, constant, events, task
+
+sys.path.insert(0, str(Path(__file__).parent))
+from pipeshub_auth import AuthError, credentials_from_env, resolve_tokens  # noqa: E402
 
 # --------------------------------------------------------------------------
 # Config
@@ -37,6 +45,12 @@ from locust import HttpUser, LoadTestShape, constant, events, task
 
 TOKEN = os.environ.get("PIPESHUB_TOKEN", "")
 AGENT_KEY = os.environ.get("PIPESHUB_AGENT_KEY", "")
+
+# Tokens the simulated users draw from, resolved once at test_start. One shared
+# token measures a per-user cache as if every request came from the same person,
+# so multi-user runs are the only honest way to A/B one.
+TOKENS: list[str] = []
+_token_cursor = itertools.count()
 
 # The query service, exposed directly by the loadtest compose overlay. Probing
 # through the Node gateway would fold Node's latency into the measurement.
@@ -74,21 +88,47 @@ AGENT_QUESTIONS = [
 ]
 
 
-def _auth_headers() -> dict[str, str]:
+def _auth_headers(token: str) -> dict[str, str]:
     return {
-        "Authorization": f"Bearer {TOKEN}",
+        "Authorization": f"Bearer {token}",
         "Content-Type": "application/json",
         "Accept": "text/event-stream",
     }
 
 
 @events.test_start.add_listener
-def _check_config(environment, **_kwargs) -> None:
-    if not TOKEN:
-        raise SystemExit(
-            "PIPESHUB_TOKEN is not set. Log in to the UI, open devtools > Network, "
-            "and copy the Bearer token from any API request."
-        )
+def _resolve_identities(environment, **_kwargs) -> None:
+    """Turn credentials into tokens before the clock starts.
+
+    Logging in here rather than per user keeps the auth round trips out of the
+    measurement window, and fails the run up front if a password is wrong —
+    five bad attempts lock the account for 24h.
+    """
+    global TOKENS
+
+    try:
+        credentials = credentials_from_env()
+    except AuthError as e:
+        raise SystemExit(str(e)) from e
+
+    if credentials:
+        host = environment.host or os.environ.get("PIPESHUB_HOST", "http://localhost:3000")
+        try:
+            TOKENS = resolve_tokens(host, credentials)
+        except AuthError as e:
+            raise SystemExit(f"Could not log in load-test users: {e}") from e
+        print(f"[loadtest] resolved {len(TOKENS)} user tokens via password login")
+        return
+
+    if TOKEN:
+        TOKENS = [TOKEN]
+        print("[loadtest] using the single PIPESHUB_TOKEN identity")
+        return
+
+    raise SystemExit(
+        "No credentials. Set PIPESHUB_USERS='email:password,...' (see seed_users.py), "
+        "or PIPESHUB_EMAILS + PIPESHUB_PASSWORD, or PIPESHUB_TOKEN for a single user."
+    )
 
 
 # --------------------------------------------------------------------------
@@ -133,10 +173,15 @@ class StreamingChatUser(HttpUser):
 
     prefix: str = "chat"
     questions: list[str] = QUESTIONS
+    token: str = ""
     # `/conversations/stream` rejects a request without an explicit chatMode
     # (es_validators.ts: UNIVERSAL_STREAM_CHAT_MODES). It used to default, so
     # omitting it silently 400s every request rather than failing loudly.
     chat_mode: str = "internal_search"
+
+    def on_start(self) -> None:
+        # Round-robin so identities are spread evenly however Locust ramps.
+        self.token = TOKENS[next(_token_cursor) % len(TOKENS)] if TOKENS else TOKEN
 
     def endpoint(self) -> str:
         raise NotImplementedError
@@ -164,6 +209,13 @@ class StreamingChatUser(HttpUser):
         _lim = os.environ.get("PIPESHUB_LIMIT")
         if _lim:
             body["limit"] = int(_lim)
+        # Reasoning depth. Unset, aimodels applies DEFAULT_REASONING_EFFORT
+        # ("high"), which dominates turn latency on a reasoning model -- set
+        # this to A/B it. Values: none|low|medium|high|max ("none" is floored
+        # to "low" by _reasoning_effort_kwargs).
+        _eff = os.environ.get("PIPESHUB_REASONING_EFFORT")
+        if _eff:
+            body["reasoningEffort"] = _eff
 
         start = time.monotonic()
         seen_first_packet = False
@@ -174,7 +226,7 @@ class StreamingChatUser(HttpUser):
             with self.client.post(
                 self.endpoint(),
                 json=body,
-                headers=_auth_headers(),
+                headers=_auth_headers(self.token),
                 stream=True,
                 timeout=STREAM_TIMEOUT,
                 catch_response=True,

--- a/loadtest/perftest.sh
+++ b/loadtest/perftest.sh
@@ -254,6 +254,13 @@ else
 fi
 
 say ""
+# The sampler runs SECS+10 so it covers the drain; without waiting, the report
+# could aggregate a CSV still being appended to and the numbers would change
+# after they were printed.
+if [ -n "${RES_PID:-}" ]; then
+    wait "$RES_PID" 2>/dev/null || true
+fi
+
 say "==================== RESOURCES (CPU %, RAM MB) ===================="
 if [ -s "$OUTDIR/resources.csv" ]; then
     "$PYTHON" "$HERE/instr/agg_resources.py" "$OUTDIR/resources.csv" "$(nproc)" 2>/dev/null | tee -a "$REPORT"

--- a/loadtest/perftest.sh
+++ b/loadtest/perftest.sh
@@ -29,8 +29,32 @@ HOST=${PIPESHUB_HOST}
 QUERY_FILE=${PIPESHUB_QUERY_FILE:-$HERE/queries.txt}
 # users=0 is the collect-only mode (someone else drives the load): no requests
 # are sent from here, so no credential is needed.
+#
+# TOKENS[] is what the load loop indexes by user. It comes either from
+# PIPESHUB_USERS (email:password pairs, logged in here) or from a single TOKEN.
+# Anything cached per user has to be measured with real distinct identities —
+# one shared token makes a per-user cache look like it always hits.
+TOKENS=()
 if [ "$USERS" -gt 0 ]; then
-  : "${TOKEN:?set TOKEN in loadtest/.env, or export it — see .env.example}"
+  if [ -n "${PIPESHUB_USERS:-}${PIPESHUB_EMAILS:-}" ]; then
+    detect_python || exit 1
+    echo "== logging in load-test users"
+    if ! TOKEN_BLOB=$(PIPESHUB_HOST="$HOST" LOADTEST_DIR="$HERE" \
+        "$PYTHON" "$HERE/resolve_tokens.py"); then
+      echo "ABORT: could not log in load-test users (see error above)." >&2
+      exit 1
+    fi
+    # tr -d '\r': on Windows the helper's stdout is CRLF and `mapfile -t` strips
+    # only the newline, leaving a carriage return inside the token. That makes
+    # the Authorization header malformed and every request 400s.
+    mapfile -t TOKENS < <(printf '%s\n' "$TOKEN_BLOB" | tr -d '\r' | grep .)
+    [ "${#TOKENS[@]}" -gt 0 ] && [ -n "${TOKENS[0]}" ] || {
+      echo "ABORT: no tokens resolved." >&2; exit 1; }
+    echo "== resolved ${#TOKENS[@]} user tokens"
+  else
+    : "${TOKEN:?set TOKEN or PIPESHUB_USERS in loadtest/.env — see .env.example}"
+    TOKENS=("$TOKEN")
+  fi
 fi
 # Checked before the run, not after: every reporting section below reads the
 # query service, so a 300s run against an unreachable one produces only zeroes.
@@ -45,14 +69,14 @@ say() { echo "$@" | tee -a "$REPORT"; }
 # --- exactly like a throughput collapse. Fail fast instead.
 if [ "$USERS" -gt 0 ]; then
   probe=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$HOST/api/v1/conversations/stream" \
-    -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+    -H "Authorization: Bearer ${TOKENS[0]}" -H "Content-Type: application/json" \
     -H "Accept: text/event-stream" -d "{\"query\":\"ping\",\"chatMode\":\"internal_search\"}" \
     --max-time 60 2>/dev/null) || true
   # curl already prints 000 when it never got a response; appending a fallback
   # to the same capture produced "HTTP 000000".
   [ -n "$probe" ] || probe=000
   if [ "$probe" != "200" ]; then
-    say "ABORT: auth probe returned HTTP $probe (expected 200). Refresh TOKEN."
+    say "ABORT: auth probe returned HTTP $probe (expected 200). Refresh TOKEN/PIPESHUB_USERS."
     exit 1
   fi
 fi
@@ -76,9 +100,15 @@ else
 fi
 [ ${#QUERIES[@]} -gt 0 ] || { say "ABORT: $QUERY_FILE contains no queries."; exit 1; }
 mapfile -t BODIES < <(printf '%s\n' "${QUERIES[@]}" | "$PYTHON" -c '
-import json, sys
+import json, os, sys
+# The reasoning effort changes how much work a turn is, so an A/B across arms
+# has to pin it — leaving it unset lets the service default drift between runs.
+effort = os.environ.get("PIPESHUB_REASONING_EFFORT") or None
 for line in sys.stdin.read().splitlines():
-    print(json.dumps({"query": line, "chatMode": "internal_search"}))
+    body = {"query": line, "chatMode": "internal_search"}
+    if effort:
+        body["reasoningEffort"] = effort
+    print(json.dumps(body))
 ')
 
 say "== $LABEL: $USERS users, ${SECS}s, ${#QUERIES[@]} quer$([ ${#QUERIES[@]} -eq 1 ] && echo y || echo ies), host $HOST, mode $PIPESHUB_MODE"
@@ -104,6 +134,15 @@ else
   say "   (py-spy not installed — skipping CPU profile; see README.md)"
 fi
 
+# --- resource sampler (CPU + RAM for every service, continuously)
+# One-off readings of `docker stats` disagreed by 20x within a single run,
+# so this samples kernel counters for the whole window and the report shows
+# the distribution rather than a spot value.
+if [ -x "$HERE/resource_sampler.sh" ]; then
+    "$HERE/resource_sampler.sh" "$OUTDIR" "$(( SECS + 10 ))" 2 >/dev/null 2>&1 &
+    RES_PID=$!
+fi
+
 # --- memory sampler
 ( END_M=$(( $(date +%s) + SECS + 15 ))
   while [ "$(date +%s)" -lt "$END_M" ]; do
@@ -111,6 +150,16 @@ fi
     sleep 2
   done ) &
 MEM_PID=$!
+
+# How long a single turn may take before curl gives up. The default matches the
+# old hard-coded value. Raise it when a config is slow enough that turns outlast
+# it — a truncated SSE stream still reports HTTP 200 (the status line is sent
+# before the body), so the only symptom is curl_exit=28 and a turn that never
+# reaches the server's completion marker.
+# PIPESHUB_MAX_TIME is the older spelling; existing run scripts still pass it,
+# and ignoring it would silently cap turns at 300s and record saturation as
+# errors.
+TURN_MAX_SECONDS=${PIPESHUB_TURN_MAX_SECONDS:-${PIPESHUB_MAX_TIME:-300}}
 
 # Query order per user, drawn from a PRNG seeded on (label, user index): random
 # across users but reproducible, so two arms of an A/B see the SAME sequence
@@ -129,6 +178,9 @@ END=$(( $(date +%s) + SECS ))
 echo "user,turn,query_index,http_code,time_total,curl_exit" > "$OUTDIR/requests.csv"
 LOAD_PIDS=()
 for u in $(seq 1 "$USERS"); do
+  # Simulated users cycle through the real identities; with one token this is
+  # the old behaviour, with N it spreads them evenly.
+  user_token=${TOKENS[$(( (u - 1) % ${#TOKENS[@]} ))]}
   ( turn=0
     read -r -a seq <<< "${USER_SEQ[$((u - 1))]}"
     while [ "$(date +%s)" -lt "$END" ]; do
@@ -138,10 +190,10 @@ for u in $(seq 1 "$USERS"); do
       # one that was merely slow.
       res=$(curl -s -N -o /dev/null -w '%{http_code} %{time_total}' \
         -X POST "$HOST/api/v1/conversations/stream" \
-        -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
+        -H "Authorization: Bearer $user_token" -H "Content-Type: application/json" \
         -H "Accept: text/event-stream" \
         -d "${BODIES[$qi]}" \
-        --max-time 300 2>/dev/null)
+        --max-time "$TURN_MAX_SECONDS" 2>/dev/null)
       # Immediately, and with no `|| true` in between: that would make this the
       # exit status of `true` and record every request as curl_exit=0, losing
       # exactly the timeouts (28) this column exists to surface. Safe without a
@@ -201,6 +253,13 @@ else
   say "   (no profile captured)"
 fi
 
+say ""
+say "==================== RESOURCES (CPU %, RAM MB) ===================="
+if [ -s "$OUTDIR/resources.csv" ]; then
+    "$PYTHON" "$HERE/instr/agg_resources.py" "$OUTDIR/resources.csv" "$(nproc)" 2>/dev/null | tee -a "$REPORT"
+else
+    say "  (resource sampler produced no data)"
+fi
 say ""
 say "==================== MEMORY (query service RSS, MB) ===================="
 if [ -s "$OUTDIR/memory.csv" ]; then

--- a/loadtest/pipeshub_auth.py
+++ b/loadtest/pipeshub_auth.py
@@ -63,8 +63,12 @@ def _authenticate(base_url: str, session_token: str, email: str, password: str, 
         data = resp.json()
     except ValueError:
         raise AuthError(f"authenticate returned non-JSON for {email}") from None
+    if not isinstance(data, dict):
+        raise AuthError(
+            f"authenticate returned non-object JSON for {email}: {type(data).__name__}"
+        )
     token = data.get("accessToken")
-    if not token:
+    if not isinstance(token, str) or not token:
         # A multi-step org config answers with `nextStep` instead of a token.
         raise AuthError(
             f"authenticate returned no accessToken for {email} (keys: {sorted(data)})"

--- a/loadtest/pipeshub_auth.py
+++ b/loadtest/pipeshub_auth.py
@@ -1,0 +1,119 @@
+"""Password login for the load test, so runs stop depending on a pasted token.
+
+PipesHub authenticates in two calls: `initAuth` hands back a single-use
+`x-session-token`, and `authenticate` exchanges it plus the password for a
+24h access token — long enough that a run never needs to refresh.
+
+Shared by `locustfile_play.py` and `seed_users.py`; mirrors
+`integration-tests/helper/local_auth.py`.
+"""
+
+from __future__ import annotations
+
+import os
+
+import requests
+
+DEFAULT_TIMEOUT = 30
+
+
+class AuthError(RuntimeError):
+    pass
+
+
+def login(base_url: str, email: str, password: str, timeout: int = DEFAULT_TIMEOUT) -> str:
+    """Return an access token for `email`, or raise AuthError."""
+    base_url = base_url.rstrip("/")
+    session_token = _init_auth(base_url, email, timeout)
+    return _authenticate(base_url, session_token, email, password, timeout)
+
+
+def _init_auth(base_url: str, email: str, timeout: int) -> str:
+    resp = requests.post(
+        f"{base_url}/api/v1/userAccount/initAuth",
+        json={"email": email},
+        timeout=timeout,
+    )
+    if resp.status_code >= 400:
+        raise AuthError(f"initAuth failed for {email}: HTTP {resp.status_code}: {resp.text[:200]}")
+    session_token = resp.headers.get("x-session-token")
+    if not session_token:
+        raise AuthError(f"initAuth returned no x-session-token for {email}")
+    return session_token
+
+
+def _authenticate(base_url: str, session_token: str, email: str, password: str, timeout: int) -> str:
+    resp = requests.post(
+        f"{base_url}/api/v1/userAccount/authenticate",
+        headers={"x-session-token": session_token},
+        json={
+            "method": "password",
+            "credentials": {"password": password},
+            "email": email,
+        },
+        timeout=timeout,
+    )
+    if resp.status_code >= 400:
+        # Five wrong passwords block the account for 24h, so surface this loudly
+        # rather than letting a retry loop burn the remaining attempts.
+        raise AuthError(
+            f"authenticate failed for {email}: HTTP {resp.status_code}: {resp.text[:200]}"
+        )
+    try:
+        data = resp.json()
+    except ValueError:
+        raise AuthError(f"authenticate returned non-JSON for {email}") from None
+    token = data.get("accessToken")
+    if not token:
+        # A multi-step org config answers with `nextStep` instead of a token.
+        raise AuthError(
+            f"authenticate returned no accessToken for {email} (keys: {sorted(data)})"
+        )
+    return token
+
+
+def parse_credentials(users_env: str = "", emails_env: str = "", shared_password: str = "") -> list[tuple[str, str]]:
+    """Read credentials from the two supported env formats.
+
+    `PIPESHUB_USERS` is `email:password` pairs, comma separated. `PIPESHUB_EMAILS`
+    is a comma-separated list that pairs each address with `PIPESHUB_PASSWORD`.
+    """
+    pairs: list[tuple[str, str]] = []
+
+    for entry in (users_env or "").split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" not in entry:
+            raise AuthError(f"PIPESHUB_USERS entry {entry!r} is not 'email:password'")
+        email, password = entry.split(":", 1)
+        if not email.strip() or not password.strip():
+            raise AuthError(f"PIPESHUB_USERS entry {entry!r} has an empty field")
+        pairs.append((email.strip(), password.strip()))
+
+    if not pairs and emails_env:
+        if not shared_password:
+            raise AuthError("PIPESHUB_EMAILS is set but PIPESHUB_PASSWORD is not")
+        for email in emails_env.split(","):
+            email = email.strip()
+            if email:
+                pairs.append((email, shared_password))
+
+    return pairs
+
+
+def credentials_from_env() -> list[tuple[str, str]]:
+    return parse_credentials(
+        users_env=os.environ.get("PIPESHUB_USERS", ""),
+        emails_env=os.environ.get("PIPESHUB_EMAILS", ""),
+        shared_password=os.environ.get("PIPESHUB_PASSWORD", ""),
+    )
+
+
+def resolve_tokens(base_url: str, credentials: list[tuple[str, str]]) -> list[str]:
+    """Log every credential in. Raises on the first failure — a run with fewer
+    identities than intended would quietly measure the wrong thing."""
+    tokens = []
+    for email, password in credentials:
+        tokens.append(login(base_url, email, password))
+    return tokens

--- a/loadtest/resolve_tokens.py
+++ b/loadtest/resolve_tokens.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Print one access token per configured load-test user, newline separated.
+
+Called by `perftest.sh` so the shell harness gets the same identities the
+locust harness does. Exits non-zero on the first failure — a run with fewer
+users than intended measures the wrong thing.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.environ.get("LOADTEST_DIR") or os.path.dirname(os.path.abspath(__file__)))
+
+from pipeshub_auth import AuthError, credentials_from_env, resolve_tokens  # noqa: E402
+
+
+def main() -> int:
+    host = os.environ.get("PIPESHUB_HOST", "http://localhost:3000")
+    try:
+        credentials = credentials_from_env()
+        if not credentials:
+            raise AuthError("PIPESHUB_USERS/PIPESHUB_EMAILS is set but parsed to no credentials")
+        for token in resolve_tokens(host, credentials):
+            print(token)
+    except AuthError as e:
+        print(f"AUTH ERROR: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/loadtest/resource_sampler.sh
+++ b/loadtest/resource_sampler.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# resource_sampler.sh <outdir> <seconds> [interval] — CPU and RAM for every
+# service, sampled continuously for the whole run.
+#
+# Why not `docker stats`: it returns one instantaneous, heavily smoothed number
+# per container and nothing per-process, so a pegged uvicorn worker or a pegged
+# gateway inside the shared app container is invisible. Two spot readings of the
+# same run disagreed by 20x here, which is how a wrong "the datastores are idle"
+# conclusion got made.
+#
+# Instead this reads the kernel's own accounting and differentiates it:
+#   containers -> cgroup v2 cpu.stat usage_usec + memory.current
+#   processes  -> /proc/<pid>/stat utime+stime, /proc/<pid>/statm RSS
+# Both are monotonic counters, so CPU% over an interval is exact rather than
+# sampled, and a burst between samples still shows up in the total.
+#
+# Uvicorn workers are multiprocessing.spawn children, so their argv is
+# "spawn_main(...)" and pgrep -f app.query_main only ever matches the idle
+# master -- they are found by parent PID instead.
+set -uo pipefail
+
+OUTDIR=${1:?usage: resource_sampler.sh <outdir> <seconds> [interval]}
+SECS=${2:-300}
+INTERVAL=${3:-2}
+CONTAINER=${PIPESHUB_CONTAINER:-pipeshub-ai}
+CSV="$OUTDIR/resources.csv"
+mkdir -p "$OUTDIR"
+
+SUDO=""
+[ "$(id -u)" -ne 0 ] && command -v sudo >/dev/null 2>&1 && SUDO="sudo"
+DOCKER="$SUDO docker"
+
+CONTAINERS="${PIPESHUB_STACK_CONTAINERS:-$CONTAINER mongodb neo4j qdrant redis}"
+CLK=$(getconf CLK_TCK 2>/dev/null || echo 100)
+
+# container id -> cgroup dir
+declare -A CG
+for c in $CONTAINERS; do
+    cid=$($DOCKER inspect "$c" --format '{{.Id}}' 2>/dev/null) || continue
+    [ -n "$cid" ] || continue
+    d="/sys/fs/cgroup/system.slice/docker-${cid}.scope"
+    [ -r "$d/cpu.stat" ] || d=$($SUDO find /sys/fs/cgroup -maxdepth 4 -type d -name "*${cid}*" 2>/dev/null | head -1)
+    [ -n "$d" ] && CG[$c]="$d"
+done
+
+# tracked processes inside the app container: name -> pid list
+discover_pids() {
+    local master workers
+    master=$($DOCKER exec "$CONTAINER" pgrep -f '[a]pp.query_main' 2>/dev/null | tr -d '\r' | head -1)
+    if [ -n "$master" ]; then
+        workers=$($DOCKER exec "$CONTAINER" sh -c "pgrep -P $master -f multiprocessing-fork" 2>/dev/null | tr -d '\r')
+        # one worker => uvicorn runs it in the master process, no children
+        [ -z "$workers" ] && workers="$master"
+        echo "query_worker:$(echo "$workers" | tr '\n' ' ')"
+    fi
+    for svc in node:'[n]ode dist/index.js' indexing:'[a]pp.indexing_main' \
+               connectors:'[a]pp.connectors_main' docling:'[a]pp.docling_main' \
+               embedding:'[a]pp.embedding_main'; do
+        local name=${svc%%:*} pat=${svc#*:}
+        local p
+        p=$($DOCKER exec "$CONTAINER" pgrep -f "$pat" 2>/dev/null | tr -d '\r' | head -1)
+        [ -n "$p" ] && echo "$name:$p"
+    done
+}
+
+PROCSPEC=$(discover_pids)
+PIDS=$(echo "$PROCSPEC" | cut -d: -f2- | tr '\n' ' ')
+
+# one exec per sample: read every tracked pid's cpu ticks and RSS pages
+read_procs() {
+    $DOCKER exec "$CONTAINER" sh -c '
+      for p in '"$PIDS"'; do
+        if [ -r /proc/$p/stat ]; then
+          set -- $(cat /proc/$p/stat)
+          # fields 14,15 = utime,stime; statm field 2 = resident pages
+          rss=$(awk "{print \$2}" /proc/$p/statm 2>/dev/null || echo 0)
+          echo "$p $(( ${14} + ${15} )) $rss"
+        fi
+      done' 2>/dev/null | tr -d '\r'
+}
+
+read_cg() {
+    local c d
+    for c in "${!CG[@]}"; do
+        d=${CG[$c]}
+        u=$($SUDO awk '/^usage_usec/{print $2}' "$d/cpu.stat" 2>/dev/null)
+        m=$($SUDO cat "$d/memory.current" 2>/dev/null)
+        [ -n "$u" ] && echo "$c $u ${m:-0}"
+    done
+}
+
+echo "ts,scope,name,cpu_pct,rss_mb" > "$CSV"
+
+declare -A P0 R0 C0 M0
+while read -r pid ticks rss; do P0[$pid]=$ticks; R0[$pid]=$rss; done < <(read_procs)
+while read -r c usec mem; do C0[$c]=$usec; M0[$c]=$mem; done < <(read_cg)
+T0=$(date +%s.%N)
+
+END=$(( $(date +%s) + SECS ))
+while [ "$(date +%s)" -lt "$END" ]; do
+    sleep "$INTERVAL"
+    NOW=$(date +%s); T1=$(date +%s.%N)
+    DT=$(echo "$T1 - $T0" | bc)
+    [ "$(echo "$DT <= 0" | bc)" = "1" ] && continue
+
+    while read -r pid ticks rss; do
+        a=${P0[$pid]:-}
+        if [ -n "$a" ]; then
+            pct=$(echo "scale=2; ($ticks - $a) / ($CLK * $DT) * 100" | bc)
+            mb=$(echo "scale=1; $rss * 4096 / 1048576" | bc)
+            name=$(echo "$PROCSPEC" | awk -F: -v P="$pid" '{n=$1; for(i=2;i<=NF;i++){split($i,a," "); for(j in a) if(a[j]==P) print n}}' | head -1)
+            echo "$NOW,process,${name:-pid$pid}:$pid,$pct,$mb" >> "$CSV"
+        fi
+        P0[$pid]=$ticks; R0[$pid]=$rss
+    done < <(read_procs)
+
+    while read -r c usec mem; do
+        a=${C0[$c]:-}
+        if [ -n "$a" ]; then
+            pct=$(echo "scale=2; ($usec - $a) / (1000000 * $DT) * 100" | bc)
+            mb=$(echo "scale=1; $mem / 1048576" | bc)
+            echo "$NOW,container,$c,$pct,$mb" >> "$CSV"
+        fi
+        C0[$c]=$usec; M0[$c]=$mem
+    done < <(read_cg)
+
+    echo "$NOW,host,loadavg,$(cut -d' ' -f1 /proc/loadavg),0" >> "$CSV"
+    T0=$T1
+done

--- a/loadtest/seed_users.py
+++ b/loadtest/seed_users.py
@@ -24,7 +24,9 @@ Giving that account a password, in order of preference:
     export PIPESHUB_SCOPED_JWT_SECRET='...'
     ./seed_users.py --count 8
 
-Prints the `PIPESHUB_USERS` line to paste into `.env`. Local stacks only.
+Writes the `PIPESHUB_USERS` line to a 0600 file to paste into `.env` --
+not to stdout, which reaches scrollback, CI logs and shell history.
+Local stacks only.
 """
 
 from __future__ import annotations
@@ -33,6 +35,7 @@ import argparse
 import datetime
 import os
 import subprocess
+from pathlib import Path
 import sys
 import uuid
 
@@ -181,6 +184,8 @@ def main() -> int:
                         help="needs 8+ chars with upper, lower, digit and symbol")
     parser.add_argument("--prefix", default="loadtest", help="email local-part prefix")
     parser.add_argument("--domain", default=DEFAULT_EMAIL_DOMAIN)
+    parser.add_argument("--credentials-out", default="loadtest_users.env",
+                        help="file the PIPESHUB_USERS line is written to (mode 0600)")
     args = parser.parse_args()
 
     admin_email = os.environ.get("PIPESHUB_ADMIN_EMAIL", "").strip()
@@ -214,8 +219,18 @@ def main() -> int:
             print(f"ERROR provisioning {email}: {e}", file=sys.stderr)
             return 1
 
-    print(f"\nProvisioned {len(created)} users. Add to loadtest/.env:\n")
-    print("PIPESHUB_USERS=" + ",".join(f"{email}:{password}" for email, password in created))
+    # Written to a 0600 file rather than stdout: these are real (if disposable)
+    # credentials, and stdout ends up in terminal scrollback, CI logs and shell
+    # history. The caller gets a path to paste from instead.
+    line = "PIPESHUB_USERS=" + ",".join(f"{email}:{password}" for email, password in created)
+    out_path = Path(args.credentials_out).expanduser()
+    fd = os.open(out_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as fh:
+        fh.write(line + "\n")
+
+    print(f"\nProvisioned {len(created)} users.")
+    print(f"Credentials written to {out_path} (mode 0600).")
+    print(f"Add them to loadtest/.env:\n  cat {out_path} >> .env")
     print(
         "\nNote: these users see only what the org shares with them. Give them KB "
         "access if the run should search the same corpus."

--- a/loadtest/seed_users.py
+++ b/loadtest/seed_users.py
@@ -65,7 +65,22 @@ def create_user(base_url: str, admin_token: str, email: str, full_name: str) -> 
         raise RuntimeError(
             f"createUser failed for {email}: HTTP {resp.status_code}: {resp.text[:300]}"
         )
-    return resp.json()
+    try:
+        data = resp.json()
+    except ValueError as e:
+        raise RuntimeError(f"createUser returned non-JSON for {email}") from e
+    if not isinstance(data, dict):
+        raise RuntimeError(
+            f"createUser returned non-object JSON for {email}: {type(data).__name__}"
+        )
+    user_id = data.get("_id") or data.get("id")
+    org_id = data.get("orgId")
+    if not isinstance(user_id, str) or not user_id or not isinstance(org_id, str) or not org_id:
+        raise RuntimeError(
+            f"createUser response missing string _id/id and orgId for {email}: "
+            f"{sorted(data)}"
+        )
+    return {"_id": user_id, "id": user_id, "orgId": org_id}
 
 
 def _credential_document(user_id: str, org_id: str, hashed: str) -> dict:
@@ -207,10 +222,8 @@ def main() -> int:
         email = f"{args.prefix}-{run_id}-{i}@{args.domain}"
         try:
             user = create_user(args.base_url, admin_token, email, f"Load Test {run_id} {i}")
-            user_id = user.get("_id") or user.get("id")
-            org_id = user.get("orgId")
-            if not user_id or not org_id:
-                raise RuntimeError(f"createUser response missing _id/orgId: {sorted(user)}")
+            user_id = user["_id"]
+            org_id = user["orgId"]
             how = seed_password(args.base_url, user_id, org_id, args.password)
             login(args.base_url, email, args.password)  # prove it works now, not mid-run
             created.append((email, args.password))

--- a/loadtest/seed_users.py
+++ b/loadtest/seed_users.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Provision load-test users on a local stack.
+
+The accessible-record cache is keyed per user, so a run driven by one identity
+measures a cache hit rate no real deployment would see. This creates N users
+that all share the org's knowledge bases, so the multi-user run exercises the
+real thing.
+
+Creating a user needs an org admin token. The *invite* route needs SMTP, but
+`POST /api/v1/users` does not — it creates the account with no credentials and
+sends no mail — so no mail server has to exist for any of this.
+
+Giving that account a password, in order of preference:
+
+1. `POST /api/v1/userAccount/password/reset/token` with a `password:reset`
+   scoped JWT. Pure API, nothing touches the database. Needs the deployment's
+   scoped JWT secret in `PIPESHUB_SCOPED_JWT_SECRET` (see --print-secret-help).
+2. Writing bcrypt credentials into Mongo directly, the way
+   `integration-tests/helper/second_user_auth.py` does. Needs `bcrypt` and
+   `pymongo`, and a reachable Mongo.
+
+    export PIPESHUB_ADMIN_EMAIL=admin@example.com
+    export PIPESHUB_ADMIN_PASSWORD='...'
+    export PIPESHUB_SCOPED_JWT_SECRET='...'
+    ./seed_users.py --count 8
+
+Prints the `PIPESHUB_USERS` line to paste into `.env`. Local stacks only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import subprocess
+import sys
+import uuid
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from pipeshub_auth import AuthError, login  # noqa: E402
+
+DEFAULT_BASE_URL = os.environ.get("PIPESHUB_HOST", "http://localhost:3000")
+DEFAULT_PASSWORD = os.environ.get("PIPESHUB_SEED_PASSWORD", "LoadTest123!")
+DEFAULT_EMAIL_DOMAIN = "loadtest.pipeshub.local"
+MONGO_URI = os.environ.get("PIPESHUB_MONGO_URI", "mongodb://admin:password@localhost:27017/?authSource=admin")
+MONGO_DB = os.environ.get("PIPESHUB_MONGO_DB", "es")
+MONGO_CONTAINER = os.environ.get("PIPESHUB_MONGO_CONTAINER", "mongodb")
+PASSWORD_RESET_SCOPE = "password:reset"
+TIMEOUT = 30
+
+
+def create_user(base_url: str, admin_token: str, email: str, full_name: str) -> dict:
+    resp = requests.post(
+        f"{base_url.rstrip('/')}/api/v1/users",
+        headers={"Authorization": f"Bearer {admin_token}", "Content-Type": "application/json"},
+        json={"fullName": full_name, "email": email},
+        timeout=TIMEOUT,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(
+            f"createUser failed for {email}: HTTP {resp.status_code}: {resp.text[:300]}"
+        )
+    return resp.json()
+
+
+def _credential_document(user_id: str, org_id: str, hashed: str) -> dict:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return {
+        # Both ids are declared as String in userCredentials.schema.ts.
+        "userId": str(user_id),
+        "orgId": str(org_id),
+        "hashedPassword": hashed,
+        "ipAddress": "127.0.0.1",
+        "wrongCredentialCount": 0,
+        "isBlocked": False,
+        "forceNewPasswordGeneration": False,
+        "isDeleted": False,
+        "createdAt": now,
+        "updatedAt": now,
+    }
+
+
+def seed_password_direct(user_id: str, org_id: str, password: str) -> None:
+    """Write credentials through a direct Mongo connection."""
+    import bcrypt
+    from pymongo import MongoClient
+
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    client = MongoClient(MONGO_URI, serverSelectionTimeoutMS=5000)
+    try:
+        collection = client[MONGO_DB].userCredentials
+        collection.delete_many({"userId": str(user_id), "orgId": str(org_id)})
+        collection.insert_one(_credential_document(user_id, org_id, hashed))
+    finally:
+        client.close()
+
+
+def seed_password_via_docker(user_id: str, org_id: str, password: str) -> None:
+    """Fallback for the standard compose file, which does not publish 27017."""
+    import bcrypt
+
+    hashed = bcrypt.hashpw(password.encode(), bcrypt.gensalt()).decode()
+    script = f"""
+    db = db.getSiblingDB("{MONGO_DB}");
+    db.userCredentials.deleteMany({{userId: "{user_id}", orgId: "{org_id}"}});
+    db.userCredentials.insertOne({{
+        userId: "{user_id}",
+        orgId: "{org_id}",
+        hashedPassword: "{hashed}",
+        ipAddress: "127.0.0.1",
+        wrongCredentialCount: 0,
+        isBlocked: false,
+        forceNewPasswordGeneration: false,
+        isDeleted: false,
+        createdAt: new Date(),
+        updatedAt: new Date()
+    }});
+    """
+    result = subprocess.run(
+        ["docker", "exec", "-i", MONGO_CONTAINER, "mongosh", "--quiet",
+         MONGO_URI.replace("/?", f"/{MONGO_DB}?"), "--eval", script],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"mongosh via docker exec failed: {result.stderr[:400] or result.stdout[:400]}"
+        )
+
+
+def seed_password_via_api(base_url: str, user_id: str, org_id: str, password: str) -> None:
+    """Set the password through the reset-token route — no database access.
+
+    The route accepts any token signed with the deployment's scoped secret that
+    carries the `password:reset` scope, which is the same thing the emailed
+    reset link contains.
+    """
+    import jwt
+
+    secret = os.environ.get("PIPESHUB_SCOPED_JWT_SECRET", "").strip()
+    if not secret:
+        raise RuntimeError("PIPESHUB_SCOPED_JWT_SECRET is not set")
+
+    scoped_token = jwt.encode(
+        {"userId": str(user_id), "orgId": str(org_id), "scopes": [PASSWORD_RESET_SCOPE]},
+        secret,
+        algorithm="HS256",
+    )
+    resp = requests.post(
+        f"{base_url.rstrip('/')}/api/v1/userAccount/password/reset/token",
+        headers={"Authorization": f"Bearer {scoped_token}", "Content-Type": "application/json"},
+        json={"password": password},
+        timeout=TIMEOUT,
+    )
+    if resp.status_code >= 400:
+        raise RuntimeError(f"password reset failed: HTTP {resp.status_code}: {resp.text[:200]}")
+
+
+def seed_password(base_url: str, user_id: str, org_id: str, password: str) -> str:
+    errors: list[str] = []
+    for label, attempt in (
+        ("api", lambda: seed_password_via_api(base_url, user_id, org_id, password)),
+        ("mongo", lambda: seed_password_direct(user_id, org_id, password)),
+        ("docker", lambda: seed_password_via_docker(user_id, org_id, password)),
+    ):
+        try:
+            attempt()
+            return label
+        except Exception as e:  # noqa: BLE001 - try the next strategy
+            errors.append(f"{label}: {e}")
+    raise RuntimeError("could not set a password.\n  " + "\n  ".join(errors))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--count", type=int, default=8, help="users to provision (default 8)")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--password", default=DEFAULT_PASSWORD,
+                        help="needs 8+ chars with upper, lower, digit and symbol")
+    parser.add_argument("--prefix", default="loadtest", help="email local-part prefix")
+    parser.add_argument("--domain", default=DEFAULT_EMAIL_DOMAIN)
+    args = parser.parse_args()
+
+    admin_email = os.environ.get("PIPESHUB_ADMIN_EMAIL", "").strip()
+    admin_password = os.environ.get("PIPESHUB_ADMIN_PASSWORD", "").strip()
+    if not admin_email or not admin_password:
+        print("ERROR: set PIPESHUB_ADMIN_EMAIL and PIPESHUB_ADMIN_PASSWORD", file=sys.stderr)
+        return 2
+
+    print(f"Logging in as {admin_email} ...")
+    try:
+        admin_token = login(args.base_url, admin_email, admin_password)
+    except AuthError as e:
+        print(f"ERROR: admin login failed: {e}", file=sys.stderr)
+        return 1
+
+    run_id = uuid.uuid4().hex[:6]
+    created: list[tuple[str, str]] = []
+    for i in range(args.count):
+        email = f"{args.prefix}-{run_id}-{i}@{args.domain}"
+        try:
+            user = create_user(args.base_url, admin_token, email, f"Load Test {run_id} {i}")
+            user_id = user.get("_id") or user.get("id")
+            org_id = user.get("orgId")
+            if not user_id or not org_id:
+                raise RuntimeError(f"createUser response missing _id/orgId: {sorted(user)}")
+            how = seed_password(args.base_url, user_id, org_id, args.password)
+            login(args.base_url, email, args.password)  # prove it works now, not mid-run
+            created.append((email, args.password))
+            print(f"  [{i + 1}/{args.count}] {email} (credentials via {how})")
+        except Exception as e:  # noqa: BLE001
+            print(f"ERROR provisioning {email}: {e}", file=sys.stderr)
+            return 1
+
+    print(f"\nProvisioned {len(created)} users. Add to loadtest/.env:\n")
+    print("PIPESHUB_USERS=" + ",".join(f"{email}:{password}" for email, password in created))
+    print(
+        "\nNote: these users see only what the org shares with them. Give them KB "
+        "access if the run should search the same corpus."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Query service performance work

Reduces CPU and latency in the query path. All changes are behind existing config or default to current behaviour, except the accessible-records cache (see caveats).

Measured on the test deployment (4 workers, 32 users, 300s, azure_direct):

Metric | Before | After
-- | -- | --
Steady-state throughput | 37.8 req/min | 43.0 req/min
p50 turn latency | 34.4s | 27.9s
Node gateway p50 | 2,738 ms | 573 ms

At 128 users, 4 workers sustain ~90 req/min, up from ~72 on the previous build.

---
1. perf: cache accessible record ids per user

What was slow: every turn recomputed "which records may this user see" from the Neo4j permission graph — an 8-path traversal that dominated per-fetch and citation CPU.

What changed: a read-through Redis cache of that map, shared across workers, invalidated from the connector and indexing services.

Connectors now declare a PermissionModel. APP_LEVEL means the source has no per-record ACLs, so a single connector-wide query answers for every user. RECORD_LEVEL (the default) keeps the per-user traversal. Only connectors writing a blanket ORG or creator-USER permission are declared APP_LEVEL.

Every failure path : Redis down, corrupt entry, loader error -> falls through to a live query rather than serving a stale or empty permission set.

---
2. perf: batch graph and storage lookups in query path

What was slow: one graph query per record, and a fresh aiohttp session and Redis client per BlobStorage instance — which is constructed at ~20 call sites per request. An unbounded connection pool opened ~1,400 sockets to the Node API at 32 concurrent query requests, past its listen backlog, until connections were refused.

What changed:
- Per-record graph queries are batched into one WHERE id IN [...] query
- The HTTP session and Redis client are process-wide and bounded
- Large objects use ranged parallel downloads with a single-download fallback
- Storage download URLs can be cached in Redis (off by default via PIPESHUB_SIGNED_URL_CACHE_SECONDS)

Two correctness fixes the batching depended on: the Arango provider now translates a generic id filter to _key (Arango moves id into _key on write, so the batch matched nothing on the default datastore), and the connection pool expires idle connections below Node's 5s keepAliveTimeout, which was causing Server disconnected on reused sockets.

---
3. perf: use provider SDKs directly for LLM calls

What was slow: LangChain builds an AIMessageChunk per streamed token and pydantic validates each one — ~9% of query-service CPU under load.

What changed: direct transports for all four configured providers (Azure OpenAI, OpenAI, Anthropic, Gemini), selected by PIPESHUB_AGENT_TRANSPORT=langchain|direct. Default remains langchain.

The switch is binary because a deployment chooses how it talks to providers; which provider serves a request comes from the model that request selected, so dispatch happens per request. A provider without a direct transport, or one with misconfigured credentials, falls back to LangChain rather than failing the turn.

Each transport captures configuration from the same model object the LangChain arm uses — not just credentials. Copying only credentials is what let the two arms drift: azure_direct was silently sending no reasoning and using Chat Completions where LangChain used the Responses API at effort=high.

Also included: the Responses stream is decoded from raw SSE, skipping the SDK's per-event validation against a 53-member union (~12% of query CPU, 33× cheaper per event), and image attachments now reach OpenAI, Azure and Gemini instead of being flattened to an empty string.

---
4. perf: node gateway jwt verification and document lookup

What was slow: two hot paths on the single-threaded Node gateway, the first bottleneck under load.

JWT verification called createPublicKey() on an HS256 string secret on every request. That always throws for a symmetric secret, and the throw/catch was ~20% of gateway CPU. The key object is now built once — measured 29× faster per verify. Verification semantics are unchanged: jsonwebtoken performs the same coercion internally and still selects HS algorithms from the resulting secret KeyObject, so algorithm confusion stays blocked.

The document-download route hydrated a full Mongoose model to read a handful of fields and sign a URL, never saving. It now opts into .lean() through typed overloads; other callers of getDocumentInfo do mutate and save, so the lean return is a distinct type they cannot accidentally receive.

 ---
5. test: loadtest harness for query service

Diagnostic tooling only — nothing under backend/ depends on it. Runs a load profile against the query service and reports throughput, per-phase turn latency, per-process and per-container CPU/RAM, and a py-spy flame graph.

Notes worth keeping with the code: CPU is read from cgroup v2 and /proc deltas rather than docker stats, which is smoothed per container and hides a pegged worker. The resource sampler must stay executable or perftest.sh silently skips it. Throughput should be read from the steady-state figure — the headline divides all turns by a variable window and so flatters a backlogged run.

---

Reviewer notes

The accessible-records cache is enabled by default (PIPESHUB_ACCESSIBLE_RECORDS_CACHE). loadtest/KNOWN_ISSUES.md documents five open issues in it — a transient graph error being cached as an empty permission set, revocation paths without invalidation hooks, an unbounded TTL, a cross-event-loop issue in the indexing service, and a lost-invalidation race. Setting the flag to 0 makes all of them dormant without a code change.

The Arango query path has no end-to-end coverage. The provider primitive is verified against a real ArangoDB, but no full-stack run with indexed documents has been done, and Arango is the default datastore.

1 worker current flame graph
<img width="1200" height="842" alt="current_w1_u32_t1_cpu" src="https://github.com/user-attachments/assets/042ad607-9dcb-446d-b002-e46c9e63f204" />

4 worker current flame graph
<img width="1200" height="970" alt="current_w4_u16_t1_cpu" src="https://github.com/user-attachments/assets/59afdd27-0254-49c0-9610-31bf5e0136f4" />


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

Manually as well as with loadtest scripts

### Test Configuration

- [x] Unit tests pass
- [x] Integration tests pass
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [x] **Search capabilities** are working correctly
- [x] **Knowledge search** is functioning properly
- [x] **Connector indexing** is working as expected
- [x] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [x] Feature works in development environment
- [x] Feature works in staging environment
- [ ] Error handling scenarios tested
- [x] Edge cases considered and tested
- [x] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added direct support for OpenAI, Azure OpenAI, Anthropic, and Gemini models, including streaming, tool calls, images, reasoning, and structured responses.
  - Added connector permission models and accessible-record caching with automatic invalidation.
  - Added multi-user load testing, authentication helpers, resource monitoring, and performance reporting.

- **Improvements**
  - Improved retrieval, document batching, blob storage, signed URL caching, and asynchronous URL fetching.
  - Enhanced logging efficiency, JWT handling, document downloads, and search defaults.

- **Bug Fixes**
  - Improved tool-call parsing, API fallback behavior, image handling, and record identifier mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->