### PR TITLE
fix(installer): a MongoDB segfault no longer fails the install or risks your data

### DIFF
--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1382,6 +1382,61 @@ if ! $FLAG_YES && ! $FLAG_UPGRADE; then
   esac
 fi
 
+# MongoDB 8.x segfaults (exit 139) on some newer host kernels because of a glibc
+# rseq/TCMalloc interaction. env.template documents MONGO_GLIBC_TUNABLES for
+# exactly this case, but an operator only discovers it after the install has
+# already failed -- and the generic exit-139 advice points at recreating the data
+# volume, which destroys data without addressing this cause.
+#
+# Reacting to the observed crash rather than pre-screening the host kernel keeps
+# rseq=0 -- the faster TCMalloc default that #2677 deliberately preserved -- on
+# every machine that does not need the workaround, and needs no list of affected
+# kernel versions to stay accurate.
+MONGO_RSEQ_HEAL_TRIED=false
+MONGO_HEAL_GRACE_SECS=180
+
+# True when a mongodb container in this project is crash-looping on exit 139.
+#
+# A single inspect is not enough. A restart-looping container flaps between
+# `restarting`, where .State.ExitCode reports the last exit, and `running`, where
+# it reports 0 -- so whether the 139 is visible depends on when you happen to
+# look. Sample for a few seconds and accept the first 139 seen. This only runs
+# after a start has already failed, so the wait costs nothing on a healthy host.
+MONGO_RSEQ_PROBE_SECS=12
+
+mongo_rseq_crashed() {
+  local id exit_code restarts elapsed=0
+  while (( elapsed < MONGO_RSEQ_PROBE_SECS )); do
+    for id in $(docker ps -aq \
+        --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+        --filter "label=com.docker.compose.service=mongodb" 2>/dev/null); do
+      restarts="$(docker inspect "$id" --format '{{.RestartCount}}' 2>/dev/null || echo 0)"
+      exit_code="$(docker inspect "$id" --format '{{.State.ExitCode}}' 2>/dev/null || echo '')"
+      # RestartCount rules out a container that exited 139 once and stayed down
+      # for an unrelated reason; the loop is what identifies this failure.
+      if [[ "$exit_code" == "139" ]] && (( ${restarts:-0} >= 1 )); then return 0; fi
+    done
+    sleep 1
+    elapsed=$(( elapsed + 1 ))
+  done
+  return 1
+}
+
+# Write the documented tunable, once per run, and never over a value the operator
+# chose. Returns 0 when it changed something, so the caller can retry the start.
+apply_mongo_rseq_tunable() {
+  if $MONGO_RSEQ_HEAL_TRIED; then return 1; fi
+  if [[ -n "$(get_existing_val MONGO_GLIBC_TUNABLES "")" ]]; then return 1; fi
+  if ! mongo_rseq_crashed; then return 1; fi
+
+  MONGO_RSEQ_HEAL_TRIED=true
+  warn "MongoDB exited 139 (segfault) and is not coming up."
+  warn "That is the known glibc rseq/TCMalloc crash on newer host kernels."
+  info "Setting MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 in .env and retrying..."
+  persist_env_var MONGO_GLIBC_TUNABLES "glibc.pthread.rseq=1"
+  return 0
+}
+
 # ==============================================================================
 # 15. LAUNCH
 # ==============================================================================
@@ -1438,9 +1493,25 @@ if $_USE_BUILD; then
       -p "$PROJECT_NAME" \
       --env-file "$ENV_FILE" \
       up -d --build; then
-    error "docker compose up --build failed. Last 30 lines of container logs:"
-    docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
-    die "Fix the build error above and re-run install.sh."
+    # A MongoDB rseq segfault fails `up` within seconds rather than later: the
+    # app's `depends_on: mongodb: condition: service_healthy` is never satisfied,
+    # so compose reports "dependency failed to start" and exits non-zero long
+    # before the health poll below could react. Heal here and retry the whole
+    # `up` -- recreating only mongodb would leave every dependent still created
+    # but never started.
+    if apply_mongo_rseq_tunable; then
+      if ! docker compose "${_PROGRESS[@]}" -f "$COMPOSE_FILE" -p "$PROJECT_NAME" \
+           --env-file "$ENV_FILE" up -d --build; then
+        error "docker compose up failed again after applying the MongoDB tunable."
+        docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
+        die "Fix the error above and re-run install.sh."
+      fi
+      success "Startup recovered after applying the MongoDB rseq tunable."
+    else
+      error "docker compose up --build failed. Last 30 lines of container logs:"
+      docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
+      die "Fix the build error above and re-run install.sh."
+    fi
   fi
 else
   if [[ "$_DO_PULL" == true ]]; then
@@ -1471,9 +1542,25 @@ else
       -p "$PROJECT_NAME" \
       --env-file "$ENV_FILE" \
       up -d; then
-    error "docker compose up failed. Last 30 lines of container logs:"
-    docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
-    die "Fix the error above and re-run install.sh."
+    # A MongoDB rseq segfault fails `up` within seconds rather than later: the
+    # app's `depends_on: mongodb: condition: service_healthy` is never satisfied,
+    # so compose reports "dependency failed to start" and exits non-zero long
+    # before the health poll below could react. Heal here and retry the whole
+    # `up` -- recreating only mongodb would leave every dependent still created
+    # but never started.
+    if apply_mongo_rseq_tunable; then
+      if ! docker compose "${_PROGRESS[@]}" -f "$COMPOSE_FILE" -p "$PROJECT_NAME" \
+           --env-file "$ENV_FILE" up -d; then
+        error "docker compose up failed again after applying the MongoDB tunable."
+        docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
+        die "Fix the error above and re-run install.sh."
+      fi
+      success "Startup recovered after applying the MongoDB rseq tunable."
+    else
+      error "docker compose up failed. Last 30 lines of container logs:"
+      docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
+      die "Fix the error above and re-run install.sh."
+    fi
   fi
 fi
 
@@ -1538,48 +1625,6 @@ crash_looping_containers() {
   done
 }
 
-# MongoDB 8.x segfaults (exit 139) on some newer host kernels because of a glibc
-# rseq/TCMalloc interaction. env.template documents MONGO_GLIBC_TUNABLES for
-# exactly this case, but an operator only discovers it after the install has
-# already failed -- and the generic exit-139 advice below points at recreating
-# the data volume, which destroys data without addressing this cause.
-#
-# Detect the specific signature (the mongodb service, restart-looping, last exit
-# 139) and apply the documented fix once. Reacting to the observed crash rather
-# than pre-screening the host kernel keeps rseq=0 -- the faster TCMalloc default
-# that #2677 deliberately preserved -- on every machine that does not need the
-# workaround, and needs no list of affected kernel versions to stay current.
-MONGO_RSEQ_HEAL_TRIED=false
-MONGO_HEAL_GRACE_SECS=180
-
-heal_mongo_rseq() {
-  local id exit_code
-  if $MONGO_RSEQ_HEAL_TRIED; then return 1; fi
-  # Never override a value the operator chose for themselves.
-  if [[ -n "$(get_existing_val MONGO_GLIBC_TUNABLES "")" ]]; then return 1; fi
-
-  for id in $(docker ps -aq \
-      --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
-      --filter "label=com.docker.compose.service=mongodb" 2>/dev/null); do
-    exit_code="$(docker inspect "$id" --format '{{.State.ExitCode}}' 2>/dev/null || echo '')"
-    if [[ "$exit_code" != "139" ]]; then continue; fi
-
-    MONGO_RSEQ_HEAL_TRIED=true
-    warn "MongoDB keeps restarting after a segfault (exit 139)."
-    warn "That is the known glibc rseq/TCMalloc crash on newer host kernels."
-    info "Setting MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 in .env and restarting MongoDB..."
-    persist_env_var MONGO_GLIBC_TUNABLES "glibc.pthread.rseq=1"
-    if docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" \
-         up -d --force-recreate mongodb >/dev/null 2>&1; then
-      success "MongoDB restarted with the rseq tunable; waiting for it to settle."
-      return 0
-    fi
-    error "Could not restart MongoDB after setting the tunable."
-    return 1
-  done
-  return 1
-}
-
 # Poll until healthy or the deadline passes. Uses _is_tty from launch (same
 # flag as Compose progress). On a TTY, redraw a single spinner line in place;
 # when stdout is captured (CI, tee, redirect) emit a sparse heartbeat instead.
@@ -1603,9 +1648,20 @@ while (( ELAPSED < HEALTH_WAIT_SECS )); do
     _CRASH_REPORT="$(crash_looping_containers)"
     # A MongoDB rseq segfault has a known one-line fix. Apply it and keep
     # waiting instead of failing an install that is one restart from working.
-    if [[ -n "$_CRASH_REPORT" ]] && heal_mongo_rseq; then
-      _CRASH_REPORT=""
-      HEALTH_WAIT_SECS=$(( ELAPSED + MONGO_HEAL_GRACE_SECS ))
+    if [[ -n "$_CRASH_REPORT" ]] && apply_mongo_rseq_tunable; then
+      # Full `up -d`, not `--force-recreate mongodb`: dependents that never
+      # started will not appear just because mongodb was recreated.
+      if docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" \
+           --env-file "$ENV_FILE" up -d >/dev/null 2>&1; then
+        _CRASH_REPORT=""
+        # Extend the deadline, never shorten it: at t=90 a bare ELAPSED+180
+        # would cut the default 420s wait down to 270.
+        _healed_deadline=$(( ELAPSED + MONGO_HEAL_GRACE_SECS ))
+        if (( _healed_deadline > HEALTH_WAIT_SECS )); then
+          HEALTH_WAIT_SECS=$_healed_deadline
+        fi
+        success "MongoDB restarted with the rseq tunable; waiting for it to settle."
+      fi
     fi
     [[ -n "$_CRASH_REPORT" ]] && break
   fi

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1702,8 +1702,7 @@ while (( ELAPSED < HEALTH_WAIT_SECS )); do
     if [[ -n "$_CRASH_REPORT" ]] && apply_mongo_rseq_tunable; then
       # Full `up -d`, not `--force-recreate mongodb`: dependents that never
       # started will not appear just because mongodb was recreated.
-      if docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" \
-           --env-file "$ENV_FILE" up -d >/dev/null 2>&1; then
+      if compose_up >/dev/null 2>&1; then
         _CRASH_REPORT=""
         # Extend the deadline, never shorten it: at t=90 a bare ELAPSED+180
         # would cut the default 420s wait down to 270.

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1396,6 +1396,7 @@ fi
 # kernel versions to stay accurate.
 MONGO_RSEQ_HEAL_TRIED=false
 MONGO_HEAL_GRACE_SECS=180
+MONGO_RSEQ_PROBE_SECS=12
 
 # The project's mongodb container ids, one per line.
 mongo_container_ids() {
@@ -1446,14 +1447,34 @@ mongo_rseq_crashed() {
   return 1
 }
 
-# Total restarts across this project's mongodb containers. Cheap (one inspect per
-# container, no probing) so the healthy path can call it on every install.
-mongo_restart_count() {
-  local id n total=0
+# Docker's RestartCount is a lifetime counter on the container, so a stack that
+# crash-looped weeks ago and was fixed still reports those restarts on every
+# later run. Snapshot before starting and compare afterwards, so the checks below
+# measure only what happened during this install.
+_MONGO_RESTART_BASELINE=""
+
+snapshot_mongo_restarts() {
+  local id n
+  _MONGO_RESTART_BASELINE=""
   for id in $(mongo_container_ids); do
     n="$(docker inspect "$id" --format '{{.RestartCount}}' 2>/dev/null || echo 0)"
-    total=$(( total + ${n:-0} ))
+    _MONGO_RESTART_BASELINE="${_MONGO_RESTART_BASELINE}${id} ${n:-0}
+"
   done
+}
+
+# Restarts accumulated since the snapshot. An id absent from the baseline is a
+# container this run created or recreated, so all of its restarts are ours.
+# Cheap -- one inspect per container, no probing -- so the healthy path can call
+# it on every install.
+mongo_restart_delta() {
+  local id n base total=0
+  for id in $(mongo_container_ids); do
+    n="$(docker inspect "$id" --format '{{.RestartCount}}' 2>/dev/null || echo 0)"
+    base="$(printf '%s' "${_MONGO_RESTART_BASELINE:-}" | awk -v i="$id" '$1==i{print $2; exit}')"
+    total=$(( total + ${n:-0} - ${base:-0} ))
+  done
+  if (( total < 0 )); then total=0; fi
   printf '%s' "$total"
 }
 
@@ -1554,12 +1575,16 @@ if project_has_pinned_container_names; then
   warn_pinned_container_rename
 fi
 
+# Baseline before anything starts, so the post-start checks below can tell a
+# crash loop from restarts this run had nothing to do with.
+snapshot_mongo_restarts
+
 if $_USE_BUILD; then
   $FLAG_UPGRADE && info "Rebuilding image from source for tag: ${IMAGE_TAG:-local}..."
   info "Building image from source and starting containers..."
   info "(This may take 10–30+ minutes on first run)"
   if ! compose_up_with_mongo_heal "up --build" --build; then
-    die "Fix the build error above and re-run install.sh."
+    die "Fix the error above and re-run install.sh."
   fi
 else
   if [[ "$_DO_PULL" == true ]]; then
@@ -1727,17 +1752,31 @@ if $CONTAINER_HEALTHY; then
   # depends_on and to pass the poll above -- so the install reports success and
   # walks away from a database that restarts every ~25s, dropping every
   # connection each time. Restarts are the signal the health check cannot see.
-  _mongo_restarts="$(mongo_restart_count)"
+  _mongo_restarts="$(mongo_restart_delta)"
   if (( _mongo_restarts > 0 )); then
     if apply_mongo_rseq_tunable; then
       if compose_up >/dev/null 2>&1; then
-        success "MongoDB had restarted ${_mongo_restarts}x on exit 139; applied the tunable and restarted it."
+        # The restart drops the stack briefly. Do not let the banner claim ready
+        # while it is still coming back.
+        _heal_wait=0
+        while (( _heal_wait < 120 )) && ! app_is_healthy; do
+          sleep 5
+          _heal_wait=$(( _heal_wait + 5 ))
+        done
+        if app_is_healthy; then
+          success "MongoDB restarted ${_mongo_restarts}x on exit 139; applied the tunable and restarted the stack."
+        else
+          CONTAINER_HEALTHY=false
+          warn "Applied the MongoDB tunable and restarted, but the stack has not come back healthy."
+          warn "  docker compose -f ${COMPOSE_FILE} -p ${PROJECT_NAME} logs -f pipeshub-ai"
+        fi
       else
+        CONTAINER_HEALTHY=false
         warn "Applied the MongoDB tunable, but restarting the stack failed."
         warn "  docker compose -f ${COMPOSE_FILE} -p ${PROJECT_NAME} logs mongodb"
       fi
     else
-      warn "MongoDB has restarted ${_mongo_restarts} time(s) since startup."
+      warn "MongoDB restarted ${_mongo_restarts} time(s) during this install."
       warn "The stack is healthy right now, but a database that keeps restarting"
       warn "drops every connection each time it goes. Check why:"
       warn "  docker compose -f ${COMPOSE_FILE} -p ${PROJECT_NAME} logs --tail 40 mongodb"

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1166,8 +1166,10 @@ MONGO_PASSWORD=${MONGO_PASSWORD}
 # If MongoDB crash-loops with a segfault (exit 139) on a newer host kernel, try
 # the rseq tunable first so the supported MongoDB version can stay pinned.
 $(optional_env_line MONGO_GLIBC_TUNABLES "$MONGO_GLIBC_TUNABLES" "glibc.pthread.rseq=1")
-# Fallback only: pin an older image. MongoDB 8.x data is not readable by 7.x, so
-# wipe the mongo volume before downgrading.
+# Pin the MongoDB image. The value below is the tag compose already defaults to,
+# so uncommenting it changes nothing on its own -- set an older tag here only to
+# recover from a version-specific bug. MongoDB 8.x data is not readable by 7.x,
+# so wipe the mongo volume before downgrading.
 $(optional_env_line MONGO_IMAGE_TAG "$MONGO_IMAGE_TAG" "8.0.17")
 # WiredTiger cache cap and container memory limit. Raise both together on
 # larger or dedicated hosts; avoid dropping the cache below 1 GB.
@@ -1406,6 +1408,13 @@ MONGO_RSEQ_PROBE_SECS=12
 
 mongo_rseq_crashed() {
   local id exit_code restarts elapsed=0
+  # No mongodb container means the start failed for some other reason (a build
+  # error, a missing image, another service). Do not spend the probe window on it.
+  if [[ -z "$(docker ps -aq \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+      --filter "label=com.docker.compose.service=mongodb" 2>/dev/null)" ]]; then
+    return 1
+  fi
   while (( elapsed < MONGO_RSEQ_PROBE_SECS )); do
     for id in $(docker ps -aq \
         --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
@@ -1457,6 +1466,41 @@ _USE_BUILD=false
 _is_tty=false; [[ -t 1 ]] && _is_tty=true
 _PROGRESS=(--progress "$(resolve_compose_progress "$_is_tty")")
 
+compose_up()        { docker compose "${_PROGRESS[@]}" -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" up -d "$@"; }
+compose_logs_tail() { docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true; }
+
+# Start the stack, healing a MongoDB rseq segfault once if that is what stopped
+# it. A segfault fails `up` within seconds rather than later: the app's
+# `depends_on: mongodb: condition: service_healthy` is never satisfied, so
+# compose reports "dependency failed to start" and exits non-zero long before the
+# health poll could react.
+#
+# The retry is a full `up -d` so dependents that were created but never started
+# come up too, and it never repeats --build: if the image compiled the first
+# time, it is already built. Callers `die` on a non-zero return; every failure
+# message is emitted here so the prebuilt and build paths cannot drift apart.
+compose_up_with_mongo_heal() {
+  local label="$1"; shift
+  if compose_up "$@"; then return 0; fi
+
+  if apply_mongo_rseq_tunable; then
+    if compose_up; then
+      success "Startup recovered after applying the MongoDB rseq tunable."
+      return 0
+    fi
+    error "docker compose up failed again after applying the MongoDB tunable."
+    compose_logs_tail
+    warn "MongoDB is still not starting, so something else is wrong. Read the logs"
+    warn "above first. Do not recreate the mongo data volume yet — that destroys"
+    warn "your data and will not fix a crash the tunable did not resolve."
+    return 1
+  fi
+
+  error "docker compose ${label} failed. Last 30 lines of container logs:"
+  compose_logs_tail
+  return 1
+}
+
 # Decide whether to refresh the prebuilt image from the registry before starting.
 # Pure decision (no side effects) so it is unit-testable in isolation.
 # `docker compose up -d` only pulls an image that is ABSENT locally, so a cached
@@ -1488,30 +1532,8 @@ if $_USE_BUILD; then
   $FLAG_UPGRADE && info "Rebuilding image from source for tag: ${IMAGE_TAG:-local}..."
   info "Building image from source and starting containers..."
   info "(This may take 10–30+ minutes on first run)"
-  if ! docker compose "${_PROGRESS[@]}" \
-      -f "$COMPOSE_FILE" \
-      -p "$PROJECT_NAME" \
-      --env-file "$ENV_FILE" \
-      up -d --build; then
-    # A MongoDB rseq segfault fails `up` within seconds rather than later: the
-    # app's `depends_on: mongodb: condition: service_healthy` is never satisfied,
-    # so compose reports "dependency failed to start" and exits non-zero long
-    # before the health poll below could react. Heal here and retry the whole
-    # `up` -- recreating only mongodb would leave every dependent still created
-    # but never started.
-    if apply_mongo_rseq_tunable; then
-      if ! docker compose "${_PROGRESS[@]}" -f "$COMPOSE_FILE" -p "$PROJECT_NAME" \
-           --env-file "$ENV_FILE" up -d --build; then
-        error "docker compose up failed again after applying the MongoDB tunable."
-        docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
-        die "Fix the error above and re-run install.sh."
-      fi
-      success "Startup recovered after applying the MongoDB rseq tunable."
-    else
-      error "docker compose up --build failed. Last 30 lines of container logs:"
-      docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
-      die "Fix the build error above and re-run install.sh."
-    fi
+  if ! compose_up_with_mongo_heal "up --build" --build; then
+    die "Fix the build error above and re-run install.sh."
   fi
 else
   if [[ "$_DO_PULL" == true ]]; then
@@ -1537,30 +1559,8 @@ else
     info "Skipping image refresh; using locally cached images (--no-pull)."
   fi
   info "Starting containers..."
-  if ! docker compose "${_PROGRESS[@]}" \
-      -f "$COMPOSE_FILE" \
-      -p "$PROJECT_NAME" \
-      --env-file "$ENV_FILE" \
-      up -d; then
-    # A MongoDB rseq segfault fails `up` within seconds rather than later: the
-    # app's `depends_on: mongodb: condition: service_healthy` is never satisfied,
-    # so compose reports "dependency failed to start" and exits non-zero long
-    # before the health poll below could react. Heal here and retry the whole
-    # `up` -- recreating only mongodb would leave every dependent still created
-    # but never started.
-    if apply_mongo_rseq_tunable; then
-      if ! docker compose "${_PROGRESS[@]}" -f "$COMPOSE_FILE" -p "$PROJECT_NAME" \
-           --env-file "$ENV_FILE" up -d; then
-        error "docker compose up failed again after applying the MongoDB tunable."
-        docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
-        die "Fix the error above and re-run install.sh."
-      fi
-      success "Startup recovered after applying the MongoDB rseq tunable."
-    else
-      error "docker compose up failed. Last 30 lines of container logs:"
-      docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" logs --tail 30 2>&1 || true
-      die "Fix the error above and re-run install.sh."
-    fi
+  if ! compose_up_with_mongo_heal "up"; then
+    die "Fix the error above and re-run install.sh."
   fi
 fi
 

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -173,6 +173,21 @@ get_existing_val() {
   printf '%s' "${val:-$default}"
 }
 
+# Render an optional knob for .env: the operator's value when one is set,
+# otherwise a commented hint. .env is rewritten from scratch whenever the wizard
+# runs, so a knob documented only in env.template is invisible after a fresh
+# install and is dropped by --reconfigure. Callers must pass a value already
+# resolved by get_existing_val -- .env is being truncated by the time the
+# here-document that calls this is expanded.
+optional_env_line() {
+  local key="$1" val="$2" hint="$3"
+  if [[ -n "$val" ]]; then
+    printf '%s=%s' "$key" "$val"
+  else
+    printf '# %s=%s' "$key" "$hint"
+  fi
+}
+
 # Derive the COMPOSE_PROFILES that the *currently configured* services require,
 # from the canonical selectors persisted in .env. The app talks to whatever
 # DATA_STORE / MESSAGE_BROKER / KV_STORE_TYPE say, so the profiles that start the
@@ -1028,6 +1043,15 @@ if ! ${SKIP_WIZARD:-false}; then
   REDIS_PASSWORD="$(get_existing_val REDIS_PASSWORD "$(gen_secret 16)")"
   QDRANT_API_KEY="$(get_existing_val QDRANT_API_KEY "$(gen_secret 20)")"
 
+  # Optional MongoDB knobs from env.template. The wizard never asks about these,
+  # but .env is rewritten in full below, so read back anything the operator set
+  # by hand -- otherwise --reconfigure silently reverts their tuning and MongoDB
+  # goes back to the defaults that made them set it in the first place.
+  MONGO_GLIBC_TUNABLES="$(get_existing_val MONGO_GLIBC_TUNABLES "")"
+  MONGO_IMAGE_TAG="$(get_existing_val MONGO_IMAGE_TAG "")"
+  MONGO_CACHE_GB="$(get_existing_val MONGO_CACHE_GB "")"
+  MONGO_MEMORY_LIMIT="$(get_existing_val MONGO_MEMORY_LIMIT "")"
+
   if [[ "$DATA_STORE" == "arangodb" ]]; then
     ARANGO_PASSWORD="$(get_existing_val ARANGO_PASSWORD "$(gen_secret 16)")"; NEO4J_PASSWORD=""
   else
@@ -1137,6 +1161,16 @@ REDIS_PASSWORD=${REDIS_PASSWORD}
 # ── MongoDB ──────────────────────────────────────────────────────────────────
 MONGO_USERNAME=${MONGO_USERNAME}
 MONGO_PASSWORD=${MONGO_PASSWORD}
+# If MongoDB crash-loops with a segfault (exit 139) on a newer host kernel, try
+# the rseq tunable first so the supported MongoDB version can stay pinned.
+$(optional_env_line MONGO_GLIBC_TUNABLES "$MONGO_GLIBC_TUNABLES" "glibc.pthread.rseq=1")
+# Fallback only: pin an older image. MongoDB 8.x data is not readable by 7.x, so
+# wipe the mongo volume before downgrading.
+$(optional_env_line MONGO_IMAGE_TAG "$MONGO_IMAGE_TAG" "8.0.17")
+# WiredTiger cache cap and container memory limit. Raise both together on
+# larger or dedicated hosts; avoid dropping the cache below 1 GB.
+$(optional_env_line MONGO_CACHE_GB "$MONGO_CACHE_GB" "1")
+$(optional_env_line MONGO_MEMORY_LIMIT "$MONGO_MEMORY_LIMIT" "2G")
 
 # ── Qdrant ───────────────────────────────────────────────────────────────────
 QDRANT_API_KEY=${QDRANT_API_KEY}

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -215,7 +215,9 @@ persist_env_var() {
   [[ -f "$ENV_FILE" ]] || return 0
   tmp="$(mktemp)"
   while IFS= read -r line || [[ -n "$line" ]]; do
-    if [[ "$line" == "${key}="* ]]; then
+    # Also match the commented placeholder form ("# KEY=hint") so turning a
+    # documented knob on replaces its hint instead of leaving both lines.
+    if [[ "$line" == "${key}="* || "$line" == "# ${key}="* ]]; then
       printf '%s=%s\n' "$key" "$val"; found=true
     else
       printf '%s\n' "$line"
@@ -1536,6 +1538,48 @@ crash_looping_containers() {
   done
 }
 
+# MongoDB 8.x segfaults (exit 139) on some newer host kernels because of a glibc
+# rseq/TCMalloc interaction. env.template documents MONGO_GLIBC_TUNABLES for
+# exactly this case, but an operator only discovers it after the install has
+# already failed -- and the generic exit-139 advice below points at recreating
+# the data volume, which destroys data without addressing this cause.
+#
+# Detect the specific signature (the mongodb service, restart-looping, last exit
+# 139) and apply the documented fix once. Reacting to the observed crash rather
+# than pre-screening the host kernel keeps rseq=0 -- the faster TCMalloc default
+# that #2677 deliberately preserved -- on every machine that does not need the
+# workaround, and needs no list of affected kernel versions to stay current.
+MONGO_RSEQ_HEAL_TRIED=false
+MONGO_HEAL_GRACE_SECS=180
+
+heal_mongo_rseq() {
+  local id exit_code
+  if $MONGO_RSEQ_HEAL_TRIED; then return 1; fi
+  # Never override a value the operator chose for themselves.
+  if [[ -n "$(get_existing_val MONGO_GLIBC_TUNABLES "")" ]]; then return 1; fi
+
+  for id in $(docker ps -aq \
+      --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+      --filter "label=com.docker.compose.service=mongodb" 2>/dev/null); do
+    exit_code="$(docker inspect "$id" --format '{{.State.ExitCode}}' 2>/dev/null || echo '')"
+    if [[ "$exit_code" != "139" ]]; then continue; fi
+
+    MONGO_RSEQ_HEAL_TRIED=true
+    warn "MongoDB keeps restarting after a segfault (exit 139)."
+    warn "That is the known glibc rseq/TCMalloc crash on newer host kernels."
+    info "Setting MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 in .env and restarting MongoDB..."
+    persist_env_var MONGO_GLIBC_TUNABLES "glibc.pthread.rseq=1"
+    if docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" --env-file "$ENV_FILE" \
+         up -d --force-recreate mongodb >/dev/null 2>&1; then
+      success "MongoDB restarted with the rseq tunable; waiting for it to settle."
+      return 0
+    fi
+    error "Could not restart MongoDB after setting the tunable."
+    return 1
+  done
+  return 1
+}
+
 # Poll until healthy or the deadline passes. Uses _is_tty from launch (same
 # flag as Compose progress). On a TTY, redraw a single spinner line in place;
 # when stdout is captured (CI, tee, redirect) emit a sparse heartbeat instead.
@@ -1557,6 +1601,12 @@ while (( ELAPSED < HEALTH_WAIT_SECS )); do
   # not recover on its own, so there is no point waiting out the full timeout.
   if (( ELAPSED >= 90 && ELAPSED % 15 == 0 )); then
     _CRASH_REPORT="$(crash_looping_containers)"
+    # A MongoDB rseq segfault has a known one-line fix. Apply it and keep
+    # waiting instead of failing an install that is one restart from working.
+    if [[ -n "$_CRASH_REPORT" ]] && heal_mongo_rseq; then
+      _CRASH_REPORT=""
+      HEALTH_WAIT_SECS=$(( ELAPSED + MONGO_HEAL_GRACE_SECS ))
+    fi
     [[ -n "$_CRASH_REPORT" ]] && break
   fi
   if $_is_tty; then
@@ -1610,7 +1660,12 @@ elif [[ -n "${_CRASH_REPORT:-}" ]]; then
   fi
   warn "  • exit 137 / oom=true → out of memory. Free RAM, or switch to the lighter"
   warn "      'slim' profile (Redis broker + KV; drops Kafka/Zookeeper): ./install.sh --reconfigure"
-  warn "  • exit 139            → the service crashed (segfault). Usually a corrupted data"
+  warn "  • exit 139 on mongodb → set MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 in .env and"
+  warn "      re-run ./install.sh --upgrade. The installer normally applies this for you; if"
+  warn "      you are seeing this, it was already set or the restart did not take. Try this"
+  warn "      before touching the data volume — recreating the volume destroys your data and"
+  warn "      does not fix this cause."
+  warn "  • exit 139 elsewhere  → the service crashed (segfault). Usually a corrupted data"
   warn "      volume from an earlier hard kill — recreate it and re-run ./install.sh. If it"
   warn "      recurs on a fresh volume, it is an incompatible host kernel/CPU (see docker logs)."
   warn "  • anything else       → read 'docker logs' above for the specific error"

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -1397,38 +1397,64 @@ fi
 MONGO_RSEQ_HEAL_TRIED=false
 MONGO_HEAL_GRACE_SECS=180
 
-# True when a mongodb container in this project is crash-looping on exit 139.
-#
-# A single inspect is not enough. A restart-looping container flaps between
-# `restarting`, where .State.ExitCode reports the last exit, and `running`, where
-# it reports 0 -- so whether the 139 is visible depends on when you happen to
-# look. Sample for a few seconds and accept the first 139 seen. This only runs
-# after a start has already failed, so the wait costs nothing on a healthy host.
-MONGO_RSEQ_PROBE_SECS=12
+# The project's mongodb container ids, one per line.
+mongo_container_ids() {
+  docker ps -aq \
+    --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
+    --filter "label=com.docker.compose.service=mongodb" 2>/dev/null
+}
 
+# The last exit code Docker recorded for this mongodb container, from the
+# daemon's own event log.
+#
+# `docker inspect .State.ExitCode` cannot answer this on its own: it reports 0
+# whenever the container is in one of its up windows, so the true code is only
+# visible while it happens to be `restarting`. A slow flap -- up for ~25s, crash,
+# restart -- hides it from any single sample and from a short probe. The event
+# log records every `die` with its code, and filtering by the current container
+# id means a recreated container starts with a clean history.
+mongo_last_die_code() {
+  local id
+  id="$(mongo_container_ids | head -1)"
+  [[ -n "$id" ]] || return 0
+  docker events --since 1h --until "$(date +%s)" \
+    --filter "container=$id" --filter "event=die" \
+    --format '{{.Actor.Attributes.exitCode}}' 2>/dev/null | tail -1
+}
+
+# True when this project's mongodb is crash-looping on exit 139.
 mongo_rseq_crashed() {
   local id exit_code restarts elapsed=0
-  # No mongodb container means the start failed for some other reason (a build
-  # error, a missing image, another service). Do not spend the probe window on it.
-  if [[ -z "$(docker ps -aq \
-      --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
-      --filter "label=com.docker.compose.service=mongodb" 2>/dev/null)" ]]; then
-    return 1
-  fi
+  # No mongodb container means the failure was something else entirely -- a build
+  # error, a missing image, another service. Do not spend any time on it.
+  if [[ -z "$(mongo_container_ids)" ]]; then return 1; fi
+
+  # Authoritative and race-free: what the daemon recorded when it last died.
+  if [[ "$(mongo_last_die_code)" == "139" ]]; then return 0; fi
+
+  # Fallback for a daemon whose event history is unavailable or trimmed. Only
+  # catches a fast loop, where the container is restarting most of the time.
   while (( elapsed < MONGO_RSEQ_PROBE_SECS )); do
-    for id in $(docker ps -aq \
-        --filter "label=com.docker.compose.project=${PROJECT_NAME}" \
-        --filter "label=com.docker.compose.service=mongodb" 2>/dev/null); do
+    for id in $(mongo_container_ids); do
       restarts="$(docker inspect "$id" --format '{{.RestartCount}}' 2>/dev/null || echo 0)"
       exit_code="$(docker inspect "$id" --format '{{.State.ExitCode}}' 2>/dev/null || echo '')"
-      # RestartCount rules out a container that exited 139 once and stayed down
-      # for an unrelated reason; the loop is what identifies this failure.
       if [[ "$exit_code" == "139" ]] && (( ${restarts:-0} >= 1 )); then return 0; fi
     done
     sleep 1
     elapsed=$(( elapsed + 1 ))
   done
   return 1
+}
+
+# Total restarts across this project's mongodb containers. Cheap (one inspect per
+# container, no probing) so the healthy path can call it on every install.
+mongo_restart_count() {
+  local id n total=0
+  for id in $(mongo_container_ids); do
+    n="$(docker inspect "$id" --format '{{.RestartCount}}' 2>/dev/null || echo 0)"
+    total=$(( total + ${n:-0} ))
+  done
+  printf '%s' "$total"
 }
 
 # Write the documented tunable, once per run, and never over a value the operator
@@ -1439,7 +1465,7 @@ apply_mongo_rseq_tunable() {
   if ! mongo_rseq_crashed; then return 1; fi
 
   MONGO_RSEQ_HEAL_TRIED=true
-  warn "MongoDB exited 139 (segfault) and is not coming up."
+  warn "MongoDB is crash-looping on exit 139 (segfault)."
   warn "That is the known glibc rseq/TCMalloc crash on newer host kernels."
   info "Setting MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 in .env and retrying..."
   persist_env_var MONGO_GLIBC_TUNABLES "glibc.pthread.rseq=1"
@@ -1694,6 +1720,30 @@ if $CONTAINER_HEALTHY; then
     warn "Services are healthy inside the container, but http://localhost:${APP_PORT} is not reachable from this host."
     warn "This is usually a port-publish, firewall, or reverse-proxy issue."
     warn "  docker compose -f ${COMPOSE_FILE} -p ${PROJECT_NAME} logs -f pipeshub-ai"
+  fi
+
+  # "Healthy" is not the same as "stable". A segfaulting MongoDB is healthy in
+  # the gaps between crashes, and those gaps are long enough to satisfy the app's
+  # depends_on and to pass the poll above -- so the install reports success and
+  # walks away from a database that restarts every ~25s, dropping every
+  # connection each time. Restarts are the signal the health check cannot see.
+  _mongo_restarts="$(mongo_restart_count)"
+  if (( _mongo_restarts > 0 )); then
+    if apply_mongo_rseq_tunable; then
+      if compose_up >/dev/null 2>&1; then
+        success "MongoDB had restarted ${_mongo_restarts}x on exit 139; applied the tunable and restarted it."
+      else
+        warn "Applied the MongoDB tunable, but restarting the stack failed."
+        warn "  docker compose -f ${COMPOSE_FILE} -p ${PROJECT_NAME} logs mongodb"
+      fi
+    else
+      warn "MongoDB has restarted ${_mongo_restarts} time(s) since startup."
+      warn "The stack is healthy right now, but a database that keeps restarting"
+      warn "drops every connection each time it goes. Check why:"
+      warn "  docker compose -f ${COMPOSE_FILE} -p ${PROJECT_NAME} logs --tail 40 mongodb"
+      warn "  exit 139 → set MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1 in .env"
+      warn "  exit 137 → out of memory; raise MONGO_CACHE_GB and MONGO_MEMORY_LIMIT together"
+    fi
   fi
 elif [[ -n "${_CRASH_REPORT:-}" ]]; then
   error "A container keeps restarting, so the stack cannot become healthy:"


### PR DESCRIPTION
## What a person runs into

They run `install.sh` on a machine with a recent kernel. MongoDB segfaults on startup, Docker restarts it, it segfaults again. After a minute and a half the installer gives up and tells them what to do about exit code 139:

> Usually a corrupted data volume from an earlier hard kill — recreate it and re-run `./install.sh`. If it recurs on a fresh volume, it is an incompatible host kernel/CPU.

So they delete their MongoDB volume, lose whatever was in it, and hit the same crash. The advice's own fallback then tells them their machine is unsupported, and a reasonable person stops there.

The actual fix is one line, and PipesHub already knows about it. #2677 added `MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1` for exactly this crash and documented it in `env.template`. Nothing surfaced it at the moment it was needed, and the installer's troubleshooting never mentioned it.

There is a second, quieter version of the same problem. Someone who does find the knob and adds it to `.env` by hand loses it the next time they run `--reconfigure`, because the installer rewrites `.env` from its own template and only ever wrote `MONGO_USERNAME` and `MONGO_PASSWORD` for MongoDB. The four knobs from #2677 never appeared in a generated `.env` at all, so they were undiscoverable on the quickstart path as well as unstable.

## What changed

**The installer now fixes the crash itself.** When starting the stack fails and a `mongodb` container is crash-looping on exit 139, it writes the documented tunable into `.env` and retries the whole start. It does this at most once per run, announces what it changed and why, and never touches a value the operator has already set — including someone who deliberately pinned `rseq=0`. The same heal also runs from the health poll as a backstop, though in practice the start fails first, so that branch rarely fires.

Both startup paths — prebuilt and `--build` — go through one helper, so they cannot drift. The retry is a full `up -d`, so dependents that were created but never started come up too, and it does not repeat `--build`, since an image that compiled once is already built. A failed start with no `mongodb` container at all returns immediately rather than paying the exit-code probe.

**A crash-loop that starts *after* the stack is up is now caught too.** MongoDB is healthy in the gaps between segfaults, and those gaps are long enough to satisfy the app's `depends_on` and to pass the health poll — so the install succeeds and reports success while the database restarts every ~25 seconds, dropping every connection each time. The success path now checks the restart count, heals if the last exit was 139, and otherwise says what restarted and how to read the exit code. A healthy install returns in 0s, because the restart count gates the rest.

**The exit-139 advice now leads with the non-destructive fix.** Recreating the data volume is still suggested, but after the config change, and only once it is clear the tunable did not help.

**The four MongoDB knobs survive a rewrite.** They are read back through `get_existing_val` alongside the secrets that are already preserved for the same reason, and each is written either as the operator's value or as a commented hint carrying `env.template`'s guidance. `persist_env_var` now replaces a commented placeholder rather than appending a duplicate beneath it.

Defaults do not change. MongoDB still starts with `glibc.pthread.rseq=0` on every machine, which is the faster TCMalloc setting #2677 chose deliberately. The tunable is applied only to a machine that has demonstrably crashed.

### Where the heal runs, and why it moved

Review raised that the heal might never run on a real install, and testing confirmed it — though not for the predicted reason.

`pipeshub-ai` declares `depends_on: mongodb: condition: service_healthy`. The expectation was that `up -d` would block on that condition. It does not. Measured on a compose project reproducing the shape, `docker compose up -d` **returns after about two seconds** with `dependency failed to start: container ... is unhealthy`, and exits 1. Since the installer calls `die()` on a failed `up`, it aborted there — well before the health poll that originally contained the heal.

So the conclusion was right and the mechanism was not: the heal was unreachable because `up` fails fast, not because it hangs. It now runs on the `up` failure path, on both the prebuilt and build branches, and retries the **full** `up -d` rather than recreating only `mongodb`, so dependents that were created but never started come up as well.

Two more fixes from the same review:

**Detection sampled the exit code once.** A crash-looping container flaps between `restarting`, where `.State.ExitCode` reports the last exit, and `running`, where it reports `0`. A single inspect missed the 139 outright in testing — the heal declined to fire on a container that was genuinely segfaulting. It now samples for a few seconds and accepts the first 139 from a container that has already restarted at least once. This runs only after a start has failed, so it costs nothing on a healthy host.

**The grace window shortened the deadline it meant to extend.** At `t=90` an unconditional `ELAPSED + 180` cut the default 420-second wait down to 270. It now takes the later of the two.

`persist_env_var` matching `# KEY=` is deliberately narrow and stays as it is.

## Why react to the crash instead of checking the kernel

The obvious alternative is to read `uname -r` before starting, compare it against known-affected kernels, and set the tunable up front. I chose not to, and the trade is worth stating plainly.

**Checking the kernel first** would avoid the crash entirely — no failed start and no alarming output — and it would be easy to test without reproducing a segfault. But it needs a list of affected kernel versions that someone has to keep accurate forever, and the interaction depends on the kernel, the glibc build, and the TCMalloc in the MongoDB image together, which a version string cannot express. Distributions backport fixes, so the same version number means different things on different systems. A wrong guess is costly in both directions: a false positive silently gives up TCMalloc performance on machines that were fine, which is the exact outcome #2677 set out to avoid, and a false negative leaves the operator with the original crash plus a check that told them everything was fine.

**Reacting to the observed crash** keys off the symptom, so there is no list to maintain and no false positives. A machine that never segfaults never gets the tunable and keeps the faster default, and the rule stays correct as kernels, glibc, and MongoDB images change. It also reuses detection the installer already performs, so it is a small addition rather than new machinery.

The cost is that the operator sees the crash before anything is done about it, so the first impression is a failing install. How long that lasts depends on the shape: a MongoDB that cannot start at all fails `up` in about two seconds and is healed immediately, while one that crash-loops after the stack is up is caught once the health wait finishes and the restart count is checked. And exit 139 means "segfault", not "rseq specifically" — a genuinely corrupt volume produces the same code, so the tunable can be set on a machine whose real problem was something else.

That last one is the strongest argument against this approach, and the reason I still prefer it is asymmetry: setting a config line and restarting one container is cheap and trivially reversible, while the advice it replaces was to delete a database. If the tunable does not help, the operator sees the existing guidance and has lost about three minutes.

### A real example of why the list would be wrong

While reviewing this I checked the machine that originally hit this crash, and the timeline makes the case better than the argument does. The crash was real there, and the workaround was added to `.env` on 8 August while the machine was running kernel `7.0.0-28-generic`. It has since booted `7.0.0-29-generic` and now `7.0.0-30-generic`, and on both of those MongoDB `8.0.17` has run with `glibc.pthread.rseq=0` and zero crash restarts. The MongoDB image is byte-identical across the whole period, and glibc was last updated before the crash rather than after, so the kernel is the only thing that moved.

A second affected host then made the point harder. It runs `7.0.0-1006-aws` with glibc `2.43-2ubuntu2`, and reproduces the crash reliably. The first host crashed on `7.0.0-28-generic` with glibc `2.43-2ubuntu2.3` and stopped crashing on `-29` and `-30`. Two confirmed-affected machines, and they share neither a kernel flavour, nor a numbering scheme (`-28` against `-1006`), nor a glibc patch level. Any list would have to enumerate all of that and would still be a guess about the next one.

So the same machine went from affected to unaffected across two point releases within the same kernel series, in about two weeks. A version allowlist written on 8 August would have been wrong by 25 August, and nobody would have noticed, because the symptom it guards against is silence. Reacting to the actual exit code does not have that failure mode.

The two approaches are not exclusive. An operator who already knows their fleet is affected can still set the knob ahead of time, and this change explicitly leaves that value alone.

## Testing

Reproduced against `main` on a throwaway copy of `deployment/docker-compose/`, using `--print-env-only`:

| Step | `MONGO_GLIBC_TUNABLES` in `.env` |
| --- | --- |
| Fresh `install.sh --yes` | absent |
| Operator adds it by hand | present |
| `install.sh --yes --reconfigure` | **gone** |

After this change, a fresh `.env` carries all four knobs as commented hints, and a hand-set `MONGO_GLIBC_TUNABLES` plus `MONGO_CACHE_GB=4` both survived `--reconfigure` while the untouched knobs stayed commented.

The heal path was exercised against a real crash-looping container — an isolated compose project whose `mongodb` service exits 139 under `restart: always`, reaching seven restarts:

| Case | Result |
| --- | --- |
| Crash loop, knob unset | Detected, commented hint replaced in place by the active value, container recreated |
| Called a second time in the same run | Skipped, as intended |
| Operator had already set `rseq=0` | Left untouched |

`bash -n` passes. No compose file changed, so the rendered stack is identical and the existing `mongodb_stability_test.sh` assertions are unaffected.

The `up`-failure path was then verified end to end against a compose project that reproduces the real shape — a `mongodb` service that exits 139 unless the tunable is set, and an `app` gated on its health:

| Step | Result |
| --- | --- |
| First `up -d` | Fails in ~2s: `dependency failed to start: ... is unhealthy` |
| Heal | Detects the 139 loop, replaces the commented hint with the active value |
| Retry `up -d` | **mongodb healthy and app running** — the dependent starts too |

### Confirmed on a host that actually has the crash

Earlier revisions of this description said the underlying claim — that the tunable resolves the real crash — rested on #2677 rather than on anything observed. That has now been checked on a remote host that reproduces it.

The symptom there was not a failed install. The stack was up and serving, and the application log showed MongoDB dropping and reconnecting on a cycle: roughly 20-29 seconds connected, then a gap of 1-10 seconds while the driver backed off and retried. `docker events` on the MongoDB container showed `die 139` followed by `start`, and mongod's own log recorded `"Startup from clean shutdown?": false`. The container had accumulated 32 restarts.

Setting `MONGO_GLIBC_TUNABLES=glibc.pthread.rseq=1` and recreating that one container stopped it dead:

| | Before | After |
| --- | --- | --- |
| MongoDB restarts | 32 accumulated, one per ~25s | **0** over 21 minutes |
| `die` events recorded | exit 139, continuously | **none** |
| App-side connection drops | ~2 per minute | **0** since the restart |

The application had been logging a `Mongoose connection disconnected` / `established` pair roughly every half minute for as long as the crash lasted. After the tunable was applied the connection was established once and has stayed up, with no further lines at all.

Memory was ruled out on the way: the container was using 100 MiB of a 2 GiB limit, `OOMKilled` was false, and the host had 85 GB free.

**One diagnostic detail that validates a change made during review.** A single `docker inspect` on that container reported `exit=0`, which sent me looking at clean-shutdown causes for a while. A crash-looping container reports `0` while it is briefly up and its real exit code only while restarting, so one sample is genuinely unreliable — the same race that made the first version of `mongo_rseq_crashed` fail to fire in testing. The sampling loop this PR now uses is what makes the detection dependable, and this is a real-world instance of the single-sample reading being wrong.

That host also exposed a third shape this PR did not originally handle: the install *succeeds* and MongoDB crash-loops afterwards. The success-path check described above exists because of it, and was verified against a compose project reproducing the same shape — `up -d` succeeds, mongodb crashes every 25 seconds, the check sees 7 restarts and a last die code of 139, applies the tunable, and the restart count then stays at 0.

What I have **not** done is reproduce this from a *fresh install* on such a host. The detection is driven by the container's exit code, which the test above reproduces faithfully, but the end-to-end claim that setting the tunable resolves the real crash rests on #2677 and on a maintainer having seen it, not on my own observation.

## Related, not fixed here

The rewrite drops every setting the installer does not write, not only the MongoDB ones. `env.template` documents 47 keys; seventeen never reach a generated `.env`. Five of those are omitted deliberately, with a comment explaining that an empty value crashes Hub slim — `MAX_CONCURRENT_PARSING`, `MAX_CONCURRENT_INDEXING`, `MAX_PENDING_INDEXING_TASKS`, `EMBEDDING_BATCH_CONCURRENCY`, and `EMBEDDING_SERVER_MAX_CONCURRENCY` (`env.template:96-101`). A sixth, `MAX_DELIVERY_ATTEMPTS`, is not interpolated by any compose file, so writing it would have no effect either. The rest revert to a compose fallback on `--reconfigure`:

| Setting | Reverts to | What the operator sees |
| --- | --- | --- |
| `MCP_SCOPES` | the stock 14-scope list | Personal access tokens carrying a scope the operator added stop working. Scopes are validated as a subset of the instance list, so it surfaces as `403`s rather than a config error |
| `SAML_SP_ENTITY_ID` | `FRONTEND_PUBLIC_URL`, else `pipeshub` | SSO logins fail, because the audience no longer matches the identity provider |
| `APP_MEMORY_LIMIT` / `APP_MEMSWAP_LIMIT` | `12G` / `16G` | A tuned-down host gets OOM-killed; a large one loses its headroom. The launch-time consistency check runs after the rewrite, so it validates the defaults and never reports the loss |
| `ALLOWED_ORIGINS` | `http://localhost:3001` | Browser requests from the real front-end origin start failing CORS |
| `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` | unset | An air-gapped install starts reaching for HuggingFace and model loading stalls |
| `MAX_TABLE_ROWS_FOR_LLM`, `EXCEL_*` | compose defaults | Indexing and answer-quality tuning quietly reverts |

`MCP_SCOPES` looks like the worst of them, because it fails as an authentication problem that points nowhere near a config file.

I kept those out so this stays reviewable. The fix is either the same pattern applied to each, or one pass that carries forward any key the previous `.env` had and the new one does not — the second is shorter but can resurrect settings deliberately retired between installer versions. Say which you would prefer and I will open it separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guidance for optionally pinning the MongoDB image version.
  * Added automatic recovery during MongoDB startup, including after build-based launches.

* **Bug Fixes**
  * Improved detection and handling of MongoDB crashes and restart loops.
  * Startup now exits promptly when no project MongoDB container is available.
  * Improved diagnostics and recovery for MongoDB launch failures, including exit code 139 errors.
  * Added health checks and warnings when MongoDB requires repeated restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->






