### PR TITLE
fix(agents): stop one uncitable claim stripping citations from a whole answer

### DIFF
--- a/backend/python/app/agents/agent_loop/prompt_builder.py
+++ b/backend/python/app/agents/agent_loop/prompt_builder.py
@@ -197,7 +197,13 @@ used. Web search results use a different marker instead: `url/Citation ID: https
   carrying the real link.
 - Cite the block each fact actually came from; use a distinct ID for each distinct claim.
 - One ID per link, inline right after the key claim it supports. The system numbers them.
-  Omit the citation when no Citation ID is available for a fact.
+  Omit the citation for a fact that has no Citation ID — that fact only. Keep citing every
+  other fact that does have one. Counts and totals are derived
+  from the result set and have no Citation ID of their own: state the count uncited, then
+  cite each item you list under it. An answer must never end up with zero citations
+  because one claim could not be cited.
+- Every list item, table row, or bullet describing a record carries that record's citation,
+  e.g. `| RecordName | One-line summary. [source](refN) |`.
 - Keep prose readable: cite the specific claim it backs, not every clause or sentence in a
   row — a paragraph built from one source needs one citation at its end, not one per sentence.
   Never stack multiple `[source](...)` links back to back; if several blocks support the same


### PR DESCRIPTION
Fixes the behaviour reported in #2975. **Partial** — measured, and honest about the remainder.

## The problem

Ask a knowledge base how many of something it has, and the answer arrives with no sources on anything — including the parts that came straight out of your documents.

Same corpus, same user, three documents. Only the question changes:

| Question | Citations |
| --- | --- |
| "What is each document about?" | **23**, then **6** |
| "How many documents are in the knowledge base?" | **0**, **0** |
| "How many are there **and what is each one about?**" | **0**, **0**, **0** |

Row 3 is row 1 with four words added. Those four words cost every citation, while the per-document summaries stay in the answer, now unattributed.

## Why

A count is not stated in any block — it comes from the shape of the result set. So it genuinely has no Citation ID, and the rule said:

> Omit the citation when no Citation ID is available for a fact.

Correct per-fact. But the model applies it to the **whole response**: one uncitable claim, and citations vanish from everything around it.

## The change

Scope the rule to the fact it is about, say what to do with a count, and require a citation on each item in a list or table.

## Measured

Same corpus, same question, same instance. Cited runs on "how many distinct documents are there and what is each one about?":

| | cited runs |
| --- | --- |
| stock | **0 / 14** |
| with this change | **6 / 16** (38%) |

Fisher one-sided **p = 0.0135**.

Variance is high — the same text produced 5/8 on one sample and 1/8 on the next, which is why both are pooled here rather than quoting the better one. Refusals were checked separately and stay correctly uncited (5/5 runs), so the rule does not push the model to invent a `refN` when the corpus genuinely has nothing.

**This does not fully fix it.** Three runs in five still strip every citation, and nothing downstream can tell those from a fabrication — #2975 should stay open, and the `exit 6` rule in the CLI should stay as it is.

Wordings that did **not** work, so nobody repeats them: scoping the rule without an imperative (0/8), scoping the imperative to "any part came from the context" (1/8), and appending an explicit refusal carve-out to the working text (0/8). The blunt "an answer must never end up with zero citations because one claim could not be cited" is the part carrying the effect.

## A wrong turn worth recording

My first attempt patched `app/modules/qna/prompt_templates.py:59`, which carries an identical instruction. It changed nothing across 8 runs, because that template is the non-agent path — `/chat/stream` runs through the agent loop, whose citation rules live here in `prompt_builder.py`. Two copies of the same rule in two prompts, one live for this route.

Worth knowing before someone else spends an afternoon on the other file. It may also be worth having one of them import the other, so a fix cannot land in the copy that is not running.

## Why it matters beyond the citation list

Anything that gates on citations has to reject an uncited answer, because nothing downstream can tell a stripped one from an invented one. The result is that a correct, complete answer gets reported to the user as "the documents do not appear to contain this."

Happy to run any alternative against this corpus — the reproduction is three questions and takes about a minute.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved citation handling for factual responses.
  * Preserved citations for citable facts while allowing uncited individual facts when no Citation ID is available.
  * Added citation requirements for every record-describing list item, table row, and bullet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

