### PR TITLE
docs: correct the contributor setup guide and the manual Compose examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ or use Neo4j Desktop if you prefer a local GUI.
    The Python services read `DATA_STORE` and write `dataStoreType` into the KV store (etcd/Redis) on startup; the Node.js API uses that for health checks and treats `NEO4J_*` as the live Neo4j connection.
 4. Start the **connectors** Python service (`python -m app.connectors_main`) before or with the rest of the stack so deployment metadata stays consistent. If you already bootstrapped against ArangoDB on the same etcd data, reset etcd or the deployment key in KV store before switching graph backends to avoid mismatched state.
 
-To run the whole stack in Docker rather than service by service, use `./install.sh --build` from the repository root. (`deployment/docker-compose/docker-compose.build.neo4j.yml` still exists but is a legacy standalone build file: it hardcodes Neo4j and Kafka, does not generate a `.env`, and is not what `--build` drives.)
+To run the whole stack in Docker rather than service by service, use `./install.sh --build` from the repository root. (`deployment/docker-compose/docker-compose.build.neo4j.yml` still exists but is a legacy standalone build file: it hardcodes `DATA_STORE=neo4j` with no ArangoDB or etcd profiles, builds `pipeshub-ai:latest`, pins port 3000, does not generate a `.env`, and is not what `--build` drives.)
 
 **ArangoDB (alternative to Neo4j):** (Password must match with .env)
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (API Key must match with .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **ETCD Server:**
@@ -96,17 +96,20 @@ docker run -d --name etcd-server --restart always `
   --listen-peer-urls http://0.0.0.0:2380
 ```
 
-**ArangoDB:** (Password must match with .env)
+PipesHub supports two graph databases, selected with `DATA_STORE`. **Neo4j is the default** — it is what `install.sh`, the Helm chart and `backend/env.template` ship with, so unless you are specifically working on ArangoDB support, set up Neo4j. ArangoDB remains fully supported for existing installations.
+
+**Neo4j (default):** either run the container
+
 ```bash
-docker run -e ARANGO_ROOT_PASSWORD=your_password -p 8529:8529 --name arango --restart always -d arangodb:3.12.4
+docker run -d --name neo4j --restart always -p 7474:7474 -p 7687:7687 \
+  -e NEO4J_AUTH=neo4j/your_password neo4j:5.26.0
 ```
 
-**Neo4j Desktop (instead of ArangoDB):** PipesHub can use **Neo4j** as the graph database (`DATA_STORE=neo4j`) instead of ArangoDB. This is useful if you prefer a local GUI and do not want the ArangoDB container.
+or use Neo4j Desktop if you prefer a local GUI.
 
-1. Install [Neo4j Desktop](https://neo4j.com/download/), create a **local DBMS**, set its password, and **Start** it.
+1. If using Desktop: install [Neo4j Desktop](https://neo4j.com/download/), create a **local DBMS**, set its password, and **Start** it.
 2. Leave the default Bolt listener on **localhost:7687** (or note the host/port shown in Desktop if you changed them).
-3. **Do not** start the ArangoDB Docker container above when using Neo4j.
-4. In `backend/.env` (the template you copy into `backend/nodejs/apps/.env` and `backend/python/.env`), set at least:
+3. In `backend/.env` (the template you copy into `backend/nodejs/apps/.env` and `backend/python/.env`), set at least:
    ```bash
    DATA_STORE=neo4j
    NEO4J_URI=bolt://localhost:7687
@@ -115,9 +118,15 @@ docker run -e ARANGO_ROOT_PASSWORD=your_password -p 8529:8529 --name arango --re
    NEO4J_DATABASE=neo4j
    ```
    The Python services read `DATA_STORE` and write `dataStoreType` into the KV store (etcd/Redis) on startup; the Node.js API uses that for health checks and treats `NEO4J_*` as the live Neo4j connection.
-5. Start the **connectors** Python service (`python -m app.connectors_main`) before or with the rest of the stack so deployment metadata stays consistent. If you already bootstrapped against ArangoDB on the same etcd data, reset etcd or the deployment key in KV store before switching graph backends to avoid mismatched state.
+4. Start the **connectors** Python service (`python -m app.connectors_main`) before or with the rest of the stack so deployment metadata stays consistent. If you already bootstrapped against ArangoDB on the same etcd data, reset etcd or the deployment key in KV store before switching graph backends to avoid mismatched state.
 
-For a full stack in Docker with Neo4j instead of ArangoDB, see `docker-compose.build.neo4j.yml` in `deployment/docker-compose/` (documented in the repository `README.md`).
+To run the whole stack in Docker rather than service by service, use `./install.sh --build` from the repository root. (`deployment/docker-compose/docker-compose.build.neo4j.yml` still exists but is a legacy standalone build file: it hardcodes Neo4j and Kafka, does not generate a `.env`, and is not what `--build` drives.)
+
+**ArangoDB (alternative to Neo4j):** (Password must match with .env)
+```bash
+docker run -e ARANGO_ROOT_PASSWORD=your_password -p 8529:8529 --name arango --restart always -d arangodb:3.12.4
+```
+Set `DATA_STORE=arangodb` in `backend/.env`, and do not run the Neo4j container alongside it. If you already bootstrapped against one backend on the same etcd data, reset the deployment key in the KV store before switching.
 
 **MongoDB:** (Password must match with .env MONGO URI)
 
@@ -126,7 +135,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +143,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**
@@ -229,6 +238,10 @@ python -m app.connectors_main
 python -m app.indexing_main
 python -m app.query_main
 python -m app.docling_main
+
+# Only when running with USE_PARSING_SERVICE=true
+python -m app.parsing_main
+python -m app.extraction_main
 ```
 
 ### Setting Up Frontend
@@ -268,12 +281,16 @@ Our project consists of three main components:
 
 1. **Frontend**: Next.js application for the user interface
 2. **Node.js Backend**: Handles API requests, authentication, and business logic
-3. **Python Services**: Five microservices for:
+3. **Python Services**: Seven microservices for:
    - **Embedding** (port 8002): Serves local HuggingFace / SentenceTransformer models via an OpenAI-compatible API (`app.embedding_main`). Indexing and query call this service for default dense embeddings.
    - **Connectors** (port 8088): Handles data source connections
    - **Indexing** (port 8091): Manages document indexing and processing
    - **Query** (port 8000): Processes search and retrieval requests
    - **Docling** (port 8081): Advanced PDF/document parsing for complex formats
+   - **Parsing** (port 8092): Turns file bytes into a structured block container
+   - **Extraction** (port 8093): Derives semantic metadata from those blocks
+
+   Parsing and Extraction are optional: start them only when running with `USE_PARSING_SERVICE=true`, which is also when `check_system_health.sh` checks them.
 
 When running services locally with `make`, start **embedding** before **indexing** and **query** if you rely on the built-in local embedding model (`BAAI/bge-large-en-v1.5`). Cloud/API embedding providers (OpenAI, Cohere, etc.) do not require the embedding server.
 

--- a/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
+++ b/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
@@ -171,6 +171,7 @@ $EDITOR .env
 ### Slim (Neo4j, Redis Streams, Redis KV)
 
 ```bash
+DATA_STORE=neo4j \
 COMPOSE_PROFILES=graph-neo4j \
   docker compose -p pipeshub-ai up -d
 ```
@@ -178,6 +179,7 @@ COMPOSE_PROFILES=graph-neo4j \
 ### Full (ArangoDB, Kafka, etcd)
 
 ```bash
+DATA_STORE=arangodb KV_STORE_TYPE=etcd MESSAGE_BROKER=kafka \
 COMPOSE_PROFILES=graph-arango,kv-etcd,broker-kafka \
   docker compose -p pipeshub-ai up -d
 ```
@@ -206,6 +208,14 @@ docker compose -p pipeshub-ai exec -T pipeshub-ai bash
 | `broker-kafka` | Kafka + Zookeeper | `MESSAGE_BROKER=kafka` |
 
 Always-on services (no profile needed): `redis`, `mongodb`, `qdrant`.
+
+> **A profile and its variable must be set together.** `COMPOSE_PROFILES` only decides
+> which containers start. Which backend the application talks to comes from the variable
+> in the right-hand column, and each of those has its own default —
+> `DATA_STORE=arangodb`, `KV_STORE_TYPE=redis`, `MESSAGE_BROKER=redis`. Setting the
+> profile alone starts a container the app never connects to, while the app keeps using
+> the default backend. When you set `.env` through `install.sh` this is handled for you;
+> it only matters for the manual Compose commands above.
 
 ---
 

--- a/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
+++ b/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
@@ -211,11 +211,23 @@ Always-on services (no profile needed): `redis`, `mongodb`, `qdrant`.
 
 > **A profile and its variable must be set together.** `COMPOSE_PROFILES` only decides
 > which containers start. Which backend the application talks to comes from the variable
-> in the right-hand column, and each of those has its own default —
-> `DATA_STORE=arangodb`, `KV_STORE_TYPE=redis`, `MESSAGE_BROKER=redis`. Setting the
-> profile alone starts a container the app never connects to, while the app keeps using
-> the default backend. When you set `.env` through `install.sh` this is handled for you;
-> it only matters for the manual Compose commands above.
+> in the right-hand column. Set the profile alone and you start a container the app never
+> connects to, while the app carries on using whatever the variable falls back to.
+>
+> Those fallbacks live in `docker-compose.yml` and apply **only when no `.env` supplies a
+> value**, which is the case for the manual commands above:
+>
+> | Variable | Fallback in `docker-compose.yml` |
+> |----------|----------------------------------|
+> | `DATA_STORE` | `arangodb` (line 111) |
+> | `KV_STORE_TYPE` | `redis` (line 126) |
+> | `MESSAGE_BROKER` | `redis` (line 134) |
+>
+> These are **not** the defaults you get from `install.sh`, which chooses Neo4j and writes
+> `DATA_STORE=neo4j` into `.env`. If you installed with `install.sh`, your `.env` already
+> sets all three and none of this applies. The Compose fallback for `DATA_STORE` differs
+> from the installer's choice and is due to be aligned; until then, set the variable
+> explicitly whenever you drive Compose by hand.
 
 ---
 

--- a/docs/i18n/de/CONTRIBUTING.md
+++ b/docs/i18n/de/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Willkommen in unserem Open-Source-Projekt! Wir freuen uns, dass du an einem Beitrag interessiert bist. Dieses Dokument bietet Richtlinien und Anleitungen, die dir den Einstieg als Mitwirkender erleichtern.
 
 ## 💻 Entwickler-Beitrags-Build

--- a/docs/i18n/de/CONTRIBUTING.md
+++ b/docs/i18n/de/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (Der API Key muss mit der .env übereinstimmen)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **ETCD-Server:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/es/CONTRIBUTING.md
+++ b/docs/i18n/es/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (la API Key debe coincidir con .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **Servidor ETCD:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/es/CONTRIBUTING.md
+++ b/docs/i18n/es/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 ¡Bienvenido a nuestro proyecto de código abierto! Nos alegra que te interese contribuir. Este documento ofrece directrices e instrucciones para ayudarte a empezar como colaborador.
 
 ## 💻 Compilación de contribución para desarrolladores

--- a/docs/i18n/fr/CONTRIBUTING.md
+++ b/docs/i18n/fr/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis :**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant :** (l'API Key doit correspondre à .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **Serveur ETCD :**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper :**

--- a/docs/i18n/fr/CONTRIBUTING.md
+++ b/docs/i18n/fr/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Bienvenue dans notre projet open source ! Nous sommes ravis que vous souhaitiez contribuer. Ce document fournit des directives et des instructions pour vous aider à démarrer en tant que contributeur.
 
 ## 💻 Build de contribution pour développeurs

--- a/docs/i18n/he/CONTRIBUTING.md
+++ b/docs/i18n/he/CONTRIBUTING.md
@@ -65,12 +65,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (ה-API Key חייב להתאים ל-.env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **שרת ETCD:**
@@ -128,7 +128,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -136,7 +136,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/he/CONTRIBUTING.md
+++ b/docs/i18n/he/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 <div dir="rtl">
 
 ברוכים הבאים לפרויקט הקוד הפתוח שלנו! אנו שמחים שאתם מתעניינים בתרומה. מסמך זה מספק הנחיות והוראות שיעזרו לכם להתחיל כתורמים.

--- a/docs/i18n/it/CONTRIBUTING.md
+++ b/docs/i18n/it/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Benvenuto nel nostro progetto open source! Siamo lieti che tu sia interessato a contribuire. Questo documento fornisce linee guida e istruzioni per aiutarti a iniziare come collaboratore.
 
 ## 💻 Build di contributo per sviluppatori

--- a/docs/i18n/it/CONTRIBUTING.md
+++ b/docs/i18n/it/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (l'API Key deve corrispondere a .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **Server ETCD:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/ja/CONTRIBUTING.md
+++ b/docs/i18n/ja/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis：**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant：**（API Key は .env と一致している必要があります）
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **ETCD サーバー：**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper：**

--- a/docs/i18n/ja/CONTRIBUTING.md
+++ b/docs/i18n/ja/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 私たちのオープンソースプロジェクトへようこそ！ あなたが貢献に関心を持ってくださっていることを嬉しく思います。本ドキュメントは、貢献者として始めるためのガイドラインと手順を提供します。
 
 ## 💻 開発者向け貢献ビルド

--- a/docs/i18n/ko/CONTRIBUTING.md
+++ b/docs/i18n/ko/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (API Key는 .env와 일치해야 합니다)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **ETCD 서버:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/ko/CONTRIBUTING.md
+++ b/docs/i18n/ko/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 저희 오픈소스 프로젝트에 오신 것을 환영합니다! 기여에 관심을 가져주셔서 기쁩니다. 이 문서는 기여자로서 시작하는 데 도움이 되는 지침과 안내를 제공합니다.
 
 ## 💻 개발자 기여 빌드

--- a/docs/i18n/pt/CONTRIBUTING.md
+++ b/docs/i18n/pt/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (a API Key deve corresponder ao .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **Servidor ETCD:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/pt/CONTRIBUTING.md
+++ b/docs/i18n/pt/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Bem-vindo ao nosso projeto de código aberto! Ficamos felizes que você tenha interesse em contribuir. Este documento fornece diretrizes e instruções para ajudá-lo a começar como colaborador.
 
 ## 💻 Build de contribuição para desenvolvedores

--- a/docs/i18n/ru/CONTRIBUTING.md
+++ b/docs/i18n/ru/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Добро пожаловать в наш проект с открытым исходным кодом! Мы рады, что вы заинтересованы во внесении вклада. Этот документ содержит рекомендации и инструкции, которые помогут вам начать работу в качестве контрибьютора.
 
 ## 💻 Сборка для вклада разработчиков

--- a/docs/i18n/ru/CONTRIBUTING.md
+++ b/docs/i18n/ru/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (API Key должен совпадать с .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **Сервер ETCD:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/tr/CONTRIBUTING.md
+++ b/docs/i18n/tr/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Açık kaynak projemize hoş geldiniz! Katkıda bulunmakla ilgilendiğiniz için mutluyuz. Bu belge, bir katkıda bulunan olarak başlamanıza yardımcı olacak yönergeler ve talimatlar sunar.
 
 ## 💻 Geliştirici Katkı Derlemesi

--- a/docs/i18n/tr/CONTRIBUTING.md
+++ b/docs/i18n/tr/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (API Key, .env ile eşleşmelidir)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **ETCD Sunucusu:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/vi/CONTRIBUTING.md
+++ b/docs/i18n/vi/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis:**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant:** (API Key phải khớp với .env)
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **Máy chủ ETCD:**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper:**

--- a/docs/i18n/vi/CONTRIBUTING.md
+++ b/docs/i18n/vi/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 Chào mừng bạn đến với dự án mã nguồn mở của chúng tôi! Chúng tôi rất vui vì bạn quan tâm đến việc đóng góp. Tài liệu này cung cấp các hướng dẫn và chỉ dẫn giúp bạn bắt đầu với tư cách là người đóng góp.
 
 ## 💻 Bản dựng đóng góp cho nhà phát triển

--- a/docs/i18n/zh-CN/CONTRIBUTING.md
+++ b/docs/i18n/zh-CN/CONTRIBUTING.md
@@ -63,12 +63,12 @@ brew install mariadb-connector-c # Add to path
 
 **Redis：**
 ```bash
-docker run -d --name redis --restart always -p 6379:6379 redis:bookworm
+docker run -d --name redis --restart always -p 6379:6379 redis:7.4-bookworm
 ```
 
 **Qdrant：**（API Key 必须与 .env 一致）
 ```bash
-docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.13.6
+docker run -p 6333:6333 -p 6334:6334 -e QDRANT__SERVICE__API_KEY=your_qdrant_secret_api_key qdrant/qdrant:v1.15
 ```
 
 **ETCD 服务器：**
@@ -126,7 +126,7 @@ Bash:
 docker run -d --name mongodb --restart always -p 27017:27017 \
   -e MONGO_INITDB_ROOT_USERNAME=admin \
   -e MONGO_INITDB_ROOT_PASSWORD=password \
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 Powershell:
@@ -134,7 +134,7 @@ Powershell:
 docker run -d --name mongodb --restart always -p 27017:27017 `
   -e MONGO_INITDB_ROOT_USERNAME=admin `
   -e MONGO_INITDB_ROOT_PASSWORD=password `
-  mongo:8.0.6
+  mongo:8.0.17
 ```
 
 **Zookeeper：**

--- a/docs/i18n/zh-CN/CONTRIBUTING.md
+++ b/docs/i18n/zh-CN/CONTRIBUTING.md
@@ -6,6 +6,12 @@
 
 </div>
 
+> [!NOTE]
+> This translation is behind the English original and may contain outdated setup
+> instructions. For the current guide, see
+> [CONTRIBUTING.md](../../../CONTRIBUTING.md).
+
+
 欢迎来到我们的开源项目！我们很高兴你有兴趣参与贡献。本文档提供了帮助你作为贡献者起步的指南和说明。
 
 ## 💻 开发者贡献构建


### PR DESCRIPTION
## Summary

Seven corrections to `CONTRIBUTING.md` and the manual Compose examples it points at. Everything the guide references still exists — the health check script, both env templates, both test READMEs, `.env.test.example` and every npm target including `test:coverage-check`. These are the parts that no longer match the code.

## Container versions — English and all 12 translations

| | Guide says | `docker-compose.yml` ships |
|---|---|---|
| Qdrant | `v1.13.6` | `v1.15` |
| MongoDB | `8.0.6` | `8.0.17` |
| Redis | `redis:bookworm` (unpinned) | `redis:7.4-bookworm` |

Following the guide sets up a different build from the one that ships. Qdrant matters most: two minors apart on a vector database is the kind of gap that produces "works on my machine".

These are byte-identical `docker run` commands in every translated copy, so the change applies cleanly across all 13 files.

## Graph database — English only

The guide presents ArangoDB as the primary graph database and introduces Neo4j as an alternative. Every shipping default says the opposite:

```
install.sh:842,844   DEFAULT_GRAPH="neo4j"
env.template:33      DATA_STORE=neo4j
values.yaml:546      # Neo4j (enabled by default)
```

New contributors are steered onto the non-default backend. Neo4j now leads, with a container command whose image and auth variable match Compose (`neo4j:5.26.0`, `NEO4J_AUTH=neo4j/<password>`), and ArangoDB follows as the supported alternative with its own `DATA_STORE=arangodb` instruction.

The pointer to `docker-compose.build.neo4j.yml` claims it is "documented in the repository `README.md`". The README does not mention it. Replaced with `./install.sh --build`, and the legacy file described by what it actually does — hardcodes `DATA_STORE=neo4j`, no ArangoDB or etcd profiles, builds `pipeshub-ai:latest`, pins port 3000, generates no `.env`.

## Service count — English only

The guide says "Five microservices" and lists five. There are seven: `parsing_main` (8092) and `extraction_main` (8093) are missing from both the architecture list and the startup commands.

The guide contradicts itself here — it recommends `./scripts/check_system_health.sh`, which probes nine ports including 8092 and 8093, so it asks contributors to verify services it never told them to start. Both are now listed, with the note that they are only needed when `USE_PARSING_SERVICE=true`, matching the condition at `check_system_health.sh:20`.

## Manual Compose examples

`ADVANCED_DEPLOYMENT.md` sets `COMPOSE_PROFILES` without the matching backend variable. A profile decides which container starts; which backend the application uses comes from a separate variable, and each defaults independently:

```
docker-compose.yml:111   DATA_STORE=${DATA_STORE:-arangodb}
docker-compose.yml:126   KV_STORE_TYPE=${KV_STORE_TYPE:-redis}
docker-compose.yml:134   MESSAGE_BROKER=${MESSAGE_BROKER:-redis}
```

The Slim example starts Neo4j while the application looks for an ArangoDB that is not running. The Full example starts etcd and Kafka while the application keeps using Redis for both. Both now set the variables alongside the profiles, and a note under the profile table states the rule once, with the defaults.

## The translations

They receive the version pins only.

They are hand-maintained — there is no translation workflow in `.github/workflows` or `scripts/` — and have drifted:

| | English | Each translation |
|---|---|---|
| Commits | 21 | 3 |
| Last updated | 2026-08-25 | 2026-07-22 |
| Lines | 550 | 509 |

All twelve are frozen at the same commit and still present ArangoDB first. Rewriting that prose needs a translator, so each translated copy now carries a short note at the top stating it is behind the English original, with a link to it. That note is in English, so it does not help a reader who reads none — it is a marker, not a fix.

The wider question of how these twelve files are maintained is worth a separate decision: continue by hand, automate, or relabel them as community-maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated contribution guides with clearer local setup instructions, including Neo4j defaults, additional Parsing and Extraction services, and revised startup commands.
  - Updated documented Redis, Qdrant, and MongoDB container image versions.
  - Added notices to translated guides directing readers to the English guide for the latest instructions.
  - Clarified manual deployment profile and environment-variable requirements, including datastore, key-value store, and message broker configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->