### PR TITLE
make webSearch schema description endpoint-neutral

### DIFF
--- a/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
+++ b/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
@@ -9523,9 +9523,8 @@ components:
 
     AgentCreateWebSearch:
       description: |
-        Accepted web-search attachment for `POST /agents/create`.
-        The gateway accepts either a provider string or an object with at least
-        a `provider` field.
+        Web-search attachment for an agent. Accepts either a provider string
+        or an object with at least a `provider` field.
       anyOf:
         - type: string
         - type: object


### PR DESCRIPTION
## Summary

The shared `AgentCreateWebSearch` schema description in `backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml` referenced only `POST /agents/create`. Both `AgentCreateRequest.webSearch` and `AgentUpdateRequest.webSearch` reference this schema via `$ref`, so generated SDK docs for the update method showed a create-only description.

This spec is the source for SDK generation, and SDK users call methods, not raw HTTP endpoints. The description is now endpoint-neutral: it describes the accepted shape (a provider string, or an object with at least a `provider` field) without naming any route. The update validator (`updateAgentBodySchema` in `es_validators.ts`) accepts `webSearch` with the same shape as create, so the text matches gateway behavior for both operations.

Follow-up to #2967. SDK repos need one Speakeasy regeneration from this spec to pick up the corrected text.

## Test plan

- `yaml.safe_load` parses the edited spec cleanly.
- Doc-only change to a schema description; no schema shape or route changes, so oasdiff breaking-change check should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the accepted web-search attachment options when creating or updating agents.
  * Updated API documentation for agent creation and modification endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->