### PR TITLE
fix(installer): stop repeating download progress lines in the terminal

### DIFF
--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1350,12 +1350,16 @@ export COMPOSE_PROFILES="${COMPOSE_PROFILES:-}"
 _USE_BUILD=false
 [[ "${IMAGE_SOURCE:-prebuilt}" == "local" ]] && _USE_BUILD=true
 
-# Compose's default "tty" progress redraws a single block via cursor-movement
-# escapes. When stdout is captured (terminal logs, `curl | bash`, CI), those
-# escapes don't collapse and every frame is recorded, producing hundreds of
-# duplicated "[+] Running N/17" blocks. Plain progress is append-only and stays
-# readable in every context.
-_PROGRESS=(--progress plain)
+# TTY: Compose redraws one progress block in place. Captured stdout (CI, piped
+# logs): `--progress plain` is append-only so cursor-escape frames do not
+# explode. Do not force plain on a TTY — that prints a new line per layer tick
+# and turns a multi-GB pull into thousands of Downloading/Extracting lines.
+# Same TTY vs captured split as the health-wait spinner vs heartbeat.
+if [[ -t 1 ]]; then
+  _PROGRESS=(--progress tty)
+else
+  _PROGRESS=(--progress plain)
+fi
 
 # Decide whether to refresh the prebuilt image from the registry before starting.
 # Pure decision (no side effects) so it is unit-testable in isolation.

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -294,6 +294,14 @@ resolve_banner_dirs() {
   fi
 }
 
+# Compose --progress tty|plain from a TTY flag. Keep this explicit instead of
+# `--progress auto`: auto is the same split inside Compose, but would re-detect
+# independently of the health-wait spinner. One _is_tty drives both.
+resolve_compose_progress() { # args: is_tty (true|false) -> tty|plain
+  [[ "$1" == true ]] && { echo tty; return; }
+  echo plain
+}
+
 # PIPESHUB_PROJECT wins. Else COMPOSE_PROJECT_NAME in this directory's .env so
 # --stop / --uninstall only tear down this copy. Else the default name.
 resolve_project_name() {
@@ -1350,16 +1358,13 @@ export COMPOSE_PROFILES="${COMPOSE_PROFILES:-}"
 _USE_BUILD=false
 [[ "${IMAGE_SOURCE:-prebuilt}" == "local" ]] && _USE_BUILD=true
 
-# TTY: Compose redraws one progress block in place. Captured stdout (CI, piped
-# logs): `--progress plain` is append-only so cursor-escape frames do not
-# explode. Do not force plain on a TTY — that prints a new line per layer tick
-# and turns a multi-GB pull into thousands of Downloading/Extracting lines.
-# Same TTY vs captured split as the health-wait spinner vs heartbeat.
-if [[ -t 1 ]]; then
-  _PROGRESS=(--progress tty)
-else
-  _PROGRESS=(--progress plain)
-fi
+# One TTY check for Compose pull/up progress and the health-wait spinner below.
+# curl | bash pipes stdin only; stdout stays on the terminal, so in-place
+# progress is the majority install path. Forced `--progress plain` on a TTY
+# prints a new line per layer tick and floods the log. Captured stdout (CI,
+# tee, redirect) still gets plain so cursor-escape frames do not explode.
+_is_tty=false; [[ -t 1 ]] && _is_tty=true
+_PROGRESS=(--progress "$(resolve_compose_progress "$_is_tty")")
 
 # Decide whether to refresh the prebuilt image from the registry before starting.
 # Pure decision (no side effects) so it is unit-testable in isolation.
@@ -1497,9 +1502,9 @@ crash_looping_containers() {
   done
 }
 
-# Poll until healthy or the deadline passes. On a TTY, redraw a single spinner
-# line in place (clean, one line); when output is captured (logs, curl | bash,
-# CI) emit a sparse heartbeat instead so transcripts don't fill with frames.
+# Poll until healthy or the deadline passes. Uses _is_tty from launch (same
+# flag as Compose progress). On a TTY, redraw a single spinner line in place;
+# when stdout is captured (CI, tee, redirect) emit a sparse heartbeat instead.
 ELAPSED=0
 CHECK_EVERY=5
 HEARTBEAT_EVERY=30
@@ -1507,7 +1512,6 @@ START_TS=$SECONDS
 _spinner=('⠋' '⠙' '⠹' '⠸' '⠼' '⠴' '⠦' '⠧' '⠇' '⠏')
 _spin=0
 _CRASH_REPORT=""
-_is_tty=false; [[ -t 1 ]] && _is_tty=true
 
 while (( ELAPSED < HEALTH_WAIT_SECS )); do
   if (( ELAPSED % CHECK_EVERY == 0 )) && app_is_healthy; then

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -11,7 +11,7 @@
 #     the main fallback all hit the correct download URLs.
 #   - Regression guards on the in-tree installer edits (16 GB-class RAM floor,
 #     host-side reachability check, health-gated "ready" banner, clone vs
-#     standalone command directory, plain compose progress, generous/overridable
+#     standalone command directory, TTY-aware compose progress, generous/overridable
 #     health-wait timeout).
 #   - Compose app healthcheck stays reconciled with the installer's readiness
 #     check (core services only; embedding excluded).
@@ -218,11 +218,12 @@ check ".env chmod is guarded" "$inner" '&& ! chmod 600 "$ENV_FILE"; then'
 check ".env chmod failure calls die" "$inner" 'die "Could not restrict permissions on $ENV_FILE"'
 check ".env backup locked to owner-only" "$inner" 'chmod 600 "$_backup"'
 check "crash-loop wait has 90s startup grace" "$inner" "ELAPSED >= 90"
-# Interactive TTY: Compose tty progress (in-place). Captured stdout: plain
-# (append-only) so cursor-escape frames do not explode in CI logs.
-check "tty progress when stdout is a TTY" "$inner" "_PROGRESS=(--progress tty)"
-check "plain progress when stdout is captured" "$inner" "_PROGRESS=(--progress plain)"
+# Compose progress and the health spinner share one _is_tty. The mapping
+# (true→tty, false→plain) is exercised via extract_fn below — grepping for
+# both strings would stay green if the branches were swapped.
 check "progress flag applied to compose up/pull" "$inner" 'docker compose "${_PROGRESS[@]}"'
+check "progress decision uses the testable helper" "$inner" 'resolve_compose_progress "$_is_tty"'
+check "one TTY flag for progress and health spinner" "$inner" '_is_tty=false; [[ -t 1 ]] && _is_tty=true'
 # First start (embedding model download + cold stack) can edge past 5 min; the
 # default must be generous and overridable so it does not falsely report failure.
 check "health wait default is 420s and overridable" "$inner" 'HEALTH_WAIT_SECS="${HEALTH_WAIT_SECS:-420}"'
@@ -474,6 +475,19 @@ check "pull fallback inspects sandbox image" "$inner" 'docker image inspect "$_S
 check "air-gapped guidance present" "$inner" "air-gapped host, preload the image"
 # Must not have reverted to a blanket pull of every service image on the hot path.
 if [[ "$inner" == *"up -d --pull always"* ]]; then fail "must refresh only the app image, not force-pull all services"; else pass "does not force-pull all service images"; fi
+
+echo "== In-tree installer: compose progress mode (real function) =="
+# Mapping must be tied to the TTY flag. Grepping for both "tty" and "plain"
+# in the script stays green if the branches are swapped.
+eval "$(extract_fn resolve_compose_progress "$INNER_INSTALLER")"
+check "tty terminal gets in-place progress" "$(resolve_compose_progress true)" "tty"
+check "captured stdout gets append-only progress" "$(resolve_compose_progress false)" "plain"
+check "unknown TTY flag defaults to plain" "$(resolve_compose_progress '')" "plain"
+if [[ "$(grep -Fc '_is_tty=false; [[ -t 1 ]] && _is_tty=true' "$INNER_INSTALLER")" -eq 1 ]]; then
+  pass "TTY flag assigned once"
+else
+  fail "TTY flag assigned once"
+fi
 
 echo "== In-tree installer: container outbound connectivity (warn-only) =="
 check "defines outbound probe helper" "$inner" "container_has_outbound_internet()"

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -218,10 +218,11 @@ check ".env chmod is guarded" "$inner" '&& ! chmod 600 "$ENV_FILE"; then'
 check ".env chmod failure calls die" "$inner" 'die "Could not restrict permissions on $ENV_FILE"'
 check ".env backup locked to owner-only" "$inner" 'chmod 600 "$_backup"'
 check "crash-loop wait has 90s startup grace" "$inner" "ELAPSED >= 90"
-# Compose animates progress with cursor escapes that explode into hundreds of
-# duplicated frames when output is captured; force append-only plain progress.
-check "plain progress flag defined" "$inner" "_PROGRESS=(--progress plain)"
-check "plain progress applied to compose up/pull" "$inner" 'docker compose "${_PROGRESS[@]}"'
+# Interactive TTY: Compose tty progress (in-place). Captured stdout: plain
+# (append-only) so cursor-escape frames do not explode in CI logs.
+check "tty progress when stdout is a TTY" "$inner" "_PROGRESS=(--progress tty)"
+check "plain progress when stdout is captured" "$inner" "_PROGRESS=(--progress plain)"
+check "progress flag applied to compose up/pull" "$inner" 'docker compose "${_PROGRESS[@]}"'
 # First start (embedding model download + cold stack) can edge past 5 min; the
 # default must be generous and overridable so it does not falsely report failure.
 check "health wait default is 420s and overridable" "$inner" 'HEALTH_WAIT_SECS="${HEALTH_WAIT_SECS:-420}"'


### PR DESCRIPTION
## Summary

When you run `./install.sh` in a terminal, Docker Compose was printing a **new line for every small update** while it downloaded images. First install of the slim image could fill the screen with thousands of almost-identical `Downloading` / `Extracting` lines. The images are only downloaded once — this was noisy logging, not extra work.

That happened because the installer always used Compose `--progress plain`. That mode is meant for CI and saved log files. In a real terminal it is the wrong choice.

`curl … | bash` only pipes **input** into bash. The terminal is still where output goes, so those users should get the in-place progress view too.

**This PR:**
- In a real terminal: `--progress tty` so Compose redraws **one** progress view in place
- When output is saved or piped (CI, `tee`, redirect to a file): keep `--progress plain` so animation frames do not explode into duplicated lines
- One `_is_tty` flag drives both image-pull progress and the “waiting for health” spinner, so they cannot drift apart
- An explicit `tty` / `plain` choice rather than Compose `--progress auto`, because `auto` would detect the terminal on its own and could disagree with the spinner

## Test plan

- [ ] `bash deployment/docker-compose/tests/installer_test.sh`
- [ ] In a normal terminal, pull a missing image (`docker rmi pipeshubai/pipeshub-ai:slim` if it is already local, then `./install.sh`) and confirm progress updates **in place**, not a wall of repeated lines
- [ ] Confirm CI still uses plain progress: the tests call `resolve_compose_progress true` / `false` and check the result is `tty` / `plain` (not just that both strings exist in the file)