### PR TITLE
fix(agents): count "how many times is X mentioned" over the full record

### DIFF
--- a/backend/python/app/agents/actions/knowledge_graph/ops/fetch.py
+++ b/backend/python/app/agents/actions/knowledge_graph/ops/fetch.py
@@ -156,7 +156,15 @@ async def execute_fetch_record(
 
 
 def _occurrence_count_note(query: str, records: list[dict[str, Any]]) -> str:
-    """If the user asked how often a phrase appears, count it over full records."""
+    """If the user asked how often a phrase appears, count it over full records.
+
+    Args:
+        query: Original user query from ``tool_state["query"]``.
+        records: Fetched record dicts (full block text, not the truncated prompt).
+
+    Returns:
+        Markdown occurrence-count note, or ``""`` when the query is not a tally.
+    """
     from app.modules.agents.record_escalation.occurrence_count import (
         count_occurrences,
         format_occurrence_count_note,

--- a/backend/python/app/agents/actions/knowledge_graph/ops/fetch.py
+++ b/backend/python/app/agents/actions/knowledge_graph/ops/fetch.py
@@ -128,6 +128,12 @@ async def execute_fetch_record(
             "\n\nCite facts from the above using each block's `[refN]` id "
             "as a markdown link, e.g. [source](ref2). Do NOT use external URLs as citations."
         )
+        occurrence_note = _occurrence_count_note(
+            context.tool_state.get("query") or "",
+            result["records"],
+        )
+        if occurrence_note:
+            text += "\n\n" + occurrence_note
         not_available = result.get("not_available_ids", [])
         if not_available:
             if record_id_shortener is not None:
@@ -147,3 +153,27 @@ async def execute_fetch_record(
         return ToolOutput(success=True, data=text), ref_mapper
 
     return _to_tool_output(result), citation_ref_mapper
+
+
+def _occurrence_count_note(query: str, records: list[dict[str, Any]]) -> str:
+    """If the user asked how often a phrase appears, count it over full records."""
+    from app.modules.agents.record_escalation.occurrence_count import (
+        count_occurrences,
+        format_occurrence_count_note,
+        parse_occurrence_phrase,
+        record_plain_text,
+    )
+
+    phrase = parse_occurrence_phrase(query)
+    if not phrase:
+        return ""
+
+    per_record: list[tuple[str, str, int]] = []
+    for record in records:
+        rid = str(record.get("id") or "")
+        if not rid:
+            continue
+        name = str(record.get("record_name") or record.get("recordName") or "")
+        n = count_occurrences(record_plain_text(record), phrase)
+        per_record.append((rid, name, n))
+    return format_occurrence_count_note(phrase=phrase, per_record=per_record)

--- a/backend/python/app/modules/agents/record_escalation/__init__.py
+++ b/backend/python/app/modules/agents/record_escalation/__init__.py
@@ -10,6 +10,11 @@ from app.modules.agents.record_escalation.models import (
     FetchPlan,
     FetchVerdict,
 )
+from app.modules.agents.record_escalation.occurrence_count import (
+    count_occurrences,
+    is_occurrence_count_query,
+    parse_occurrence_phrase,
+)
 from app.modules.agents.record_escalation.policy import (
     build_candidates,
     needs_whole_document,
@@ -26,7 +31,10 @@ __all__ = [
     "FetchVerdict",
     "analyze_coverage",
     "build_candidates",
+    "count_occurrences",
+    "is_occurrence_count_query",
     "needs_whole_document",
+    "parse_occurrence_phrase",
     "policy_text",
     "render_candidate_table",
     "render_coverage_note",

--- a/backend/python/app/modules/agents/record_escalation/occurrence_count.py
+++ b/backend/python/app/modules/agents/record_escalation/occurrence_count.py
@@ -69,6 +69,18 @@ _PHRASE_AFTER_COUNT_OF_RE = re.compile(
     re.IGNORECASE | re.VERBOSE | re.DOTALL,
 )
 
+_PHRASE_DOCUMENT_MENTIONS_RE = re.compile(
+    r"""
+    (?: how \s+ many \s+ times | how \s+ often )
+    \s+ does \s+ (?: the \s+ )?
+    (?: document | record | book | file | pdf | text )
+    \s+ mention \s+
+    (?P<phrase>.+?)
+    [\s?.!]* $
+    """,
+    re.IGNORECASE | re.VERBOSE | re.DOTALL,
+)
+
 _TRAILING_SCOPE_RE = re.compile(
     r"""
     \s+ in \s+ (?: the \s+ )?
@@ -82,7 +94,15 @@ _LEADING_ARTICLES_RE = re.compile(r"^(?:the|a|an)\s+", re.IGNORECASE)
 
 
 def is_occurrence_count_query(*texts: str) -> bool:
-    """True when the request is tallying a phrase inside a document."""
+    """Return True when the request is tallying a phrase inside a document.
+
+    Args:
+        *texts: Query fragments (raw user text and optional rewritten goal).
+
+    Returns:
+        True if this is an in-document occurrence count, not a corpus-level
+        "how many documents" question and not an unrelated "how many times".
+    """
     combined = " ".join(t for t in texts if t)
     if not combined.strip():
         return False
@@ -92,7 +112,14 @@ def is_occurrence_count_query(*texts: str) -> bool:
 
 
 def parse_occurrence_phrase(*texts: str) -> str | None:
-    """Extract the phrase to count, or None if this is not that question."""
+    """Extract the phrase to count, or None if this is not that question.
+
+    Args:
+        *texts: Query fragments to parse.
+
+    Returns:
+        Normalized phrase (for example ``harry potter``), or ``None``.
+    """
     combined = " ".join(t for t in texts if t)
     if not is_occurrence_count_query(combined):
         return None
@@ -102,6 +129,7 @@ def parse_occurrence_phrase(*texts: str) -> str | None:
         return _normalize_phrase(quoted.group("phrase"))
 
     for pattern in (
+        _PHRASE_DOCUMENT_MENTIONS_RE,
         _PHRASE_AFTER_TIMES_RE,
         _PHRASE_AFTER_OFTEN_RE,
         _PHRASE_AFTER_COUNT_OF_RE,
@@ -115,7 +143,15 @@ def parse_occurrence_phrase(*texts: str) -> str | None:
 
 
 def count_occurrences(haystack: str, phrase: str) -> int:
-    """Case-insensitive, non-overlapping phrase count over ``haystack``."""
+    """Return a case-insensitive, non-overlapping phrase count.
+
+    Args:
+        haystack: Full record text (not retrieved snippets).
+        phrase: Phrase extracted from the user query.
+
+    Returns:
+        Number of matches. ``0`` if either argument is empty.
+    """
     if not haystack or not phrase:
         return 0
     pattern = _phrase_regex(phrase)
@@ -123,7 +159,14 @@ def count_occurrences(haystack: str, phrase: str) -> int:
 
 
 def record_plain_text(record: Mapping[str, Any]) -> str:
-    """Concatenate block text for a fetched record, skipping fragment children."""
+    """Concatenate block text for a fetched record, skipping fragment children.
+
+    Args:
+        record: Record dict with ``block_containers.blocks`` or top-level ``blocks``.
+
+    Returns:
+        Newline-joined plain text used for occurrence counting.
+    """
     containers = record.get("block_containers") or {}
     blocks = containers.get("blocks") if isinstance(containers, Mapping) else None
     if not isinstance(blocks, list):
@@ -145,7 +188,15 @@ def format_occurrence_count_note(
     phrase: str,
     per_record: list[tuple[str, str, int]],
 ) -> str:
-    """Instruction block so the model states the computed count instead of recounting."""
+    """Build the instruction block so the model uses the computed count.
+
+    Args:
+        phrase: Phrase that was counted.
+        per_record: ``(record_id, record_name, count)`` rows.
+
+    Returns:
+        Markdown note, or ``""`` if ``per_record`` is empty.
+    """
     if not per_record:
         return ""
     lines = [
@@ -165,12 +216,28 @@ def format_occurrence_count_note(
 
 
 def _normalize_phrase(raw: str) -> str | None:
+    """Strip trailing "in the book/document" and leading articles from a capture.
+
+    Args:
+        raw: Raw regex capture.
+
+    Returns:
+        Cleaned phrase, or ``None`` if nothing usable remains.
+    """
     cleaned = _TRAILING_SCOPE_RE.sub("", raw or "").strip()
     cleaned = _LEADING_ARTICLES_RE.sub("", cleaned).strip(" \t\n\r\"'`.,;:?!")
     return cleaned or None
 
 
 def _phrase_regex(phrase: str) -> re.Pattern[str]:
+    """Compile a case-insensitive matcher with flexible whitespace and word bounds.
+
+    Args:
+        phrase: Normalized phrase to search for.
+
+    Returns:
+        Compiled pattern. A never-matching pattern if ``phrase`` is empty.
+    """
     tokens = [re.escape(t) for t in phrase.split() if t]
     if not tokens:
         return re.compile(r"(?!)")
@@ -183,6 +250,14 @@ def _phrase_regex(phrase: str) -> re.Pattern[str]:
 
 
 def _block_text(block: Mapping[str, Any]) -> str:
+    """Extract searchable text from one block.
+
+    Args:
+        block: A block dict whose ``data`` is a string or a mapping.
+
+    Returns:
+        Text content, or ``""`` if the block has none.
+    """
     data = block.get("data")
     if isinstance(data, str):
         return data

--- a/backend/python/app/modules/agents/record_escalation/occurrence_count.py
+++ b/backend/python/app/modules/agents/record_escalation/occurrence_count.py
@@ -1,0 +1,194 @@
+"""Detect occurrence-count questions and count a phrase over full record text.
+
+Used when the agent would otherwise tally a word from retrieved snippets
+(issue #2996). Pure functions: no I/O, no LLM.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+# Intent: the user wants a tally of a phrase inside a document, not a
+# corpus-level "how many documents" count and not a locatable fact.
+_OCCURRENCE_INTENT_RE = re.compile(
+    r"""
+    how \s+ many \s+ times
+    | how \s+ often
+    | how \s+ many \s+ mentions?
+    | (?: count | number \s+ of ) \s+ (?: the \s+ )?
+      (?: occurrences? | mentions? | appearances? )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+# Without one of these, "how many times did we meet" is not a document tally.
+_OCCURRENCE_SCOPE_RE = re.compile(
+    r"""
+    mentioned | mentions | appear(?:s|ed|ances?)? | occur(?:s|red|rences?)?
+    | show(?:s|ed)? \s+ up
+    | \b (?: book | document | doc | file | pdf | record | text | chapter ) \b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_QUOTED_PHRASE_RE = re.compile(r"""["“”'](?P<phrase>[^"“”']+)["“”']""")
+
+_PHRASE_AFTER_TIMES_RE = re.compile(
+    r"""
+    how \s+ many \s+ times \s+
+    (?: is | are | does | do | was | were )? \s*
+    (?P<phrase>.+?) \s+
+    (?: mentioned | appear(?:s|ed)? | occur(?:s|red)? | show(?:s|ed)? \s+ up )
+    """,
+    re.IGNORECASE | re.VERBOSE | re.DOTALL,
+)
+
+_PHRASE_AFTER_OFTEN_RE = re.compile(
+    r"""
+    how \s+ often \s+
+    (?: is | are | does | do | was | were )? \s*
+    (?P<phrase>.+?) \s+
+    (?: mentioned | appear(?:s|ed)? | occur(?:s|red)? )
+    """,
+    re.IGNORECASE | re.VERBOSE | re.DOTALL,
+)
+
+_PHRASE_AFTER_COUNT_OF_RE = re.compile(
+    r"""
+    (?:
+        (?: count | number \s+ of ) \s+ (?: the \s+ )?
+        (?: occurrences? | mentions? | appearances? )
+      | how \s+ many \s+ mentions?
+    )
+    \s+ of \s+
+    (?P<phrase>.+?)
+    (?: \s+ in \b | $ )
+    """,
+    re.IGNORECASE | re.VERBOSE | re.DOTALL,
+)
+
+_TRAILING_SCOPE_RE = re.compile(
+    r"""
+    \s+ in \s+ (?: the \s+ )?
+    (?: book | document | doc | file | pdf | record | text | chapter | it )
+    [\s?.!]* $
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_LEADING_ARTICLES_RE = re.compile(r"^(?:the|a|an)\s+", re.IGNORECASE)
+
+
+def is_occurrence_count_query(*texts: str) -> bool:
+    """True when the request is tallying a phrase inside a document."""
+    combined = " ".join(t for t in texts if t)
+    if not combined.strip():
+        return False
+    if not _OCCURRENCE_INTENT_RE.search(combined):
+        return False
+    return bool(_OCCURRENCE_SCOPE_RE.search(combined))
+
+
+def parse_occurrence_phrase(*texts: str) -> str | None:
+    """Extract the phrase to count, or None if this is not that question."""
+    combined = " ".join(t for t in texts if t)
+    if not is_occurrence_count_query(combined):
+        return None
+
+    quoted = _QUOTED_PHRASE_RE.search(combined)
+    if quoted:
+        return _normalize_phrase(quoted.group("phrase"))
+
+    for pattern in (
+        _PHRASE_AFTER_TIMES_RE,
+        _PHRASE_AFTER_OFTEN_RE,
+        _PHRASE_AFTER_COUNT_OF_RE,
+    ):
+        match = pattern.search(combined)
+        if match:
+            phrase = _normalize_phrase(match.group("phrase"))
+            if phrase:
+                return phrase
+    return None
+
+
+def count_occurrences(haystack: str, phrase: str) -> int:
+    """Case-insensitive, non-overlapping phrase count over ``haystack``."""
+    if not haystack or not phrase:
+        return 0
+    pattern = _phrase_regex(phrase)
+    return sum(1 for _ in pattern.finditer(haystack))
+
+
+def record_plain_text(record: Mapping[str, Any]) -> str:
+    """Concatenate block text for a fetched record, skipping fragment children."""
+    containers = record.get("block_containers") or {}
+    blocks = containers.get("blocks") if isinstance(containers, Mapping) else None
+    if not isinstance(blocks, list):
+        blocks = record.get("blocks") or []
+    parts: list[str] = []
+    for block in blocks:
+        if not isinstance(block, Mapping):
+            continue
+        if block.get("parent_block_index") is not None:
+            continue
+        text = _block_text(block)
+        if text:
+            parts.append(text)
+    return "\n".join(parts)
+
+
+def format_occurrence_count_note(
+    *,
+    phrase: str,
+    per_record: list[tuple[str, str, int]],
+) -> str:
+    """Instruction block so the model states the computed count instead of recounting."""
+    if not per_record:
+        return ""
+    lines = [
+        "## Computed occurrence count — do not recount",
+        f'Phrase: "{phrase}"',
+        "Counted with a case-insensitive search over the **full record text** "
+        "(not the retrieved snippets, not the truncated blocks shown above).",
+    ]
+    for record_id, record_name, n in per_record:
+        name = record_name or "(unnamed)"
+        lines.append(f'- Record ID `{record_id}` ({name}): **{n}**')
+    lines.append(
+        "When stating how many times the phrase appears, use these numbers "
+        "and cite the record. Do not invent a different tally from the visible blocks."
+    )
+    return "\n".join(lines)
+
+
+def _normalize_phrase(raw: str) -> str | None:
+    cleaned = _TRAILING_SCOPE_RE.sub("", raw or "").strip()
+    cleaned = _LEADING_ARTICLES_RE.sub("", cleaned).strip(" \t\n\r\"'`.,;:?!")
+    return cleaned or None
+
+
+def _phrase_regex(phrase: str) -> re.Pattern[str]:
+    tokens = [re.escape(t) for t in phrase.split() if t]
+    if not tokens:
+        return re.compile(r"(?!)")
+    body = r"\s+".join(tokens)
+    if re.match(r"\w", phrase[0], re.UNICODE):
+        body = r"\b" + body
+    if re.search(r"\w$", phrase, re.UNICODE):
+        body = body + r"\b"
+    return re.compile(body, re.IGNORECASE)
+
+
+def _block_text(block: Mapping[str, Any]) -> str:
+    data = block.get("data")
+    if isinstance(data, str):
+        return data
+    if isinstance(data, Mapping):
+        for key in ("text", "row_natural_language_text", "content"):
+            value = data.get(key)
+            if isinstance(value, str) and value.strip():
+                return value
+    return ""

--- a/backend/python/app/modules/agents/record_escalation/policy.py
+++ b/backend/python/app/modules/agents/record_escalation/policy.py
@@ -110,8 +110,11 @@ def needs_whole_document(marker: str | None, *texts: str) -> bool:
     Args:
         marker: The WHOLE_DOCUMENT marker from the intent call ("yes"/"no"), or
                 None when the intent call was skipped or produced no marker.
-                A real model judgment, so it wins outright when present.
-        *texts: Request texts, used only when `marker` is None.
+                A real model judgment, so it wins outright when present —
+                except occurrence-count questions (#2996), which always need
+                the full record even if the marker said "no".
+        *texts: Request texts. Used when `marker` is None, and always used to
+                detect occurrence-count questions.
 
     The fallback is class-based (see the module constants above), not a list of
     known request shapes: it fires on aggregative operations, aggregative
@@ -119,17 +122,17 @@ def needs_whole_document(marker: str | None, *texts: str) -> bool:
     True because a false positive only costs a candidate list the model can
     ignore, whereas a false negative hides coverage information it needs.
     """
+    combined = " ".join(t for t in texts if t)
+    # Occurrence tallies are a property of the whole record even if the intent
+    # marker said "no" — snippets under-count (issue #2996).
+    if is_occurrence_count_query(combined):
+        return True
+
     if marker is not None:
         return marker.lower().strip() == "yes"
 
-    combined = " ".join(t for t in texts if t)
     if not combined.strip():
         return False
-
-    # Occurrence tallies ("how many times is X mentioned") are a property of
-    # the whole record. Retrieval snippets under-count; see issue #2996.
-    if is_occurrence_count_query(combined):
-        return True
 
     if _AGGREGATIVE_OPERATION_RE.search(combined):
         return True

--- a/backend/python/app/modules/agents/record_escalation/policy.py
+++ b/backend/python/app/modules/agents/record_escalation/policy.py
@@ -19,6 +19,9 @@ from app.modules.agents.record_escalation.models import (
     FetchCandidate,
     FetchPlan,
 )
+from app.modules.agents.record_escalation.occurrence_count import (
+    is_occurrence_count_query,
+)
 
 # ---------------------------------------------------------------------------
 # Fallback signal — used only when the intent call produced no marker
@@ -122,6 +125,11 @@ def needs_whole_document(marker: str | None, *texts: str) -> bool:
     combined = " ".join(t for t in texts if t)
     if not combined.strip():
         return False
+
+    # Occurrence tallies ("how many times is X mentioned") are a property of
+    # the whole record. Retrieval snippets under-count; see issue #2996.
+    if is_occurrence_count_query(combined):
+        return True
 
     if _AGGREGATIVE_OPERATION_RE.search(combined):
         return True
@@ -231,8 +239,11 @@ def policy_text(tool_ref: str) -> str:
         f"visible in a block you hold, or metadata alone (status, assignee) "
         f"settles the goal. This covers both no content yet from lookup/"
         f"navigate/list_files, and incomplete coverage for a whole-document "
-        f"property (a summary, risks or key points, a comparison, whether it "
-        f"mentions something anywhere). Never infer content from a title.\n\n"
+        f"property (a summary, risks or key points, a comparison, how many "
+        f"times a phrase appears, whether it mentions something anywhere). "
+        f"Never infer content from a title. If a fetch result includes a "
+        f"Computed occurrence count, use that number — do not recount from "
+        f"snippets or visible blocks.\n\n"
         f"A retrieval result may include a candidate list showing how much of "
         f"each record you hold ('you have 4 of 87 blocks'), which tells you "
         f"whether reading further would add anything; use it when present. "

--- a/backend/python/tests/unit/modules/agents/record_escalation/test_kernel.py
+++ b/backend/python/tests/unit/modules/agents/record_escalation/test_kernel.py
@@ -287,6 +287,8 @@ class TestNeedsWholeDocument:
             "read it end-to-end",
             "What are the gaps in this proposal?",
             "any action items in the minutes?",
+            "How many times is harry potter mentioned in the book?",
+            "count the occurrences of GDPR in the document",
         ],
     )
     def test_whole_document_shapes_trigger(self, query):

--- a/backend/python/tests/unit/modules/agents/record_escalation/test_occurrence_count.py
+++ b/backend/python/tests/unit/modules/agents/record_escalation/test_occurrence_count.py
@@ -1,0 +1,171 @@
+"""Tests for occurrence-count helpers (issue #2996)."""
+from __future__ import annotations
+
+import pytest
+
+from app.agents.actions.knowledge_graph.ops.fetch import _occurrence_count_note
+from app.modules.agents.record_escalation.occurrence_count import (
+    count_occurrences,
+    format_occurrence_count_note,
+    is_occurrence_count_query,
+    parse_occurrence_phrase,
+    record_plain_text,
+)
+from app.modules.agents.record_escalation.policy import needs_whole_document
+
+
+class TestIsOccurrenceCountQuery:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "How many times is harry potter mentioned in the book?",
+            "how many times is \"Harry Potter\" mentioned",
+            "count the occurrences of GDPR in the document",
+            "how many mentions of ACME",
+            "how often does the warranty appear in the contract",
+            "number of appearances of foo in the pdf",
+        ],
+    )
+    def test_positive(self, text: str) -> None:
+        assert is_occurrence_count_query(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "how many documents do we have",
+            "how many risks does this contract list",
+            "When was the disaster recovery test performed?",
+            "how many times did we meet last week",
+            "",
+        ],
+    )
+    def test_negative(self, text: str) -> None:
+        assert is_occurrence_count_query(text) is False
+
+
+class TestParseOccurrencePhrase:
+    def test_unquoted_mentioned_in_book(self) -> None:
+        assert (
+            parse_occurrence_phrase(
+                "How many times is harry potter mentioned in the book?"
+            )
+            == "harry potter"
+        )
+
+    def test_quoted_wins(self) -> None:
+        assert (
+            parse_occurrence_phrase(
+                'How many times is "Harry Potter" mentioned in the book?'
+            )
+            == "Harry Potter"
+        )
+
+    def test_count_occurrences_of(self) -> None:
+        assert (
+            parse_occurrence_phrase("count the occurrences of GDPR in the document")
+            == "GDPR"
+        )
+
+    def test_how_often(self) -> None:
+        assert (
+            parse_occurrence_phrase(
+                "how often does the warranty appear in the contract"
+            )
+            == "warranty"
+        )
+
+    def test_not_occurrence_query(self) -> None:
+        assert parse_occurrence_phrase("how many documents do we have") is None
+
+
+class TestCountOccurrences:
+    def test_case_insensitive_phrase(self) -> None:
+        text = "Harry Potter sat down. Then harry potter stood up. HARRY POTTER."
+        assert count_occurrences(text, "Harry Potter") == 3
+
+    def test_does_not_count_partial_words(self) -> None:
+        assert count_occurrences("potteries and Potter", "Potter") == 1
+
+    def test_flexible_whitespace(self) -> None:
+        assert count_occurrences("harry   potter", "harry potter") == 1
+
+    def test_empty(self) -> None:
+        assert count_occurrences("", "x") == 0
+        assert count_occurrences("abc", "") == 0
+
+
+class TestRecordPlainText:
+    def test_skips_fragment_children(self) -> None:
+        record = {
+            "block_containers": {
+                "blocks": [
+                    {"index": 0, "data": "Hello Harry Potter"},
+                    {"index": 1, "parent_block_index": 0, "data": "Harry Potter"},
+                    {"index": 2, "data": {"text": " more Harry Potter"}},
+                ]
+            }
+        }
+        text = record_plain_text(record)
+        assert text.count("Harry Potter") == 2
+        assert "Hello" in text
+
+    def test_top_level_blocks_fallback(self) -> None:
+        record = {"blocks": [{"data": "only here"}]}
+        assert record_plain_text(record) == "only here"
+
+
+class TestFormatNote:
+    def test_includes_counts(self) -> None:
+        note = format_occurrence_count_note(
+            phrase="Harry Potter",
+            per_record=[("rec-1", "book", 47)],
+        )
+        assert "47" in note
+        assert "Harry Potter" in note
+        assert "do not recount" in note.lower()
+
+
+class TestNeedsWholeDocumentOccurrence:
+    def test_reported_query_needs_whole_document(self) -> None:
+        assert (
+            needs_whole_document(
+                None,
+                "How many times is harry potter mentioned in the book?",
+            )
+            is True
+        )
+
+    def test_corpus_how_many_documents_is_not_this_path(self) -> None:
+        # Corpus enumeration is a different question (#2975 / #2988).
+        assert needs_whole_document(None, "how many documents do we have") is False
+
+
+class TestOccurrenceCountNoteOnFetch:
+    """#2996 step 3: tally is computed over full record text, not snippets."""
+
+    def test_counts_full_text_and_skips_fragments(self) -> None:
+        record = {
+            "id": "rec-hp",
+            "record_name": "harry potter 50 pages",
+            "block_containers": {
+                "blocks": [
+                    {"index": 0, "data": "Harry Potter went to school. "},
+                    {"index": 1, "data": "Then harry potter came home. HARRY POTTER."},
+                    {"index": 2, "parent_block_index": 0, "data": "Harry Potter"},
+                ]
+            },
+        }
+        note = _occurrence_count_note(
+            "How many times is harry potter mentioned in the book?",
+            [record],
+        )
+        assert "Computed occurrence count" in note
+        assert "**3**" in note
+        assert "rec-hp" in note
+
+    def test_blank_for_non_tally_query(self) -> None:
+        record = {
+            "id": "rec-1",
+            "block_containers": {"blocks": [{"index": 0, "data": "Harry Potter"}]},
+        }
+        assert _occurrence_count_note("summarize this document", [record]) == ""

--- a/backend/python/tests/unit/modules/agents/record_escalation/test_occurrence_count.py
+++ b/backend/python/tests/unit/modules/agents/record_escalation/test_occurrence_count.py
@@ -24,6 +24,8 @@ class TestIsOccurrenceCountQuery:
             "how many mentions of ACME",
             "how often does the warranty appear in the contract",
             "number of appearances of foo in the pdf",
+            "how many times does the document mention GDPR",
+            "how often does the record mention harry potter",
         ],
     )
     def test_positive(self, text: str) -> None:
@@ -76,6 +78,16 @@ class TestParseOccurrencePhrase:
 
     def test_not_occurrence_query(self) -> None:
         assert parse_occurrence_phrase("how many documents do we have") is None
+
+    def test_document_mention_wording(self) -> None:
+        assert (
+            parse_occurrence_phrase("how many times does the document mention GDPR")
+            == "GDPR"
+        )
+        assert (
+            parse_occurrence_phrase("how often does the record mention harry potter")
+            == "harry potter"
+        )
 
 
 class TestCountOccurrences:
@@ -138,6 +150,15 @@ class TestNeedsWholeDocumentOccurrence:
     def test_corpus_how_many_documents_is_not_this_path(self) -> None:
         # Corpus enumeration is a different question (#2975 / #2988).
         assert needs_whole_document(None, "how many documents do we have") is False
+
+    def test_occurrence_query_overrides_marker_no(self) -> None:
+        assert (
+            needs_whole_document(
+                "no",
+                "How many times is harry potter mentioned in the book?",
+            )
+            is True
+        )
 
 
 class TestOccurrenceCountNoteOnFetch:

--- a/backend/python/tests/unit/modules/agents/record_escalation/test_policy.py
+++ b/backend/python/tests/unit/modules/agents/record_escalation/test_policy.py
@@ -213,3 +213,7 @@ class TestPolicyText:
         text = policy_text("custom_fetch_tool")
         assert "custom_fetch_tool" in text
         assert "knowledgegraph__fetch_record" not in text
+
+    def test_mentions_occurrence_counts(self) -> None:
+        text = policy_text("fetch_tool")
+        assert "Computed occurrence count" in text


### PR DESCRIPTION
## Summary
- Fixes #2996: "how many times is X mentioned" was counted from retrieved chunks (26 vs 47 on a 50-page PDF).
- `needs_whole_document` now treats occurrence-count questions as whole-record (separate from corpus-level "how many documents").
- After `fetch_record`, the phrase is counted with a regex over full block text and attached as a computed, citable tally so the model does not recount snippets.

## Test plan
- [x] `pytest tests/unit/modules/agents/record_escalation/` — 144 passed
- [x] Upload a long PDF, ask "How many times is X mentioned?", confirm the answer matches a full-text count and cites the record

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for answering questions about how often a phrase appears across complete records.
  * Results now include computed, case-insensitive occurrence counts for each matching record.
  * Counting supports word boundaries, varied formatting, and multiple document structures.

* **Bug Fixes**
  * Improved accuracy by counting across full documents rather than incomplete text fragments.
  * Non-occurrence queries remain unaffected.
  * Queries requesting occurrence counts now receive whole-record results even when other indicators suggest otherwise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->