### PR TITLE
Fix/servicenow connector defects

### DIFF
--- a/backend/python/app/connectors/sources/servicenow/servicenow/connector.py
+++ b/backend/python/app/connectors/sources/servicenow/servicenow/connector.py
@@ -256,16 +256,12 @@ class ServiceNowConnector(BaseConnector):
                 data_store_provider=self.data_store_provider,
             )
 
-        # Sync points for different entity types
+        # Sync points for different entity types. Groups, roles and knowledge
+        # bases have none: those three reads must stay full, see
+        # _fetch_all_memberships and _sync_knowledge_bases.
         self.user_sync_point = _create_sync_point(SyncDataPointType.USERS)
-        self.group_sync_point = _create_sync_point(SyncDataPointType.GROUPS)
-        self.kb_sync_point = _create_sync_point(SyncDataPointType.RECORD_GROUPS)
         self.category_sync_point = _create_sync_point(SyncDataPointType.RECORD_GROUPS)
         self.article_sync_point = _create_sync_point(SyncDataPointType.RECORDS)
-
-        # Role sync points (roles are represented as special user groups)
-        self.role_sync_point = _create_sync_point(SyncDataPointType.GROUPS)
-        self.role_assignment_sync_point = _create_sync_point(SyncDataPointType.GROUPS)
 
         # Organizational entity sync points
         self.company_sync_point = _create_sync_point(SyncDataPointType.GROUPS)
@@ -1095,26 +1091,23 @@ class ServiceNowConnector(BaseConnector):
 
 
     async def _fetch_all_memberships(self) -> List[SysUserGroupMembership]:
-        """Fetch all user-group memberships from ServiceNow
-        
+        """Fetch every user-group membership from ServiceNow.
+
+        This read must stay full. ``on_new_user_groups`` deletes all permission
+        edges that point to a group before it writes the members given to it, so
+        a delta read would drop every membership whose ``sys_user_grmember`` row
+        did not change inside the delta window.
+
         Returns:
             List of SysUserGroupMembership Pydantic models
         """
         try:
-            last_sync_data = await self.group_sync_point.read_sync_point(ServiceNowSyncPointKeys.GROUPS)
-            last_sync_time = (last_sync_data.get(ServiceNowSyncPointKeys.LAST_SYNC_TIME) if last_sync_data else None)
-
-            if last_sync_time:
-                self.logger.info(f"🔄 Delta sync: fetching user memberships updated after {last_sync_time}")
-                query = f"{ServiceNowFields.SYS_UPDATED_ON}>{last_sync_time}^{ServiceNowQueryValues.ORDER_BY_UPDATED}"
-            else:
-                self.logger.info("🆕 Full sync: fetching all user memberships")
-                query = ServiceNowQueryValues.ORDER_BY_UPDATED
+            self.logger.info("Fetching all user memberships")
+            query = ServiceNowQueryValues.ORDER_BY_UPDATED
 
             all_memberships: List[SysUserGroupMembership] = []
             batch_size = ServiceNowDefaults.BATCH_SIZE
             offset = ServiceNowDefaults.PAGINATION_OFFSET
-            latest_update_time = None
 
             while True:
                 datasource = await self._get_fresh_datasource()
@@ -1145,8 +1138,6 @@ class ServiceNowConnector(BaseConnector):
 
                 # Parse records into Pydantic models
                 memberships = [SysUserGroupMembership(**record.model_dump()) for record in response.result]
-                latest_update_time = memberships[-1].sys_updated_on
-
                 all_memberships.extend(memberships)
                 offset += batch_size
 
@@ -1154,8 +1145,6 @@ class ServiceNowConnector(BaseConnector):
                     break
 
             self.logger.info(f"Fetched {len(all_memberships)} memberships")
-            if latest_update_time:
-                await self.group_sync_point.update_sync_point(ServiceNowSyncPointKeys.GROUPS, {ServiceNowSyncPointKeys.LAST_SYNC_TIME: latest_update_time})
             return all_memberships
 
         except Exception as e:
@@ -1314,25 +1303,21 @@ class ServiceNowConnector(BaseConnector):
     async def _fetch_all_role_assignments(self) -> List[SysUserRoleAssignment]:
         """
         Fetch all user-role assignments from sys_user_has_role table.
-        
+
+        This read must stay full, for the reason given in
+        ``_fetch_all_memberships``: roles go through the same
+        ``on_new_user_groups`` replace-on-write path.
+
         Returns:
             List of SysUserRoleAssignment Pydantic models
         """
         try:
-            last_sync_data = await self.role_assignment_sync_point.read_sync_point(ServiceNowSyncPointKeys.ROLE_ASSIGNMENTS)
-            last_sync_time = last_sync_data.get(ServiceNowSyncPointKeys.LAST_SYNC_TIME) if last_sync_data else None
-
-            if last_sync_time:
-                self.logger.info(f"🔄 Delta sync: fetching role assignments updated after {last_sync_time}")
-                query = f"state={ServiceNowFields.ACTIVE}^{ServiceNowFields.SYS_UPDATED_ON}>{last_sync_time}^{ServiceNowQueryValues.ORDER_BY_UPDATED}"
-            else:
-                self.logger.info("🆕 Full sync: fetching all active role assignments")
-                query = f"state={ServiceNowFields.ACTIVE}^{ServiceNowQueryValues.ORDER_BY_UPDATED}"
+            self.logger.info("Fetching all active role assignments")
+            query = f"state={ServiceNowFields.ACTIVE}^{ServiceNowQueryValues.ORDER_BY_UPDATED}"
 
             all_assignments: List[SysUserRoleAssignment] = []
             batch_size = ServiceNowDefaults.BATCH_SIZE
             offset = ServiceNowDefaults.PAGINATION_OFFSET
-            latest_update_time = None
 
             while True:
                 datasource = await self._get_fresh_datasource()
@@ -1363,17 +1348,10 @@ class ServiceNowConnector(BaseConnector):
                 # Parse records into Pydantic models
                 assignments = [SysUserRoleAssignment(**record.model_dump()) for record in response.result]
                 all_assignments.extend(assignments)
-                latest_update_time = assignments[-1].sys_updated_on
 
                 offset += batch_size
                 if len(assignments) < batch_size:
                     break
-
-            if latest_update_time:
-                await self.role_assignment_sync_point.update_sync_point(
-                    ServiceNowSyncPointKeys.ROLE_ASSIGNMENTS,
-                    {ServiceNowSyncPointKeys.LAST_SYNC_TIME: latest_update_time}
-                )
 
             self.logger.info(f"Fetched {len(all_assignments)} role assignments")
             return all_assignments
@@ -1697,22 +1675,17 @@ class ServiceNowConnector(BaseConnector):
             admin_users: List of admin users to grant explicit READ permissions
         """
         try:
-            # Get sync checkpoint for delta sync
-            last_sync_data = await self.kb_sync_point.read_sync_point(ServiceNowSyncPointKeys.KNOWLEDGE_BASES)
-            last_sync_time = (last_sync_data.get(ServiceNowSyncPointKeys.LAST_SYNC_TIME) if last_sync_data else None)
-
-            if last_sync_time:
-                self.logger.info(f"🔄 Delta sync: Fetching KBs updated after {last_sync_time}")
-                query = f"{ServiceNowFields.SYS_UPDATED_ON}>{last_sync_time}^{ServiceNowQueryValues.ORDER_BY_UPDATED}"
-            else:
-                self.logger.info("🆕 Full sync: Fetching all knowledge bases")
-                query = ServiceNowQueryValues.ORDER_BY_UPDATED
+            # This read stays full. A knowledge base holds its read grants in
+            # kb_uc_can_read_mtom, and a change there does not touch
+            # kb_knowledge_base.sys_updated_on. A delta on the base row would
+            # therefore never see a new or a removed grant.
+            self.logger.info("Fetching all knowledge bases")
+            query = ServiceNowQueryValues.ORDER_BY_UPDATED
 
             # Pagination variables
             batch_size = ServiceNowDefaults.BATCH_SIZE
             offset = ServiceNowDefaults.PAGINATION_OFFSET
             total_synced = 0
-            latest_update_time = None
 
             # Paginate through all KBs
             while True:
@@ -1752,10 +1725,6 @@ class ServiceNowConnector(BaseConnector):
                 if not kbs_data:
                     self.logger.info("✅ No more knowledge bases to fetch")
                     break
-
-                # Track the latest update timestamp for checkpoint
-                if kbs_data:
-                    latest_update_time = kbs_data[-1].sys_updated_on
 
                 # Transform to RecordGroup entities
                 kb_record_groups = []
@@ -1823,10 +1792,6 @@ class ServiceNowConnector(BaseConnector):
                 # If this page has fewer records than batch_size, we're done
                 if len(kbs_data) < batch_size:
                     break
-
-            # Save checkpoint for next sync
-            if latest_update_time:
-                await self.kb_sync_point.update_sync_point(ServiceNowSyncPointKeys.KNOWLEDGE_BASES, {ServiceNowSyncPointKeys.LAST_SYNC_TIME: latest_update_time})
 
             self.logger.info(f"✅ Knowledge base sync complete, Total synced: {total_synced}")
 

--- a/backend/python/app/connectors/sources/servicenow/servicenow/connector.py
+++ b/backend/python/app/connectors/sources/servicenow/servicenow/connector.py
@@ -916,8 +916,11 @@ class ServiceNowConnector(BaseConnector):
                     )
                     
                 except ServiceNowAPIError as e:
-                    self.logger.error(f"❌ API error: {e.message} (status: {e.status_code})")
-                    break
+                    # A short list is indistinguishable from a complete one to
+                    # everything downstream, so the sync would report success over
+                    # whatever this page did not return.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 # Extract users from response
                 users_data = response.result
@@ -1068,8 +1071,11 @@ class ServiceNowConnector(BaseConnector):
                         sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
                     )
                     
-                except ServiceNowAPIError:
-                    break
+                except ServiceNowAPIError as e:
+                    # A partial list makes the caller delete permission edges that
+                    # it cannot rebuild, so stop the sync instead.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 if not response.result:
                     break
@@ -1130,8 +1136,11 @@ class ServiceNowConnector(BaseConnector):
                         sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
                     )
                     
-                except ServiceNowAPIError:
-                    break
+                except ServiceNowAPIError as e:
+                    # A partial list makes the caller delete permission edges that
+                    # it cannot rebuild, so stop the sync instead.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 if not response.result:
                     break
@@ -1278,8 +1287,11 @@ class ServiceNowConnector(BaseConnector):
                         sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
                     )
                     
-                except ServiceNowAPIError:
-                    break
+                except ServiceNowAPIError as e:
+                    # A partial list makes the caller delete permission edges that
+                    # it cannot rebuild, so stop the sync instead.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 if not response.result:
                     break
@@ -1339,8 +1351,11 @@ class ServiceNowConnector(BaseConnector):
                         sysparm_no_count=ServiceNowQueryValues.NO_COUNT_TRUE,
                         sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
                     )
-                except ServiceNowAPIError:
-                    break
+                except ServiceNowAPIError as e:
+                    # A partial list makes the caller delete permission edges that
+                    # it cannot rebuild, so stop the sync instead.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 if not response.result:
                     break
@@ -1397,8 +1412,11 @@ class ServiceNowConnector(BaseConnector):
                         sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
                     )
                     
-                except ServiceNowAPIError:
-                    break
+                except ServiceNowAPIError as e:
+                    # A partial list makes the caller delete permission edges that
+                    # it cannot rebuild, so stop the sync instead.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 if not response.result:
                     break
@@ -1604,8 +1622,11 @@ class ServiceNowConnector(BaseConnector):
                     )
                     
                 except ServiceNowAPIError as e:
-                    self.logger.error(f"❌ API error: {e.message} (status: {e.status_code})")
-                    break
+                    # A short list is indistinguishable from a complete one to
+                    # everything downstream, so the sync would report success over
+                    # whatever this page did not return.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 # Extract entities from response
                 entities_data = response.result
@@ -1715,9 +1736,15 @@ class ServiceNowConnector(BaseConnector):
                     )
                     
                 except ServiceNowAPIError as e:
-                    if "Expecting value" not in str(e):
-                        self.logger.error(f"❌ API error: {e.message} (status: {e.status_code})")
-                    break
+                    # An empty page comes back as a body that is not JSON, so this
+                    # particular failure is how the read ends, not a fault.
+                    if "Expecting value" in str(e):
+                        break
+                    # A short list is indistinguishable from a complete one to
+                    # everything downstream, so the sync would report success over
+                    # whatever this page did not return.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 # Extract KBs from response
                 kbs_data = response.result
@@ -1856,9 +1883,12 @@ class ServiceNowConnector(BaseConnector):
                         sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
                     )
                     
+                    # A short list is indistinguishable from a complete one to
+                    # everything downstream, so the sync would report success over
+                    # whatever this page did not return.
                 except ServiceNowAPIError as e:
-                    self.logger.error(f"❌ API error: {e.message} (status: {e.status_code}")
-                    break
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 # Extract categories from response
                 categories_data = response.result
@@ -1935,6 +1965,7 @@ class ServiceNowConnector(BaseConnector):
             offset = ServiceNowDefaults.PAGINATION_OFFSET
             total_articles_synced = 0
             total_attachments_synced = 0
+            total_records_dropped = 0
             latest_update_time = None
 
             # Paginate through all articles
@@ -1970,8 +2001,11 @@ class ServiceNowConnector(BaseConnector):
                     )
                     
                 except ServiceNowAPIError as e:
-                    self.logger.error(f"❌ API error: {e.message} (status: {e.status_code})")
-                    break
+                    # A short list is indistinguishable from a complete one to
+                    # everything downstream, so the sync would report success over
+                    # whatever this page did not return.
+                    self.logger.error(f"❌ API error at offset {offset}: {e.message} (status: {e.status_code})")
+                    raise
 
                 # Extract articles from response
                 articles_data = response.result
@@ -2000,7 +2034,7 @@ class ServiceNowConnector(BaseConnector):
 
                 # Process batch of RecordUpdates
                 if record_updates:
-                    await self._process_record_updates_batch(record_updates)
+                    total_records_dropped += await self._process_record_updates_batch(record_updates)
 
                 # Move to next batch
                 offset += batch_size
@@ -2013,7 +2047,11 @@ class ServiceNowConnector(BaseConnector):
             if latest_update_time:
                 await self.article_sync_point.update_sync_point(ServiceNowSyncPointKeys.ARTICLES, {ServiceNowSyncPointKeys.LAST_SYNC_TIME: latest_update_time})
 
-            self.logger.info(f"✅ Articles synced: {total_articles_synced} articles, {total_attachments_synced} attachments")
+            self.logger.info(
+                f"✅ Articles synced: {total_articles_synced} articles, "
+                f"{total_attachments_synced} attachments, "
+                f"{total_records_dropped} record(s) dropped without permissions"
+            )
 
         except Exception as e:
             self.logger.error(f"❌ Error syncing articles: {e}", exc_info=True)
@@ -2117,7 +2155,7 @@ class ServiceNowConnector(BaseConnector):
             self.logger.error(f"Failed to process article {article_data.get('sys_id')}: {e}", exc_info=True)
             return []
 
-    async def _process_record_updates_batch(self, record_updates: List[RecordUpdate]) -> None:
+    async def _process_record_updates_batch(self, record_updates: List[RecordUpdate]) -> int:
         """
         Process a batch of RecordUpdates using the data entities processor.
 
@@ -2126,20 +2164,39 @@ class ServiceNowConnector(BaseConnector):
 
         Args:
             record_updates: List of RecordUpdate objects
+
+        Returns:
+            int: Number of records dropped because they carry no permissions.
         """
         try:
             if not record_updates:
-                return
+                return 0
 
             # Convert RecordUpdates to (Record, Permissions) tuples
             records_with_permissions = []
+            dropped_external_ids = []
             for update in record_updates:
-                if update.record and update.new_permissions:
+                if not update.record:
+                    continue
+                if update.new_permissions:
                     records_with_permissions.append((update.record, update.new_permissions))
+                else:
+                    dropped_external_ids.append(update.external_record_id)
+
+            # A record with no principal reaches nobody, so it is not written. Name
+            # the records, otherwise the sync reports a count it did not store.
+            if dropped_external_ids:
+                self.logger.warning(
+                    "Dropped %d record(s) with no permissions: %s",
+                    len(dropped_external_ids),
+                    dropped_external_ids,
+                )
 
             # Use processor's batch method
             if records_with_permissions:
                 await self.data_entities_processor.on_new_records(records_with_permissions)
+
+            return len(dropped_external_ids)
 
         except Exception as e:
             self.logger.error(f"Failed to process record updates batch: {e}", exc_info=True)

--- a/backend/python/app/connectors/sources/servicenow/servicenow/connector.py
+++ b/backend/python/app/connectors/sources/servicenow/servicenow/connector.py
@@ -239,6 +239,12 @@ class ServiceNowConnector(BaseConnector):
 
         # Configuration
         self.instance_url: Optional[str] = None
+        # The portal that serves the knowledge pages. Read from the instance
+        # during init(), because it differs from one instance to the next.
+        self.kb_portal_suffix: str = ServiceNowDefaults.KB_PORTAL_SUFFIX
+        # Whether article criteria override the criteria of the knowledge base.
+        # Read from the instance during init(); false is the ServiceNow default.
+        self.apply_article_read_criteria: bool = False
         self.client_id: Optional[str] = None
         self.client_secret: Optional[str] = None
         self.redirect_uri: Optional[str] = None
@@ -316,7 +322,8 @@ class ServiceNowConnector(BaseConnector):
 
             oauth_config_data = oauth_config.get(OAuthConfigKeys.CONFIG, {})
 
-            self.instance_url = oauth_config_data.get(AuthFieldKeys.INSTANCE_URL)
+            # A trailing slash would give "https://<instance>.service-now.com//kb?...".
+            self.instance_url = (oauth_config_data.get(AuthFieldKeys.INSTANCE_URL) or "").rstrip("/") or None
             self.client_id = oauth_config_data.get(AuthFieldKeys.CLIENT_ID)
             self.client_secret = oauth_config_data.get(AuthFieldKeys.CLIENT_SECRET)
             self.redirect_uri = oauth_config.get(AuthFieldKeys.REDIRECT_URI)
@@ -370,6 +377,10 @@ class ServiceNowConnector(BaseConnector):
                 self.logger.error("❌ Connection test failed")
                 return False
 
+            self.kb_portal_suffix = await self._resolve_kb_portal_suffix()
+
+            self.apply_article_read_criteria = await self._resolve_article_read_criteria()
+
             self.logger.info("✅ ServiceNow KB Connector initialized successfully")
             return True
 
@@ -406,9 +417,8 @@ class ServiceNowConnector(BaseConnector):
         if not fresh_token:
             raise Exception("No access token available")
 
-        # Update client's token if it changed (mutation)
         if self.servicenow_client.access_token != fresh_token:
-            self.servicenow_client.access_token = fresh_token
+            self.servicenow_client.set_access_token(fresh_token)
 
         return ServiceNowDataSource(self.servicenow_client)
 
@@ -565,6 +575,101 @@ class ServiceNowConnector(BaseConnector):
             raise HTTPException(
                 status_code=HttpStatusCode.INTERNAL_SERVER_ERROR.value, detail=f"Failed to stream record: {str(e)}"
             )
+
+    async def _read_instance_property(self, name: str) -> Optional[str]:
+        """Read one sys_properties value. None means the property is not set.
+
+        A read that fails raises, because "not set" and "could not tell" are
+        different answers and only the caller knows which way to lean on the
+        second one.
+        """
+        datasource = await self._get_fresh_datasource()
+        response = await datasource.get_now_table_tableName(
+            tableName=ServiceNowTables.SYS_PROPERTIES,
+            sysparm_query=f"{ServiceNowFields.NAME}={name}",
+            sysparm_fields=ServiceNowFields.VALUE,
+            sysparm_limit=ServiceNowDefaults.DEFAULT_LIMIT,
+            sysparm_display_value=ServiceNowQueryValues.DISPLAY_VALUE_FALSE,
+            sysparm_no_count=ServiceNowQueryValues.NO_COUNT_TRUE,
+            sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
+        )
+        if response.result:
+            return (response.result[0].get(ServiceNowFields.VALUE) or "").strip()
+        return None
+
+    async def _resolve_article_read_criteria(self) -> bool:
+        """Whether an article's own Can Read criteria override its knowledge base.
+
+        ServiceNow applies them as an override only when
+        glide.knowman.apply_article_read_criteria is true, and leaves the
+        property unset on a default instance, so unset means false.
+
+        A property that cannot be read is a different case: the answer decides
+        who reaches an article, so it leans to true. That indexes an article
+        under its own criteria when the base would have opened it wider, which
+        shows fewer people less than they are entitled to, rather than showing
+        somebody something the instance restricts.
+        """
+        try:
+            value = await self._read_instance_property(
+                ServiceNowDefaults.ARTICLE_READ_CRITERIA_PROPERTY
+            )
+        except Exception as e:
+            self.logger.warning(
+                "Could not read "
+                f"{ServiceNowDefaults.ARTICLE_READ_CRITERIA_PROPERTY} ({e}); "
+                "applying article read criteria as an override until it can be read"
+            )
+            return True
+
+        applies = (value or "").strip().lower() == "true"
+        self.logger.info(f"Article read criteria override the knowledge base: {applies}")
+        return applies
+
+    async def _resolve_kb_portal_suffix(self) -> str:
+        """Find the Service Portal that serves the knowledge pages.
+
+        The article pages (kb_article_view, kb_category, kb_home) belong to a
+        portal, and each instance chooses its own. The Knowledge Management
+        portal plugin records that choice in a system property. When the
+        property is empty the default portal serves the pages.
+
+        Returns:
+            str: The portal URL suffix, for example "kb" or "esc".
+        """
+        try:
+            suffix = await self._read_instance_property(ServiceNowDefaults.KB_PORTAL_PROPERTY)
+        except Exception as e:
+            # A link that points at the wrong portal is wrong on screen only, so
+            # this one falls back rather than leaning any particular way.
+            self.logger.warning(f"Could not read the knowledge portal property: {e}")
+            suffix = None
+        if suffix:
+            self.logger.info(f"Knowledge portal from the instance property: /{suffix}")
+            return suffix
+
+        try:
+            datasource = await self._get_fresh_datasource()
+            response = await datasource.get_now_table_tableName(
+                tableName=ServiceNowTables.SP_PORTAL,
+                sysparm_query=f"{ServiceNowFields.DEFAULT}=true",
+                sysparm_fields=ServiceNowFields.URL_SUFFIX,
+                sysparm_limit=ServiceNowDefaults.DEFAULT_LIMIT,
+                sysparm_display_value=ServiceNowQueryValues.DISPLAY_VALUE_FALSE,
+                sysparm_no_count=ServiceNowQueryValues.NO_COUNT_TRUE,
+                sysparm_exclude_reference_link=ServiceNowQueryValues.EXCLUDE_REFERENCE_LINK_TRUE,
+            )
+            suffix = (response.result[0].get(ServiceNowFields.URL_SUFFIX) or "").strip() if response.result else ""
+            if suffix:
+                self.logger.info(f"Knowledge portal from the default portal: /{suffix}")
+                return suffix
+        except Exception as e:
+            self.logger.warning(f"Could not read the default portal: {e}")
+
+        self.logger.info(
+            f"Knowledge portal falls back to /{ServiceNowDefaults.KB_PORTAL_SUFFIX}"
+        )
+        return ServiceNowDefaults.KB_PORTAL_SUFFIX
 
     async def _fetch_article_content(self, article_sys_id: str) -> str:
         """
@@ -2132,6 +2237,7 @@ class ServiceNowConnector(BaseConnector):
                     att_data,
                     parent_record_group_type=article_record.record_group_type,
                     parent_external_record_group_id=article_record.external_record_group_id,
+                    inherit_permissions=article_record.inherit_permissions,
                 )
 
                 if att_record:
@@ -2698,7 +2804,11 @@ class ServiceNowConnector(BaseConnector):
             # Construct web URL
             web_url = None
             if self.instance_url:
-                web_url = ServiceNowURLPatterns.KB_BASE.format(instance_url=self.instance_url, sys_id=sys_id)
+                web_url = ServiceNowURLPatterns.KB_BASE.format(
+                    instance_url=self.instance_url,
+                    portal=self.kb_portal_suffix,
+                    sys_id=sys_id,
+                )
 
             # Create RecordGroup for Knowledge Base
             kb_record_group = RecordGroup(
@@ -2752,7 +2862,11 @@ class ServiceNowConnector(BaseConnector):
             # Construct web URL
             web_url = None
             if self.instance_url:
-                web_url = ServiceNowURLPatterns.KB_CATEGORY.format(instance_url=self.instance_url, sys_id=sys_id)
+                web_url = ServiceNowURLPatterns.KB_CATEGORY.format(
+                    instance_url=self.instance_url,
+                    portal=self.kb_portal_suffix,
+                    sys_id=sys_id,
+                )
 
             # Create RecordGroup for Category
             category_record_group = RecordGroup(
@@ -2807,7 +2921,11 @@ class ServiceNowConnector(BaseConnector):
             # Construct web URL
             web_url = None
             if self.instance_url:
-                web_url = ServiceNowURLPatterns.KB_ARTICLE.format(instance_url=self.instance_url, sys_id=sys_id)
+                web_url = ServiceNowURLPatterns.KB_ARTICLE.format(
+                    instance_url=self.instance_url,
+                    portal=self.kb_portal_suffix,
+                    sys_id=sys_id,
+                )
 
             # Extract category sys_id for external_record_group_id
             # Fallback to KB if category is empty/missing
@@ -2830,11 +2948,22 @@ class ServiceNowConnector(BaseConnector):
                     self.logger.warning(f"Article {sys_id} has no category and no KB - skipping")
                     return None
 
+            # An article that carries its own Can Read criteria must not also
+            # receive the grants of its knowledge base, but only on an instance
+            # where that override is switched on. See KBKnowledgeSNC.canRead.
+            own_read_criteria = bool((article_data.can_read_user_criteria or "").strip())
+            inherit_permissions = not (self.apply_article_read_criteria and own_read_criteria)
+
             # Create WebpageRecord for Article
             record_id = str(uuid.uuid4())
             article_record = WebpageRecord(
                 id=record_id,
+                inherit_permissions=inherit_permissions,
                 external_record_id=sys_id,
+                # The processor rewrites a stored record, and re-queues it for
+                # indexing, only when this differs from what it holds. Leaving it
+                # unset froze every record at its first index.
+                external_revision_id=article_data.sys_updated_on,
                 version=0,
                 record_name=short_description,
                 record_type=RecordType.WEBPAGE,
@@ -2860,6 +2989,8 @@ class ServiceNowConnector(BaseConnector):
         attachment_data: AttachmentMetadata,
         parent_record_group_type: Optional[RecordGroupType] = None,
         parent_external_record_group_id: Optional[str] = None,
+        *,
+        inherit_permissions: bool = True,
     ) -> Optional[FileRecord]:
         """
         Transform ServiceNow sys_attachment to FileRecord entity.
@@ -2868,6 +2999,8 @@ class ServiceNowConnector(BaseConnector):
             attachment_data: ServiceNow sys_attachment AttachmentMetadata model
             parent_record_group_type: The record group type from parent article (CATEGORY or KB)
             parent_external_record_group_id: The external record group ID from parent article
+            inherit_permissions: Follows the parent article, so an attachment never
+                reaches a reader that the article itself keeps out
 
         Returns:
             FileRecord: Transformed attachment or None if invalid
@@ -2915,6 +3048,8 @@ class ServiceNowConnector(BaseConnector):
             attachment_record_id = str(uuid.uuid4())
             attachment_record = FileRecord(
                 id=attachment_record_id,
+                inherit_permissions=inherit_permissions,
+                external_revision_id=attachment_data.sys_updated_on,
                 org_id=self.data_entities_processor.org_id,
                 record_name=file_name,
                 record_type=RecordType.FILE,

--- a/backend/python/app/connectors/sources/servicenow/servicenow/constants.py
+++ b/backend/python/app/connectors/sources/servicenow/servicenow/constants.py
@@ -146,11 +146,8 @@ class ServiceNowRoles:
 class ServiceNowSyncPointKeys:
     """Keys for sync point storage"""
     USERS = "users"
-    GROUPS = "groups"
-    KNOWLEDGE_BASES = "knowledge_bases"
     CATEGORIES = "categories"
     ARTICLES = "articles"
-    ROLE_ASSIGNMENTS = "role_assignments"
     LAST_SYNC_TIME = "last_sync_time"
 
 

--- a/backend/python/app/connectors/sources/servicenow/servicenow/constants.py
+++ b/backend/python/app/connectors/sources/servicenow/servicenow/constants.py
@@ -28,6 +28,8 @@ class ServiceNowTables:
     SYS_USER_ROLE_CONTAINS = "sys_user_role_contains"
     SYS_ATTACHMENT = "sys_attachment"
     USER_CRITERIA = "user_criteria"
+    SYS_PROPERTIES = "sys_properties"
+    SP_PORTAL = "sp_portal"
     KB_UC_CAN_READ_MTOM = "kb_uc_can_read_mtom"
     KB_UC_CAN_CONTRIBUTE_MTOM = "kb_uc_can_contribute_mtom"
     CORE_COMPANY = "core_company"
@@ -81,6 +83,8 @@ class ServiceNowFields:
     RESULT = "result"
     CONTAINS = "contains"
     PARENT_TABLE = "parent_table"
+    URL_SUFFIX = "url_suffix"
+    DEFAULT = "default"
 
 
 class ServiceNowQueryParams:
@@ -104,10 +108,14 @@ class ServiceNowQueryValues:
 
 
 class ServiceNowURLPatterns:
-    """ServiceNow URL patterns for constructing web URLs"""
-    KB_BASE = "{instance_url}kb?kb={sys_id}"
-    KB_ARTICLE = "{instance_url}/sp?id=kb_article&sys_id={sys_id}"
-    KB_CATEGORY = "{instance_url}sp?id=kb_category&kb_category={sys_id}"
+    """ServiceNow URL patterns for constructing web URLs.
+
+    The knowledge pages live in a Service Portal, and the instance decides
+    which portal that is. See ServiceNowConnector._resolve_kb_portal_suffix.
+    """
+    KB_BASE = "{instance_url}/{portal}?id=kb_home&kb={sys_id}"
+    KB_ARTICLE = "{instance_url}/{portal}?id=kb_article_view&sys_kb_id={sys_id}"
+    KB_CATEGORY = "{instance_url}/{portal}?id=kb_category&kb_category={sys_id}"
     ATTACHMENT = "{instance_url}/sys_attachment.do?sys_id={sys_id}"
 
 
@@ -131,6 +139,12 @@ class ServiceNowDefaults:
     ADMIN_ROLE_NAME = "admin"
     DEFAULT_MIME_TYPE = "application/octet-stream"
     UNKNOWN_VALUE = "Unknown"
+    # The out-of-box Knowledge Portal. Used only when the instance tells us nothing.
+    KB_PORTAL_SUFFIX = "kb"
+    KB_PORTAL_PROPERTY = "sn_km_portal.glide.knowman.serviceportal.portal_url"
+    # When true, an article's own Can Read criteria decide, and the grants of
+    # the parent knowledge base no longer reach that article.
+    ARTICLE_READ_CRITERIA_PROPERTY = "glide.knowman.apply_article_read_criteria"
 
 
 class ServiceNowConfigPaths:

--- a/backend/python/app/sources/client/servicenow/servicenow.py
+++ b/backend/python/app/sources/client/servicenow/servicenow.py
@@ -242,6 +242,15 @@ class ServiceNowRESTClientViaOAuthAuthorizationCode(HTTPClient):
         """Check if OAuth flow has been completed"""
         return self._oauth_completed
 
+    def set_access_token(self, access_token: str) -> None:
+        """Use a new access token for the requests that follow.
+
+        The transport reads self.headers, so writing self.access_token on its
+        own leaves the stale bearer token on every request.
+        """
+        self.access_token = access_token
+        self.headers["Authorization"] = f"Bearer {access_token}"
+
     def get_authorization_url(self, state: Optional[str] = None, scope: str = "useraccount") -> str:
         """Generate OAuth authorization URL
         Args:

--- a/backend/python/tests/unit/connectors/sources/test_servicenow_connector.py
+++ b/backend/python/tests/unit/connectors/sources/test_servicenow_connector.py
@@ -223,9 +223,14 @@ class TestServiceNowConnectorInit:
 
     def test_sync_points_created(self, servicenow_connector):
         assert servicenow_connector.user_sync_point is not None
-        assert servicenow_connector.group_sync_point is not None
-        assert servicenow_connector.kb_sync_point is not None
+        assert servicenow_connector.category_sync_point is not None
         assert servicenow_connector.article_sync_point is not None
+
+    def test_no_sync_point_for_groups_roles_and_knowledge_bases(self, servicenow_connector):
+        """These three reads must stay full, so none may carry a checkpoint."""
+        assert not hasattr(servicenow_connector, "group_sync_point")
+        assert not hasattr(servicenow_connector, "role_assignment_sync_point")
+        assert not hasattr(servicenow_connector, "kb_sync_point")
 
     def test_org_entity_sync_points(self, servicenow_connector):
         for key in ["company", "department", "location", "cost_center"]:
@@ -682,11 +687,24 @@ class TestFetchAllGroups:
 # ===========================================================================
 
 class TestFetchAllMemberships:
-    async def test_fetches_memberships(self, servicenow_connector):
-        servicenow_connector.group_sync_point = AsyncMock()
-        servicenow_connector.group_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.group_sync_point.update_sync_point = AsyncMock()
+    @pytest.mark.asyncio
+    async def test_membership_query_carries_no_delta_even_with_a_sync_point(self, servicenow_connector):
+        """on_new_user_groups replaces every edge, so a delta read loses members."""
+        sync_point = AsyncMock()
+        sync_point.read_sync_point = AsyncMock(return_value={"last_sync_time": "2026-08-26 09:00:00"})
+        sync_point.update_sync_point = AsyncMock()
+        servicenow_connector.group_sync_point = sync_point
 
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(return_value=_table_api_response([]))
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        await servicenow_connector._fetch_all_memberships()
+
+        query = mock_ds.get_now_table_tableName.call_args.kwargs["sysparm_query"]
+        assert "sys_updated_on>" not in query
+
+    async def test_fetches_memberships(self, servicenow_connector):
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
@@ -698,13 +716,8 @@ class TestFetchAllMemberships:
             result = await servicenow_connector._fetch_all_memberships()
             assert len(result) == 1
 
-    async def test_delta_sync(self, servicenow_connector):
-        servicenow_connector.group_sync_point = AsyncMock()
-        servicenow_connector.group_sync_point.read_sync_point = AsyncMock(
-            return_value={"last_sync_time": "2024-01-01"}
-        )
-        servicenow_connector.group_sync_point.update_sync_point = AsyncMock()
-
+    async def test_reads_every_row(self, servicenow_connector):
+        """A delta read plus a replace write removes members that nobody removed."""
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
@@ -713,6 +726,8 @@ class TestFetchAllMemberships:
             mock_ds.return_value = mock_datasource
             result = await servicenow_connector._fetch_all_memberships()
             assert result == []
+            call_kwargs = mock_datasource.get_now_table_tableName.call_args.kwargs
+            assert "sys_updated_on>" not in call_kwargs["sysparm_query"]
 
 
 # ===========================================================================
@@ -797,10 +812,6 @@ class TestFetchRoles:
             assert len(result) == 1
 
     async def test_fetches_role_assignments(self, servicenow_connector):
-        servicenow_connector.role_assignment_sync_point = AsyncMock()
-        servicenow_connector.role_assignment_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.role_assignment_sync_point.update_sync_point = AsyncMock()
-
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
@@ -845,28 +856,22 @@ class TestFetchRoles:
             await servicenow_connector._fetch_all_roles()
 
     @pytest.mark.asyncio
-    async def test_fetch_all_role_assignments_delta_sync(self, servicenow_connector):
-        servicenow_connector.role_assignment_sync_point = AsyncMock()
-        servicenow_connector.role_assignment_sync_point.read_sync_point = AsyncMock(
-            return_value={"last_sync_time": "2024-01-01 00:00:00"}
-        )
-        servicenow_connector.role_assignment_sync_point.update_sync_point = AsyncMock()
-
+    async def test_fetch_all_role_assignments_reads_every_row(self, servicenow_connector):
+        """A delta read plus a replace write removes roles that nobody revoked."""
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(return_value=_table_api_response([]))
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
         await servicenow_connector._fetch_all_role_assignments()
         call_kwargs = mock_ds.get_now_table_tableName.call_args.kwargs
-        assert "2024-01-01" in call_kwargs["sysparm_query"]
+        assert "sys_updated_on>" not in call_kwargs["sysparm_query"]
 
     @pytest.mark.asyncio
     async def test_fetch_all_role_assignments_outer_exception(self, servicenow_connector):
-        servicenow_connector.role_assignment_sync_point = AsyncMock()
-        servicenow_connector.role_assignment_sync_point.read_sync_point = AsyncMock(
-            side_effect=RuntimeError("sync point fail")
+        servicenow_connector._get_fresh_datasource = AsyncMock(
+            side_effect=RuntimeError("datasource fail")
         )
-        with pytest.raises(RuntimeError, match="sync point fail"):
+        with pytest.raises(RuntimeError, match="datasource fail"):
             await servicenow_connector._fetch_all_role_assignments()
 
     @pytest.mark.asyncio
@@ -1201,11 +1206,24 @@ class TestSyncSingleOrganizationalEntity:
 # ===========================================================================
 
 class TestSyncKnowledgeBases:
-    async def test_syncs_knowledge_bases(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
+    @pytest.mark.asyncio
+    async def test_knowledge_base_query_carries_no_delta_even_with_a_sync_point(self, servicenow_connector):
+        """Read grants live in kb_uc_can_read_mtom, which never bumps the base row."""
+        sync_point = AsyncMock()
+        sync_point.read_sync_point = AsyncMock(return_value={"last_sync_time": "2026-08-25 07:30:06"})
+        sync_point.update_sync_point = AsyncMock()
+        servicenow_connector.kb_sync_point = sync_point
 
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(return_value=_table_api_response([]))
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        await servicenow_connector._sync_knowledge_bases([])
+
+        query = mock_ds.get_now_table_tableName.call_args.kwargs["sysparm_query"]
+        assert "sys_updated_on>" not in query
+
+    async def test_syncs_knowledge_bases(self, servicenow_connector):
         tx = _make_mock_tx_store()
         tx.get_record_group_by_external_id = AsyncMock(return_value=None)
         tx.batch_upsert_record_groups = AsyncMock()
@@ -1234,13 +1252,10 @@ class TestSyncKnowledgeBases:
             )
             mock_ds.return_value = mock_datasource
             await servicenow_connector._sync_knowledge_bases([])
-            servicenow_connector.kb_sync_point.update_sync_point.assert_called()
+            call_kwargs = mock_datasource.get_now_table_tableName.call_args.kwargs
+            assert "sys_updated_on>" not in call_kwargs["sysparm_query"]
 
     async def test_adds_admin_permissions(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
         tx = _make_mock_tx_store()
         tx.get_record_group_by_external_id = AsyncMock(return_value=None)
         tx.batch_upsert_record_groups = AsyncMock()
@@ -1275,10 +1290,6 @@ class TestSyncKnowledgeBases:
             servicenow_connector.data_entities_processor.on_new_record_groups.assert_called()
 
     async def test_empty_kbs(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
@@ -1552,10 +1563,6 @@ class TestFetchAllGroupsDeep:
 
 class TestFetchAllMembershipsDeep:
     async def test_paginates_memberships(self, servicenow_connector):
-        servicenow_connector.group_sync_point = AsyncMock()
-        servicenow_connector.group_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.group_sync_point.update_sync_point = AsyncMock()
-
         page1 = [{"sys_id": f"m{i}", "user": f"u{i}", "group": "g1", "sys_updated_on": "2024-01-01"} for i in range(100)]
         page2 = [{"sys_id": "m100", "user": "u100", "group": "g1", "sys_updated_on": "2024-01-02"}]
 
@@ -1570,8 +1577,6 @@ class TestFetchAllMembershipsDeep:
             assert len(result) == 101
 
     async def test_handles_exception(self, servicenow_connector):
-        servicenow_connector.group_sync_point = AsyncMock()
-        servicenow_connector.group_sync_point.read_sync_point = AsyncMock(return_value=None)
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock,
                           side_effect=Exception("API down")):
             with pytest.raises(Exception, match="API down"):
@@ -1584,9 +1589,6 @@ class TestFetchAllMembershipsDeep:
 
     @pytest.mark.asyncio
     async def test_fetch_all_memberships_api_error_breaks(self, servicenow_connector):
-        servicenow_connector.group_sync_point = AsyncMock()
-        servicenow_connector.group_sync_point.read_sync_point = AsyncMock(return_value=None)
-
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(
             side_effect=ServiceNowAPIError(500, "fail", None)
@@ -1685,13 +1687,8 @@ class TestSyncUsersErrors:
 # ===========================================================================
 
 class TestSyncKnowledgeBasesDeep:
-    async def test_delta_sync_kbs(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(
-            return_value={"last_sync_time": "2024-01-01 00:00:00"}
-        )
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
+    async def test_reads_every_knowledge_base(self, servicenow_connector):
+        """A criterion change does not touch the base row, so a delta would miss it."""
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
@@ -1701,10 +1698,6 @@ class TestSyncKnowledgeBasesDeep:
             await servicenow_connector._sync_knowledge_bases([])
 
     async def test_api_error_kbs(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
@@ -1714,8 +1707,7 @@ class TestSyncKnowledgeBasesDeep:
             await servicenow_connector._sync_knowledge_bases([])
 
     async def test_exception_in_kb_sync_propagated(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(
+        servicenow_connector._get_fresh_datasource = AsyncMock(
             side_effect=Exception("kb error")
         )
         with pytest.raises(Exception, match="kb error"):
@@ -1723,10 +1715,6 @@ class TestSyncKnowledgeBasesDeep:
 
     @pytest.mark.asyncio
     async def test_sync_knowledge_bases_pagination(self, servicenow_connector, mock_data_entities_processor):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
         page1 = [
             _kb_api_row(sys_id=f"kb{i}", title=f"KB {i}", sys_updated_on="2024-01-01")
             for i in range(100)
@@ -1753,10 +1741,6 @@ class TestSyncKnowledgeBasesDeep:
 
     @pytest.mark.asyncio
     async def test_sync_knowledge_bases_owner_permission(self, servicenow_connector):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(return_value=_table_api_response([
             _kb_api_row(sys_id="kb1", title="KB 1", owner="owner1", sys_updated_on="2024-01-01"),
@@ -1775,10 +1759,6 @@ class TestSyncKnowledgeBasesDeep:
 
     @pytest.mark.asyncio
     async def test_sync_knowledge_bases_transform_returns_none_skipped(self, servicenow_connector, mock_data_entities_processor):
-        servicenow_connector.kb_sync_point = AsyncMock()
-        servicenow_connector.kb_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.kb_sync_point.update_sync_point = AsyncMock()
-
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(return_value=_table_api_response([
             {"sys_id": "kb1", "title": "", "sys_updated_on": "2024-01-01"},
@@ -2192,10 +2172,6 @@ class TestFlattenAndRoles:
 
     @pytest.mark.asyncio
     async def test_fetch_all_role_assignments_pagination(self, servicenow_connector):
-        servicenow_connector.role_assignment_sync_point = AsyncMock()
-        servicenow_connector.role_assignment_sync_point.read_sync_point = AsyncMock(return_value=None)
-        servicenow_connector.role_assignment_sync_point.update_sync_point = AsyncMock()
-
         page1 = [
             {"sys_id": f"ra{i}", "user": f"u{i}", "role": "r1", "sys_updated_on": "2024-01-01"}
             for i in range(100)
@@ -2214,9 +2190,6 @@ class TestFlattenAndRoles:
 
     @pytest.mark.asyncio
     async def test_fetch_all_role_assignments_api_error(self, servicenow_connector):
-        servicenow_connector.role_assignment_sync_point = AsyncMock()
-        servicenow_connector.role_assignment_sync_point.read_sync_point = AsyncMock(return_value=None)
-
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(
             side_effect=ServiceNowAPIError(500, "fail", None)

--- a/backend/python/tests/unit/connectors/sources/test_servicenow_connector.py
+++ b/backend/python/tests/unit/connectors/sources/test_servicenow_connector.py
@@ -10,8 +10,9 @@ from fastapi import HTTPException
 from app.config.constants.arangodb import Connectors, MimeTypes
 from app.connectors.sources.servicenow.servicenow.constants import ORGANIZATIONAL_ENTITIES
 from app.connectors.sources.servicenow.servicenow.connector import ServiceNowConnector
-from app.models.entities import AppUser, AppUserGroup, FileRecord, RecordType, WebpageRecord
+from app.models.entities import AppUser, AppUserGroup, FileRecord, RecordGroupType, RecordType, WebpageRecord
 from app.models.permission import EntityType, Permission, PermissionType
+from app.sources.client.servicenow.servicenow import ServiceNowRESTClientViaOAuthAuthorizationCode
 from app.sources.external.servicenow.models import (
     ServiceNowAPIError,
     SysUserGroup,
@@ -327,14 +328,20 @@ class TestGetFreshDatasource:
             await servicenow_connector._get_fresh_datasource()
 
     async def test_returns_datasource_with_fresh_token(self, servicenow_connector):
-        servicenow_connector.servicenow_client = MagicMock()
-        servicenow_connector.servicenow_client.access_token = "old-token"
+        """A real client, because the transport sends headers, not the attribute."""
+        client = ServiceNowRESTClientViaOAuthAuthorizationCode(
+            instance_url="https://dev194883.service-now.com",
+            client_id="cid", client_secret="secret",
+            redirect_uri="http://localhost/cb", access_token="old-token",
+        )
+        servicenow_connector.servicenow_client = client
         servicenow_connector.config_service.get_config = AsyncMock(return_value={
             "credentials": {"access_token": "new-token"},
         })
         ds = await servicenow_connector._get_fresh_datasource()
         assert ds is not None
-        assert servicenow_connector.servicenow_client.access_token == "new-token"
+        assert client.access_token == "new-token"
+        assert client.headers["Authorization"] == "Bearer new-token"
 
     async def test_no_config_raises(self, servicenow_connector):
         servicenow_connector.servicenow_client = MagicMock()
@@ -2771,3 +2778,262 @@ class TestSyncArticles:
         )
         with pytest.raises(RuntimeError, match="article sync fail"):
             await servicenow_connector._sync_articles()
+
+
+# ===========================================================================
+# _resolve_kb_portal_suffix and the article web URL
+# ===========================================================================
+
+class TestResolveKbPortalSuffix:
+    @pytest.mark.asyncio
+    async def test_uses_the_instance_property(self, servicenow_connector):
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(
+            return_value=_table_api_response([{"value": "kb"}])
+        )
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        assert await servicenow_connector._resolve_kb_portal_suffix() == "kb"
+        assert mock_ds.get_now_table_tableName.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_default_portal(self, servicenow_connector):
+        """An empty property means the default portal serves the knowledge pages."""
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(side_effect=[
+            _table_api_response([{"value": ""}]),
+            _table_api_response([{"url_suffix": "esc"}]),
+        ])
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        assert await servicenow_connector._resolve_kb_portal_suffix() == "esc"
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_the_knowledge_portal_on_error(self, servicenow_connector):
+        """A wrong link is better than a failed sync."""
+        servicenow_connector._get_fresh_datasource = AsyncMock(side_effect=RuntimeError("no access"))
+
+        assert await servicenow_connector._resolve_kb_portal_suffix() == "kb"
+
+
+class TestArticleWebUrl:
+    def test_article_url_uses_the_resolved_portal(self, servicenow_connector):
+        servicenow_connector.instance_url = "https://dev194883.service-now.com"
+        servicenow_connector.kb_portal_suffix = "esc"
+
+        record = servicenow_connector._transform_to_article_webpage_record(
+            KBKnowledge(sys_id="art1", short_description="Title", kb_category="cat1")
+        )
+
+        assert record.weburl == (
+            "https://dev194883.service-now.com/esc?id=kb_article_view&sys_kb_id=art1"
+        )
+
+
+# ===========================================================================
+# glide.knowman.apply_article_read_criteria
+# ===========================================================================
+
+class TestRecordRevision:
+    """A stored record is rewritten, and re-queued for indexing, only when
+    external_revision_id changes. Leaving it unset froze every record at its
+    first index: title, webUrl and content never updated again."""
+
+    def test_article_carries_a_revision_id(self, servicenow_connector):
+        record = servicenow_connector._transform_to_article_webpage_record(
+            KBKnowledge(
+                sys_id="art1",
+                short_description="Title",
+                kb_category="cat1",
+                sys_updated_on="2026-08-26 09:15:00",
+            )
+        )
+        assert record.external_revision_id == "2026-08-26 09:15:00"
+
+    def test_a_changed_article_gets_a_different_revision_id(self, servicenow_connector):
+        def build(updated_on):
+            return servicenow_connector._transform_to_article_webpage_record(
+                KBKnowledge(
+                    sys_id="art1",
+                    short_description="Title",
+                    kb_category="cat1",
+                    sys_updated_on=updated_on,
+                )
+            )
+
+        before = build("2026-08-26 09:15:00")
+        after = build("2026-08-26 11:42:00")
+        assert before.external_revision_id != after.external_revision_id
+
+    def test_attachment_carries_a_revision_id(self, servicenow_connector):
+        record = servicenow_connector._transform_to_attachment_file_record(
+            AttachmentMetadata(
+                sys_id="att1",
+                file_name="doc.pdf",
+                content_type="application/pdf",
+                size_bytes="1024",
+                table_sys_id="art1",
+                sys_created_on="2026-08-01 10:00:00",
+                sys_updated_on="2026-08-26 11:42:00",
+            ),
+            parent_record_group_type=RecordGroupType.SERVICENOW_CATEGORY,
+            parent_external_record_group_id="cat1",
+        )
+        assert record.external_revision_id == "2026-08-26 11:42:00"
+
+
+class TestArticleReadCriteriaResolution:
+    """The property decides who reaches an article, so a read that fails must
+    not be read as "the instance does not apply criteria"."""
+
+    def _connector(self, connector, *, value=None, error=None):
+        if error is not None:
+            connector._read_instance_property = AsyncMock(side_effect=error)
+        else:
+            connector._read_instance_property = AsyncMock(return_value=value)
+        return connector
+
+    @pytest.mark.asyncio
+    async def test_property_true_applies_the_override(self, servicenow_connector):
+        self._connector(servicenow_connector, value="true")
+        assert await servicenow_connector._resolve_article_read_criteria() is True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("value", ["false", "", None])
+    async def test_unset_or_false_means_the_base_grant_carries(self, servicenow_connector, value):
+        """ServiceNow leaves the property unset on a default instance, so unset
+        is a real answer and it means false."""
+        self._connector(servicenow_connector, value=value)
+        assert await servicenow_connector._resolve_article_read_criteria() is False
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_property_leans_restrictive(self, servicenow_connector):
+        """Not "could not tell, therefore no restriction". A token without rights
+        on sys_properties would otherwise open every article that carries its own
+        criteria, for the whole life of the process."""
+        self._connector(servicenow_connector, error=ServiceNowAPIError(403, "forbidden", None))
+        assert await servicenow_connector._resolve_article_read_criteria() is True
+
+    @pytest.mark.asyncio
+    async def test_an_unreadable_property_does_not_stop_the_connector(self, servicenow_connector):
+        self._connector(servicenow_connector, error=RuntimeError("network"))
+        assert await servicenow_connector._resolve_article_read_criteria() is True
+
+    @pytest.mark.asyncio
+    async def test_a_sys_properties_outage_does_not_open_restricted_articles(
+        self, servicenow_connector
+    ):
+        """The behavioural check, driven through the sync path rather than the
+        resolver: when sys_properties cannot be read at all, an article that
+        carries its own criteria must not fall back to the knowledge base grant.
+        """
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(
+            side_effect=ServiceNowAPIError(403, "no rights on sys_properties", None)
+        )
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        servicenow_connector.apply_article_read_criteria = (
+            await servicenow_connector._resolve_article_read_criteria()
+        )
+
+        record = servicenow_connector._transform_to_article_webpage_record(
+            KBKnowledge(
+                sys_id="art1",
+                short_description="Restricted",
+                kb_category="cat1",
+                can_read_user_criteria="crit1",
+            )
+        )
+        assert record.inherit_permissions is False
+
+    @pytest.mark.asyncio
+    async def test_a_failed_portal_read_still_falls_back(self, servicenow_connector):
+        """The portal suffix only affects how a link looks, so it keeps falling
+        back instead of leaning anywhere."""
+        servicenow_connector._read_instance_property = AsyncMock(
+            side_effect=ServiceNowAPIError(403, "forbidden", None)
+        )
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(side_effect=RuntimeError("no portal either"))
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        assert await servicenow_connector._resolve_kb_portal_suffix() == "kb"
+
+
+class TestArticleReadCriteriaOverride:
+    """ServiceNow applies article Can Read criteria as an override only when
+    glide.knowman.apply_article_read_criteria is true. Confirmed on a developer
+    instance: with the property false, a knowledge base grant opens an article
+    whose own criteria name a different group."""
+
+    def _article(self):
+        return KBKnowledge(
+            sys_id="art1",
+            short_description="Restricted",
+            kb_category="cat1",
+            can_read_user_criteria="crit1",
+        )
+
+    def test_article_inherits_the_base_grant_by_default(self, servicenow_connector):
+        servicenow_connector.apply_article_read_criteria = False
+
+        record = servicenow_connector._transform_to_article_webpage_record(self._article())
+
+        assert record.inherit_permissions is True
+
+    def test_own_criteria_stop_the_inheritance_when_the_property_is_on(self, servicenow_connector):
+        servicenow_connector.apply_article_read_criteria = True
+
+        record = servicenow_connector._transform_to_article_webpage_record(self._article())
+
+        assert record.inherit_permissions is False
+
+    def test_an_article_without_criteria_always_inherits(self, servicenow_connector):
+        servicenow_connector.apply_article_read_criteria = True
+        article = self._article()
+        article.can_read_user_criteria = ""
+
+        record = servicenow_connector._transform_to_article_webpage_record(article)
+
+        assert record.inherit_permissions is True
+
+    def test_the_attachment_follows_its_article(self, servicenow_connector):
+        record = servicenow_connector._transform_to_attachment_file_record(
+            AttachmentMetadata(
+                sys_id="att1",
+                file_name="doc.pdf",
+                content_type="application/pdf",
+                size_bytes="1024",
+                table_sys_id="art1",
+                sys_created_on="2026-08-01 10:00:00",
+                sys_updated_on="2026-08-01 10:00:00",
+            ),
+            parent_record_group_type=RecordGroupType.SERVICENOW_CATEGORY,
+            parent_external_record_group_id="cat1",
+            inherit_permissions=False,
+        )
+
+        assert record.inherit_permissions is False
+
+
+# ===========================================================================
+# Token refresh reaches the transport
+# ===========================================================================
+
+class TestAccessTokenRefresh:
+    def test_set_access_token_rewrites_the_authorization_header(self):
+        """The transport sends headers, so a token written anywhere else is inert."""
+        client = ServiceNowRESTClientViaOAuthAuthorizationCode(
+            instance_url="https://dev194883.service-now.com",
+            client_id="cid",
+            client_secret="secret",
+            redirect_uri="http://localhost/cb",
+            access_token="first-token",
+        )
+        assert client.headers["Authorization"] == "Bearer first-token"
+
+        client.set_access_token("second-token")
+
+        assert client.access_token == "second-token"
+        assert client.headers["Authorization"] == "Bearer second-token"

--- a/backend/python/tests/unit/connectors/sources/test_servicenow_connector.py
+++ b/backend/python/tests/unit/connectors/sources/test_servicenow_connector.py
@@ -671,15 +671,16 @@ class TestFetchAllGroups:
             result = await servicenow_connector._fetch_all_groups()
             assert result == []
 
-    async def test_api_failure(self, servicenow_connector):
+    async def test_api_failure_propagates(self, servicenow_connector):
+        """A partial group list would make the caller delete edges it cannot rebuild."""
         with patch.object(servicenow_connector, "_get_fresh_datasource", new_callable=AsyncMock) as mock_ds:
             mock_datasource = AsyncMock()
             mock_datasource.get_now_table_tableName = AsyncMock(
                 side_effect=ServiceNowAPIError(500, "Error", None)
             )
             mock_ds.return_value = mock_datasource
-            result = await servicenow_connector._fetch_all_groups()
-            assert result == []
+            with pytest.raises(ServiceNowAPIError):
+                await servicenow_connector._fetch_all_groups()
 
 
 # ===========================================================================
@@ -1183,11 +1184,14 @@ class TestSyncSingleOrganizationalEntity:
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        with patch.object(servicenow_connector.logger, "error") as mock_error:
+        with patch.object(servicenow_connector.logger, "error") as mock_error, \
+             pytest.raises(ServiceNowAPIError):
             await servicenow_connector._sync_single_organizational_entity(
                 "company", ORGANIZATIONAL_ENTITIES["company"]
             )
-            mock_error.assert_called()
+        mock_error.assert_called()
+        # A page that failed must not leave a checkpoint claiming it was read.
+        sync_point.update_sync_point.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_sync_point_read_exception_propagates(self, servicenow_connector):
@@ -1487,7 +1491,9 @@ class TestSyncCategories:
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        await servicenow_connector._sync_categories()
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._sync_categories()
+        servicenow_connector.category_sync_point.update_sync_point.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_sync_categories_skips_invalid_transform(self, servicenow_connector, mock_data_entities_processor):
@@ -1562,6 +1568,27 @@ class TestFetchAllGroupsDeep:
 # ===========================================================================
 
 class TestFetchAllMembershipsDeep:
+    @pytest.mark.asyncio
+    async def test_a_failed_page_does_not_yield_a_partial_membership_list(self, servicenow_connector):
+        """A partial list makes the caller delete edges it cannot rebuild."""
+        sync_point = AsyncMock()
+        sync_point.read_sync_point = AsyncMock(return_value=None)
+        sync_point.update_sync_point = AsyncMock()
+        servicenow_connector.group_sync_point = sync_point
+
+        full_page = _table_api_response([
+            {"sys_id": f"m{i}", "user": f"u{i}", "group": "g1", "sys_updated_on": "2026-08-01 10:00:00"}
+            for i in range(100)
+        ])
+        mock_ds = AsyncMock()
+        mock_ds.get_now_table_tableName = AsyncMock(
+            side_effect=[full_page, ServiceNowAPIError(500, "page two failed", None)]
+        )
+        servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
+
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._fetch_all_memberships()
+
     async def test_paginates_memberships(self, servicenow_connector):
         page1 = [{"sys_id": f"m{i}", "user": f"u{i}", "group": "g1", "sys_updated_on": "2024-01-01"} for i in range(100)]
         page2 = [{"sys_id": "m100", "user": "u100", "group": "g1", "sys_updated_on": "2024-01-02"}]
@@ -1588,15 +1615,16 @@ class TestFetchAllMembershipsDeep:
 # ===========================================================================
 
     @pytest.mark.asyncio
-    async def test_fetch_all_memberships_api_error_breaks(self, servicenow_connector):
+    async def test_fetch_all_memberships_api_error_propagates(self, servicenow_connector):
+        """A partial membership list would silently remove users from their groups."""
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(
             side_effect=ServiceNowAPIError(500, "fail", None)
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        result = await servicenow_connector._fetch_all_memberships()
-        assert result == []
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._fetch_all_memberships()
 
 
 class TestGetAdminUsersDeep:
@@ -1670,8 +1698,11 @@ class TestSyncUsersErrors:
                 side_effect=ServiceNowAPIError(401, "Unauthorized", None)
             )
             mock_ds.return_value = mock_datasource
-            await servicenow_connector._sync_users()
+            with pytest.raises(ServiceNowAPIError):
+                await servicenow_connector._sync_users()
             servicenow_connector.data_entities_processor.on_new_app_users.assert_not_called()
+            # A page that failed must not leave a checkpoint claiming it was read.
+            servicenow_connector.user_sync_point.update_sync_point.assert_not_awaited()
 
     async def test_exception_propagated(self, servicenow_connector):
         servicenow_connector.user_sync_point = AsyncMock()
@@ -1704,7 +1735,8 @@ class TestSyncKnowledgeBasesDeep:
                 side_effect=ServiceNowAPIError(500, "Server error", None)
             )
             mock_ds.return_value = mock_datasource
-            await servicenow_connector._sync_knowledge_bases([])
+            with pytest.raises(ServiceNowAPIError):
+                await servicenow_connector._sync_knowledge_bases([])
 
     async def test_exception_in_kb_sync_propagated(self, servicenow_connector):
         servicenow_connector._get_fresh_datasource = AsyncMock(
@@ -2189,15 +2221,15 @@ class TestFlattenAndRoles:
         assert len(result) == 101
 
     @pytest.mark.asyncio
-    async def test_fetch_all_role_assignments_api_error(self, servicenow_connector):
+    async def test_fetch_all_role_assignments_api_error_propagates(self, servicenow_connector):
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(
             side_effect=ServiceNowAPIError(500, "fail", None)
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        result = await servicenow_connector._fetch_all_role_assignments()
-        assert result == []
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._fetch_all_role_assignments()
 
     @pytest.mark.asyncio
     async def test_fetch_role_hierarchy_empty_results(self, servicenow_connector):
@@ -2209,26 +2241,26 @@ class TestFlattenAndRoles:
         assert result == []
 
     @pytest.mark.asyncio
-    async def test_fetch_role_hierarchy_api_error(self, servicenow_connector):
+    async def test_fetch_role_hierarchy_api_error_propagates(self, servicenow_connector):
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(
             side_effect=ServiceNowAPIError(500, "fail", None)
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        result = await servicenow_connector._fetch_role_hierarchy()
-        assert result == []
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._fetch_role_hierarchy()
 
     @pytest.mark.asyncio
-    async def test_fetch_all_roles_api_error(self, servicenow_connector):
+    async def test_fetch_all_roles_api_error_propagates(self, servicenow_connector):
         mock_ds = AsyncMock()
         mock_ds.get_now_table_tableName = AsyncMock(
             side_effect=ServiceNowAPIError(500, "fail", None)
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        result = await servicenow_connector._fetch_all_roles()
-        assert result == []
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._fetch_all_roles()
 
 
 # ===========================================================================
@@ -2399,6 +2431,28 @@ class TestProcessRecordUpdatesBatch:
         )
         await servicenow_connector._process_record_updates_batch([update])
         mock_data_entities_processor.on_new_records.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_process_record_updates_batch_reports_dropped_records(self, servicenow_connector, mock_data_entities_processor):
+        """A dropped record is never written, so the caller must be able to count it."""
+        granted = _record_update(
+            record=MagicMock(spec=WebpageRecord),
+            new_permissions=[Permission(email="u@test.com", type=PermissionType.READ, entity_type=EntityType.USER)],
+            external_record_id="art1",
+        )
+        dropped = _record_update(
+            record=MagicMock(spec=WebpageRecord),
+            new_permissions=[],
+            external_record_id="art2",
+        )
+        servicenow_connector.logger = MagicMock()
+
+        dropped_count = await servicenow_connector._process_record_updates_batch([granted, dropped])
+
+        assert dropped_count == 1
+        written = mock_data_entities_processor.on_new_records.call_args.args[0]
+        assert len(written) == 1
+        assert servicenow_connector.logger.warning.call_args.args[2] == ["art2"]
 
 
 # ===========================================================================
@@ -2642,9 +2696,11 @@ class TestSyncArticles:
         )
         servicenow_connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
 
-        await servicenow_connector._sync_articles()
+        with pytest.raises(ServiceNowAPIError):
+            await servicenow_connector._sync_articles()
         mock_data_entities_processor = servicenow_connector.data_entities_processor
         mock_data_entities_processor.on_new_records.assert_not_called()
+        servicenow_connector.article_sync_point.update_sync_point.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_sync_articles_updates_sync_checkpoint(self, servicenow_connector):

--- a/backend/python/tests/unit/connectors/sources/test_servicenow_connector_comprehensive.py
+++ b/backend/python/tests/unit/connectors/sources/test_servicenow_connector_comprehensive.py
@@ -641,8 +641,10 @@ class TestFetchAllGroups:
             side_effect=ServiceNowAPIError(500, "API error", None)
         )
         connector._get_fresh_datasource = AsyncMock(return_value=mock_ds)
-        groups = await connector._fetch_all_groups()
-        assert groups == []
+        # An empty list reads as "this instance has no groups", so the
+        # failure has to leave the loop rather than be answered with one.
+        with pytest.raises(ServiceNowAPIError):
+            await connector._fetch_all_groups()
 
 
 class TestFetchAllMemberships:

--- a/backend/python/tests/unit/connectors/sources/test_servicenow_connector_comprehensive.py
+++ b/backend/python/tests/unit/connectors/sources/test_servicenow_connector_comprehensive.py
@@ -549,7 +549,9 @@ class TestGetFreshDatasource:
         })
         with patch("app.connectors.sources.servicenow.servicenow.connector.ServiceNowDataSource"):
             ds = await connector._get_fresh_datasource()
-        assert connector.servicenow_client.access_token == "new-token"
+        # The transport authenticates from headers, so a refreshed token that
+        # only reaches the attribute leaves every request on the stale one.
+        connector.servicenow_client.set_access_token.assert_called_once_with("new-token")
 
     @pytest.mark.asyncio
     async def test_no_config_raises(self, connector):

--- a/backend/python/tests/unit/connectors/sources/test_servicenow_connector_coverage.py
+++ b/backend/python/tests/unit/connectors/sources/test_servicenow_connector_coverage.py
@@ -226,7 +226,9 @@ class TestGetFreshDatasource:
         })
         with patch("app.connectors.sources.servicenow.servicenow.connector.ServiceNowDataSource"):
             ds = await connector._get_fresh_datasource()
-        assert connector.servicenow_client.access_token == "new-token"
+        # The transport authenticates from headers, so a refreshed token that
+        # only reaches the attribute leaves every request on the stale one.
+        connector.servicenow_client.set_access_token.assert_called_once_with("new-token")
 
 
 # ===========================================================================


### PR DESCRIPTION
## Description

Eight defects in the ServiceNow connector, found while auditing it against a
ServiceNow developer instance, fixed as three commits.

**First commit, read permission sources in full, not as a delta.** Two reads
paginate on a `sys_updated_on` watermark and hand the result to a caller that
replaces what it finds. `on_new_user_groups` deletes every permission edge
pointing at a group before writing the members it was given, so a delta read
empties every group whose `sys_user_grmember` rows did not change inside the
window. Knowledge bases have the mirror problem: a base holds its read grants in
`kb_uc_can_read_mtom`, and changing a grant there does not touch
`kb_knowledge_base.sys_updated_on`, so a delta never sees a grant added or
revoked. Both reads are now full. Neither can be a delta while its caller
replaces rather than merges, and the volumes are small: groups, memberships,
roles and knowledge bases, rather than articles.

**Second commit, stop a partial read from passing as a complete one.** Ten
paginated reads answered an API error by leaving the loop, so the sync continued
with whatever had arrived and reported success. For five of them the caller then
deletes permission edges it cannot rebuild, so a page that fails partway removes
access. The other five go silently incomplete, and the article and category
reads additionally write a checkpoint across the window they never finished, so
those rows are not fetched again until something else changes them. All ten now
propagate, leaving the checkpoint untouched. One exception is preserved: an
empty page from `kb_knowledge_base` returns a body that is not JSON, so
`"Expecting value"` is how that read ends rather than a fault. The record writer
had the same silence. `_process_record_updates_batch` dropped records whose
permission list came out empty and returned nothing, so the sync logged more
articles than it wrote; it now returns and reports the count.

**Third commit, follow the instance instead of assuming.** Four values were
assumed rather than read from the instance:

- Article, category and KB links were hard-coded to the Service Portal
  (`/sp?id=kb_article&sys_id=`). The knowledge portal is per-instance in
  `sn_km_portal.glide.knowman.serviceportal.portal_url`; on the tested instance
  that is `kb`, giving `/kb?id=kb_article_view&sys_kb_id=`. Every stored link
  pointed at a page that does not serve the article.
- Article *Can Read* criteria were always applied as an override. ServiceNow
  only does that when `glide.knowman.apply_article_read_criteria` is true.
- A refreshed access token was written to `client.access_token` only, while the
  transport authenticates from `client.headers["Authorization"]`, so after a
  refresh every request still carried the old bearer until the process
  restarted.
- `external_revision_id` was never set, so `_handle_updated_record` compared
  `None` to `None` and no existing record was ever rewritten or re-queued.
  Records froze at first index: title, link and content never changed again.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

Two of these restore permission correctness, so they are security adjacent
without being a vulnerability disclosure. The connector was granting access
ServiceNow does not grant, and revoking access ServiceNow still grants.

## Related Issues

- Fixes #3094 (a revoked knowledge-base grant is never withdrawn, and one membership insert empties a group)
- Fixes #3095 (an API error mid-pagination is swallowed, so a partial sync reports success)
- Fixes #3096 (an indexed record is never rewritten, so article edits never reach search)

## How Has This Been Tested?

Two ways: unit tests in the repository, and a live ServiceNow developer instance
with a PipesHub deployment, measured before and after each fix.

The live method was the same each time. Deploy upstream `main`, reproduce the
defect and record the state. Deploy the same image plus the fix, changing
`IMAGE_TAG` only and without restarting the data engines. Repeat the identical
action and record the state again.

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass (not run; no integration suite covers this connector)
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable) (N/A, no UI change)
- [ ] Mobile responsiveness tested (if applicable) (N/A, no UI change)

## Core Functionality Testing

- [x] **Search capabilities** are working correctly
- [x] **Knowledge search** is functioning properly
- [x] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly (link *construction* is
      fixed and verified in the stored record; citation rendering was not tested)
- [ ] **Documentation** is updated (no docs change needed; no API surface changes)

## What You Have Tested

- [x] Feature works in development environment
- [ ] Feature works in staging environment (no staging available)
- [x] Error handling scenarios tested
- [x] Edge cases considered and tested
- [x] Performance impact assessed
- [x] Security implications reviewed

### Test Results

Unit tests, against the three ServiceNow test files plus everything else that
imports the connector:

```
upstream main   531 passed
this PR         548 passed
```

Each commit passes on its own (534 → 536 → 548). Three failures are present both
before and after, in `test_all_apps.py` for Box, MinIO and Google Cloud Storage,
which fail on missing optional dependencies (`box_sdk_gen`, `aioboto3`,
`google.api_core`) and are unrelated to this change.

Ruff on the three changed source files: **98 findings, down from 101 on
upstream `main`**. No new rule violations.

#### The tests, before and after

Checking out this branch's tests against upstream's source, so the tests exist
but the fixes do not, **45 ServiceNow tests fail**, and each fails with the
defect it describes rather than with an import or setup error:

| witness test | failure against upstream `main` |
| --- | --- |
| `test_reads_every_row` | `TypeError: 'coroutine' object is not iterable` |
| `test_knowledge_base_query_carries_no_delta_even_with_a_sync_point` | `assert 'sys_updated_on>' not in 'sys_updated…'` |
| `test_a_failed_page_does_not_yield_a_partial_membership_list` | `Failed: DID NOT RAISE ServiceNowAPIError` |
| `test_process_record_updates_batch_reports_dropped_records` | `assert None == 1` |
| `test_article_url_uses_the_resolved_portal` | `assert '…/sp?id=kb_article&sys_id=art1' == '…/kb?id=kb_article_view&sys_kb_id=art1'` |
| `test_own_criteria_stop_the_inheritance_when_the_property_is_on` | `assert True is False` |
| `test_set_access_token_rewrites_the_authorization_header` | `AttributeError: … object has no attribute 'set_access_token'` |
| `test_article_carries_a_revision_id` | `assert None == '2026-08-26 09:15:00'` |

Reproduce it with:

```bash
git checkout <this-branch>
git checkout origin/main -- backend/python/app/connectors/sources/servicenow/ \
                            backend/python/app/sources/client/servicenow/
cd backend/python && pytest tests/unit/connectors/sources/test_servicenow_connector*.py
```

Some existing tests also changed, because they asserted the defective behaviour.
Two examples worth naming, since they show why these defects survived:

- one asserted that a failed page returns an empty list, so it passed whether
  the read failed on page 1 or page 40, and could not tell a partial sync from a
  complete one;
- one asserted that a refreshed token lands on `client.access_token`, which was
  true the whole time every request still carried the stale bearer. The token
  bug had test coverage, and the coverage is why nobody noticed.

**Memberships destroyed by the delta read.** Inserting one unrelated membership
row, then running one routine sync:

| | upstream `main` | with the fix |
| --- | --- | --- |
| members of a 4-member group after the sync | **0** | **4, intact** |
| articles a plain user could retrieve | 11 / 11 → **0 / 11** | 11 / 11 → **11 / 11** |

**Knowledge-base grant revoked in ServiceNow**, then one routine delta sync:

| Time (UTC) | Grant in ServiceNow | KB `GROUP` edges |
| --- | --- | --- |
| 16:06:46 | present | 1 |
| 16:07:53 | **deleted** | n/a |
| 16:08:54 | absent | **0, withdrawn in 25 s** |

On upstream `main` that edge stayed at 1 indefinitely.

**Article links.** Two probe articles, identical but for the build that indexed
them:

| Probe | Indexed by | Stored `webUrl` |
| --- | --- | --- |
| A | upstream `main` | `/sp?id=kb_article&sys_id=…` |
| B | with the fix | `/kb?id=kb_article_view&sys_kb_id=…` |

The `/kb` was read from the instance, not hard-coded. Instance configuration
confirming what "correct" is: `sn_km_portal.glide.knowman.serviceportal.portal_url = kb`,
while the default portal in `sp_portal` is `esc`.

**Article read criteria.** One article whose own *Can Read* criteria name a
group the reader is not in, with the reader holding a knowledge-base grant:

| `glide.knowman.apply_article_read_criteria` | ServiceNow serves it | PipesHub, upstream | PipesHub, fixed |
| --- | --- | --- | --- |
| `false` (instance default) | yes | not returned | **returned** |
| `true` | no | not returned | **not returned** |

**Records never rewritten.** One published article edited in place:

| | upstream `main` | with the fix |
| --- | --- | --- |
| connector read the change | `Articles synced: 1` | `Articles synced: 1` |
| stored record | **unchanged** | title updated, `version 0 → 1`, re-indexed |
| `externalRevisionId` | `None` | `2026-08-27 08:42:17`, equal to `sys_updated_on` |

Worse than staleness: the sync point advanced to the discarded article's own
`sys_updated_on`, so no later delta sync could repair it.

## Screenshots/Videos

N/A, no UI change. Evidence is the recorded state above, taken from the graph
and from the connector logs.

## Code Quality Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (none needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Each fix has tests that fail without it. Several existing tests asserted the
defective behaviour and were rewritten to the new contract. One asserted that a
failed page returns an empty list. Another asserted that a refreshed token lands
on `client.access_token`, which was true while every request still carried the
stale bearer.

## Documentation

- [ ] Documentation has been updated (if applicable) (not applicable)
- [ ] API documentation updated (if applicable) (no API surface change)
- [ ] README updated (if applicable) (not applicable)
- [ ] Changelog updated (if applicable) (happy to add one if the project wants it)

## Security Considerations

- [x] No sensitive data is exposed
- [x] Input validation is implemented where necessary
- [x] Authentication/authorization is properly handled
- [x] No security vulnerabilities introduced

Two of the fixes change who can retrieve what, in both directions: a revoked
knowledge-base grant is now withdrawn, and article read criteria are applied
only when the instance says they should be. Both were verified against what
ServiceNow itself serves to the same user, rather than against an assumption.

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

No API or schema change. Two behaviour changes are worth calling out even though
neither breaks a contract:

1. A sync that hits an API error now **fails** rather than completing with
   partial data. This is the point of the change, but an operator used to green
   syncs may see red ones where the data was previously wrong and silent.
2. Existing records carry `external_revision_id = None`, so the first sync after
   deploying rewrites and re-embeds **every** article once.

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [x] Performance impact assessed and acceptable

Two full reads replace delta reads, over groups, memberships, roles and
knowledge bases, which are small tables. On the tested instance: 54 groups, 606 roles.

The one-time re-index above is the real cost. Fifty-four articles on the tested
instance. On a large tenant it is a full re-embed, once.

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

## Deployment Notes

Expect one full re-index of ServiceNow articles on the first sync after
deploying, caused by `external_revision_id` moving from unset to a real value.
No configuration change is required. The connector reads two instance
properties it previously ignored, `sn_km_portal.glide.knowman.serviceportal.portal_url`
and `glide.knowman.apply_article_read_criteria`, and falls back to the previous
behaviour if either is absent.

## Additional Notes

Scope is confined to the ServiceNow connector: `connector.py`, `constants.py`,
and one purely additive method on `sources/client/servicenow/servicenow.py`
(`set_access_token`, which no other caller relies on).

Every measurement above comes from one ServiceNow developer instance running the
Knowledge Management application with `kb_version 3` (knowledge versioning on).
Behaviour that depends on instance configuration, meaning the knowledge portal
and the read-criteria property, is read from the instance rather than assumed,
but has only been observed on that one instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - ServiceNow knowledge-base, category, and article links now use the configured knowledge portal.
  - Article and attachment records include revision information for more reliable updates.
  - Article permission settings, including read criteria, are applied consistently to attachments.

- **Bug Fixes**
  - ServiceNow access-token refreshes now apply immediately to subsequent requests.
  - Synchronization failures are surfaced instead of silently producing incomplete results.
  - Full synchronization improves data completeness for groups, roles, memberships, and knowledge bases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->