### PR TITLE
Fix: track token refresh background tasks so they are not GC'd or leaked

### DIFF
--- a/backend/python/app/connectors/core/base/token_service/token_refresh_service.py
+++ b/backend/python/app/connectors/core/base/token_service/token_refresh_service.py
@@ -48,6 +48,7 @@ class TokenRefreshService:
         self._messaging_producer = messaging_producer
         self.logger = logging.getLogger("connector_service")
         self._refresh_tasks: dict[str, asyncio.Task] = {}
+        self._background_tasks: list[asyncio.Task] = []
         self._running = False
         self._refresh_lock = asyncio.Lock()  # Prevent concurrent refresh operations
         self._processing_connectors: set = set()  # Track connectors currently being processed to prevent recursion
@@ -77,14 +78,24 @@ class TokenRefreshService:
         if wait_for_initial_refresh:
             await self._refresh_all_tokens()
         else:
-            asyncio.create_task(self._refresh_all_tokens())
+            self._background_tasks.append(asyncio.create_task(self._refresh_all_tokens()))
 
         # Start periodic refresh check
-        asyncio.create_task(self._periodic_refresh_check())
+        self._background_tasks.append(asyncio.create_task(self._periodic_refresh_check()))
 
     async def stop(self) -> None:
         """Stop the token refresh service"""
         self._running = False
+
+        # Cancel the initial-scan/periodic loop tasks too, not just per-connector
+        # refreshes. Without this, an in-flight initial scan (or a periodic loop
+        # mid-sleep) keeps running after stop() returns, since `_running = False`
+        # alone is only checked at the loops' next iteration. Holding the
+        # references also keeps the tasks from being garbage collected while
+        # they run, as the event loop only keeps weak references to them.
+        for task in self._background_tasks:
+            task.cancel()
+        self._background_tasks.clear()
 
         # Cancel all refresh tasks
         for task in self._refresh_tasks.values():

--- a/backend/python/app/connectors/core/base/token_service/toolset_token_refresh_service.py
+++ b/backend/python/app/connectors/core/base/token_service/toolset_token_refresh_service.py
@@ -47,6 +47,7 @@ class ToolsetTokenRefreshService:
         self.configuration_service = configuration_service
         self.logger = logging.getLogger("connector_service")
         self._refresh_tasks: Dict[str, asyncio.Task] = {}
+        self._background_tasks: list[asyncio.Task] = []
         self._running = False
         self._refresh_lock = asyncio.Lock()  # Prevent concurrent refresh operations
         self._processing_toolsets: set = set()  # Track toolsets currently being processed to prevent recursion
@@ -98,17 +99,27 @@ class ToolsetTokenRefreshService:
         if wait_for_initial_refresh:
             await self._refresh_all_tokens()
         else:
-            asyncio.create_task(self._refresh_all_tokens())
+            self._background_tasks.append(asyncio.create_task(self._refresh_all_tokens()))
 
         # Start periodic refresh check
-        asyncio.create_task(self._periodic_refresh_check())
+        self._background_tasks.append(asyncio.create_task(self._periodic_refresh_check()))
 
         # Start periodic lock cleanup
-        asyncio.create_task(self._cleanup_old_locks())
+        self._background_tasks.append(asyncio.create_task(self._cleanup_old_locks()))
 
     async def stop(self) -> None:
         """Stop the toolset token refresh service"""
         self._running = False
+
+        # Cancel the initial-scan/periodic loop tasks too, not just per-toolset
+        # refreshes. Without this, an in-flight initial scan (or a periodic loop
+        # mid-sleep) keeps running after stop() returns, since `_running = False`
+        # alone is only checked at the loops' next iteration. Holding the
+        # references also keeps the tasks from being garbage collected while
+        # they run, as the event loop only keeps weak references to them.
+        for task in self._background_tasks:
+            task.cancel()
+        self._background_tasks.clear()
 
         # Cancel all refresh tasks
         for task in self._refresh_tasks.values():


### PR DESCRIPTION
`TokenRefreshService` and `ToolsetTokenRefreshService` throw away the task handles when they start their background loops:

```python
asyncio.create_task(self._refresh_all_tokens())
asyncio.create_task(self._periodic_refresh_check())
```

Two things go wrong with that.

The event loop only keeps a weak reference to a running task, so a task nothing else holds can get collected while it's still running. If `_periodic_refresh_check` goes, OAuth refresh just stops. Connectors keep working until the tokens expire and there's nothing in the logs pointing at why.

And `stop()` can't stop those loops. It only cancels `_refresh_tasks`, which is the per-connector refreshes. The periodic loop is normally parked in `await asyncio.sleep(300)`, so it doesn't see `_running = False` until its next iteration and keeps going after `stop()` has returned.

`MCPTokenRefreshService` already handles this — it keeps the handles in `_background_tasks` and cancels them in `stop()`. The comment there says the same thing:

> Cancel the initial-scan/periodic loop tasks too, not just per-credential delayed refreshes — without this, an in-flight initial scan (or a periodic loop mid-sleep) keeps running after stop() returns and can schedule new refresh tasks post-shutdown

So this is just that same pattern in the other two services. Nothing changes while they're running.

Also worth saying that startup relies on these surviving — `startup_service.py` starts all three with `wait_for_initial_refresh=False` so startup isn't blocked, with the comment "The first scan runs as a background task and the periodic refresher takes over afterwards".

I found it with `ruff check --select RUF006`, which isn't in the current select list. There are 9 more hits in the connectors and `api/routes/mcp_servers.py` if you'd want that rule on repo-wide — happy to do it separately, felt like its own call.

`ruff check` on that directory gives the same 66 pre-existing findings before and after, so this doesn't add any.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown handling for background token refresh processes.
  * Ensured scheduled initial scans, periodic refreshes, and cleanup tasks are properly cancelled and cleared when services stop.
  * Reduced the risk of lingering background activity after shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->