### PR TITLE
fix(installer): show where to re-run install.sh after curl or clone

### DIFF
--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -432,8 +432,9 @@ prompt_input() {
 
 # ==============================================================================
 # 1. BANNER
+# Do not clear the screen: curl | bash has just printed which git ref was
+# downloaded, and that line must stay visible above the ASCII banner.
 # ==============================================================================
-[[ -t 1 ]] && clear 2>/dev/null || true
 cat <<'BANNER'
 
   ██████╗ ██╗██████╗ ███████╗███████╗██╗  ██╗██╗   ██╗██████╗
@@ -444,7 +445,11 @@ cat <<'BANNER'
   ╚═╝     ╚═╝╚═╝     ╚══════╝╚══════╝╚═╝  ╚═╝ ╚═════╝ ╚═════╝
                         AI Platform Installer
 BANNER
-printf "  ${DIM}v%s${RESET}\n\n" "$INSTALLER_VERSION"
+printf "  ${DIM}v%s${RESET}\n" "$INSTALLER_VERSION"
+if [[ -n "${PIPESHUB_INSTALL_REF:-}" ]]; then
+  printf "  ${DIM}Git ref: %s${RESET}\n" "$PIPESHUB_INSTALL_REF"
+fi
+printf "\n"
 
 # ==============================================================================
 # 2. PRE-FLIGHT CHECKS

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1611,12 +1611,36 @@ if [[ -n "${FRONTEND_PUBLIC_URL:-}" ]]; then
   printf "  ${YELLOW}Note:${RESET} Ensure DNS for %s points to this machine\n" "${FRONTEND_PUBLIC_URL}"
   printf "  and that your reverse proxy (Nginx, Caddy, Cloudflare) is configured.\n"
 fi
+# curl | bash leaves the user's shell wherever they started. Clone users can
+# re-run the repo-root wrapper; standalone users must use this directory.
+_BANNER_CLI_DIR="$SCRIPT_DIR"
+_BANNER_IN_CLONE=false
+if [[ -f "${SCRIPT_DIR}/../../Dockerfile" && -f "${SCRIPT_DIR}/../../install.sh" ]]; then
+  _clone_root="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+  _compose_in_clone="$(cd "${_clone_root}/deployment/docker-compose" && pwd)"
+  if [[ "$SCRIPT_DIR" == "$_compose_in_clone" ]]; then
+    _BANNER_IN_CLONE=true
+    _BANNER_CLI_DIR="$_clone_root"
+  fi
+fi
+
+printf "\n  ${BOLD}This install${RESET}\n"
+printf "  ${DIM}%s${RESET}\n" "$(printf '─%.0s' {1..53})"
+printf "  ${CYAN}Files:${RESET}     %s\n" "$SCRIPT_DIR"
+printf "  ${CYAN}Commands:${RESET}  %s\n" "$_BANNER_CLI_DIR"
+
 printf "\n  ${BOLD}Useful commands${RESET}\n"
 printf "  ${DIM}%s${RESET}\n\n" "$(printf '─%.0s' {1..53})"
 printf "  ${DIM}# Check health from this host${RESET}\n"
 printf "  curl -fsS http://localhost:%s/api/v1/health/services\n\n" "$APP_PORT"
 printf "  ${DIM}# View logs${RESET}\n"
 printf "  docker compose -f %s -p %s logs -f pipeshub-ai\n\n" "$COMPOSE_FILE" "$PROJECT_NAME"
+if $_BANNER_IN_CLONE; then
+  printf "  ${DIM}# From the repository root${RESET}\n"
+else
+  printf "  ${DIM}# From the install directory (curl | bash does not cd your shell)${RESET}\n"
+fi
+printf "  cd %q\n" "$_BANNER_CLI_DIR"
 printf "  ${DIM}# Stop (data preserved)${RESET}\n"
 printf "  ./install.sh --stop\n\n"
 printf "  ${DIM}# Upgrade to latest images (or rebuild from source if IMAGE_SOURCE=local)${RESET}\n"

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -269,6 +269,29 @@ suggest_separate_project_name() {
   printf '%s' "$base"
 }
 
+# Where to cd before ./install.sh after a successful install.
+# Dockerfile + install.sh two levels up is not enough to call this a clone:
+# curl | bash from ~/myservice/deploy can see the user's own files. Only treat
+# as clone when this script is that repo's deployment/docker-compose.
+# Sets BANNER_IN_CLONE (true|false) and BANNER_CLI_DIR.
+resolve_banner_dirs() {
+  local clone_root="" compose_in_clone=""
+  BANNER_IN_CLONE=false
+  BANNER_CLI_DIR="$SCRIPT_DIR"
+
+  if [[ -f "${SCRIPT_DIR}/../../Dockerfile" && -f "${SCRIPT_DIR}/../../install.sh" ]]; then
+    clone_root="$(cd "${SCRIPT_DIR}/../.." && pwd)" || true
+    if [[ -n "$clone_root" ]]; then
+      # Missing compose dir must not abort: this runs after the stack is up.
+      compose_in_clone="$(cd "${clone_root}/deployment/docker-compose" 2>/dev/null && pwd)" || true
+      if [[ -n "$compose_in_clone" && "$SCRIPT_DIR" == "$compose_in_clone" ]]; then
+        BANNER_IN_CLONE=true
+        BANNER_CLI_DIR="$clone_root"
+      fi
+    fi
+  fi
+}
+
 # PIPESHUB_PROJECT wins. Else COMPOSE_PROJECT_NAME in this directory's .env so
 # --stop / --uninstall only tear down this copy. Else the default name.
 resolve_project_name() {
@@ -1613,21 +1636,16 @@ if [[ -n "${FRONTEND_PUBLIC_URL:-}" ]]; then
 fi
 # curl | bash leaves the user's shell wherever they started. Clone users can
 # re-run the repo-root wrapper; standalone users must use this directory.
-_BANNER_CLI_DIR="$SCRIPT_DIR"
-_BANNER_IN_CLONE=false
-if [[ -f "${SCRIPT_DIR}/../../Dockerfile" && -f "${SCRIPT_DIR}/../../install.sh" ]]; then
-  _clone_root="$(cd "${SCRIPT_DIR}/../.." && pwd)"
-  _compose_in_clone="$(cd "${_clone_root}/deployment/docker-compose" && pwd)"
-  if [[ "$SCRIPT_DIR" == "$_compose_in_clone" ]]; then
-    _BANNER_IN_CLONE=true
-    _BANNER_CLI_DIR="$_clone_root"
-  fi
-fi
+resolve_banner_dirs
 
 printf "\n  ${BOLD}This install${RESET}\n"
 printf "  ${DIM}%s${RESET}\n" "$(printf '─%.0s' {1..53})"
-printf "  ${CYAN}Files:${RESET}     %s\n" "$SCRIPT_DIR"
-printf "  ${CYAN}Commands:${RESET}  %s\n" "$_BANNER_CLI_DIR"
+if [[ "$SCRIPT_DIR" == "$BANNER_CLI_DIR" ]]; then
+  printf "  ${CYAN}Directory:${RESET}  %s\n" "$SCRIPT_DIR"
+else
+  printf "  ${CYAN}Files:${RESET}     %s\n" "$SCRIPT_DIR"
+  printf "  ${CYAN}Commands:${RESET}  %s\n" "$BANNER_CLI_DIR"
+fi
 
 printf "\n  ${BOLD}Useful commands${RESET}\n"
 printf "  ${DIM}%s${RESET}\n\n" "$(printf '─%.0s' {1..53})"
@@ -1635,12 +1653,12 @@ printf "  ${DIM}# Check health from this host${RESET}\n"
 printf "  curl -fsS http://localhost:%s/api/v1/health/services\n\n" "$APP_PORT"
 printf "  ${DIM}# View logs${RESET}\n"
 printf "  docker compose -f %s -p %s logs -f pipeshub-ai\n\n" "$COMPOSE_FILE" "$PROJECT_NAME"
-if $_BANNER_IN_CLONE; then
+if $BANNER_IN_CLONE; then
   printf "  ${DIM}# From the repository root${RESET}\n"
 else
   printf "  ${DIM}# From the install directory (curl | bash does not cd your shell)${RESET}\n"
 fi
-printf "  cd %q\n" "$_BANNER_CLI_DIR"
+printf "  cd %q\n\n" "$BANNER_CLI_DIR"
 printf "  ${DIM}# Stop (data preserved)${RESET}\n"
 printf "  ./install.sh --stop\n\n"
 printf "  ${DIM}# Upgrade to latest images (or rebuild from source if IMAGE_SOURCE=local)${RESET}\n"

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -270,9 +270,10 @@ suggest_separate_project_name() {
 }
 
 # Where to cd before ./install.sh after a successful install.
-# Dockerfile + install.sh two levels up is not enough to call this a clone:
-# curl | bash from ~/myservice/deploy can see the user's own files. Only treat
-# as clone when this script is that repo's deployment/docker-compose.
+# Dockerfile + install.sh two levels up is not enough: any containerized app
+# can look like that, including a copy of this installer at
+# <project>/deployment/docker-compose. Only treat as clone when the root
+# install.sh is the PipesHub wrapper (the thing clone users should re-run).
 # Sets BANNER_IN_CLONE (true|false) and BANNER_CLI_DIR.
 resolve_banner_dirs() {
   local clone_root="" compose_in_clone=""
@@ -281,7 +282,8 @@ resolve_banner_dirs() {
 
   if [[ -f "${SCRIPT_DIR}/../../Dockerfile" && -f "${SCRIPT_DIR}/../../install.sh" ]]; then
     clone_root="$(cd "${SCRIPT_DIR}/../.." && pwd)" || true
-    if [[ -n "$clone_root" ]]; then
+    if [[ -n "$clone_root" ]] \
+        && grep -q 'INNER_SUBPATH="deployment/docker-compose"' "${clone_root}/install.sh" 2>/dev/null; then
       # Missing compose dir must not abort: this runs after the stack is up.
       compose_in_clone="$(cd "${clone_root}/deployment/docker-compose" 2>/dev/null && pwd)" || true
       if [[ -n "$compose_in_clone" && "$SCRIPT_DIR" == "$compose_in_clone" ]]; then

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -182,7 +182,11 @@ check "host-side reachability check present" "$inner" "check_host_reachable"
 check "host reachability gates readiness" "$inner" "CONTAINER_HEALTHY && \$HOST_REACHABLE"
 check "ready banner is health-gated" "$inner" "PipesHub AI is ready!"
 check "not-ready banner exists" "$inner" "not confirmed ready yet"
-if [[ "$inner" == *"&& clear"* ]]; then fail "banner must not clear the screen"; else pass "banner must not clear the screen"; fi
+if grep -qE '^[[:space:]]*(clear\b|tput[[:space:]]+clear)' "$INNER_INSTALLER" "$ROOT_INSTALLER"; then
+  fail "banner must not clear the screen"
+else
+  pass "banner must not clear the screen"
+fi
 check "banner prints wrapper git ref" "$inner" 'PIPESHUB_INSTALL_REF'
 check "banner clone uses repo-root wrapper" "$inner" "From the repository root"
 check "banner standalone warns curl does not cd" "$inner" "curl | bash does not cd your shell"

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -59,6 +59,7 @@ make_fake_inner() {
   cat >"$path" <<'EOF'
 #!/usr/bin/env bash
 echo "INNER_RAN args=[$*]"
+echo "PIPESHUB_INSTALL_REF=${PIPESHUB_INSTALL_REF:-}"
 EOF
   chmod +x "$path"
 }
@@ -120,6 +121,7 @@ echo "== Root wrapper: standalone mode downloads + execs =="
   out="$(PATH="$bindir:$PATH" bash "$work/install.sh" beta 2>&1)"
   check "standalone execs downloaded installer" "$out" "INNER_RAN"
   check "standalone forwards args" "$out" "args=[beta]"
+  check "standalone exports resolved release as install ref" "$out" "PIPESHUB_INSTALL_REF=v9.9.9"
   [[ -f "$PIPESHUB_DIR/docker-compose.yml" ]] && pass "compose file downloaded" || fail "compose file downloaded"
   [[ -f "$PIPESHUB_DIR/install.sh" ]] && pass "installer downloaded" || fail "installer downloaded"
   check "uses latest release tag in URL" "$(cat "$CURL_LOG")" "/v9.9.9/"
@@ -135,9 +137,10 @@ echo "== Root wrapper: PIPESHUB_REF override wins =="
   export RELEASE_JSON='{"tag_name":"v9.9.9"}'   # should be ignored
   export PIPESHUB_REF="my-branch"
   export PIPESHUB_DIR="$work/pipeshub"
-  PATH="$bindir:$PATH" bash "$work/install.sh" >/dev/null 2>&1
+  out="$(PATH="$bindir:$PATH" bash "$work/install.sh" 2>&1)"
   log="$(cat "$CURL_LOG")"
   check "explicit ref used in URL" "$log" "/my-branch/"
+  check "standalone exports PIPESHUB_REF as install ref" "$out" "PIPESHUB_INSTALL_REF=my-branch"
   if [[ "$log" == *"/v9.9.9/"* ]]; then fail "explicit ref must not fall back to release"; else pass "explicit ref overrides release tag"; fi
 )
 
@@ -179,6 +182,8 @@ check "host-side reachability check present" "$inner" "check_host_reachable"
 check "host reachability gates readiness" "$inner" "CONTAINER_HEALTHY && \$HOST_REACHABLE"
 check "ready banner is health-gated" "$inner" "PipesHub AI is ready!"
 check "not-ready banner exists" "$inner" "not confirmed ready yet"
+if [[ "$inner" == *"&& clear"* ]]; then fail "banner must not clear the screen"; else pass "banner must not clear the screen"; fi
+check "banner prints wrapper git ref" "$inner" 'PIPESHUB_INSTALL_REF'
 check "banner clone uses repo-root wrapper" "$inner" "From the repository root"
 check "banner standalone warns curl does not cd" "$inner" "curl | bash does not cd your shell"
 check "banner cds before ./install.sh" "$inner" 'cd %q'

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -178,6 +178,10 @@ check "host-side reachability check present" "$inner" "check_host_reachable"
 check "host reachability gates readiness" "$inner" "CONTAINER_HEALTHY && \$HOST_REACHABLE"
 check "ready banner is health-gated" "$inner" "PipesHub AI is ready!"
 check "not-ready banner exists" "$inner" "not confirmed ready yet"
+check "banner prints install file directory" "$inner" 'Files:'
+check "banner clone uses repo-root wrapper" "$inner" "From the repository root"
+check "banner standalone warns curl does not cd" "$inner" "curl | bash does not cd your shell"
+check "banner cds before ./install.sh" "$inner" 'cd %q'
 check "profile repair on reuse present" "$inner" "Repairing to"
 check "cross-directory guard present" "$inner" "Existing deployment detected"
 check "separate-instance prompt present" "$inner" "Install a separate instance here"

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -553,7 +553,8 @@ eval "$(extract_fn resolve_banner_dirs "$INNER_INSTALLER")"
   set -euo pipefail
   repo="$TMP_ROOT/banner-clone"
   mkdir -p "$repo/deployment/docker-compose"
-  touch "$repo/Dockerfile" "$repo/install.sh"
+  touch "$repo/Dockerfile"
+  cp "$ROOT_INSTALLER" "$repo/install.sh"
   SCRIPT_DIR="$(cd "$repo/deployment/docker-compose" && pwd)"
   resolve_banner_dirs
   check "clone commands use repo root" "$BANNER_CLI_DIR" "$(cd "$repo" && pwd)"
@@ -572,7 +573,8 @@ eval "$(extract_fn resolve_banner_dirs "$INNER_INSTALLER")"
   set -euo pipefail
   repo="$TMP_ROOT/banner-nested"
   mkdir -p "$repo/deployment/docker-compose" "$repo/deployment/pipeshub"
-  touch "$repo/Dockerfile" "$repo/install.sh"
+  touch "$repo/Dockerfile"
+  cp "$ROOT_INSTALLER" "$repo/install.sh"
   SCRIPT_DIR="$(cd "$repo/deployment/pipeshub" && pwd)"
   resolve_banner_dirs
   check "standalone nested in a clone stays SCRIPT_DIR" "$BANNER_CLI_DIR" "$SCRIPT_DIR"
@@ -594,6 +596,17 @@ if [[ -f "$TMP_ROOT/banner-landmine" ]]; then
 else
   fail "missing compose dir does not abort under set -e"
 fi
+(
+  set -euo pipefail
+  other="$TMP_ROOT/other-app"
+  mkdir -p "$other/deployment/docker-compose"
+  touch "$other/Dockerfile"
+  printf '%s\n' '#!/bin/sh' 'echo my-app' >"$other/install.sh"
+  SCRIPT_DIR="$(cd "$other/deployment/docker-compose" && pwd)"
+  resolve_banner_dirs
+  check "unrelated compose-layout app stays SCRIPT_DIR" "$BANNER_CLI_DIR" "$SCRIPT_DIR"
+  if $BANNER_IN_CLONE; then fail "unrelated root install.sh is not a pipeshub clone"; else pass "unrelated root install.sh is not a pipeshub clone"; fi
+)
 
 eval "$(extract_fn project_has_pinned_container_names "$INNER_INSTALLER")"
 (

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -10,8 +10,9 @@
 #   - Standalone PIPESHUB_REF resolution: explicit ref, latest-release tag, and
 #     the main fallback all hit the correct download URLs.
 #   - Regression guards on the in-tree installer edits (16 GB-class RAM floor,
-#     host-side reachability check, health-gated "ready" banner, plain compose
-#     progress, generous/overridable health-wait timeout).
+#     host-side reachability check, health-gated "ready" banner, clone vs
+#     standalone command directory, plain compose progress, generous/overridable
+#     health-wait timeout).
 #   - Compose app healthcheck stays reconciled with the installer's readiness
 #     check (core services only; embedding excluded).
 #   - Compose runtime robustness: HuggingFace offline mode is documented and
@@ -178,10 +179,13 @@ check "host-side reachability check present" "$inner" "check_host_reachable"
 check "host reachability gates readiness" "$inner" "CONTAINER_HEALTHY && \$HOST_REACHABLE"
 check "ready banner is health-gated" "$inner" "PipesHub AI is ready!"
 check "not-ready banner exists" "$inner" "not confirmed ready yet"
-check "banner prints install file directory" "$inner" 'Files:'
 check "banner clone uses repo-root wrapper" "$inner" "From the repository root"
 check "banner standalone warns curl does not cd" "$inner" "curl | bash does not cd your shell"
 check "banner cds before ./install.sh" "$inner" 'cd %q'
+check "banner cd is a preamble not bound to --stop" "$inner" 'cd %q\n\n'
+check "banner collapses equal paths to Directory" "$inner" 'Directory:'
+check "banner shows Files and Commands when they diverge" "$inner" 'Files:'
+check "banner uses resolve_banner_dirs" "$inner" "resolve_banner_dirs"
 check "profile repair on reuse present" "$inner" "Repairing to"
 check "cross-directory guard present" "$inner" "Existing deployment detected"
 check "separate-instance prompt present" "$inner" "Install a separate instance here"
@@ -533,6 +537,54 @@ if valid_compose_project_name "_work"; then fail "raw _work is invalid"; else pa
   SCRIPT_DIR="$repo/deployment/docker-compose"
   check "suggests repo root when run from compose dir" "$(suggest_separate_project_name)" "my-repo"
 )
+
+echo "== In-tree installer: success-banner directories (real function) =="
+eval "$(extract_fn resolve_banner_dirs "$INNER_INSTALLER")"
+(
+  set -euo pipefail
+  repo="$TMP_ROOT/banner-clone"
+  mkdir -p "$repo/deployment/docker-compose"
+  touch "$repo/Dockerfile" "$repo/install.sh"
+  SCRIPT_DIR="$(cd "$repo/deployment/docker-compose" && pwd)"
+  resolve_banner_dirs
+  check "clone commands use repo root" "$BANNER_CLI_DIR" "$(cd "$repo" && pwd)"
+  if $BANNER_IN_CLONE; then pass "clone is detected"; else fail "clone is detected"; fi
+)
+(
+  set -euo pipefail
+  stand="$TMP_ROOT/banner-stand/pipeshub"
+  mkdir -p "$stand"
+  SCRIPT_DIR="$(cd "$stand" && pwd)"
+  resolve_banner_dirs
+  check "plain standalone stays in SCRIPT_DIR" "$BANNER_CLI_DIR" "$SCRIPT_DIR"
+  if $BANNER_IN_CLONE; then fail "plain standalone is not a clone"; else pass "plain standalone is not a clone"; fi
+)
+(
+  set -euo pipefail
+  repo="$TMP_ROOT/banner-nested"
+  mkdir -p "$repo/deployment/docker-compose" "$repo/deployment/pipeshub"
+  touch "$repo/Dockerfile" "$repo/install.sh"
+  SCRIPT_DIR="$(cd "$repo/deployment/pipeshub" && pwd)"
+  resolve_banner_dirs
+  check "standalone nested in a clone stays SCRIPT_DIR" "$BANNER_CLI_DIR" "$SCRIPT_DIR"
+  if $BANNER_IN_CLONE; then fail "nested standalone is not a clone"; else pass "nested standalone is not a clone"; fi
+)
+(
+  set -euo pipefail
+  svc="$TMP_ROOT/myservice"
+  mkdir -p "$svc/deploy/pipeshub"
+  touch "$svc/Dockerfile" "$svc/install.sh"
+  SCRIPT_DIR="$(cd "$svc/deploy/pipeshub" && pwd)"
+  resolve_banner_dirs
+  printf 'survived\n' >"$TMP_ROOT/banner-landmine"
+  check "false clone guess stays SCRIPT_DIR" "$BANNER_CLI_DIR" "$SCRIPT_DIR"
+  if $BANNER_IN_CLONE; then fail "user Dockerfile is not a pipeshub clone"; else pass "user Dockerfile is not a pipeshub clone"; fi
+)
+if [[ -f "$TMP_ROOT/banner-landmine" ]]; then
+  pass "missing compose dir does not abort under set -e"
+else
+  fail "missing compose dir does not abort under set -e"
+fi
 
 eval "$(extract_fn project_has_pinned_container_names "$INNER_INSTALLER")"
 (

--- a/install.sh
+++ b/install.sh
@@ -101,6 +101,8 @@ dl "$base_url/install.sh" "$DEST/install.sh" \
 chmod +x "$DEST/install.sh"
 
 note "Launching installer..."
+# Inner banner prints this so the ref survives even if the terminal scrolls.
+export PIPESHUB_INSTALL_REF="$REF"
 # Reconnect stdin to the terminal so the installer's interactive prompts work
 # even though our own stdin is the piped script body (curl | bash). Probe that
 # /dev/tty is actually openable (it isn't in CI or a detached pipe, where the


### PR DESCRIPTION
## Problem

The installer finishes by printing `./install.sh --stop` / `--upgrade` / `--uninstall` as if the user’s shell were already in the right directory.

That is wrong for `curl | bash`: the wrapper cannot `cd` the calling shell, so those commands fail unless the user `cd`s first. Clone users have a different cwd again — they should re-run the **repo-root** `./install.sh`, not the copy under `deployment/docker-compose`.

Two related bugs showed up while checking that banner:

1. The wizard called `clear` on a TTY, which wiped the wrapper’s `Installing from ref: …` line (the only record of which git tag/branch was just downloaded).
2. The success banner tried to tell clone vs `curl | bash` by looking **two directories up** from the installer for `Dockerfile` and `install.sh`. If both files existed, it then ran `cd <that-root>/deployment/docker-compose` to confirm this really was a PipesHub checkout.

   That `cd` is fatal under `set -e`: a failed command substitution in an assignment exits the whole script. The heuristic is also easy to trip without being in a PipesHub clone. Example: the user is in their own app, two levels up there is a `Dockerfile` and `install.sh`, and they run `curl | bash` so the installer lands in `./pipeshub`:

   ```text
   ~/work/myservice/              ← their app (Dockerfile + install.sh)
     Dockerfile
     install.sh
     deploy/
       pipeshub/                  ← curl download (this installer’s SCRIPT_DIR)
         install.sh
         docker-compose.yml
   ```

   Two levels up from `deploy/pipeshub` is `myservice`, so the files exist. Then `cd ~/work/myservice/deployment/docker-compose` fails because that folder is not there. The installer had already started containers; this is only printing the “you’re done” banner. `curl | bash` still exits 1, so the user (and any CI that checks the installer exit code) thinks the install failed.

## What changed

After a successful install, the banner now prints **where files live** and **where to `cd` before `./install.sh`**.

| How they installed | `cd` to | Then run |
| --- | --- | --- |
| `curl \| bash` (standalone) | the download dir (default `./pipeshub`) | `./install.sh --upgrade` |
| `git clone` then `./install.sh` | repository root | `./install.sh --upgrade` (root wrapper) |

- Standalone: one `Directory:` line (files and commands are the same path), plus “curl \| bash does not cd your shell”.
- Clone: `Files:` (`deployment/docker-compose`) and `Commands:` (repo root). The `cd` is a preamble (`cd` then a blank line, then `--stop`), not glued to the stop recipe.

Clone vs standalone is **not** “Dockerfile + install.sh two levels up”. It requires this script to be that repo’s `deployment/docker-compose/install.sh` **and** the repo-root `install.sh` to be the PipesHub wrapper (it contains `INNER_SUBPATH="deployment/docker-compose"`). A copy sitting in someone else’s `deployment/docker-compose` next to their own `./install.sh` stays standalone. So does a standalone download dropped inside a real clone at a different path.

Other installer UX on the same banner path:

- No `clear`. The wrapper’s download log stays on screen.
- Standalone only: wrapper exports `PIPESHUB_INSTALL_REF`; the ASCII banner reprints `Git ref: …` under the version line. Clone mode omits that line (no download).
- Missing compose dir in clone detection is `|| true` so a cosmetic banner cannot fail the install.

Logs still use an absolute `docker compose -f …` path, so they work from any cwd.

## Test plan

### Unit tests (no Docker)

From the repository root of this PR:

```bash
bash deployment/docker-compose/tests/installer_test.sh
```

Expect all checks to pass (currently 179).

### Manual: `curl | bash` (this PR, not the latest GitHub release)

`https://get.pipeshub.com/install` always fetches the **wrapper** from `main`. `PIPESHUB_REF` selects which **inner** `install.sh` + `docker-compose.yml` are downloaded. This PR changes **both**, so to review the full curl path, curl **this branch’s wrapper** and set `PIPESHUB_REF` to the **same branch**.

Use an **empty directory**, a **Compose project name that is not already in use**, and a **free host port**. Otherwise you will attach to (or fight with) an existing PipesHub stack. Do not pass `--uninstall` unless you intend to delete that project’s volumes.

`--print-env-only` exits before the success banner — do not use it for this check. `--yes` is fine if you want to skip the wizard.

```bash
mkdir -p /tmp/pipeshub-pr3083 && cd /tmp/pipeshub-pr3083

PIPESHUB_REF=fix/installer-success-banner-cwd \
PIPESHUB_DIR="$PWD/pipeshub" \
PIPESHUB_PROJECT=pipeshub-pr3083 \
PIPESHUB_PORT=3500 \
  curl -fsSL https://raw.githubusercontent.com/pipeshub-ai/pipeshub-ai/fix/installer-success-banner-cwd/install.sh | bash
```

**At start**, above the ASCII logo (must still be visible — the wizard must not clear the screen):

```text
> Installing from ref: fix/installer-success-banner-cwd
> Downloading deployment files into: …/pipeshub-pr3083/pipeshub
> Launching installer...
```

Under the logo:

```text
  v1.0.0
  Git ref: fix/installer-success-banner-cwd
```

If the first lines say a release tag such as `v0.6.0` instead of this branch, `PIPESHUB_REF` was not set (or you ran `./pipeshub/install.sh` from an old download instead of curl). Stop and re-run.

**At the end**, the success (or “not confirmed ready”) banner should look like:

```text
  This install
  ─────────────────────────────────────────────────────
  Directory:  /tmp/pipeshub-pr3083/pipeshub

  Useful commands
  ─────────────────────────────────────────────────────
  # From the install directory (curl | bash does not cd your shell)
  cd /tmp/pipeshub-pr3083/pipeshub

  # Stop (data preserved)
  ./install.sh --stop
```

`cd` must be followed by a blank line so it is not read as part of `--stop`. `--upgrade` / `--reconfigure` / `--uninstall` below it are meant to run from that same directory.

Optional: `cd` into that directory in a new shell and run `./install.sh --stop` to confirm the printed path is real. Then `./install.sh --upgrade` or leave the stack running.

### Manual: git clone

Use a **different** project name and port from the curl test (and from any stack you already run).

```bash
git clone -b fix/installer-success-banner-cwd https://github.com/pipeshub-ai/pipeshub-ai.git
cd pipeshub-ai

PIPESHUB_PROJECT=pipeshub-pr3083-clone PIPESHUB_PORT=3510 ./install.sh
```

There must be **no** `Git ref:` line (clone does not download a ref).

**At the end:**

```text
  This install
  ─────────────────────────────────────────────────────
  Files:     …/pipeshub-ai/deployment/docker-compose
  Commands:  …/pipeshub-ai

  Useful commands
  ─────────────────────────────────────────────────────
  # From the repository root
  cd …/pipeshub-ai

  # Stop (data preserved)
  ./install.sh --stop
```

`cd` is the clone root, not `deployment/docker-compose`. From that root, `./install.sh --stop` / `--upgrade` should work (the wrapper execs the inner installer).

## Out of scope

The git ref is shown for this run only. It is not written to `.env`. A later change could persist “which installer checkout was used” if we want that a month later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved installation detection to distinguish PipesHub clones from unrelated projects with similar layouts.
  - Preserved the selected installation version or branch throughout the standalone installation process.
  - Improved installer behavior when running in nested or standalone directory structures.

- **Tests**
  - Expanded coverage for clone detection, standalone installations, and terminal screen-clearing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->