### PR TITLE
fix(auth): stop returning the OAuth client secret when JIT provisioning is disabled

### DIFF
--- a/backend/nodejs/apps/src/modules/auth/controller/userAccount.controller.ts
+++ b/backend/nodejs/apps/src/modules/auth/controller/userAccount.controller.ts
@@ -351,17 +351,22 @@ export class UserAccountController {
 
             // Always add to allowed list if config exists
             allowedMethods.push(method);
-            authProviders[mapping.key === 'azuread' ? 'azuread' : mapping.key] = configData;
+
+            // This response is served to unauthenticated callers, so the OAuth
+            // config must be stripped of its server-side credentials before it
+            // goes out. That is independent of JIT, which only controls whether
+            // an account is provisioned on first sign-in.
+            if (method === AuthMethodType.OAUTH) {
+              const { clientSecret, tokenEndpoint, userInfoEndpoint, ...publicConfig } = configData;
+              authProviders.oauth = publicConfig;
+            } else {
+              authProviders[mapping.key === 'azuread' ? 'azuread' : mapping.key] = configData;
+            }
 
             // Only add to JIT lists if enableJit is strictly true
             if (configData?.enableJit === true) {
               jitEnabledMethods.push(method);
               jitConfig[mapping.key] = true;
-
-              if (method === AuthMethodType.OAUTH) {
-                const { clientSecret, tokenEndpoint, userInfoEndpoint, ...publicConfig } = configData;
-                authProviders.oauth = publicConfig;
-              }
             }
           } catch (e) {
             this.logger.debug(`${method} config fetch failed, not adding to allowed methods`);

--- a/backend/nodejs/apps/tests/modules/auth/controller/userAccount.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/auth/controller/userAccount.controller.test.ts
@@ -1165,6 +1165,75 @@ describe('UserAccountController', () => {
     });
   });
 
+  describe('initAuth - OAuth credentials are never returned', () => {
+    const oauthConfig = (enableJit: boolean) => ({
+      providerName: 'Okta',
+      clientId: 'public-client-id',
+      clientSecret: 'SUPER-SECRET',
+      authorizationUrl: 'https://idp.example.com/authorize',
+      tokenEndpoint: 'https://idp.example.com/token',
+      userInfoEndpoint: 'https://idp.example.com/userinfo',
+      enableJit,
+    });
+
+    const arrange = (enableJit: boolean) => {
+      sinon.stub(Org, 'findOne').resolves({ _id: 'o1', isDeleted: false } as any);
+      sinon.stub(OrgAuthConfig, 'findOne').resolves({
+        orgId: 'o1',
+        authSteps: [{ order: 1, allowedMethods: [{ type: 'oauth' }] }],
+      } as any);
+      mockConfigService.getConfig.resolves({ data: oauthConfig(enableJit) });
+      mockSessionService.createSession.resolves({
+        token: 'session-oauth-123',
+        userId: 'u1',
+        email: 'user@example.com',
+        authConfig: [{ order: 1, allowedMethods: [{ type: 'oauth' }] }],
+        currentStep: 0,
+      });
+    };
+
+    // initAuth is unauthenticated. The server-side credentials must not appear
+    // in its response whether or not JIT provisioning happens to be enabled.
+    [true, false].forEach((enableJit) => {
+      it(`should not return clientSecret, tokenEndpoint or userInfoEndpoint when enableJit is ${enableJit}`, async () => {
+        const req: any = { body: { email: 'user@example.com' } };
+        arrange(enableJit);
+
+        await controller.initAuth(req, res, next);
+
+        expect(next.called, 'initAuth should not error').to.be.false;
+        const oauth = res.json.firstCall.args[0].authProviders.oauth;
+
+        expect(oauth).to.not.have.property('clientSecret');
+        expect(oauth).to.not.have.property('tokenEndpoint');
+        expect(oauth).to.not.have.property('userInfoEndpoint');
+
+        // the values the sign-in page legitimately needs are still there
+        expect(oauth.clientId).to.equal('public-client-id');
+        expect(oauth.providerName).to.equal('Okta');
+        expect(oauth.authorizationUrl).to.equal('https://idp.example.com/authorize');
+      });
+    });
+
+    it('should still report JIT as enabled when the config enables it', async () => {
+      const req: any = { body: { email: 'user@example.com' } };
+      arrange(true);
+
+      await controller.initAuth(req, res, next);
+
+      expect(res.json.firstCall.args[0].jitEnabled).to.be.true;
+    });
+
+    it('should report JIT as disabled when the config disables it', async () => {
+      const req: any = { body: { email: 'user@example.com' } };
+      arrange(false);
+
+      await controller.initAuth(req, res, next);
+
+      expect(res.json.firstCall.args[0].jitEnabled).to.be.false;
+    });
+  });
+
   describe('exchangeOAuthToken', () => {
     it('should call next(BadRequestError) when required params are missing', async () => {
       const req: any = {


### PR DESCRIPTION
## What's wrong

`initAuth` is the endpoint the sign-in page calls before anyone has logged in. It tells the browser which sign-in methods exist and gives it the public details it needs to render them — so whatever it returns is readable by anyone who can reach the login page.

For OAuth, it was returning the client secret.

## Why it happens

The code does two things in the wrong order. First it puts the **whole** config into the response, then it removes the sensitive fields — but only inside an `if` that checks something unrelated:

```ts
// userAccount.controller.ts, before this change
authProviders[...] = configData;                    // ← full config, every time

if (configData?.enableJit === true) {               // ← unrelated condition
  jitEnabledMethods.push(method);
  jitConfig[mapping.key] = true;

  if (method === AuthMethodType.OAUTH) {
    const { clientSecret, tokenEndpoint, userInfoEndpoint, ...publicConfig } = configData;
    authProviders.oauth = publicConfig;             // ← the fix, only under JIT
  }
}
```

`enableJit` decides whether somebody signing in for the first time gets an account created automatically. That is a question about **provisioning**. Whether a field is safe to send to a browser is a question about **secrecy**. They have nothing to do with each other, so using one to gate the other means the cleanup simply does not run half the time.

When JIT is on, the secret is removed and everything is fine. When JIT is off, the line never executes and `clientSecret`, `tokenEndpoint` and `userInfoEndpoint` go out with the response.

## Why that combination is the bad one

Turning JIT **off** is the more locked-down setting: it means "do not let people create their own accounts, I will invite them". So the configuration an administrator chooses to be *more* careful is exactly the one that leaks. That is also what our documentation recommends for identity providers shared with a wider audience, which is how this was found.

## The fix

Strip the OAuth credentials whenever the config is added, rather than as a side effect of the JIT check:

```ts
if (method === AuthMethodType.OAUTH) {
  const { clientSecret, tokenEndpoint, userInfoEndpoint, ...publicConfig } = configData;
  authProviders.oauth = publicConfig;
} else {
  authProviders[mapping.key === 'azuread' ? 'azuread' : mapping.key] = configData;
}

if (configData?.enableJit === true) {
  jitEnabledMethods.push(method);
  jitConfig[mapping.key] = true;
}
```

The JIT block now does only what its name says. Nothing else changes: `jitEnabled` and `jitConfig` behave exactly as before, and the sign-in page still receives `providerName`, `clientId`, `authorizationUrl`, `scope` and `redirectUri` — everything it actually uses.

This also brings the two code paths into agreement. The authenticated version of this logic at `userAccount.controller.ts:1557` already strips unconditionally; only the unauthenticated one was conditional.

## Only OAuth is affected

I checked every other provider rather than assuming:

| Provider | What is stored | Secret? |
|---|---|---|
| OAuth | clientId, **clientSecret**, endpoints | **yes** |
| Google | clientId | no |
| Microsoft | clientId, tenantId | no |
| Azure AD | clientId, tenantId | no |
| SAML | entryPoint, certificate, emailKey | no — the certificate is the identity provider's public signing certificate |

So no other branch needs changing.

## Tests

Four tests in `userAccount.controller.test.ts` covering both JIT states, because the whole defect was that the two behaved differently:

- secrets absent when `enableJit: true`
- secrets absent when `enableJit: false`  ← the case that was broken
- the public fields the login page needs are still present
- `jitEnabled` still reports correctly either way

I confirmed they catch the bug by reverting the source change and re-running:

```
✔ ...when enableJit is true
1) ...when enableJit is false
   AssertionError: expected { providerName: 'Okta', …(6) } to not have property 'clientSecret'

3 passing, 1 failing
```

With the fix in place the whole controller suite passes: **163 passing**.

## After merging

Any OAuth client secret configured on an instance that had JIT disabled should be treated as exposed and **rotated at the identity provider**, then re-entered in PipesHub. Registering only the exact redirect URI at the provider limits what a leaked secret can be used for, and is worth confirming while you are there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpNmn9X69EiiBEDGYTmLWZ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth authentication settings no longer expose server-side credentials or endpoints in initialization responses.
  * OAuth provider details remain available for sign-in while sensitive information stays protected.
  * JIT-enabled and JIT-disabled configurations now report their status correctly.

* **Tests**
  * Added coverage verifying credential removal and JIT status across OAuth configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->