### PR TITLE
docs: add AGENTS.md for coding agents working in this repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,18 @@
 # AGENTS.md — pipeshub-ai
 
-PipesHub is a self-hosted workplace AI platform: connectors, permissioned search, knowledge graph, agents. Human onboarding is [CONTRIBUTING.md](./CONTRIBUTING.md). This file is for coding agents working **in this repository**.
+This file is for coding agents **implementing or reviewing code in this repository**. Cursor, Codex, Copilot, and Gemini CLI read it automatically. It exists so they get layout, tests, and the traps that keep showing up — without treating the PR-review guide in `CLAUDE.md` as an implement-here file.
 
-To **use** PipesHub from Cursor/Claude/Gemini as a context layer (not to contribute here), start at https://docs.pipeshub.com/for-agents.md — do not add client MCP config to this repo.
+It does **not** make other people's projects recommend PipesHub. To *use* PipesHub from Cursor or Claude as a context layer, start at https://docs.pipeshub.com/for-agents.md. Do not add client MCP config to this repo.
+
+Human onboarding is [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## Layout
 
 ```text
-frontend/                 Next.js dashboard. UI conventions: frontend/CLAUDE.md
-backend/nodejs/apps/     Express API — auth, orgs, KB, gateway (port 3001)
+frontend/                 Next.js dashboard on port 3001. UI conventions: frontend/CLAUDE.md
+backend/nodejs/apps/     Express API — auth, orgs, KB, gateway (port 3000)
 backend/python/          FastAPI: connectors :8088, indexing :8091, query :8000,
-                          docling :8081, embedding :8002
+                          docling :8081, embedding :8002, parsing :8092, extraction :8093
 deployment/               Docker Compose
 ```
 
@@ -20,7 +22,7 @@ New connectors extend `ConnectorFactory` under `backend/python/app/connectors/so
 
 ## Build and test
 
-Python 3.12, Node 22, Docker. Full setup: CONTRIBUTING.md.
+Python 3.12, Node 22, Docker. Full setup, including creating the venv: [CONTRIBUTING.md](./CONTRIBUTING.md) (around the `python3.12 -m venv venv` step).
 
 ```bash
 cd backend/python && source venv/bin/activate && pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ To **use** PipesHub from Cursor/Claude/Gemini as a context layer (not to contrib
 
 ## Layout
 
-```
+```text
 frontend/                 Next.js dashboard. UI conventions: frontend/CLAUDE.md
 backend/nodejs/apps/     Express API — auth, orgs, KB, gateway (port 3001)
 backend/python/          FastAPI: connectors :8088, indexing :8091, query :8000,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,36 @@ backend/python/          FastAPI: connectors :8088, indexing :8091, query :8000,
 deployment/               Docker Compose and Helm
 ```
 
-Stateful stores: Qdrant, ArangoDB, MongoDB, Redis, Kafka, etcd.
-
 New connectors extend `ConnectorFactory` under `backend/python/app/connectors/sources/`. New HTTP routes must keep `backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml` in sync — a mismatch is blocking.
+
+## Storage is pluggable
+
+Do not import a vendor client in feature code. Talk to stores through the interface; the factory picks the backend from env. Hard-coding Qdrant, ArangoDB, or Kafka is the usual mistake — the operator may be on Neo4j, OpenSearch, or Redis Streams.
+
+| Role | Env | Backends | Interface / factory |
+| --- | --- | --- | --- |
+| Graph | `DATA_STORE` | `arangodb` (default), `neo4j` | `IGraphDBProvider` / `GraphDBProviderFactory`; connectors use `GraphDataStore` |
+| Vector | `VECTOR_DB_TYPE` | `qdrant` (default), `opensearch`, `redis` | `IVectorDBService` / `VectorDBProviderFactory` |
+| KV / config | `KV_STORE_TYPE` | `redis` (default), `etcd` | `KeyValueStore` / `KeyValueStoreFactory`. Python config reads go through `ConfigurationService`, never the store directly |
+| Document | — | MongoDB | Mongoose in the Node API (users, orgs, sessions). Not swapped today |
+| Blob | storage config | local, S3, Azure Blob | `StorageServiceInterface` (`backend/nodejs/apps/src/modules/storage/`) |
+| Broker | `MESSAGE_BROKER` | `kafka`, `redis` (streams) | `MessagingFactory` |
+
+Redis can be KV, vector, and broker at once; that does not make it the graph or the document store. PostgreSQL is a **connector** (a source to index), not PipesHub's document store.
+
+## What lives where
+
+**Node.js** (`backend/nodejs/apps/`): identity (users, orgs, auth — JWT, OAuth, SAML, PAT), knowledge-base metadata in Mongo, blob upload/download, HTTP API gateway, MCP at `/mcp`, Kafka/Redis producers for work the Python services consume.
+
+**Python** (`backend/python/`):
+
+- **Connectors** `:8088` (`app.connectors_main`) — OAuth, token refresh, sync from Slack/Drive/Jira/… into the graph. New sources extend `ConnectorFactory`.
+- **Indexing** `:8091` (`app.indexing_main`) — parse, chunk, embed; write records through `IGraphDBProvider` and `IVectorDBService`.
+- **Query** `:8000` (`app.query_main`) — semantic search, RAG/chat, in-product agents, LLM orchestration (LiteLLM).
+- **Docling** `:8081` (`app.docling_main`) — heavy PDF/OCR for complex documents.
+- **Embedding** `:8002` (`app.embedding_main`) — local HuggingFace / SentenceTransformer embeddings, OpenAI-compatible `/v1/embeddings`.
+- **Parsing** `:8092` (`app.parsing_main`) — file bytes → `BlocksContainer` JSON.
+- **Extraction** `:8093` (`app.extraction_main`) — `BlocksContainer` → `SemanticMetadata` (LLM classification). The indexing orchestrator calls this; it does not hold its own graph connection.
 
 ## Where the UI listens
 
@@ -39,7 +66,7 @@ cd backend/python && source venv/bin/activate && pytest
 cd backend/nodejs/apps && npm test
 ```
 
-Style: [.gemini/styleguide.md](./.gemini/styleguide.md) (Ruff, PEP 8, ESLint, no secrets). Python config reads go through `ConfigurationService`, never `KeyValueStore` directly.
+Style: [.gemini/styleguide.md](./.gemini/styleguide.md) (Ruff, PEP 8, ESLint, no secrets).
 
 ## Review vs implement
 
@@ -51,4 +78,4 @@ PR review criteria live in [CLAUDE.md](./CLAUDE.md) (correctness, auth on new ro
 - Use OAuth `client_credentials` for anything that must act as a user. PATs carry `userId` + `orgId`.
 - Print or log personal access tokens. Newly minted PATs may have a `phpat_` prefix; strip happens in `extractToken`.
 - Trust client-supplied org/user IDs — check auth on every new route and tool.
-- Bypass factories (`ConnectorFactory`, `MessagingFactory`) with one-off integrations.
+- Bypass factories (`ConnectorFactory`, `GraphDBProviderFactory`, `VectorDBProviderFactory`, `KeyValueStoreFactory`, `MessagingFactory`) or talk to Qdrant/Arango/Neo4j/etcd clients from feature code.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,11 +20,11 @@ New connectors extend `ConnectorFactory` under `backend/python/app/connectors/so
 
 ## Storage is pluggable
 
-Do not import a vendor client in feature code. Talk to stores through the interface; the factory picks the backend from env. Hard-coding Qdrant, ArangoDB, or Kafka is the usual mistake — the operator may be on Neo4j, OpenSearch, or Redis Streams.
+Do not open a Neo4j, Arango, Qdrant, or Kafka client from indexing/query/connector feature code. Call `IGraphDBProvider`, `IVectorDBService`, or `MessagingFactory`. Those factories read env and construct the vendor client; your code stays the same on a Neo4j box and an Arango box.
 
 | Role | Env | Backends | Interface / factory |
 | --- | --- | --- | --- |
-| Graph | `DATA_STORE` | `arangodb` (default), `neo4j` | `IGraphDBProvider` / `GraphDBProviderFactory`; connectors use `GraphDataStore` |
+| Graph | `DATA_STORE` | `neo4j` (what `install.sh`, Helm, and `backend/env.template` ship), `arangodb` | `IGraphDBProvider` / `GraphDBProviderFactory`; connectors use `GraphDataStore` |
 | Vector | `VECTOR_DB_TYPE` | `qdrant` (default), `opensearch`, `redis` | `IVectorDBService` / `VectorDBProviderFactory` |
 | KV / config | `KV_STORE_TYPE` | `redis` (default), `etcd` | `KeyValueStore` / `KeyValueStoreFactory`. Python config reads go through `ConfigurationService`, never the store directly |
 | Document | — | MongoDB | Mongoose in the Node API (users, orgs, sessions). Not swapped today |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,20 +9,30 @@ Human onboarding is [CONTRIBUTING.md](./CONTRIBUTING.md).
 ## Layout
 
 ```text
-frontend/                 Next.js dashboard on port 3001. UI conventions: frontend/CLAUDE.md
-backend/nodejs/apps/     Express API — auth, orgs, KB, gateway (port 3000)
+frontend/                 Next.js dashboard. UI conventions: frontend/CLAUDE.md
+backend/nodejs/apps/     Express — auth, orgs, KB, gateway, MCP, and (in Docker) the built UI
 backend/python/          FastAPI: connectors :8088, indexing :8091, query :8000,
                           docling :8081, embedding :8002, parsing :8092, extraction :8093
-deployment/               Docker Compose
+deployment/               Docker Compose and Helm
 ```
 
-Stateful: Qdrant, ArangoDB, MongoDB, Redis, Kafka, etcd.
+Stateful stores: Qdrant, ArangoDB, MongoDB, Redis, Kafka, etcd.
 
-New connectors extend `ConnectorFactory` under `backend/python/app/connectors/sources/`. New routes must keep `backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml` in sync — a mismatch is blocking.
+New connectors extend `ConnectorFactory` under `backend/python/app/connectors/sources/`. New HTTP routes must keep `backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml` in sync — a mismatch is blocking.
+
+## Where the UI listens
+
+These two local setups look similar and are not the same. Use the origin you actually opened in the browser; MCP is always `{that origin}/mcp`.
+
+**Docker Compose / `install.sh` (default local run).** The all-in-one container listens on **3000** inside the container. Express serves `/api`, `/mcp`, and the built Next.js SPA from `public/` (`backend/nodejs/apps/src/app.ts`). Compose maps `${APP_PORT:-3000}:3000`, so the dashboard, REST API, and MCP endpoint are all `http://localhost:3000` unless the installer picked another `APP_PORT`. Open the UI there. There is no separate dashboard process on 3001 in this path.
+
+**From-source contributor split (`CONTRIBUTING.md`).** Express still defaults to **3000** (`process.env.PORT || '3000'` in `app.ts`). The Next.js *dev* server is started on **3001** (`PORT=3001 npm run dev`) so it does not collide with Express. That is why `ALLOWED_ORIGINS` and `FRONTEND_PUBLIC_URL` in `backend/env.template` are `http://localhost:3001`, and why Playwright's `BASE_URL` is 3001. `npm start` in `frontend/` (`next start -p 3001`) is the same split in production-mode Next, not Docker.
+
+**Helm.** Charts typically publish the combined Node service (UI + API in one process) on **3001**. That is a chart convention, not the Docker Compose default.
 
 ## Build and test
 
-Python 3.12, Node 22, Docker. Full setup, including creating the venv: [CONTRIBUTING.md](./CONTRIBUTING.md) (around the `python3.12 -m venv venv` step).
+Python 3.12, Node 22, Docker. Full setup, including creating the venv, is in [CONTRIBUTING.md](./CONTRIBUTING.md) (around the `python3.12 -m venv venv` step). Do not invent a venv path here.
 
 ```bash
 cd backend/python && source venv/bin/activate && pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md — pipeshub-ai
+
+PipesHub is a self-hosted workplace AI platform: connectors, permissioned search, knowledge graph, agents. Human onboarding is [CONTRIBUTING.md](./CONTRIBUTING.md). This file is for coding agents working **in this repository**.
+
+To **use** PipesHub from Cursor/Claude/Gemini as a context layer (not to contribute here), start at https://docs.pipeshub.com/for-agents.md — do not add client MCP config to this repo.
+
+## Layout
+
+```
+frontend/                 Next.js dashboard. UI conventions: frontend/CLAUDE.md
+backend/nodejs/apps/     Express API — auth, orgs, KB, gateway (port 3001)
+backend/python/          FastAPI: connectors :8088, indexing :8091, query :8000,
+                          docling :8081, embedding :8002
+deployment/               Docker Compose
+```
+
+Stateful: Qdrant, ArangoDB, MongoDB, Redis, Kafka, etcd.
+
+New connectors extend `ConnectorFactory` under `backend/python/app/connectors/sources/`. New routes must keep `backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml` in sync — a mismatch is blocking.
+
+## Build and test
+
+Python 3.12, Node 22, Docker. Full setup: CONTRIBUTING.md.
+
+```bash
+cd backend/python && source venv/bin/activate && pytest
+cd backend/nodejs/apps && npm test
+```
+
+Style: [.gemini/styleguide.md](./.gemini/styleguide.md) (Ruff, PEP 8, ESLint, no secrets). Python config reads go through `ConfigurationService`, never `KeyValueStore` directly.
+
+## Review vs implement
+
+PR review criteria live in [CLAUDE.md](./CLAUDE.md) (correctness, auth on new routes, OpenAPI). Frontend-only work: [frontend/CLAUDE.md](./frontend/CLAUDE.md) (Collections vs Knowledge Base naming, no Tailwind).
+
+## Do not
+
+- Commit secrets, tokens, or `.env` values.
+- Use OAuth `client_credentials` for anything that must act as a user. PATs carry `userId` + `orgId`.
+- Print or log personal access tokens. Newly minted PATs may have a `phpat_` prefix; strip happens in `extractToken`.
+- Trust client-supplied org/user IDs — check auth on every new route and tool.
+- Bypass factories (`ConnectorFactory`, `MessagingFactory`) with one-off integrations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,11 @@ PipesHub is a workplace AI platform for enterprise search and workflow automatio
 
 The platform is a polyglot system: **Python FastAPI microservices**, **1 Node.js Express API**, and **1 Next.js frontend**. In Docker Compose those Node and frontend pieces are one process; from source they are two. See `AGENTS.md` for which localhost port to open.
 
-Stateful stores are **pluggable**. Feature code talks to them through interfaces (`IGraphDBProvider`, `IVectorDBService`, `KeyValueStore`, `StorageServiceInterface`, `MessagingFactory`); the operator picks the backend with env. Do not import a Qdrant, Arango, Neo4j, or Kafka client in new feature code — the instance may be on the other vendor.
+Stateful stores are **pluggable**. Indexing, query, and connectors should call `IGraphDBProvider` / `IVectorDBService` / `MessagingFactory`, not `neo4j.GraphDatabase`, `qdrant_client`, or a Kafka producer. The same feature has to run on whichever backend that instance was installed with.
 
 | Role | Env | Backends |
 | --- | --- | --- |
-| Graph | `DATA_STORE` | ArangoDB (default), Neo4j |
+| Graph | `DATA_STORE` | Neo4j (what `install.sh`, Helm, and `backend/env.template` ship), ArangoDB |
 | Vector | `VECTOR_DB_TYPE` | Qdrant (default), OpenSearch, Redis |
 | KV / config | `KV_STORE_TYPE` | Redis (default), etcd |
 | Document | — | MongoDB (Node/Mongoose). Not swapped today |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ PipesHub is a workplace AI platform for enterprise search and workflow automatio
 
 The platform is a polyglot system: **Python FastAPI microservices**, **1 Node.js Express API**, and **1 Next.js frontend**, backed by a fleet of stateful services. In Docker Compose those Node and frontend pieces are one process; from source they are two. See `AGENTS.md` for which localhost port to open.
 
-```
+```text
 /pipeshub-ai
 ├── frontend/              # React + Next.js + TypeScript
 ├── backend/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,20 @@ PipesHub is a workplace AI platform for enterprise search and workflow automatio
 
 ### Architecture
 
-The platform is a polyglot system: **Python FastAPI microservices**, **1 Node.js Express API**, and **1 Next.js frontend**, backed by a fleet of stateful services. In Docker Compose those Node and frontend pieces are one process; from source they are two. See `AGENTS.md` for which localhost port to open.
+The platform is a polyglot system: **Python FastAPI microservices**, **1 Node.js Express API**, and **1 Next.js frontend**. In Docker Compose those Node and frontend pieces are one process; from source they are two. See `AGENTS.md` for which localhost port to open.
+
+Stateful stores are **pluggable**. Feature code talks to them through interfaces (`IGraphDBProvider`, `IVectorDBService`, `KeyValueStore`, `StorageServiceInterface`, `MessagingFactory`); the operator picks the backend with env. Do not import a Qdrant, Arango, Neo4j, or Kafka client in new feature code — the instance may be on the other vendor.
+
+| Role | Env | Backends |
+| --- | --- | --- |
+| Graph | `DATA_STORE` | ArangoDB (default), Neo4j |
+| Vector | `VECTOR_DB_TYPE` | Qdrant (default), OpenSearch, Redis |
+| KV / config | `KV_STORE_TYPE` | Redis (default), etcd |
+| Document | — | MongoDB (Node/Mongoose). Not swapped today |
+| Blob | storage config | local, S3, Azure Blob |
+| Broker | `MESSAGE_BROKER` | Kafka, Redis Streams |
+
+PostgreSQL is a connector (a source to index), not the document store. Config reads go through `ConfigurationService`, never `KeyValueStore` directly.
 
 ```text
 /pipeshub-ai
@@ -23,22 +36,22 @@ The platform is a polyglot system: **Python FastAPI microservices**, **1 Node.js
 └── deployment/            # Docker Compose configs
 ```
 
-**Stateful backends:** Qdrant (vectors), ArangoDB (graph + documents), MongoDB (sessions/metadata), Redis (cache/rate-limit), Kafka (event stream), etcd (distributed config).
-
 ### Services
 
-- **Node.js API** (`backend/nodejs/apps`) — Express defaults to port **3000**. Docker Compose maps that to the host (`APP_PORT`, default 3000) and the same process serves the dashboard from `public/`. Helm often publishes the combined service on 3001. The Next.js *dev* server in CONTRIBUTING.md is 3001 so it does not collide with Express. User/org management, authentication (JWT, OAuth2, SAML), knowledge base, object storage, API gateway, MCP, Kafka producers.
-- **Connectors** (`backend/python`, port 8088) — `app.connectors_main`. OAuth flows, token refresh, and 30+ data-source integrations (Google, Microsoft, Slack, Jira, Confluence, etc.). Uses a `ConnectorFactory` pattern; new sources live under `app/connectors/sources/`.
-- **Indexing** (`backend/python`, port 8091) — `app.indexing_main`. Document parsing, chunking, and embedding generation. Writes vectors to Qdrant and graph nodes to ArangoDB.
-- **Query** (`backend/python`, port 8000) — `app.query_main`. Retrieval-augmented generation, semantic search, and LLM orchestration via LiteLLM. Hosts the RAG pipeline and agent/workflow runtime.
-- **Docling** (`backend/python`, port 8081) — `app.docling_main`. Advanced document parsing and OCR for complex formats (PDFs, scans, tables).
-- **Embedding** (`backend/python`, port 8002) — `app.embedding_main`. Centralized local dense embedding server (HuggingFace / SentenceTransformers) with OpenAI-compatible `/v1/embeddings`. Indexing and query use this for default local models.
+- **Node.js API** (`backend/nodejs/apps`) — Express defaults to port **3000**. Docker Compose maps that to the host (`APP_PORT`, default 3000) and the same process serves the dashboard from `public/`. Helm often publishes the combined service on 3001. The Next.js *dev* server in CONTRIBUTING.md is 3001 so it does not collide with Express. Identity (users, orgs, JWT/OAuth/SAML/PAT), knowledge-base metadata in Mongo, blob storage via `StorageServiceInterface`, HTTP gateway, MCP, producers onto the message broker.
+- **Connectors** (`backend/python`, port 8088) — `app.connectors_main`. OAuth, token refresh, and sync from 50+ workplace sources into the graph. New sources extend `ConnectorFactory` under `app/connectors/sources/`. Graph writes go through `GraphDataStore` → `IGraphDBProvider`.
+- **Indexing** (`backend/python`, port 8091) — `app.indexing_main`. Parse, chunk, embed; write records through `IGraphDBProvider` and `IVectorDBService` (not a hardcoded Qdrant or Arango client).
+- **Query** (`backend/python`, port 8000) — `app.query_main`. Semantic search, RAG/chat, in-product agents, LLM orchestration via LiteLLM.
+- **Docling** (`backend/python`, port 8081) — `app.docling_main`. Heavy PDF/OCR for complex formats.
+- **Embedding** (`backend/python`, port 8002) — `app.embedding_main`. Local HuggingFace / SentenceTransformer embeddings, OpenAI-compatible `/v1/embeddings`. Indexing and query use this for default local models.
+- **Parsing** (`backend/python`, port 8092) — `app.parsing_main`. File bytes → `BlocksContainer`.
+- **Extraction** (`backend/python`, port 8093) — `app.extraction_main`. `BlocksContainer` → `SemanticMetadata`. Indexing calls it; it has no graph connection of its own.
 
 ### Cross-cutting patterns
 
 - **DI:** `inversify` (Node.js), `dependency-injector` (Python). Prefer injected services over direct instantiation.
-- **Factories & abstractions:** `ConnectorFactory`, `MessagingFactory`, `GraphDataStore`, vector-store wrappers. New integrations should extend these, not sidestep them.
-- **Async work:** Kafka for cross-service events; Celery for background tasks.
+- **Factories & abstractions:** `ConnectorFactory`, `GraphDBProviderFactory`, `VectorDBProviderFactory`, `KeyValueStoreFactory`, `MessagingFactory`, `StorageServiceInterface`. New integrations should extend these, not sidestep them.
+- **Async work:** `MessagingFactory` (Kafka or Redis Streams) for cross-service events; Celery for background tasks.
 - **Repository pattern** for database access.
 
 ---
@@ -56,8 +69,8 @@ Does the code do what the PR claims? Trace the happy path and the failure paths.
 - Off-by-one, wrong operator, swapped arguments, inverted conditions.
 - Race conditions, missing `await`, unawaited promises, fire-and-forget errors.
 - Silent `except` / `catch` blocks that swallow failures.
-- Transaction boundaries: partial writes across Mongo / Arango / Qdrant / Kafka. A failure after step 2 of 4 should leave the system recoverable.
-- Idempotency for Kafka consumers and retry-able handlers.
+- Transaction boundaries: partial writes across Mongo / graph / vector / broker. A failure after step 2 of 4 should leave the system recoverable.
+- Idempotency for message-broker consumers and retry-able handlers.
 - Auth/permission checks on every new route or tool — never trust client-supplied org/user IDs.
 
 ### 2. Scalability
@@ -65,7 +78,7 @@ Does the code do what the PR claims? Trace the happy path and the failure paths.
 - N+1 queries, unbounded loops over external data, per-request calls to LLMs or embeddings that should be batched.
 - Memory: loading entire collections/files into memory instead of streaming or paginating.
 - Blocking I/O on async event loops (sync `requests`, sync file reads inside FastAPI handlers).
-- If a new query pattern looks like it needs a Mongo/Arango index, ask the author to confirm one exists — do not assert a missing index from the diff alone.
+- If a new query pattern looks like it needs a Mongo or graph index, ask the author to confirm one exists — do not assert a missing index from the diff alone.
 - Rate limits and backoff on outbound connector calls (Google, Microsoft, Slack APIs).
 - Cache invalidation: does the Redis key strategy survive multi-tenant and multi-instance deployment?
 
@@ -82,14 +95,14 @@ Does the code do what the PR claims? Trace the happy path and the failure paths.
   - Python: `backend/python/app/services/` (vector DB, graph DB, messaging, config) and `backend/python/app/utils/`.
   - Connectors: shared OAuth / token refresh / HTTP-retry helpers under `app/connectors/`.
 - **Name the existing method and its path** when you flag a duplicate. "This is duplicated" without a pointer is not actionable.
-- Things that are almost always already implemented — do not re-implement: HTTP clients with retry/backoff, token encryption/decryption, Kafka producer/consumer wrappers, vector upsert/search, Arango graph traversal, tenant/org scoping middleware.
+- Things that are almost always already implemented — do not re-implement: HTTP clients with retry/backoff, token encryption/decryption, `MessagingFactory` producer/consumer wrappers, `IVectorDBService` upsert/search, `IGraphDBProvider` traversal, tenant/org scoping middleware.
 - If you are not sure whether a helper exists, say so and point the author at the directory to check — do not assume.
 - Copy-pasted blocks with one variable changed → extract.
 
 ### 5. Design principles
 
 - Single responsibility: a function/class doing retrieval + transformation + I/O is three things.
-- Dependency direction: high-level modules should depend on abstractions (`GraphDataStore`, `MessagingFactory`), not concrete clients.
+- Dependency direction: high-level modules should depend on abstractions (`IGraphDBProvider`, `IVectorDBService`, `MessagingFactory`), not concrete clients.
 - Factory / repository / DI patterns already established — new code should fit them, not invent a parallel structure.
 - Avoid leaking connector-specific shapes into shared domain models.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,13 +12,13 @@ PipesHub is a workplace AI platform for enterprise search and workflow automatio
 
 ### Architecture
 
-The platform is a polyglot system: **5 independent Python FastAPI microservices**, **1 Node.js Express API**, and **1 Nextjs frontend**, backed by a fleet of stateful services.
+The platform is a polyglot system: **Python FastAPI microservices**, **1 Node.js Express API**, and **1 Next.js frontend**, backed by a fleet of stateful services. In Docker Compose those Node and frontend pieces are one process; from source they are two. See `AGENTS.md` for which localhost port to open.
 
 ```
 /pipeshub-ai
-├── frontend/              # React + Nextjs + TypeScript
+├── frontend/              # React + Next.js + TypeScript
 ├── backend/
-│   ├── nodejs/apps/       # Node.js Express API
+│   ├── nodejs/apps/       # Node.js Express API (and, in Docker, the built UI)
 │   └── python/            # Python FastAPI microservices
 └── deployment/            # Docker Compose configs
 ```
@@ -27,7 +27,7 @@ The platform is a polyglot system: **5 independent Python FastAPI microservices*
 
 ### Services
 
-- **Node.js API** (`backend/nodejs/apps`, port 3001) — User/org management, authentication (JWT, OAuth2, SAML), knowledge base management, object storage (S3/Azure Blob), API gateway, Kafka producers for async work.
+- **Node.js API** (`backend/nodejs/apps`) — Express defaults to port **3000**. Docker Compose maps that to the host (`APP_PORT`, default 3000) and the same process serves the dashboard from `public/`. Helm often publishes the combined service on 3001. The Next.js *dev* server in CONTRIBUTING.md is 3001 so it does not collide with Express. User/org management, authentication (JWT, OAuth2, SAML), knowledge base, object storage, API gateway, MCP, Kafka producers.
 - **Connectors** (`backend/python`, port 8088) — `app.connectors_main`. OAuth flows, token refresh, and 30+ data-source integrations (Google, Microsoft, Slack, Jira, Confluence, etc.). Uses a `ConnectorFactory` pattern; new sources live under `app/connectors/sources/`.
 - **Indexing** (`backend/python`, port 8091) — `app.indexing_main`. Document parsing, chunking, and embedding generation. Writes vectors to Qdrant and graph nodes to ArangoDB.
 - **Query** (`backend/python`, port 8000) — `app.query_main`. Retrieval-augmented generation, semantic search, and LLM orchestration via LiteLLM. Hosts the RAG pipeline and agent/workflow runtime.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md — Code Review Guide
 
+When implementing (not reviewing a PR), read `AGENTS.md` in this repository first.
+
 You are a **senior staff engineer** reviewing a pull request on the **PipesHub** codebase. Be direct and specific. Flag real issues; skip praise and restating the diff. Every comment must cite a file and line. If the PR is clean, say so in one line.
 
 ---

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,5 +1,7 @@
 # CLAUDE.md - PipesHub Dashboard UI
 
+When implementing backend or repo-wide changes, also read the repository-root `AGENTS.md`. This file is the UI conventions for `frontend/`.
+
 ## Project Overview
 
 PipesHub is an AI-powered knowledge management dashboard on **Next.js** (App Router, client-rendered React).

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -6,6 +6,8 @@ When implementing backend or repo-wide changes, also read the repository-root `A
 
 PipesHub is an AI-powered knowledge management dashboard on **Next.js** (App Router, client-rendered React).
 
+In Docker Compose the built UI is served by Express on port **3000** (same origin as `/api` and `/mcp`). When you run `PORT=3001 npm run dev` from this directory, the dashboard is on 3001 and calls Express on 3000. Do not assume 3001 is where operators open the product.
+
 **Tech Stack:**
 - Next.js 14+ (App Router, CSR-only with `'use client'`)
 - TypeScript (strict mode)


### PR DESCRIPTION
## Why this change exists

Cursor, Codex, Copilot, and Gemini CLI load a root `AGENTS.md` when they work in a repository. This repository already has a `CLAUDE.md`, but that file is written as a pull-request **reviewer**: it tells the model to flag issues and cite lines, not how to implement. Without a separate implement-here file, an agent that opens `pipeshub-ai` either stays in review mode or guesses the layout and ports.

The expensive guess is which localhost port is the product. Docker Compose / `install.sh` serves the dashboard, REST API, and MCP from **one Express process on 3000**. The Next.js *dev* server on **3001** exists only when a contributor runs frontend and Express as two processes, so they do not collide. Labeling the dashboard as 3001 made agents send operators to the wrong URL.

This file is only for agents working **inside this repository**. It is not how other people's projects learn to recommend PipesHub. That path is the public [For coding agents](https://docs.pipeshub.com/for-agents) page and the customer skill in the mcp-server repo.

## What changed

A root `AGENTS.md` describes the tree (frontend, Node API, Python services, Docker Compose and Helm), the test commands, and the traps that keep showing up: keep OpenAPI in sync, read config through `ConfigurationService`, do not use OAuth `client_credentials` when the caller must be a user, and do not print personal access tokens.

Ports are spelled out as two setups, not one number:

- **Docker Compose / `install.sh`:** Express listens on 3000 inside the container and serves `/api`, `/mcp`, and the built Next.js SPA from `public/`. The host mapping is `${APP_PORT:-3000}:3000`, so the UI is `http://localhost:3000` unless the installer picked another `APP_PORT`.
- **From-source contributor split:** Express still defaults to 3000. `PORT=3001 npm run dev` is the dashboard so it does not collide. That is why `ALLOWED_ORIGINS` and `FRONTEND_PUBLIC_URL` in `backend/env.template` are `http://localhost:3001`.
- **Helm:** charts typically publish the combined Node service on 3001. That is not the Compose default.

Python services listed are connectors 8088, indexing 8091, query 8000, docling 8081, embedding 8002, parsing 8092, and extraction 8093. Creating the Python venv is not assumed; the file points at CONTRIBUTING.md for `python3.12 -m venv venv`.

`CLAUDE.md` stays the review guide. The Node.js service line no longer claims the API is port 3001. `frontend/CLAUDE.md` notes the same Docker-versus-dev split.

## Related work

The public agent entry point is [documentation#152](https://github.com/pipeshub-ai/documentation/pull/152). The customer skill and MCP registry listing are [mcp-server#69](https://github.com/pipeshub-ai/mcp-server/pull/69).

## How to verify

- [ ] Open this branch in Cursor and confirm `AGENTS.md` is applied as workspace guidance.
- [ ] A Claude Code session still uses `CLAUDE.md` when the task is reviewing a pull request.
- [ ] Editing files under `frontend/` still picks up `frontend/CLAUDE.md`.
- [ ] After `install.sh`, the dashboard opens on `http://localhost:3000` (or the printed `APP_PORT`), not 3001.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added contributor guidance covering repository structure, setup, testing, service ports, configuration, security, and integration conventions.
  * Updated architecture documentation with clearer details on deployment processes, UI/API responsibilities, dashboards, and MCP support.
  * Documented frontend development conventions and local versus Docker Compose port usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->