### PR TITLE
fixed 413 for telemetry

### DIFF
--- a/backend/nodejs/apps/src/libs/middlewares/telemetry.middleware.ts
+++ b/backend/nodejs/apps/src/libs/middlewares/telemetry.middleware.ts
@@ -6,19 +6,9 @@ import {
   normalizeOrgId,
 } from '../services/telemetry/identity';
 
-const ID_SEGMENT = /^([0-9a-fA-F]{24}|[0-9a-fA-F-]{32,36}|\d+)$/;
-
 type MetricsRequest = AuthenticatedUserRequest & {
   __metricsAttached?: boolean;
 };
-
-function normalizePath(path: string): string {
-  const normalized = path
-    .split('/')
-    .map((seg) => (ID_SEGMENT.test(seg) ? ':id' : seg))
-    .join('/');
-  return normalized === '' ? '/' : normalized;
-}
 
 function getRouteTemplate(req: AuthenticatedUserRequest): string {
   const route: unknown = req.route;
@@ -28,7 +18,8 @@ function getRouteTemplate(req: AuthenticatedUserRequest): string {
       return `${req.baseUrl}${routePath}`;
     }
   }
-  return normalizePath(req.path);
+  // Raw paths (assets, 404s, bot scans) are unbounded label values.
+  return 'unmatched';
 }
 
 function getOrgId(req: AuthenticatedUserRequest): string {

--- a/backend/nodejs/apps/src/libs/services/telemetry/metrics-backend.ts
+++ b/backend/nodejs/apps/src/libs/services/telemetry/metrics-backend.ts
@@ -33,6 +33,8 @@ export interface MetricsBackend {
   createHistogram(def: HistogramDefinition): HistogramHandle;
   /** Serialize all registered metrics in the backend's exposition format. */
   serialize(): Promise<string>;
+  /** Drop all recorded series. */
+  reset(): void;
 }
 
 /** prom-client implementation of {@link MetricsBackend}. */
@@ -91,6 +93,10 @@ export class PrometheusBackend implements MetricsBackend {
 
   serialize(): Promise<string> {
     return this.registry.metrics();
+  }
+
+  reset(): void {
+    this.registry.resetMetrics();
   }
 }
 

--- a/backend/nodejs/apps/src/libs/services/telemetry/modules/http-metrics.ts
+++ b/backend/nodejs/apps/src/libs/services/telemetry/modules/http-metrics.ts
@@ -14,6 +14,21 @@ const httpRequestDuration = metricsBackend.createHistogram({
   buckets: [0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
 });
 
+// Unbounded route values grow the push payload until the collector rejects it.
+const MAX_UNIQUE_ROUTES = 300;
+const seenRoutes = new Set<string>();
+
+function boundRoute(route: string): string {
+  if (seenRoutes.has(route)) {
+    return route;
+  }
+  if (seenRoutes.size >= MAX_UNIQUE_ROUTES) {
+    return 'other';
+  }
+  seenRoutes.add(route);
+  return route;
+}
+
 export function recordHttpRequest(
   route: string,
   method: string,
@@ -24,7 +39,7 @@ export function recordHttpRequest(
 ): void {
   const labels = {
     service: SERVICE_NAME,
-    route: route === '' ? 'unmatched' : route,
+    route: boundRoute(route === '' ? 'unmatched' : route),
     method,
     status: String(statusCode),
     org: orgId == null || orgId === '' ? 'unknown' : orgId,

--- a/backend/nodejs/apps/src/libs/services/telemetry/telemetry.service.ts
+++ b/backend/nodejs/apps/src/libs/services/telemetry/telemetry.service.ts
@@ -289,6 +289,15 @@ export class TelemetryService implements ITelemetryService {
       );
       logger.debug('Successfully pushed metrics to server');
     } catch (error: unknown) {
+      // The registry only grows, so a 413 would otherwise recur until restart.
+      if (axios.isAxiosError(error) && error.response?.status === 413) {
+        logger.warn(
+          'Collector rejected metrics payload as too large; resetting metric registry',
+          { serverUrl: this.metricsServerUrl },
+        );
+        metricsBackend.reset();
+        return;
+      }
       this.handlePushError(error);
     }
   }

--- a/backend/nodejs/apps/tests/libs/middlewares/telemetry.middleware.test.ts
+++ b/backend/nodejs/apps/tests/libs/middlewares/telemetry.middleware.test.ts
@@ -48,7 +48,7 @@ describe('telemetry middleware', () => {
 
   it('should record method, status, and a positive duration on finish', () => {
     const middleware = metricsMiddleware();
-    const req = mockReq({ method: 'POST' });
+    const req = mockReq({ method: 'POST', route: { path: '/api/v1/users' } });
     const res = mockRes(201);
 
     middleware(req, res as any, sinon.stub());
@@ -77,30 +77,17 @@ describe('telemetry middleware', () => {
     expect(recordStub.firstCall.args[0]).to.equal('/api/v1/users/:userId');
   });
 
-  it('should normalize id-like segments when no route template matched (404s stay low-cardinality)', () => {
+  it('should record "unmatched" when no route template matched (404s, assets, and bot scans stay one series)', () => {
     const middleware = metricsMiddleware();
     const req = mockReq({
-      path: '/api/v1/users/507f1f77bcf86cd799439011/items/42/e2c1a1f0-1234-4abc-9def-1234567890ab',
+      path: '/assets/index-Bo3xK9qw.js',
     });
     const res = mockRes(404);
 
     middleware(req, res as any, sinon.stub());
     res.emit('finish');
 
-    expect(recordStub.firstCall.args[0]).to.equal(
-      '/api/v1/users/:id/items/:id/:id',
-    );
-  });
-
-  it('should record "/" for an empty path', () => {
-    const middleware = metricsMiddleware();
-    const req = mockReq({ path: '' });
-    const res = mockRes();
-
-    middleware(req, res as any, sinon.stub());
-    res.emit('finish');
-
-    expect(recordStub.firstCall.args[0]).to.equal('/');
+    expect(recordStub.firstCall.args[0]).to.equal('unmatched');
   });
 
   it('should extract org and email-domain from the authenticated user', () => {

--- a/backend/nodejs/apps/tests/libs/services/telemetry/metrics-backend.test.ts
+++ b/backend/nodejs/apps/tests/libs/services/telemetry/metrics-backend.test.ts
@@ -95,6 +95,33 @@ describe('telemetry metrics-backend (PrometheusBackend)', () => {
     });
   });
 
+  describe('reset', () => {
+    it('should drop all series so the next push starts from an empty registry', async () => {
+      const counter = backend.createCounter({
+        name: 'test_reset_total',
+        help: 'test',
+        labelNames: ['k'],
+      });
+      const histogram = backend.createHistogram({
+        name: 'test_reset_seconds',
+        help: 'test',
+        labelNames: ['k'],
+        buckets: [1],
+      });
+      counter.inc({ k: 'a' });
+      histogram.observe({ k: 'a' }, 0.5);
+
+      backend.reset();
+
+      const text = await backend.serialize();
+      expect(text).to.not.include('test_reset_total{');
+      expect(text).to.not.include('test_reset_seconds_count{');
+
+      counter.inc({ k: 'a' });
+      expect(await backend.serialize()).to.include('test_reset_total{k="a"} 1');
+    });
+  });
+
   describe('serialize', () => {
     it('should use an isolated registry per backend instance', async () => {
       const other = new PrometheusBackend();

--- a/backend/nodejs/apps/tests/libs/services/telemetry/modules/http-metrics.test.ts
+++ b/backend/nodejs/apps/tests/libs/services/telemetry/modules/http-metrics.test.ts
@@ -44,4 +44,21 @@ describe('telemetry modules/http-metrics', () => {
       'pipeshub_http_requests_total{service="node_api",route="/api/v1/repeat",method="GET",status="200",org="org2",domain="x.io"} 2',
     );
   });
+
+  // Must run last: fills the module-level unique-route set up to the cap.
+  it('should collapse routes beyond the unique-route cap into "other"', async () => {
+    for (let i = 0; i < 300; i++) {
+      recordHttpRequest(`/api/v1/cap/${i}`, 'GET', 200, 'org1', undefined, 'a.io');
+    }
+    recordHttpRequest('/api/v1/overflow', 'GET', 200, 'org1', undefined, 'a.io');
+    recordHttpRequest('/api/v1/repeat', 'GET', 200, 'org2', undefined, 'x.io');
+
+    const text = await metricsBackend.serialize();
+    expect(text).to.not.include('route="/api/v1/overflow"');
+    expect(text).to.match(/pipeshub_http_requests_total\{[^}]*route="other"/);
+    // Routes seen before the cap keep recording under their own label.
+    expect(text).to.include(
+      'pipeshub_http_requests_total{service="node_api",route="/api/v1/repeat",method="GET",status="200",org="org2",domain="x.io"} 3',
+    );
+  });
 });

--- a/backend/nodejs/apps/tests/libs/services/telemetry/telemetry.service.test.ts
+++ b/backend/nodejs/apps/tests/libs/services/telemetry/telemetry.service.test.ts
@@ -9,6 +9,7 @@ import * as installMetricsModule from '../../../../src/libs/services/telemetry/m
 import * as cmConfigModule from '../../../../src/modules/configuration_manager/config/config';
 import { configPaths } from '../../../../src/modules/configuration_manager/paths/paths';
 import { recordEvent, eventBuffer } from '../../../../src/libs/services/telemetry/event-buffer';
+import { metricsBackend } from '../../../../src/libs/services/telemetry/metrics-backend';
 import { StoreType } from '../../../../src/libs/keyValueStore/constants/KeyValueStoreType';
 
 const VALID_URL = 'http://localhost:3031/collect-metrics';
@@ -316,6 +317,40 @@ describe('TelemetryService', () => {
 
       recordEvent('login');
       await svc.flush(); // must not throw
+    });
+  });
+
+  describe('pushMetricsToServer', () => {
+    it('should reset the metric registry when the collector responds 413', async () => {
+      sandbox.stub(metricsBackend, 'serialize').resolves('x{a="b"} 1\n');
+      const resetStub = sandbox.stub(metricsBackend, 'reset');
+      const err = Object.assign(new Error('Request failed with status code 413'), {
+        isAxiosError: true,
+        response: { status: 413 },
+      });
+      sandbox.stub(axios, 'post').rejects(err);
+      const svc = new TelemetryService(mockKvStore() as any);
+      await flushAsync();
+
+      await (svc as any).pushMetricsToServer();
+
+      expect(resetStub.calledOnce).to.be.true;
+    });
+
+    it('should not reset the registry on other collector errors', async () => {
+      sandbox.stub(metricsBackend, 'serialize').resolves('x{a="b"} 1\n');
+      const resetStub = sandbox.stub(metricsBackend, 'reset');
+      const err = Object.assign(new Error('Request failed with status code 500'), {
+        isAxiosError: true,
+        response: { status: 500 },
+      });
+      sandbox.stub(axios, 'post').rejects(err);
+      const svc = new TelemetryService(mockKvStore() as any);
+      await flushAsync();
+
+      await (svc as any).pushMetricsToServer();
+
+      expect(resetStub.called).to.be.false;
     });
   });
 

--- a/backend/python/app/telemetry/backend.py
+++ b/backend/python/app/telemetry/backend.py
@@ -45,6 +45,11 @@ class MetricsBackend(ABC):
         """Serialize all registered metrics in the backend's exposition format."""
         ...
 
+    @abstractmethod
+    def reset(self) -> None:
+        """Drop all recorded series."""
+        ...
+
 
 class _PromCounter:
     def __init__(self, metric: Counter) -> None:
@@ -81,22 +86,33 @@ class PrometheusBackend(MetricsBackend):
         # exactly what is exported and a double import can't raise
         # duplicate-registration errors.
         self._registry = CollectorRegistry()
+        self._instruments: list[Counter | Gauge | Histogram] = []
 
     def counter(self, name: str, help: str, labels: Sequence[str]) -> CounterHandle:
-        return _PromCounter(Counter(name, help, list(labels), registry=self._registry))
+        metric = Counter(name, help, list(labels), registry=self._registry)
+        self._instruments.append(metric)
+        return _PromCounter(metric)
 
     def gauge(self, name: str, help: str, labels: Sequence[str]) -> GaugeHandle:
-        return _PromGauge(Gauge(name, help, list(labels), registry=self._registry))
+        metric = Gauge(name, help, list(labels), registry=self._registry)
+        self._instruments.append(metric)
+        return _PromGauge(metric)
 
     def histogram(
         self, name: str, help: str, labels: Sequence[str], buckets: Sequence[float]
     ) -> HistogramHandle:
-        return _PromHistogram(
-            Histogram(name, help, list(labels), registry=self._registry, buckets=tuple(buckets))
-        )
+        metric = Histogram(name, help, list(labels), registry=self._registry, buckets=tuple(buckets))
+        self._instruments.append(metric)
+        return _PromHistogram(metric)
 
     def serialize(self) -> str:
         return generate_latest(self._registry).decode("utf-8")
+
+    def reset(self) -> None:
+        for metric in self._instruments:
+            # clear() raises on unlabelled metrics
+            if getattr(metric, "_labelnames", ()):
+                metric.clear()
 
 
 # One backend per process, owned by the telemetry layer.

--- a/backend/python/app/telemetry/middleware.py
+++ b/backend/python/app/telemetry/middleware.py
@@ -5,7 +5,6 @@ Registered once per FastAPI app (see ``setup_telemetry``), this makes collection
 drift that left the Python services entirely uninstrumented.
 """
 
-import re
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -13,18 +12,11 @@ from starlette.requests import Request
 from starlette.types import ASGIApp
 
 from app.telemetry.identity import domain_from_email
-from app.telemetry.modules.http_metrics import HTTP_REQUESTS, HTTP_REQUEST_DURATION
-
-# Collapses id-like path segments so a fallback (no matched route template) still
-# stays low-cardinality: mongo ObjectIds, uuids, long hex, and pure numbers.
-_ID_SEGMENT = re.compile(
-    r"^(?:[0-9a-fA-F]{24}|[0-9a-fA-F-]{32,36}|\d+)$"
+from app.telemetry.modules.http_metrics import (
+    HTTP_REQUEST_DURATION,
+    HTTP_REQUESTS,
+    bound_route,
 )
-
-
-def _normalize_path(path: str) -> str:
-    parts = [(":id" if _ID_SEGMENT.match(seg) else seg) for seg in path.split("/")]
-    return "/".join(parts) or "/"
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):
@@ -43,7 +35,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
             return response
         finally:
             elapsed = time.perf_counter() - start
-            route = self._route_template(request)
+            route = bound_route(self._route_template(request))
             org = self._org(request)
             domain = self._domain(request)
             # Never reset counters — push cumulative values, let the TSDB
@@ -62,8 +54,8 @@ class MetricsMiddleware(BaseHTTPMiddleware):
         template = getattr(route, "path_format", None) or getattr(route, "path", None)
         if template:
             return template
-        # No route matched (404) or older Starlette — normalize the raw path.
-        return _normalize_path(request.url.path)
+        # Raw paths (404s, bot scans) are unbounded label values.
+        return "unmatched"
 
     @staticmethod
     def _org(request: Request) -> str:

--- a/backend/python/app/telemetry/modules/http_metrics.py
+++ b/backend/python/app/telemetry/modules/http_metrics.py
@@ -18,3 +18,16 @@ HTTP_REQUEST_DURATION = METRICS_BACKEND.histogram(
     ["service", "route", "method"],
     buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
 )
+
+# Unbounded route values grow the push payload until the collector rejects it.
+_MAX_UNIQUE_ROUTES = 300
+_seen_routes: set[str] = set()
+
+
+def bound_route(route: str) -> str:
+    if route in _seen_routes:
+        return route
+    if len(_seen_routes) >= _MAX_UNIQUE_ROUTES:
+        return "other"
+    _seen_routes.add(route)
+    return route

--- a/backend/python/app/telemetry/pusher.py
+++ b/backend/python/app/telemetry/pusher.py
@@ -169,7 +169,15 @@ class MetricsPusher:
         timeout = aiohttp.ClientTimeout(total=PUSH_TIMEOUT_S)
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.post(cfg["url"], json=payload, headers=headers) as resp:
-                if resp.status >= 400:
+                if resp.status == 413:
+                    # The registry only grows, so a 413 would otherwise recur until restart.
+                    body = await resp.text()
+                    self._logger.warning(
+                        "Collector rejected metrics payload as too large; "
+                        f"resetting metric registry: {body[:200]}"
+                    )
+                    METRICS_BACKEND.reset()
+                elif resp.status >= 400:
                     body = await resp.text()
                     self._logger.warning(
                         f"Metrics push rejected: status={resp.status} body={body[:200]}"

--- a/backend/python/tests/unit/telemetry/modules/test_http_metrics.py
+++ b/backend/python/tests/unit/telemetry/modules/test_http_metrics.py
@@ -1,7 +1,12 @@
 """Unit tests for app.telemetry.modules.http_metrics."""
 
 from app.telemetry.backend import METRICS_BACKEND
-from app.telemetry.modules.http_metrics import HTTP_REQUEST_DURATION, HTTP_REQUESTS
+from app.telemetry.modules import http_metrics
+from app.telemetry.modules.http_metrics import (
+    HTTP_REQUEST_DURATION,
+    HTTP_REQUESTS,
+    bound_route,
+)
 
 
 class TestHttpMetrics:
@@ -47,3 +52,18 @@ class TestHttpMetrics:
         le_025 = next(line for line in bucket_lines if 'le="0.25"' in line)
         assert le_01.endswith(" 0.0")
         assert le_025.endswith(" 1.0")
+
+
+class TestBoundRoute:
+    def test_passes_routes_through_under_the_cap(self):
+        assert bound_route("/api/v1/br-a") == "/api/v1/br-a"
+        assert bound_route("/api/v1/br-a") == "/api/v1/br-a"
+
+    def test_collapses_new_routes_to_other_once_cap_is_reached(self, monkeypatch):
+        monkeypatch.setattr(
+            http_metrics, "_seen_routes", {f"/r/{i}" for i in range(300)}
+        )
+
+        assert bound_route("/api/v1/br-overflow") == "other"
+        # Routes seen before the cap keep their own label.
+        assert bound_route("/r/0") == "/r/0"

--- a/backend/python/tests/unit/telemetry/test_backend.py
+++ b/backend/python/tests/unit/telemetry/test_backend.py
@@ -80,6 +80,35 @@ class TestPrometheusBackendHistogram:
         assert 't_hist_a_sum{route="/x"} 5.05' in text
 
 
+class TestReset:
+    def test_reset_drops_series_from_all_instruments(self):
+        backend = PrometheusBackend()
+        counter = backend.counter("t_reset_c", "help", ["k"])
+        gauge = backend.gauge("t_reset_g", "help", ["k"])
+        histogram = backend.histogram("t_reset_h", "help", ["k"], buckets=(1.0,))
+
+        counter.inc("a")
+        gauge.set("a", value=3)
+        histogram.observe("a", value=0.5)
+
+        backend.reset()
+
+        text = backend.serialize()
+        assert 't_reset_c_total{k="a"}' not in text
+        assert 't_reset_g{k="a"}' not in text
+        assert 't_reset_h_count{k="a"}' not in text
+
+    def test_counting_resumes_after_reset(self):
+        backend = PrometheusBackend()
+        counter = backend.counter("t_reset_resume", "help", ["k"])
+
+        counter.inc("a", value=5)
+        backend.reset()
+        counter.inc("a")
+
+        assert 't_reset_resume_total{k="a"} 1.0' in backend.serialize()
+
+
 class TestRegistryIsolation:
     def test_each_backend_has_its_own_registry(self):
         one = PrometheusBackend()

--- a/backend/python/tests/unit/telemetry/test_middleware.py
+++ b/backend/python/tests/unit/telemetry/test_middleware.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from starlette.requests import Request
 
-from app.telemetry.middleware import MetricsMiddleware, _normalize_path
+from app.telemetry.middleware import MetricsMiddleware
 
 
 def make_request(
@@ -37,18 +37,6 @@ def make_middleware(service_name="query_service") -> MetricsMiddleware:
     return MetricsMiddleware(app=MagicMock(), service_name=service_name)
 
 
-class TestNormalizePath:
-    def test_replaces_object_ids_uuids_and_numbers(self):
-        path = "/api/v1/users/507f1f77bcf86cd799439011/items/42/e2c1a1f0-1234-4abc-9def-1234567890ab"
-        assert _normalize_path(path) == "/api/v1/users/:id/items/:id/:id"
-
-    def test_keeps_plain_segments(self):
-        assert _normalize_path("/api/v1/search") == "/api/v1/search"
-
-    def test_empty_path_becomes_root(self):
-        assert _normalize_path("") == "/"
-
-
 class TestRouteTemplate:
     def test_prefers_matched_route_path_format(self):
         route = SimpleNamespace(path_format="/api/v1/agent/{id}", path="/raw")
@@ -62,10 +50,10 @@ class TestRouteTemplate:
 
         assert MetricsMiddleware._route_template(request) == "/api/v1/agent/{id}"
 
-    def test_normalizes_raw_path_when_no_route_matched(self):
+    def test_collapses_to_unmatched_when_no_route_matched(self):
         request = make_request(path="/api/v1/agent/12345")
 
-        assert MetricsMiddleware._route_template(request) == "/api/v1/agent/:id"
+        assert MetricsMiddleware._route_template(request) == "unmatched"
 
 
 class TestIdentityExtraction:
@@ -95,6 +83,7 @@ class TestDispatch:
         request = make_request(
             path="/api/v1/search",
             method="POST",
+            route=SimpleNamespace(path_format="/api/v1/search", path="/api/v1/search"),
             user={"orgId": "org-9", "email": "a@b.io"},
         )
         response = MagicMock(status_code=201)
@@ -116,7 +105,10 @@ class TestDispatch:
 
     async def test_records_500_when_handler_raises(self):
         middleware = make_middleware()
-        request = make_request(path="/api/v1/boom")
+        request = make_request(
+            path="/api/v1/boom",
+            route=SimpleNamespace(path_format="/api/v1/boom", path="/api/v1/boom"),
+        )
         call_next = AsyncMock(side_effect=RuntimeError("kaboom"))
 
         with (

--- a/backend/python/tests/unit/telemetry/test_pusher.py
+++ b/backend/python/tests/unit/telemetry/test_pusher.py
@@ -279,6 +279,56 @@ class TestStartStop:
         await pusher.stop()
 
 
+def mock_session_returning(status: int, body: str = "") -> MagicMock:
+    """An ``aiohttp.ClientSession`` factory whose POST resolves to *status*."""
+    resp = MagicMock(status=status)
+    resp.text = AsyncMock(return_value=body)
+    post_cm = MagicMock()
+    post_cm.__aenter__ = AsyncMock(return_value=resp)
+    post_cm.__aexit__ = AsyncMock(return_value=False)
+    session = MagicMock()
+    session.post = MagicMock(return_value=post_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=session_cm)
+
+
+class TestPush:
+    PUSH_CFG = {
+        "url": "http://localhost:3031/collect-metrics",
+        "token": "k",
+        "install_id": "install-1",
+        "version": "1.0.0",
+    }
+
+    async def test_resets_registry_when_collector_responds_413(self):
+        pusher = make_pusher()
+
+        with (
+            patch("app.telemetry.pusher.METRICS_BACKEND") as backend_mock,
+            patch("aiohttp.ClientSession", mock_session_returning(413, "too large")),
+        ):
+            backend_mock.serialize.return_value = 'x{a="b"} 1.0\n'
+            await pusher._push(self.PUSH_CFG)
+
+        backend_mock.reset.assert_called_once()
+        pusher._logger.warning.assert_called_once()
+
+    async def test_does_not_reset_registry_on_other_errors(self):
+        pusher = make_pusher()
+
+        with (
+            patch("app.telemetry.pusher.METRICS_BACKEND") as backend_mock,
+            patch("aiohttp.ClientSession", mock_session_returning(500, "boom")),
+        ):
+            backend_mock.serialize.return_value = 'x{a="b"} 1.0\n'
+            await pusher._push(self.PUSH_CFG)
+
+        backend_mock.reset.assert_not_called()
+        pusher._logger.warning.assert_called_once()
+
+
 class TestShipEvents:
     async def test_skips_post_when_buffer_is_empty(self):
         event_buffer.drain()


### PR DESCRIPTION
## Description
Production installs were logging this warning on every telemetry push (every 5 minutes), permanently:

WARNING - [telemetry.service.js:386] - Server responded with error:
metadata: { "status": 413, "serverUrl": "https://metrics-collector.../collect-metrics" }

The root cause is unbounded label cardinality in the HTTP request metrics:

1. The metrics middleware (Node and Python) is registered globally, so it fires for every request — including static dashboard assets, SPA paths, 404s, and bot scans on internet-facing installs.
2. When no route template matched, the middleware fell back to the raw request path, normalizing only id-like segments (ObjectIds, UUIDs, numbers). Hashed asset filenames (/assets/index-Bo3xK9qw.js), scanner probe paths (/wp-admin, /.env), and arbitrary slugs all passed through as-is.
3. Every unique path becomes a permanent Prometheus series (multiplied by method × status × org × domain on the counter, plus 13 exposition lines per (route, method) pair on the latency histogram), and the registry never drops a series.

The serialized payload therefore grows monotonically until it crosses the collector's 4MB body limit — and from that point on, every push is rejected with 413 until the process restarts. The affected install ships zero telemetry and spams the warning forever.


## Fix
Applied identically to the Node service and all Python services.

1. Bound the route label (root cause)
- Requests with no matched route template now record the constant unmatched instead of the raw path (telemetry.middleware.ts, app/telemetry/middleware.py). Route templates from matched routes are unchanged.
- Added a 300-distinct-route backstop cap in the http-metrics modules (boundRoute / bound_route): once exceeded, new route values collapse into other. This protects the payload even if a future caller passes unbounded values.

2. Self-heal on 413 (recovery for already-deployed installs)
- Added reset() to the metrics backend abstraction (prom-client registry.resetMetrics(); prometheus_client per-instrument clear()).
- The push loop (telemetry.service.ts, app/telemetry/pusher.py) now detects a 413 response and resets the registry, so an install that has already accumulated an oversized registry recovers on the next push instead of failing every interval until restart. Counters restarting from zero is safe — VictoriaMetrics treats it like a normal process restart.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes. Provide instructions so we can reproduce.]

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [x] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [ ] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTP telemetry now limits tracking to 300 unique routes; additional routes are grouped under `other`.
  * Metrics can be reset to clear recorded counters, gauges, and histograms.

* **Bug Fixes**
  * Unmatched and 404 requests now use a consistent `unmatched` route label.
  * Oversized telemetry submissions are logged and automatically reset metrics, while other errors retain existing handling.

* **Tests**
  * Added coverage for route limits, metric resets, unmatched requests, and oversized submissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->