### PR TITLE
fix: PATs fail on any route that forwards the auth header downstream

### DIFF
--- a/backend/nodejs/apps/src/libs/middlewares/auth.middleware.ts
+++ b/backend/nodejs/apps/src/libs/middlewares/auth.middleware.ts
@@ -296,8 +296,14 @@ export class AuthMiddleware {
     // token-type peek in authenticate() and every downstream verifier see a
     // bare JWT — every other token type never has this prefix, so this is a
     // no-op for them.
-    return token.startsWith(PAT_TOKEN_PREFIX)
-      ? token.slice(PAT_TOKEN_PREFIX.length)
-      : token;
+    if (!token.startsWith(PAT_TOKEN_PREFIX)) return token;
+
+    const bare = token.slice(PAT_TOKEN_PREFIX.length);
+    // Normalise the header too, not just the return value. Several controllers
+    // forward req.headers.authorization verbatim to the Python services, which
+    // have no notion of the prefix and fail JWT decode on it. Rewriting it here
+    // keeps every downstream consumer on a bare JWT.
+    req.headers.authorization = `Bearer ${bare}`;
+    return bare;
   }
 }

--- a/backend/nodejs/apps/tests/libs/middlewares/auth.middleware.test.ts
+++ b/backend/nodejs/apps/tests/libs/middlewares/auth.middleware.test.ts
@@ -130,6 +130,24 @@ describe('AuthMiddleware', () => {
       const result = authMiddleware.extractToken(req)
       expect(result).to.equal('my-jwt')
     })
+
+    // Several controllers forward req.headers.authorization verbatim to the
+    // Python services, which know nothing about the prefix. Returning a bare
+    // token is not enough — the header itself has to be normalised, or those
+    // requests fail downstream with "Could not validate credentials".
+    it('should rewrite the authorization header so forwarded requests carry a bare JWT', () => {
+      const req = createMockRequest({
+        headers: { authorization: `Bearer ${PAT_TOKEN_PREFIX}my-jwt` },
+      })
+      authMiddleware.extractToken(req)
+      expect(req.headers.authorization).to.equal('Bearer my-jwt')
+    })
+
+    it('should leave a non-prefixed authorization header untouched', () => {
+      const req = createMockRequest({ headers: { authorization: 'Bearer plain-jwt' } })
+      authMiddleware.extractToken(req)
+      expect(req.headers.authorization).to.equal('Bearer plain-jwt')
+    })
   })
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## What's wrong

A personal access token is handed out with a `phpat_` prefix in front of the JWT. `extractToken` strips that prefix before validating — but it strips it only for its own return value. `req.headers.authorization` keeps the prefix.

That's fine for any route Node answers itself. It breaks every route that forwards the header onward to a Python service, because the Python side receives `Bearer phpat_eyJhbG...`, has no idea what `phpat_` is, and rejects it.

So a PAT works on some things and fails on others, which is a confusing way to be broken.

## Measured

Same token, same instance, twice — once bare, once with the prefix:

| Call | bare | prefixed | |
|---|---|---|---|
| `/knowledgeBase/knowledge-hub/nodes` | 200 | **401** | forwards |
| `/search` | 200 | **401** | forwards |
| `/conversations/stream` | 200 | **401** | forwards |
| `/users` | 200 | 200 | Node-only |
| `/configurationManager/ai-models/available/llm` | 403 | 403 | Node-only |

The two that pass aren't luck — Node validates them itself, using the correctly-stripped token. The 403 is a separate scope gap and identical either way, which is itself proof that authentication succeeded.

## Why this was easy to miss

It doesn't look like an auth failure from the outside. `@pipeshub-ai/mcp` builds on a generated SDK whose functions carry `errorCodes: []`, so `result.ok` reports transport failures only, never HTTP status. A 401 body flows straight into the JSON parser, no `searchResults` key is found, and an empty list comes back.

The user sees an empty knowledge base, not a rejected credential. Filed separately as pipeshub-ai/mcp-server#60.

## The fix

Normalise the header at the same place the prefix is stripped, so downstream services see the bare JWT:

```ts
if (!token.startsWith(PAT_TOKEN_PREFIX)) return token;
const bare = token.slice(PAT_TOKEN_PREFIX.length);
req.headers.authorization = `Bearer ${bare}`;
return bare;
```

One entry point, so every forwarding route is covered without touching each controller. Non-PAT tokens never carry the prefix, so they take the early return unchanged.

This also covers `/mcp`, which is how the CLI and any MCP client reach PipesHub. `mcp.routes.ts:33` runs `authenticate` before `handleMCPRequest`, and the controller reads the header back at `mcp.controller.ts:36`, stripping only `"Bearer "` — so before this fix it handed `phpat_eyJhbG...` to the SDK as `bearerAuth`. With the header rewritten it forwards a bare JWT.

## Verified live

On a running instance, with a real prefixed token:

| | before | after |
|---|---|---|
| `sources` | 0 | 1 |
| `search` | 0 hits | 7 hits |
| `ask` | "Could not validate credentials" | 3 citations |

## Tests

Two added. The existing test asserted only the *return value* of `extractToken`, which is why it passed the whole time the bug was live. The new ones assert the header itself is rewritten.

## Not in this PR

- `OAuthAuthMiddleware` has the same strip-but-don't-rewrite shape. Nothing forwards through it today, so it's latent — worth fixing before anything does.
- The Python services have no `phpat_` handling of their own. That's correct as long as Node is the only way in; noting it so it isn't assumed.
