### PR TITLE
feat(mcp): log and echo X-Pipeshub-Request-Id header

### DIFF
--- a/backend/nodejs/apps/src/modules/mcp/controller/mcp.controller.ts
+++ b/backend/nodejs/apps/src/modules/mcp/controller/mcp.controller.ts
@@ -72,16 +72,16 @@ export const handleMCPRequest =
         res.setHeader('X-Pipeshub-Request-Id', requestId);
       }
 
+      await transport.handleRequest(req, res, req.body);
+
       // Log success with request ID
       logger.info('MCP request completed', {
         method: req.method,
         userId: req.user?.userId as string | undefined,
         requestId,
       });
-
-      await transport.handleRequest(req, res, req.body);
     } catch (error: unknown) {
-      const err = error as Error;
+      const err = error instanceof Error ? error : new Error(String(error));
       const requestIdHeader = req.headers['x-pipeshub-request-id'] as
         | string
         | undefined;

--- a/backend/nodejs/apps/src/modules/mcp/controller/mcp.controller.ts
+++ b/backend/nodejs/apps/src/modules/mcp/controller/mcp.controller.ts
@@ -33,8 +33,13 @@ export const handleMCPRequest =
   ): Promise<void> => {
     try {
       // Extract the raw Bearer token from the Authorization header for the MCP SDK
-      const token = req.headers.authorization?.replace('Bearer ', '') || '';
+      const token = req.headers.authorization?.replace('Bearer ', '') ?? '';
       const serverURL = `${appConfig.oauthBackendUrl}/api/v1`;
+
+      // Read inbound X-Pipeshub-Request-Id header (Express lowercases header keys)
+      const requestId = req.headers['x-pipeshub-request-id'] as
+        | string
+        | undefined;
 
       const { createMCPServer } = await mcpServerModule;
       const { PipeshubCore } = await coreModule;
@@ -61,12 +66,30 @@ export const handleMCPRequest =
       });
 
       await mcpServer.connect(transport);
-      await transport.handleRequest(req, res, req.body);
-    } catch (error: any) {
-      logger.error('MCP request failed', {
-        error: error.message,
+
+      // Echo the request ID back as a response header if the client sent one
+      if (requestId !== undefined && requestId !== '') {
+        res.setHeader('X-Pipeshub-Request-Id', requestId);
+      }
+
+      // Log success with request ID
+      logger.info('MCP request completed', {
         method: req.method,
-        userId: req.user?.userId,
+        userId: req.user?.userId as string | undefined,
+        requestId,
+      });
+
+      await transport.handleRequest(req, res, req.body);
+    } catch (error: unknown) {
+      const err = error as Error;
+      const requestIdHeader = req.headers['x-pipeshub-request-id'] as
+        | string
+        | undefined;
+      logger.error('MCP request failed', {
+        error: err.message,
+        method: req.method,
+        userId: req.user?.userId as string | undefined,
+        requestId: requestIdHeader,
       });
       next(error);
     }

--- a/backend/nodejs/apps/tests/modules/mcp/controller/mcp.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/mcp/controller/mcp.controller.test.ts
@@ -476,7 +476,18 @@ it('should work with GET request', async () => {
       expect(next.called).to.be.false;
     });
 
-    it('should log success with method, userId, and requestId', async () => {
+    it('should log success, echo requestId header, and set header before handleRequest when client sent X-Pipeshub-Request-Id', async () => {
+      let headerSetBeforeHandleRequest = false;
+      const handleRequestStub = sinon.stub().callsFake(() => {
+        return Promise.resolve();
+      });
+      const setHeaderStub = sinon.stub().callsFake(() => {
+        headerSetBeforeHandleRequest = true;
+      });
+      sdkTransportExports.StreamableHTTPServerTransport = class {
+        constructor() {}
+        handleRequest = handleRequestStub;
+      }
       mcpServerExports.createMCPServer = sinon.stub().returns({
         server: { connect: sinon.stub().resolves() },
       });
@@ -490,6 +501,7 @@ it('should work with GET request', async () => {
         body: { jsonrpc: '2.0', method: 'initialize', id: 1 },
       });
       const res = createMockResponse();
+      res.setHeader = setHeaderStub;
       const next = createMockNext();
 
       await handleMCPRequest(appConfig)(req, res as any, next);
@@ -501,9 +513,11 @@ it('should work with GET request', async () => {
         userId: 'user-123',
         requestId: 'req-abc-123',
       });
+      expect(setHeaderStub.calledWith('X-Pipeshub-Request-Id', 'req-abc-123')).to.be.true;
+      expect(headerSetBeforeHandleRequest).to.be.true;
     });
 
-    it('should log success with requestId undefined when header is missing', async () => {
+    it('should log success with requestId undefined and not set response header when header is missing', async () => {
       mcpServerExports.createMCPServer = sinon.stub().returns({
         server: { connect: sinon.stub().resolves() },
       });
@@ -524,73 +538,7 @@ it('should work with GET request', async () => {
         userId: 'user-123',
         requestId: undefined,
       });
-    });
-
-    it('should echo X-Pipeshub-Request-Id response header when client sent one', async () => {
-      mcpServerExports.createMCPServer = sinon.stub().returns({
-        server: { connect: sinon.stub().resolves() },
-      });
-
-      const req = createMockRequest({
-        headers: {
-          authorization: 'Bearer tok',
-          'x-pipeshub-request-id': 'req-echo-456',
-        },
-        body: {},
-      });
-      const res = createMockResponse();
-      const next = createMockNext();
-
-      await handleMCPRequest(appConfig)(req, res as any, next);
-
-      expect(res.setHeader.calledWith('X-Pipeshub-Request-Id', 'req-echo-456')).to.be.true;
-    });
-
-    it('should not set X-Pipeshub-Request-Id response header when client did not send one', async () => {
-      mcpServerExports.createMCPServer = sinon.stub().returns({
-        server: { connect: sinon.stub().resolves() },
-      });
-
-      const req = createMockRequest({
-        headers: { authorization: 'Bearer tok' },
-        body: {},
-      });
-      const res = createMockResponse();
-      const next = createMockNext();
-
-      await handleMCPRequest(appConfig)(req, res as any, next);
-
       expect(res.setHeader.calledWith('X-Pipeshub-Request-Id', sinon.match.any)).to.be.false;
-    });
-
-    it('should set response header before transport.handleRequest is called', async () => {
-      let headerSetBeforeHandleRequest = false;
-      const handleRequestStub = sinon.stub().callsFake(() => {
-        headerSetBeforeHandleRequest = true;
-        return Promise.resolve();
-      });
-      sdkTransportExports.StreamableHTTPServerTransport = class {
-        constructor() {}
-        handleRequest = handleRequestStub;
-      }
-      mcpServerExports.createMCPServer = sinon.stub().returns({
-        server: { connect: sinon.stub().resolves() },
-      });
-
-      const req = createMockRequest({
-        headers: {
-          authorization: 'Bearer tok',
-          'x-pipeshub-request-id': 'req-order-789',
-        },
-        body: {},
-      });
-      const res = createMockResponse();
-      const next = createMockNext();
-
-      await handleMCPRequest(appConfig)(req, res as any, next);
-
-      expect(headerSetBeforeHandleRequest).to.be.true;
-      expect(res.setHeader.calledWith('X-Pipeshub-Request-Id', 'req-order-789')).to.be.true;
     });
   })
 
@@ -699,11 +647,11 @@ it('should work with GET request', async () => {
       expect(next.firstCall.args[0]).to.equal(error)
     })
 
-    it('should log error with requestId when client sent X-Pipeshub-Request-Id header', async () => {
+    it('should log error with requestId when header supplied, and requestId undefined when header absent', async () => {
       const error = new Error('test error message')
       mcpServerExports.createMCPServer = sinon.stub().throws(error)
 
-      const req = createAuthenticatedRequest('user-42', 'org-1', 'user@test.com', {
+      const reqWithId = createAuthenticatedRequest('user-42', 'org-1', 'user@test.com', {
         method: 'POST',
         headers: {
           authorization: 'Bearer tok',
@@ -714,7 +662,7 @@ it('should work with GET request', async () => {
       const res = createMockResponse()
       const next = createMockNext()
 
-      await handleMCPRequest(appConfig)(req, res as any, next)
+      await handleMCPRequest(appConfig)(reqWithId, res as any, next)
 
       expect(errorStub.calledOnce).to.be.true
       expect(errorStub.firstCall.args[0]).to.equal('MCP request failed')
@@ -724,25 +672,22 @@ it('should work with GET request', async () => {
         userId: 'user-42',
         requestId: 'req-error-999',
       })
-    })
 
-    it('should log error with requestId undefined when header is missing', async () => {
-      const error = new Error('no-request-id error')
-      mcpServerExports.createMCPServer = sinon.stub().throws(error)
+      errorStub.resetHistory()
 
-      const req = createAuthenticatedRequest('user-42', 'org-1', 'user@test.com', {
+      const reqWithoutId = createAuthenticatedRequest('user-42', 'org-1', 'user@test.com', {
         method: 'POST',
         headers: { authorization: 'Bearer tok' },
         body: {},
       })
-      const res = createMockResponse()
-      const next = createMockNext()
+      const res2 = createMockResponse()
+      const next2 = createMockNext()
 
-      await handleMCPRequest(appConfig)(req, res as any, next)
+      await handleMCPRequest(appConfig)(reqWithoutId, res2 as any, next2)
 
       expect(errorStub.calledOnce).to.be.true
       expect(errorStub.firstCall.args[1]).to.deep.include({
-        error: 'no-request-id error',
+        error: 'test error message',
         method: 'POST',
         userId: 'user-42',
         requestId: undefined,

--- a/backend/nodejs/apps/tests/modules/mcp/controller/mcp.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/mcp/controller/mcp.controller.test.ts
@@ -377,6 +377,22 @@ describe('MCP Controller — handleMCPRequest', () => {
   // Successful flow
   // =========================================================================
   describe('successful request flow', () => {
+    const loggerInstance = Logger.getInstance()
+    let infoStub: sinon.SinonStub
+
+    beforeEach(() => {
+      if (typeof (loggerInstance.info as any).restore === 'function') {
+        (loggerInstance.info as any).restore()
+      }
+      infoStub = sinon.stub(loggerInstance, 'info')
+    })
+
+    afterEach(() => {
+      if (typeof (loggerInstance.info as any).restore === 'function') {
+        (loggerInstance.info as any).restore()
+      }
+    })
+
     it('should not call next on success', async () => {
       mcpServerExports.createMCPServer = sinon.stub().returns({
         server: { connect: sinon.stub().resolves() },
@@ -442,23 +458,140 @@ describe('MCP Controller — handleMCPRequest', () => {
       expect(next.called).to.be.false
     })
 
-    it('should work with GET request', async () => {
+it('should work with GET request', async () => {
       mcpServerExports.createMCPServer = sinon.stub().returns({
         server: { connect: sinon.stub().resolves() },
-      })
+      });
 
       const req = createMockRequest({
         method: 'GET',
         headers: { authorization: 'Bearer tok' },
         body: {},
-      })
-      const res = createMockResponse()
-      const next = createMockNext()
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
 
-      await handleMCPRequest(appConfig)(req, res as any, next)
+      await handleMCPRequest(appConfig)(req, res as any, next);
 
-      expect(next.called).to.be.false
-    })
+      expect(next.called).to.be.false;
+    });
+
+    it('should log success with method, userId, and requestId', async () => {
+      mcpServerExports.createMCPServer = sinon.stub().returns({
+        server: { connect: sinon.stub().resolves() },
+      });
+
+      const req = createAuthenticatedRequest('user-123', 'org-1', 'user@test.com', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer tok',
+          'x-pipeshub-request-id': 'req-abc-123',
+        },
+        body: { jsonrpc: '2.0', method: 'initialize', id: 1 },
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await handleMCPRequest(appConfig)(req, res as any, next);
+
+      expect(infoStub.calledOnce).to.be.true;
+      expect(infoStub.firstCall.args[0]).to.equal('MCP request completed');
+      expect(infoStub.firstCall.args[1]).to.deep.include({
+        method: 'POST',
+        userId: 'user-123',
+        requestId: 'req-abc-123',
+      });
+    });
+
+    it('should log success with requestId undefined when header is missing', async () => {
+      mcpServerExports.createMCPServer = sinon.stub().returns({
+        server: { connect: sinon.stub().resolves() },
+      });
+
+      const req = createAuthenticatedRequest('user-123', 'org-1', 'user@test.com', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok' },
+        body: { jsonrpc: '2.0', method: 'initialize', id: 1 },
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await handleMCPRequest(appConfig)(req, res as any, next);
+
+      expect(infoStub.calledOnce).to.be.true;
+      expect(infoStub.firstCall.args[1]).to.deep.include({
+        method: 'POST',
+        userId: 'user-123',
+        requestId: undefined,
+      });
+    });
+
+    it('should echo X-Pipeshub-Request-Id response header when client sent one', async () => {
+      mcpServerExports.createMCPServer = sinon.stub().returns({
+        server: { connect: sinon.stub().resolves() },
+      });
+
+      const req = createMockRequest({
+        headers: {
+          authorization: 'Bearer tok',
+          'x-pipeshub-request-id': 'req-echo-456',
+        },
+        body: {},
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await handleMCPRequest(appConfig)(req, res as any, next);
+
+      expect(res.setHeader.calledWith('X-Pipeshub-Request-Id', 'req-echo-456')).to.be.true;
+    });
+
+    it('should not set X-Pipeshub-Request-Id response header when client did not send one', async () => {
+      mcpServerExports.createMCPServer = sinon.stub().returns({
+        server: { connect: sinon.stub().resolves() },
+      });
+
+      const req = createMockRequest({
+        headers: { authorization: 'Bearer tok' },
+        body: {},
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await handleMCPRequest(appConfig)(req, res as any, next);
+
+      expect(res.setHeader.calledWith('X-Pipeshub-Request-Id', sinon.match.any)).to.be.false;
+    });
+
+    it('should set response header before transport.handleRequest is called', async () => {
+      let headerSetBeforeHandleRequest = false;
+      const handleRequestStub = sinon.stub().callsFake(() => {
+        headerSetBeforeHandleRequest = true;
+        return Promise.resolve();
+      });
+      sdkTransportExports.StreamableHTTPServerTransport = class {
+        constructor() {}
+        handleRequest = handleRequestStub;
+      }
+      mcpServerExports.createMCPServer = sinon.stub().returns({
+        server: { connect: sinon.stub().resolves() },
+      });
+
+      const req = createMockRequest({
+        headers: {
+          authorization: 'Bearer tok',
+          'x-pipeshub-request-id': 'req-order-789',
+        },
+        body: {},
+      });
+      const res = createMockResponse();
+      const next = createMockNext();
+
+      await handleMCPRequest(appConfig)(req, res as any, next);
+
+      expect(headerSetBeforeHandleRequest).to.be.true;
+      expect(res.setHeader.calledWith('X-Pipeshub-Request-Id', 'req-order-789')).to.be.true;
+    });
   })
 
   // =========================================================================
@@ -564,6 +697,56 @@ describe('MCP Controller — handleMCPRequest', () => {
 
       expect(next.calledOnce).to.be.true
       expect(next.firstCall.args[0]).to.equal(error)
+    })
+
+    it('should log error with requestId when client sent X-Pipeshub-Request-Id header', async () => {
+      const error = new Error('test error message')
+      mcpServerExports.createMCPServer = sinon.stub().throws(error)
+
+      const req = createAuthenticatedRequest('user-42', 'org-1', 'user@test.com', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer tok',
+          'x-pipeshub-request-id': 'req-error-999',
+        },
+        body: {},
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+
+      await handleMCPRequest(appConfig)(req, res as any, next)
+
+      expect(errorStub.calledOnce).to.be.true
+      expect(errorStub.firstCall.args[0]).to.equal('MCP request failed')
+      expect(errorStub.firstCall.args[1]).to.deep.include({
+        error: 'test error message',
+        method: 'POST',
+        userId: 'user-42',
+        requestId: 'req-error-999',
+      })
+    })
+
+    it('should log error with requestId undefined when header is missing', async () => {
+      const error = new Error('no-request-id error')
+      mcpServerExports.createMCPServer = sinon.stub().throws(error)
+
+      const req = createAuthenticatedRequest('user-42', 'org-1', 'user@test.com', {
+        method: 'POST',
+        headers: { authorization: 'Bearer tok' },
+        body: {},
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+
+      await handleMCPRequest(appConfig)(req, res as any, next)
+
+      expect(errorStub.calledOnce).to.be.true
+      expect(errorStub.firstCall.args[1]).to.deep.include({
+        error: 'no-request-id error',
+        method: 'POST',
+        userId: 'user-42',
+        requestId: undefined,
+      })
     })
 
     // it('should log error with error.message, req.method, and req.user.userId', async () => {


### PR DESCRIPTION
## Description

The `pipeshub` CLI sends an `X-Pipeshub-Request-Id` header on every /mcp
request, but the backend never logged it, so client-side traces couldn't
be correlated with the exact request that served them.

This PR reads the inbound `X-Pipeshub-Request-Id` header, logs it alongside
the existing method/userId metadata on both the success and error paths,
and echoes it back as a response header when the client sent one — so
clients can confirm the correlation landed. No new ID is generated when the
header is absent.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues
- Fixes #2945

## How Has This Been Tested?
Added unit tests covering: requestId included in success-path log, requestId
included in error-path log, response header echoed when present, response
header not set when absent.

### Test Configuration
- [x] Unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for propagating request IDs through successful MCP responses.
  * Request IDs are now included in related success and error logs for improved request tracking.

* **Bug Fixes**
  * Improved handling when optional authentication values are missing.
  * Enhanced error reporting with consistent error details and request context.
  * Ensured successful request processing completes before success status logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->