### PR TITLE
fix: RSS record preview fails with "File URL not available"

### DIFF
--- a/backend/python/app/connectors/sources/rss/connector.py
+++ b/backend/python/app/connectors/sources/rss/connector.py
@@ -568,7 +568,7 @@ class RSSConnector(BaseConnector):
             path=urlparse(article_url).path or "/",
             mime_type=MimeTypes.PLAIN_TEXT.value,
             md5_hash=content_md5_hash,
-            preview_renderable=False,
+            preview_renderable=True,
         )
 
         permissions = self._create_rss_permissions()

--- a/frontend/app/components/file-preview/renderers/file-preview-renderer.tsx
+++ b/frontend/app/components/file-preview/renderers/file-preview-renderer.tsx
@@ -20,6 +20,13 @@ import type { FilePreviewRendererProps } from '../types';
 export function FilePreviewRenderer({ fileUrl, fileName, fileType, fileBlob, pagination, highlightBox, highlightPage, citations, activeCitationId, citationClickVersion, onHighlightClick, webUrl, previewRenderable }: FilePreviewRendererProps) {
   const rendererType = getRendererType(fileType || '', fileName);
 
+  // Callers skip the stream for non-previewable records, so there is no content to
+  // hand a renderer. Without this the type-matched renderer reports "File URL not
+  // available" instead of the fallback panel with its "Open in Browser" link.
+  if (previewRenderable === false && !fileUrl?.trim() && !fileBlob) {
+    return <UnknownPreview fileUrl={fileUrl} fileName={fileName} fileType={fileType} webUrl={webUrl} previewRenderable={previewRenderable} />;
+  }
+
   switch (rendererType) {
     case 'pdf':
       // PDFs support pagination


### PR DESCRIPTION
## Problem

Opening any RSS record in the knowledge-base preview panel shows a red **"File URL not available"** error instead of the article text.

## Cause

`_process_entry` in [connector.py:571](backend/python/app/connectors/sources/rss/connector.py) created every RSS `FileRecord` with `preview_renderable=False`, even though the record is a real `text/plain` / `.txt` file and the connector implements a working `stream_record`.

The preview surface treats that flag as "skip the stream" and sets `url: ''`. RSS records still declare `text/plain`, so `getRendererType` routes them to `TextRenderer`, which gets an empty URL and errors out.

Records from other connectors that set `preview_renderable=False` (Gmail, Jira, Slack) declare non-renderable MIME types, so they land on `UnknownPreview` and never hit this path. RSS was the outlier.

## Fix

1. `backend/python/app/connectors/sources/rss/connector.py` — set `preview_renderable=True`. RSS records carry real text content and `stream_record` serves it, so the preview now streams and renders the article.
2. `frontend/app/components/file-preview/renderers/file-preview-renderer.tsx` — when a record is flagged non-previewable and there is no URL or blob, render `UnknownPreview` instead of a content renderer. That gives the fallback panel with its **Open in Browser** link rather than a red error. This also covers Linear records, which declare `text/markdown` with `preview_renderable=False` and hit the same failure in `MarkdownRenderer`.

## Verification

- `npx tsc --noEmit` and `eslint` on the changed frontend file: clean.
- RSS connector unit tests: 53 passed / 146 failed, identical before and after the change. The failures are an environment gap in my venv (`pytest-asyncio` and `pytest-timeout` are not installed, so every `async def` test errors), not a regression from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - RSS feed articles can now display their plain-text content in previews.
  - Records without previewable content, a usable link, or an attached file now show a clear unsupported-preview state.

- **Bug Fixes**
  - Improved preview handling to prevent misleading missing-link errors when content cannot be rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->