### PR TITLE
fix(agent): drop usesOrgDefault from the create-agent response

### DIFF
--- a/backend/python/app/api/routes/agent.py
+++ b/backend/python/app/api/routes/agent.py
@@ -2031,7 +2031,6 @@ async def create_agent(request: Request) -> JSONResponse:
             response_agent.get("webSearch"),
         )
         response_agent["createdBy"] = user_context["userId"]
-        response_agent["usesOrgDefault"] = not response_agent.get("models")
 
         all_failed = failed_toolsets + failed_mcp_servers
         status = "partial_success" if all_failed else "success"

--- a/backend/python/tests/unit/api/routes/test_agent.py
+++ b/backend/python/tests/unit/api/routes/test_agent.py
@@ -2870,7 +2870,6 @@ class TestCreateAgent:
 
             result = await create_agent(request)
             assert result.status_code == 200
-            assert json.loads(result.body)["agent"]["usesOrgDefault"] is True
 
     @pytest.mark.asyncio
     async def test_omitted_models_allowed_falls_back_to_org_default(self) -> None:
@@ -2893,7 +2892,6 @@ class TestCreateAgent:
 
             result = await create_agent(request)
             assert result.status_code == 200
-            assert json.loads(result.body)["agent"]["usesOrgDefault"] is True
 
     @pytest.mark.asyncio
     async def test_no_reasoning_model_raises(self) -> None:
@@ -2931,7 +2929,6 @@ class TestCreateAgent:
 
             result = await create_agent(request)
             assert result.status_code == 200
-            assert json.loads(result.body)["agent"]["usesOrgDefault"] is False
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

Three `TestCreateAgent` integration tests fail on every run against `main`:

```
FAILED response-validation/enterprise-search/agents/integration_test_agents.py::TestCreateAgent::test_create_agent_rich_payload_matches_openapi_and_creates
FAILED response-validation/enterprise-search/agents/integration_test_agents.py::TestCreateAgent::test_create_agent_response_matches_openapi_spec
FAILED response-validation/enterprise-search/agents/integration_test_agents.py::TestCreateAgent::test_create_agent_without_models_field_succeeds_and_uses_org_default
```

All three with the same assertion:

```
AssertionError: Response does not match OpenAPI schema for operationId='createAgent'
status='201': Additional properties are not allowed ('usesOrgDefault' was unexpected)
```

These are the only `TestCreateAgent` cases that validate the 201 body against the spec, which is why their siblings still pass.

## Cause

`usesOrgDefault` is a **read-path projection**. It is derived in `_enrich_agent_models` for `GET /agents/{agentKey}` and per-agent on the list route, and is deliberately not part of the create contract — that boundary was settled in #2964.

#2952 set it on the create response as an unrelated drive-by change:

```python
response_agent["usesOrgDefault"] = not response_agent.get("models")
```

`AgentCreateResponseAgent` is `additionalProperties: false` and does not declare the field, so every create-agent response began failing validation.

## Fix

Revert the create-path assignment and the three unit assertions added alongside it. Both files return to their exact pre-#2952 blobs (`a7e294cc`, `78ee26ec`).

The GET and list derivations are untouched, so callers that need the flag still get it from the read paths — which is where the integration tests already assert it.

The alternative, declaring the field on `AgentCreateResponseAgent`, was tried in #3024 and rejected: it would ratify a change that was never intended and widen the create contract for no caller that asked for it.

## Verification

- All 271 unit tests in `backend/python/tests/unit/api/routes/test_agent.py` pass.
- Replayed the create-response shapes through the validator the integration tests use (`response-validation/helper/openapi_schema_validator.py`) against the unmodified spec:

```
PASS  without_models_field
PASS  response_matches_openapi_spec (models present)
PASS  rich_payload (knowledge + webSearch + toolsets)
PASS  partial_success with warnings
FAIL  NEGATIVE: usesOrgDefault present  ->  Additional properties are not allowed
```

The negative case is expected to fail — it confirms the schema guard stays live if the field is ever re-added.

- `ruff check` on both changed files: identical 22 pre-existing findings before and after, so no new lint.

## Not addressed here

The `jira`/`linear` `test_tc_update_001` failures in the same CI runs are unrelated and are **not** a code regression. The `arango` and `neo4j` matrix jobs run concurrently against the same Jira/Linear tenants (`integration-tests.yml` gives both jobs the same `JIRA_TEST_*` / `LINEAR_TEST_*` secrets) and both mutate the same reference issue. Each job read the other's edit:

| Job | Expected | Found |
| --- | --- | --- |
| arango | `PHIT-Edited-d40ec350` | `[KAN-4] PHIT-Edited-`**`6d7a71a1`** |
| neo4j | `PHIT-Edited-`**`6d7a71a1`** | `[KAN-4] Testing ref issue` |

Linear fails the same way at different assertions (stale `external_revision_id`, record count 41→40), as do `TestLinearEdges::test_tc_linear_edges_001_edge_inventory` and `azure_blob` TC-UPDATE-001 (`The specified blob does not exist`). Fixing that needs per-job isolation of the external fixtures (separate Jira project / Linear team / blob prefix) or serialization of the mutating connector tests across the matrix — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the `usesOrgDefault` field from agent creation responses.
  * Agent creation behavior and other response details remain unchanged.

* **Tests**
  * Updated agent creation checks to reflect the streamlined response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->