### PR TITLE
fix(tests): stop RSS unit tests making real network calls

### DIFF
--- a/backend/python/tests/unit/connectors/sources/test_rss_connector.py
+++ b/backend/python/tests/unit/connectors/sources/test_rss_connector.py
@@ -625,6 +625,22 @@ def _patch_fetch(**kwargs):
     )
 
 
+def _patch_fetch_raises(exc):
+    """Patch fetch_url_with_fallback to raise, exercising the connector's except branches."""
+    return patch(
+        "app.connectors.sources.rss.connector.fetch_url_with_fallback",
+        new=AsyncMock(side_effect=exc),
+    )
+
+
+def _patch_fetch_none():
+    """Patch fetch_url_with_fallback to return None — every strategy in the chain failed."""
+    return patch(
+        "app.connectors.sources.rss.connector.fetch_url_with_fallback",
+        new=AsyncMock(return_value=None),
+    )
+
+
 def _make_record(**overrides):
     """Build a minimal Record for testing."""
     defaults = {
@@ -653,9 +669,8 @@ class TestFetchAndParseFeed:
     @pytest.mark.asyncio
     async def test_http_error_returns_none(self):
         conn = _make_connector_cov()
-        resp = _make_mock_response(status=404)
-        conn.session = _make_session(resp)
-        result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        with _patch_fetch(status=404):
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None
 
     @pytest.mark.asyncio
@@ -680,16 +695,15 @@ class TestFetchAndParseFeed:
     async def test_bozo_feed_with_no_entries_returns_none(self):
         conn = _make_connector_cov()
         # Return content that feedparser can parse but marks as bozo
-        resp = _make_mock_response(status=200, content=b"not-valid-xml-at-all")
-        conn.session = _make_session(resp)
-        with patch("app.connectors.sources.rss.connector.feedparser") as mock_fp:
-            mock_feed = MagicMock()
-            mock_feed.bozo = True
-            mock_feed.entries = []
-            mock_feed.bozo_exception = Exception("parse error")
-            mock_fp.parse.return_value = mock_feed
-            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
-            assert result is None
+        with _patch_fetch(status=200, content=b"not-valid-xml-at-all"):
+            with patch("app.connectors.sources.rss.connector.feedparser") as mock_fp:
+                mock_feed = MagicMock()
+                mock_feed.bozo = True
+                mock_feed.entries = []
+                mock_feed.bozo_exception = Exception("parse error")
+                mock_fp.parse.return_value = mock_feed
+                result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+                assert result is None
 
     @pytest.mark.asyncio
     async def test_bozo_feed_with_entries_returns_feed(self):
@@ -704,24 +718,24 @@ class TestFetchAndParseFeed:
                 assert result is not None
 
     @pytest.mark.asyncio
+    async def test_all_strategies_failed_returns_none(self):
+        conn = _make_connector_cov()
+        with _patch_fetch_none():
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_timeout_returns_none(self):
         conn = _make_connector_cov()
-        session = MagicMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
-        cm.__aexit__ = AsyncMock(return_value=None)
-        session.get = MagicMock(return_value=cm)
-        conn.session = session
-        result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        with _patch_fetch_raises(asyncio.TimeoutError()):
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_exception_returns_none(self):
         conn = _make_connector_cov()
-        session = MagicMock()
-        session.get = MagicMock(side_effect=Exception("network error"))
-        conn.session = session
-        result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        with _patch_fetch_raises(Exception("network error")):
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None
 
 
@@ -743,18 +757,16 @@ class TestFetchArticleContent:
     @pytest.mark.asyncio
     async def test_http_error_returns_empty(self):
         conn = _make_connector_cov()
-        resp = _make_mock_response(status=500)
-        conn.session = _make_session(resp)
-        result = await conn._fetch_article_content("https://example.com/article")
+        with _patch_fetch(status=500):
+            result = await conn._fetch_article_content("https://example.com/article")
         assert result == ""
 
     @pytest.mark.asyncio
     async def test_non_html_content_type_returns_empty(self):
         conn = _make_connector_cov()
-        resp = _make_mock_response(status=200, content=b"binary data")
-        resp.headers = {"Content-Type": "application/pdf"}
-        conn.session = _make_session(resp)
-        result = await conn._fetch_article_content("https://example.com/file.pdf")
+        with _patch_fetch(status=200, content=b"binary data",
+                          headers={"Content-Type": "application/pdf"}):
+            result = await conn._fetch_article_content("https://example.com/file.pdf")
         assert result == ""
 
     @pytest.mark.asyncio
@@ -767,36 +779,33 @@ class TestFetchArticleContent:
                 assert result == "data"
 
     @pytest.mark.asyncio
+    async def test_all_strategies_failed_returns_empty(self):
+        conn = _make_connector_cov()
+        with _patch_fetch_none():
+            result = await conn._fetch_article_content("https://example.com/article")
+        assert result == ""
+
+    @pytest.mark.asyncio
     async def test_timeout_returns_empty(self):
         conn = _make_connector_cov()
-        session = MagicMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
-        cm.__aexit__ = AsyncMock(return_value=None)
-        session.get = MagicMock(return_value=cm)
-        conn.session = session
-        result = await conn._fetch_article_content("https://example.com/article")
+        with _patch_fetch_raises(asyncio.TimeoutError()):
+            result = await conn._fetch_article_content("https://example.com/article")
         assert result == ""
 
     @pytest.mark.asyncio
     async def test_exception_returns_empty(self):
         conn = _make_connector_cov()
-        session = MagicMock()
-        session.get = MagicMock(side_effect=Exception("connection error"))
-        conn.session = session
-        result = await conn._fetch_article_content("https://example.com/article")
+        with _patch_fetch_raises(Exception("connection error")):
+            result = await conn._fetch_article_content("https://example.com/article")
         assert result == ""
 
     @pytest.mark.asyncio
     async def test_missing_content_type_header(self):
         conn = _make_connector_cov()
-        resp = _make_mock_response(status=200, content=b"<html>body</html>")
-        mock_headers = MagicMock()
-        mock_headers.get = MagicMock(return_value="")
-        resp.headers = mock_headers
-        conn.session = _make_session(resp)
-        result = await conn._fetch_article_content("https://example.com/article")
-        assert result == ""  # Empty content-type doesn't contain 'html' or 'xml'
+        with _patch_fetch(status=200, content=b"<html>body</html>",
+                          headers={"Server": "nginx"}):
+            result = await conn._fetch_article_content("https://example.com/article")
+        assert result == ""  # Absent content-type doesn't contain 'html' or 'xml'
 
 
 # ===================================================================
@@ -1274,6 +1283,7 @@ class TestProcessEntryExtended:
     @pytest.mark.asyncio
     async def test_content_from_entry_content(self):
         conn = _make_connector_cov()
+        conn.fetch_full_content = False
         entry = {
             "title": "Test",
             "link": "https://example.com/article",

--- a/backend/python/tests/unit/connectors/sources/test_rss_connector_coverage.py
+++ b/backend/python/tests/unit/connectors/sources/test_rss_connector_coverage.py
@@ -100,6 +100,22 @@ def _patch_fetch(**kwargs):
     )
 
 
+def _patch_fetch_raises(exc):
+    """Patch fetch_url_with_fallback to raise, exercising the connector's except branches."""
+    return patch(
+        "app.connectors.sources.rss.connector.fetch_url_with_fallback",
+        new=AsyncMock(side_effect=exc),
+    )
+
+
+def _patch_fetch_none():
+    """Patch fetch_url_with_fallback to return None — every strategy in the chain failed."""
+    return patch(
+        "app.connectors.sources.rss.connector.fetch_url_with_fallback",
+        new=AsyncMock(return_value=None),
+    )
+
+
 def _make_record(**overrides):
     """Build a minimal Record for testing."""
     defaults = {
@@ -128,9 +144,8 @@ class TestFetchAndParseFeed:
     @pytest.mark.asyncio
     async def test_http_error_returns_none(self):
         conn = _make_connector()
-        resp = _make_mock_response(status=404)
-        conn.session = _make_session(resp)
-        result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        with _patch_fetch(status=404):
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None
 
     @pytest.mark.asyncio
@@ -155,16 +170,15 @@ class TestFetchAndParseFeed:
     async def test_bozo_feed_with_no_entries_returns_none(self):
         conn = _make_connector()
         # Return content that feedparser can parse but marks as bozo
-        resp = _make_mock_response(status=200, content=b"not-valid-xml-at-all")
-        conn.session = _make_session(resp)
-        with patch("app.connectors.sources.rss.connector.feedparser") as mock_fp:
-            mock_feed = MagicMock()
-            mock_feed.bozo = True
-            mock_feed.entries = []
-            mock_feed.bozo_exception = Exception("parse error")
-            mock_fp.parse.return_value = mock_feed
-            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
-            assert result is None
+        with _patch_fetch(status=200, content=b"not-valid-xml-at-all"):
+            with patch("app.connectors.sources.rss.connector.feedparser") as mock_fp:
+                mock_feed = MagicMock()
+                mock_feed.bozo = True
+                mock_feed.entries = []
+                mock_feed.bozo_exception = Exception("parse error")
+                mock_fp.parse.return_value = mock_feed
+                result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+                assert result is None
 
     @pytest.mark.asyncio
     async def test_bozo_feed_with_entries_returns_feed(self):
@@ -179,24 +193,24 @@ class TestFetchAndParseFeed:
                 assert result is not None
 
     @pytest.mark.asyncio
+    async def test_all_strategies_failed_returns_none(self):
+        conn = _make_connector()
+        with _patch_fetch_none():
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        assert result is None
+
+    @pytest.mark.asyncio
     async def test_timeout_returns_none(self):
         conn = _make_connector()
-        session = MagicMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
-        cm.__aexit__ = AsyncMock(return_value=None)
-        session.get = MagicMock(return_value=cm)
-        conn.session = session
-        result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        with _patch_fetch_raises(asyncio.TimeoutError()):
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None
 
     @pytest.mark.asyncio
     async def test_exception_returns_none(self):
         conn = _make_connector()
-        session = MagicMock()
-        session.get = MagicMock(side_effect=Exception("network error"))
-        conn.session = session
-        result = await conn._fetch_and_parse_feed("https://feed.com/rss")
+        with _patch_fetch_raises(Exception("network error")):
+            result = await conn._fetch_and_parse_feed("https://feed.com/rss")
         assert result is None
 
 
@@ -218,18 +232,16 @@ class TestFetchArticleContent:
     @pytest.mark.asyncio
     async def test_http_error_returns_empty(self):
         conn = _make_connector()
-        resp = _make_mock_response(status=500)
-        conn.session = _make_session(resp)
-        result = await conn._fetch_article_content("https://example.com/article")
+        with _patch_fetch(status=500):
+            result = await conn._fetch_article_content("https://example.com/article")
         assert result == ""
 
     @pytest.mark.asyncio
     async def test_non_html_content_type_returns_empty(self):
         conn = _make_connector()
-        resp = _make_mock_response(status=200, content=b"binary data")
-        resp.headers = {"Content-Type": "application/pdf"}
-        conn.session = _make_session(resp)
-        result = await conn._fetch_article_content("https://example.com/file.pdf")
+        with _patch_fetch(status=200, content=b"binary data",
+                          headers={"Content-Type": "application/pdf"}):
+            result = await conn._fetch_article_content("https://example.com/file.pdf")
         assert result == ""
 
     @pytest.mark.asyncio
@@ -242,36 +254,33 @@ class TestFetchArticleContent:
                 assert result == "data"
 
     @pytest.mark.asyncio
+    async def test_all_strategies_failed_returns_empty(self):
+        conn = _make_connector()
+        with _patch_fetch_none():
+            result = await conn._fetch_article_content("https://example.com/article")
+        assert result == ""
+
+    @pytest.mark.asyncio
     async def test_timeout_returns_empty(self):
         conn = _make_connector()
-        session = MagicMock()
-        cm = MagicMock()
-        cm.__aenter__ = AsyncMock(side_effect=asyncio.TimeoutError())
-        cm.__aexit__ = AsyncMock(return_value=None)
-        session.get = MagicMock(return_value=cm)
-        conn.session = session
-        result = await conn._fetch_article_content("https://example.com/article")
+        with _patch_fetch_raises(asyncio.TimeoutError()):
+            result = await conn._fetch_article_content("https://example.com/article")
         assert result == ""
 
     @pytest.mark.asyncio
     async def test_exception_returns_empty(self):
         conn = _make_connector()
-        session = MagicMock()
-        session.get = MagicMock(side_effect=Exception("connection error"))
-        conn.session = session
-        result = await conn._fetch_article_content("https://example.com/article")
+        with _patch_fetch_raises(Exception("connection error")):
+            result = await conn._fetch_article_content("https://example.com/article")
         assert result == ""
 
     @pytest.mark.asyncio
     async def test_missing_content_type_header(self):
         conn = _make_connector()
-        resp = _make_mock_response(status=200, content=b"<html>body</html>")
-        mock_headers = MagicMock()
-        mock_headers.get = MagicMock(return_value="")
-        resp.headers = mock_headers
-        conn.session = _make_session(resp)
-        result = await conn._fetch_article_content("https://example.com/article")
-        assert result == ""  # Empty content-type doesn't contain 'html' or 'xml'
+        with _patch_fetch(status=200, content=b"<html>body</html>",
+                          headers={"Server": "nginx"}):
+            result = await conn._fetch_article_content("https://example.com/article")
+        assert result == ""  # Absent content-type doesn't contain 'html' or 'xml'
 
 
 # ===================================================================
@@ -749,6 +758,7 @@ class TestProcessEntryExtended:
     @pytest.mark.asyncio
     async def test_content_from_entry_content(self):
         conn = _make_connector()
+        conn.fetch_full_content = False
         entry = {
             "title": "Test",
             "link": "https://example.com/article",

--- a/backend/python/tests/unit/connectors/sources/test_rss_connector_extended.py
+++ b/backend/python/tests/unit/connectors/sources/test_rss_connector_extended.py
@@ -336,6 +336,7 @@ class TestProcessEntry:
 
     async def test_entry_with_content_value(self):
         conn = _make_connector()
+        conn.fetch_full_content = False
         entry = _make_entry(content=[{"value": "<p>Full content</p>"}])
         result = await conn._process_entry(entry, "https://feed.com/rss")
         assert result is not None
@@ -366,6 +367,7 @@ class TestProcessEntry:
 
     async def test_entry_with_published_parsed(self):
         conn = _make_connector()
+        conn.fetch_full_content = False
         ts = time.strptime("2025-06-15", "%Y-%m-%d")
         entry = _make_entry(published_parsed=ts, content=[{"value": "Content"}])
         result = await conn._process_entry(entry, "https://feed.com/rss")


### PR DESCRIPTION
## Problem

Eight unit tests in the RSS connector suite are failing on `main`, all by timeout:

```
FAILED test_rss_connector.py::TestFetchAndParseFeed::test_http_error_returns_none
FAILED test_rss_connector.py::TestFetchAndParseFeed::test_bozo_feed_with_no_entries_returns_none
FAILED test_rss_connector.py::TestFetchAndParseFeed::test_timeout_returns_none
FAILED test_rss_connector.py::TestFetchAndParseFeed::test_exception_returns_none
```
(plus the same four in `test_rss_connector_coverage.py`)

## Root cause

`_fetch_and_parse_feed` and `_fetch_article_content` fetch through `fetch_url_with_fallback`, not through `self.session`. These tests only mocked `conn.session`.

The fallback chain in `app/connectors/sources/web/fetch_strategy.py:381-386` is ordered:

1. `curl_cffi(H2)` — real network
2. `cloudscraper` — real network
3. `aiohttp` — the only strategy that touches `session`

aiohttp is **last**, so the mock was never reached and every one of these tests issued a real HTTPS request.

That went unnoticed while the target hosts answered quickly. `feed.com` has since stopped accepting connections on 443 (it still resolves — `192.64.119.102` — but the TCP connect hangs). `_sync_curl_cffi_fetch` tries up to 3 impersonation profiles at `REQUEST_TIMEOUT = 15` each, so one call burns ~45s against a black hole. `pytest.ini` sets `--timeout=30`, and the test is killed partway through the first strategy.

Measured against the real host with the same client libraries:

```
curl_cffi   : 15.0s -> Timeout
cloudscraper: 15.0s -> ConnectTimeout
```

The `TestFetchArticleContent` tests have the identical defect but were passing by luck — they point at `example.com/article`, which 404s in ~50ms. Three `_process_entry` tests were also crawling for real, because `fetch_full_content` defaults to `True` and `_resolve_entry_text` crawls before falling back to feed content.

## Fix

Patch `fetch_url_with_fallback` — the seam the code actually calls — using the `_patch_fetch` helper that the sibling tests in the same classes already use. Two companions added for cases it can't express:

- `_patch_fetch_raises(exc)` — for the `except asyncio.TimeoutError` / `except Exception` branches
- `_patch_fetch_none()` — for `result is None`, i.e. every strategy in the chain failed

`_patch_fetch_none` also closes a real coverage gap: `connector.py:482` and `connector.py:588` handle the all-strategies-failed case, and nothing exercised it. That is precisely the production path a dead feed host takes, so it now has a test in both files.

The three `_process_entry` tests that were crawling get `fetch_full_content = False`, which is also what their names claim they're testing.

## Verification

```
199 passed in 4.38s     # the three RSS files, down from 187s for 6 tests
```

The RSS files also pass inside an empty network namespace (`unshare -rn`, exit 0), which is the real check — no test in them touches the network any more.

Full `pytest tests/unit` passes, exit 0, no failures.

## Notes for reviewers (not addressed here)

1. **The chain order contradicts its own docstring.** `fetch_strategy.py:5-9` documents aiohttp as strategy 1, "cheapest, already async"; the list at `:381-386` puts it last, behind browser impersonation. This is a production behaviour question, not a test one — every web/RSS fetch currently pays curl_cffi cost first. I did not touch it, since reordering to suit tests would be backwards. Worth confirming whether the order or the comment is the stale one.

2. **`test_rss_connector_coverage.py` is a duplicate.** `test_rss_connector.py:547` is headed "Merged from test_rss_connector_coverage.py", but the original file is still present and still collected, so every fix here had to be written twice. Deleting it looks safe but is out of scope for a test fix.

3. **A `pytest-socket`-style guard would not have caught this.** I checked: a Python-level `socket.connect` guard does not intercept curl_cffi, which drives libcurl in C — and curl_cffi is the *first* strategy. Any "unit tests can't do network I/O" guard for this codebase has to hook the strategy functions, not the socket layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded RSS connector test coverage for fetch failures, timeouts, exceptions, invalid feeds, missing responses, and unsupported content types.
  * Added coverage for complete fallback-strategy failures.
  * Updated entry-content tests to explicitly validate behavior when full-content fetching is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->