### PR TITLE
fix(config): support Qdrant Cloud via QDRANT_HTTPS and QDRANT_PREFER_GRPC env vars

### DIFF
--- a/backend/nodejs/apps/src/modules/tokens_manager/services/cm.service.ts
+++ b/backend/nodejs/apps/src/modules/tokens_manager/services/cm.service.ts
@@ -215,11 +215,18 @@ export class ConfigService {
 
   // Qdrant Configuration
   public async getQdrantConfig(): Promise<QdrantConfig> {
+    // https + prefer_grpc required for managed Qdrant Cloud (TLS on 6333/6334).
+    const qdrantHttps = (process.env.QDRANT_HTTPS || 'false').toLowerCase() === 'true';
+    const qdrantPreferGrpc =
+      (process.env.QDRANT_PREFER_GRPC || 'true').toLowerCase() === 'true';
+
     await this.saveConfigToEtcd(configPaths.db.qdrant, {
       apiKey: process.env.QDRANT_API_KEY!,
       host: process.env.QDRANT_HOST || 'localhost',
       port: parseInt(process.env.QDRANT_PORT || '6333', 10),
       grpcPort: parseInt(process.env.QDRANT_GRPC_PORT || '6334', 10),
+      https: qdrantHttps,
+      prefer_grpc: qdrantPreferGrpc,
     });
 
     return this.getEncryptedConfig<QdrantConfig>(configPaths.db.qdrant, {
@@ -227,6 +234,8 @@ export class ConfigService {
       host: process.env.QDRANT_HOST || 'localhost',
       port: parseInt(process.env.QDRANT_PORT || '6333', 10),
       grpcPort: parseInt(process.env.QDRANT_GRPC_PORT || '6334', 10),
+      https: qdrantHttps,
+      prefer_grpc: qdrantPreferGrpc,
     });
   }
 

--- a/backend/python/app/config/configuration_service.py
+++ b/backend/python/app/config/configuration_service.py
@@ -172,6 +172,9 @@ class ConfigurationService:
                     "port": int(os.getenv("QDRANT_PORT", "6333")),
                     "grpcPort": int(os.getenv("QDRANT_GRPC_PORT", "6334")),
                     "apiKey": os.getenv("QDRANT_API_KEY", "qdrant"),
+                    # Needed for managed Qdrant Cloud (TLS on 6333/6334).
+                    "https": os.getenv("QDRANT_HTTPS", "false").lower() == "true",
+                    "prefer_grpc": os.getenv("QDRANT_PREFER_GRPC", "true").lower() == "true",
                 }
         elif key == config_node_constants.OPENSEARCH.value:
             # OpenSearch configuration fallback


### PR DESCRIPTION
## Description

Adds `QDRANT_HTTPS` and `QDRANT_PREFER_GRPC` env vars so PipesHub can talk to Qdrant Cloud (or any TLS-terminated Qdrant) without a source-code edit. Both default to current behavior — no impact on existing self-hosted / local-Docker deployments.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

- Fixes #3054

## Root cause

`QdrantConfig.from_dict` (`backend/python/app/services/vector_db/qdrant/config.py`) already reads `https` and `prefer_grpc` from its input dict, but neither of the two paths that populate that dict passed them through:

- `ConfigurationService._get_env_fallback` at `backend/python/app/config/configuration_service.py:156-165` only mapped host/port/api-key from env.
- `ConfigService.getQdrantConfig` at `backend/nodejs/apps/src/modules/tokens_manager/services/cm.service.ts:217-231` seeds the KV store with the same four fields on Node startup, which masks the Python env fallback.

Result: Qdrant Cloud attempts fall back to plaintext gRPC and fail with `UNIMPLEMENTED: Received http2 header with status: 404`.

## The change

Two small edits, both additive:

- **Python** (`configuration_service.py`) — read `QDRANT_HTTPS` and `QDRANT_PREFER_GRPC` and include them in the returned dict.
- **Node** (`cm.service.ts`) — read the same two env vars and include them in the KV entry Node writes on startup.

Defaults: `https=false`, `prefer_grpc=true` — identical to current behavior.

## How Has This Been Tested?

Manual, end-to-end against a Qdrant Cloud free-tier cluster:

1. `.env` (Node + Python):
   ```
   QDRANT_HOST=<cluster>.aws.cloud.qdrant.io
   QDRANT_PORT=6333
   QDRANT_API_KEY=<key>
   QDRANT_HTTPS=true
   QDRANT_PREFER_GRPC=false
   ```
2. Started all services per `CONTRIBUTING.md` (from source).
3. **Before fix:** `curl http://localhost:3000/api/v1/health` → `vectorDb: unhealthy` (gRPC UNIMPLEMENTED).
4. **After fix:** `curl http://localhost:3000/api/v1/health` → `vectorDb: healthy`; direct connector probe `http://localhost:8088/health/vector-db` returns 200 with `latency_ms: 270.06`.

### Test Configuration

- [x] Manual testing completed

## Breaking Changes

None. Both env vars default to the existing behavior when unset.

## Follow-up (out of scope for this PR)

The UI-facing `qdrantConfigSchema` (`backend/nodejs/apps/src/modules/configuration_manager/validator/validators.ts:196`) also omits `https` and `prefer_grpc`, so users who configure Qdrant via the admin dashboard hit the same gap. Happy to open a follow-up if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Qdrant connections over HTTPS.
  * Added an option to prefer gRPC connections.
  * These settings can be controlled through environment configuration and are preserved across saved and fallback configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->