### PR TITLE
Docs: put the curl install command at the top of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@
 
 <strong>[PipesHub](https://www.pipeshub.com/)</strong> is the open-source Context Layer for Enterprise AI. Connect enterprise knowledge across your organization, preserve access permissions, generate trustworthy citations, and build AI agents, enterprise search, RAG applications, MCP servers, and agentic workflows on a single governed context layer.
 
+> [!TIP]
+> Deploy with a single command:
+> ```bash
+> curl -fsSL https://get.pipeshub.com/install | bash
+> ```
+
 ## Features
 
 - 📝 **Explainable Answers:** PipesHub delivers grounded answers with precise block citations to the original documents.


### PR DESCRIPTION
## Why

People who land on the GitHub repo should see how to run PipesHub without scrolling.

The curl command is already in the Deployment Guide and the FAQ.

This is the product README, not documentation PR #154 (that is docs.pipeshub.com).

## What changed

One GitHub tip at the top of `README.md`:

```bash
curl -fsSL https://get.pipeshub.com/install | bash
```

The Deployment Guide below is unchanged (inspect-first, clone path, flags).

## How to check

Open the README preview on this branch. The tip should sit under the “Explainable & Extensible” paragraph and above Features.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a tip to the README highlighting a one-command deployment option.
  * Included installation instructions using the official deployment script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->