### PR TITLE
fix: update process_event tests to match debug-level logging

### DIFF
--- a/backend/python/tests/unit/connectors/core/test_event_service.py
+++ b/backend/python/tests/unit/connectors/core/test_event_service.py
@@ -232,13 +232,13 @@ class TestProcessEvent:
         """process_event logs the event type."""
         svc = _make_event_service()
         await svc.process_event("sync_start", {})
-        svc.logger.info.assert_called()
+        svc.logger.debug.assert_called()
 
     @pytest.mark.asyncio
     async def test_process_exception_returns_false(self):
         """Exception during process_event returns False (lines 61-63)."""
         svc = _make_event_service()
-        svc.logger.info.side_effect = RuntimeError("log error")
+        svc.logger.debug.side_effect = RuntimeError("log error")
         result = await svc.process_event("sync_start", {})
         assert result is False
         svc.logger.error.assert_called()


### PR DESCRIPTION
#3070 changed BaseEventService.process_event to log via logger.debug instead of logger.info, but the corresponding unit tests (test_process_logs_info, test_process_exception_returns_false) were left asserting on logger.info. This makes them fail deterministically (not flaky) on every branch built off main since that merge. Updates both assertions to match the current .debug() call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated event processing tests to verify debug-level logging, including when an exception occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->