### PR TITLE
fix(openapi): declare usesOrgDefault on the create-agent response

### DIFF
--- a/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
+++ b/backend/nodejs/apps/src/modules/api-docs/pipeshub-openapi.yaml
@@ -9777,6 +9777,7 @@ components:
         - systemPrompt
         - instructions
         - models
+        - usesOrgDefault
         - tags
         - webSearch
         - isActive
@@ -9808,6 +9809,13 @@ components:
           type: array
           items:
             type: string
+        usesOrgDefault:
+          type: boolean
+          description: |
+            True when this agent has no models configured and will use the
+            organization's default LLM (marked `isDefault: true` in the AI
+            models configuration) at chat time. Derived from `models` being
+            empty — not persisted separately.
         tags:
           type: array
           items:

--- a/integration-tests/response-validation/enterprise-search/agents/integration_test_agents.py
+++ b/integration-tests/response-validation/enterprise-search/agents/integration_test_agents.py
@@ -524,10 +524,10 @@ class TestCreateAgent(AgentsTestBase):
 
         agent = body["agent"]
         assert agent.get("models") == [], f"Expected empty models, got: {agent!r}"
+        assert agent.get("usesOrgDefault") is True, f"Expected usesOrgDefault=True, got: {agent!r}"
         assert_response_matches_openapi_operation(body, "createAgent", status_code="201")
 
-        # `usesOrgDefault` is derived on read paths only, not on the create
-        # response — assert it via GET.
+        # The read path derives the same flag independently of the create response.
         get_resp = self.agents.get_agent(agent_key)
         assert get_resp.status_code == 200, f"{get_resp.status_code}: {get_resp.text}"
         get_agent = _response_json(get_resp)["agent"]
@@ -554,6 +554,7 @@ class TestCreateAgent(AgentsTestBase):
 
         agent = body["agent"]
         assert agent.get("models") == [], f"Expected empty models, got: {agent!r}"
+        assert agent.get("usesOrgDefault") is True, f"Expected usesOrgDefault=True, got: {agent!r}"
 
         # A subsequent GET reflects the same model-free state.
         get_resp = self.agents.get_agent(agent_key)
@@ -1300,9 +1301,8 @@ class TestUpdateAgent(AgentsTestBase):
         agent_key = self._created_agent_key(create_body)
         created_agent_keys.append(agent_key)
 
-        # Baseline: no models yet, so the read path reports the org-default fallback.
-        baseline_agent = _response_json(self._get_agent_raw(agent_key))["agent"]
-        assert baseline_agent.get("usesOrgDefault") is True
+        # Baseline: no models yet, so the agent reports the org-default fallback.
+        assert create_body["agent"].get("usesOrgDefault") is True
 
         # Add a model via update.
         add_payload = _build_update_payload(seeded_model=reasoning_multimodal_llm_model)

--- a/integration-tests/response-validation/enterprise-search/conversations/integration_test_agent_conversation_stream.py
+++ b/integration-tests/response-validation/enterprise-search/conversations/integration_test_agent_conversation_stream.py
@@ -357,12 +357,7 @@ class TestAgentConversationStream(_AgentStreamTestBase):
         agent_key = agent["_key"]
         try:
             assert agent.get("models") == [], f"Expected empty models, got: {agent!r}"
-
-            # `usesOrgDefault` is derived on read paths only, not on the
-            # create response — assert it via GET.
-            get_resp = self.agents.get_agent(agent_key)
-            assert get_resp.status_code == 200, f"{get_resp.status_code}: {get_resp.text}"
-            assert get_resp.json()["agent"].get("usesOrgDefault") is True
+            assert agent.get("usesOrgDefault") is True
 
             outcome = self._stream_agent_conversation(
                 agent_key,


### PR DESCRIPTION
## Problem

Three `TestCreateAgent` integration tests fail on every run against `main`:

```
FAILED response-validation/enterprise-search/agents/integration_test_agents.py::TestCreateAgent::test_create_agent_rich_payload_matches_openapi_and_creates
FAILED response-validation/enterprise-search/agents/integration_test_agents.py::TestCreateAgent::test_create_agent_response_matches_openapi_spec
FAILED response-validation/enterprise-search/agents/integration_test_agents.py::TestCreateAgent::test_create_agent_without_models_field_succeeds_and_uses_org_default
```

All three with the same assertion:

```
AssertionError: Response does not match OpenAPI schema for operationId='createAgent'
status='201': Additional properties are not allowed ('usesOrgDefault' was unexpected)
```

## Cause

#2952 added an unconditional field to the create-agent response in `backend/python/app/api/routes/agent.py`:

```python
response_agent["usesOrgDefault"] = not response_agent.get("models")
```

`AgentCreateResponseAgent` is `additionalProperties: false` and does not declare `usesOrgDefault`, so every create-agent response now fails validation. The field *was* already declared on the read schemas, which is why `getAgent` and the list endpoint kept validating fine — only `createAgent` was left out of sync.

These three are the only `TestCreateAgent` cases that validate the 201 body against the spec, which is why their siblings still pass.

## Fix

Declare `usesOrgDefault` on `AgentCreateResponseAgent`, reusing the description already used on the read schemas. It is marked `required` because the route sets it on every response — that is the contract callers can actually rely on.

The integration tests that had worked around the gap with an extra `GET` now assert the flag on the create response directly. `test_create_agent_without_models_field_...` keeps its `GET` assertion, since the read path derives the flag independently and is worth covering separately.

## Verification

Replayed the failing payload shapes through the same validator the integration tests use (`response-validation/helper/openapi_schema_validator.py`):

```
PASS  without_models_field (no models -> usesOrgDefault True)
PASS  response_matches_openapi_spec (models present)
PASS  rich_payload (knowledge + webSearch + toolsets)
PASS  partial_success with warnings
FAIL  NEGATIVE: usesOrgDefault omitted  ->  'usesOrgDefault' is a required property
```

The negative case is expected to fail — it confirms `required` is enforced rather than merely permitted.

`spectral lint --ruleset .spectral.yaml --fail-severity error` reports an identical 70 problems / 7 errors before and after this change, so no new spec-lint findings are introduced. The Python unit tests added by #2952 that assert `usesOrgDefault` on create continue to hold unchanged.

## Not addressed here

The `jira`/`linear` `test_tc_update_001` failures in the same runs are unrelated and are **not** a code regression. The `arango` and `neo4j` matrix jobs run concurrently against the same Jira/Linear tenants (`integration-tests.yml` gives both jobs the same `JIRA_TEST_*` / `LINEAR_TEST_*` secrets) and both mutate the same reference issue. Each job read the other's edit:

| Job | Expected | Found |
| --- | --- | --- |
| arango | `PHIT-Edited-d40ec350` | `[KAN-4] PHIT-Edited-`**`6d7a71a1`** |
| neo4j | `PHIT-Edited-`**`6d7a71a1`** | `[KAN-4] Testing ref issue` |

Linear fails the same way at different assertions (stale `external_revision_id`, record count 41→40), as does `TestLinearEdges::test_tc_linear_edges_001_edge_inventory` and `azure_blob` TC-UPDATE-001 (`The specified blob does not exist`). Fixing that needs per-job isolation of the external fixtures (separate Jira project / Linear team / blob prefix) or serialization of the mutating connector tests across the matrix — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent responses now include a `usesOrgDefault` indicator showing when the organization’s default language model will be used because no model is configured.

* **Tests**
  * Updated agent creation and conversation validation to verify the new default-model indicator directly in responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->