### PR TITLE
fix(org): return 400 instead of 500 for validation errors on org signup

### DIFF
--- a/backend/nodejs/apps/src/modules/user_management/controller/org.controller.ts
+++ b/backend/nodejs/apps/src/modules/user_management/controller/org.controller.ts
@@ -314,6 +314,9 @@ export class OrgController {
       await this.eventService.stop();
       res.status(200).json(org);
     } catch (error) {
+      if (error instanceof BadRequestError || error instanceof NotFoundError) {
+        throw error;
+      }
       throw new InternalServerError(
         error instanceof Error ? error.message : 'Error retrieving users',
       );

--- a/backend/nodejs/apps/src/modules/user_management/routes/org.routes.ts
+++ b/backend/nodejs/apps/src/modules/user_management/routes/org.routes.ts
@@ -7,6 +7,7 @@ import { AuthMiddleware } from '../../../libs/middlewares/auth.middleware';
 import { userAdminCheck } from '../middlewares/userAdminCheck';
 import { AuthenticatedUserRequest } from '../../../libs/middlewares/types';
 import { OrgController } from '../controller/org.controller';
+import { passwordValidator } from '../../auth/utils/passwordValidator';
 import { attachContainerMiddleware } from '../../auth/middlewares/attachContainer.middleware';
 import { FileProcessorFactory } from '../../../libs/middlewares/file_processor/fp.factory';
 import { FileProcessingType } from '../../../libs/middlewares/file_processor/fp.constant';
@@ -20,7 +21,13 @@ export const OrgCreationBody = z
     contactEmail: z.string().email('Invalid email format'),
     registeredName: z.string().optional(), // Will be enforced conditionally
     adminFullName: z.string().min(1, 'Admin full name required'),
-    password: z.string().min(8, 'Minimum 8 characters password required'),
+    password: z
+      .string()
+      .min(8, 'Minimum 8 characters password required')
+      .refine(passwordValidator, {
+        message:
+          'Password should have minimum 8 characters with at least one uppercase, one lowercase, one number and one special character',
+      }),
     sendEmail: z.boolean().optional(),
     permanentAddress: z
       .object({

--- a/backend/nodejs/apps/tests/modules/user_management/controller/org.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/user_management/controller/org.controller.test.ts
@@ -450,6 +450,8 @@ describe('OrgController', () => {
         await controller.createOrg(req, res);
         expect.fail('Should have thrown');
       } catch (error: any) {
+        expect(error).to.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(400);
         expect(error.message).to.include(
           'Password should have minimum 8 characters with at least one uppercase',
         );
@@ -468,6 +470,8 @@ describe('OrgController', () => {
         await controller.createOrg(req, res);
         expect.fail('Should have thrown');
       } catch (error: any) {
+        expect(error).to.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(400);
         expect(error.message).to.include('Password should have minimum 8 characters');
       }
     });
@@ -484,6 +488,8 @@ describe('OrgController', () => {
         await controller.createOrg(req, res);
         expect.fail('Should have thrown');
       } catch (error: any) {
+        expect(error).to.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(400);
         expect(error.message).to.include('Password should have minimum 8 characters');
       }
     });
@@ -502,6 +508,8 @@ describe('OrgController', () => {
         await controller.createOrg(req, res);
         expect.fail('Should have thrown');
       } catch (error: any) {
+        expect(error).to.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(400);
         expect(error.message).to.equal('There is already an organization');
       }
     });
@@ -520,6 +528,8 @@ describe('OrgController', () => {
         await controller.createOrg(req, res);
         expect.fail('Should have thrown');
       } catch (error: any) {
+        expect(error).to.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(400);
         expect(error.message).to.include('Please specify a correct domain name');
       }
     });
@@ -538,7 +548,29 @@ describe('OrgController', () => {
         await controller.createOrg(req, res);
         expect.fail('Should have thrown');
       } catch (error: any) {
+        expect(error).to.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(400);
         expect(error.message).to.include('Please specify a correct domain name');
+      }
+    });
+
+    it('should wrap a genuine internal failure as InternalServerError (500), not BadRequestError', async () => {
+      req.body = {
+        accountType: 'individual',
+        contactEmail: 'admin@example.com',
+        adminFullName: 'Admin User',
+        password: 'ValidPass1!',
+      };
+
+      sinon.stub(Org, 'countDocuments').rejects(new Error('Mongo connection lost'));
+
+      try {
+        await controller.createOrg(req, res);
+        expect.fail('Should have thrown');
+      } catch (error: any) {
+        expect(error).to.not.be.instanceOf(BadRequestError);
+        expect(error.statusCode).to.equal(500);
+        expect(error.message).to.equal('Mongo connection lost');
       }
     });
 

--- a/backend/nodejs/apps/tests/modules/user_management/routes/org.schema.test.ts
+++ b/backend/nodejs/apps/tests/modules/user_management/routes/org.schema.test.ts
@@ -203,10 +203,27 @@ describe('OrgCreationBody Zod Schema', () => {
       expect(result.success).to.be.false
     })
 
-    it('should accept password with exactly 8 characters', () => {
+    it('should reject an 8-character password missing complexity (digits only)', () => {
       const result = OrgCreationBody.safeParse({
         ...validIndividualBody,
         password: '12345678',
+      })
+      expect(result.success).to.be.false
+      if (!result.success) {
+        const fieldError = result.error.issues.find(
+          (i) => i.path.includes('password'),
+        )
+        expect(fieldError).to.exist
+        expect(fieldError!.message).to.include(
+          'at least one uppercase, one lowercase, one number and one special character',
+        )
+      }
+    })
+
+    it('should accept an 8-character password that meets complexity requirements', () => {
+      const result = OrgCreationBody.safeParse({
+        ...validIndividualBody,
+        password: 'Aa1!aaaa',
       })
       expect(result.success).to.be.true
     })


### PR DESCRIPTION
## Description

`POST /api/v1/org` (first-run org signup) returned HTTP 500 for every client-side validation failure (weak password, org already exists, invalid email domain) instead of 400, because `createOrg`'s catch block unconditionally rethrew every error as `InternalServerError`, discarding the `BadRequestError` already thrown for these cases.

Two changes:
1. `org.controller.ts`: the `createOrg` catch block now rethrows `BadRequestError`/`NotFoundError` unchanged instead of wrapping them, matching the pattern already used in this file's `validateSVG` catch block.
2. `org.routes.ts`: the Zod `password` schema previously only checked `.min(8, ...)`, so an 8+ character password missing complexity (e.g. `"12345678"`) passed schema validation but still hit the controller's `passwordValidator` check and returned a 500. Added a `.refine(passwordValidator, ...)` so the same complexity rule is enforced consistently at both layers.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

- Fixes #3047

## How Has This Been Tested?

- Read the actual source to confirm the root cause matches the issue exactly (`org.controller.ts` catch block at the reported lines, `org.routes.ts` schema).
- Added/updated unit tests in `org.controller.test.ts` and `org.schema.test.ts` asserting the correct error type/status code (`BadRequestError` / 400), not just the message string — the existing tests only checked `error.message`, which is why the wrong status code went unnoticed.
- Added a new controller test confirming a genuine internal failure (e.g. a DB error) still correctly produces a 500 `InternalServerError`, so the fix doesn't accidentally swallow real server errors.
- Updated the one existing schema test that had been asserting the old (buggy) behavior — it asserted `"12345678"` (no complexity) *passed* schema validation; now it correctly asserts rejection, plus a new test confirming a complexity-compliant 8-char password is accepted.
- Ran the full existing test suites for `org.controller.test.ts`, `org.routes.test.ts`, and `org.schema.test.ts` (and the full backend suite as a sanity check): all passing, 0 failures.
- `tsc --noEmit`: clean.
- `npx eslint` on changed files: no new issues (only pre-existing CRLF/line-ending noise from this being a Windows checkout, confirmed present on untouched files too, and one pre-existing `unbound-method` note on an unrelated, untouched line in the same file).

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

N/A — backend-only error-handling/validation fix, no search/indexing/citation/UI surface touched.

## What You Have Tested

- [x] Error handling scenarios tested
- [x] Edge cases considered and tested (8-char password with/without complexity, org-exists, invalid domain, multi-@ email)
- [ ] Feature works in development environment (not run against a live deployment — pure unit-level verification)
- [ ] Performance impact assessed (none expected; no new I/O or loops)
- [ ] Security implications reviewed (n/a beyond returning the correct status code — no new data exposed)

### Test Results

All three targeted test files pass locally (org.controller.test.ts, org.routes.test.ts, org.schema.test.ts), plus the full backend suite as a regression check. No failures.

## Screenshots/Videos

N/A — backend-only change, no UI surface.

## Code Quality Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Security Considerations

- [x] No sensitive data is exposed
- [x] Input validation is implemented where necessary (this PR strengthens it)
- [x] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes

None. Behavior for valid requests is unchanged; only the HTTP status code for already-invalid requests changes from 500 to 400 (the response body's error message is unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Strengthened organization password requirements to require uppercase, lowercase, numeric, and special characters.
* **Bug Fixes**
  * Improved organization creation error handling so validation and not-found errors retain their appropriate client-facing responses.
  * Unexpected failures are now reported as internal server errors.
* **Tests**
  * Added coverage for password complexity validation and organization creation error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->