### PR TITLE
Docs: drop Bitbucket from the README code-search claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ PipesHub provides developer SDKs for Python, TypeScript, and Go to help you inte
 <li>✅ 🤖 <strong>Workplace AI agents</strong>: first-class no-code agent builder</li>
 <li>✅ 🔗 <strong>MCP (Model Context Protocol)</strong> support, both server and client</li>
 <li>✅ 🧰 <strong>Developers SDKs</strong></li>
-<li>✅ 🔍 <strong>Code search</strong> across GitHub, GitLab, and Bitbucket</li>
+<li>✅ 🔍 <strong>Code search</strong> across GitHub and GitLab</li>
 <li>⬜ 👤 <strong>Personalized search</strong> based on team, role, and history</li>
 <li>✅ ☸️ <strong>Production Kubernetes</strong> deployment with HA defaults</li>
 <li>⬜ 📈 <strong>PageRank-augmented relevance</strong> across the knowledge graph</li>


### PR DESCRIPTION
## Why

The README roadmap says code search covers GitHub, GitLab, and Bitbucket. There is no Bitbucket connector. `ConnectorFactory` registers GitHub and GitLab only. Docs.pipeshub.com has GitHub and GitLab pages and no Bitbucket page.

A visitor reading the README would think Bitbucket is indexed. It is not.

The same correction is in [documentation#162](https://github.com/pipeshub-ai/documentation/pull/162).

## What changed

One line in `README.md`: code search is GitHub and GitLab.

Translated README copies under `docs/i18n/` still mention Bitbucket. Those can follow in a translation pass.

## How to check

Read the Roadmap list in the README preview. Bitbucket should not appear.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the RoadMap to reflect code search support across GitHub and GitLab.
  * Removed Bitbucket from the listed code search platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->