### PR TITLE
fix(compose): make the manual quick-start produce a working stack

### DIFF
--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -107,8 +107,8 @@ services:
       - EMBEDDING_SERVER_URL=http://localhost:8002
 
       # Graph database selection — set by install.sh
-      # DATA_STORE accepted values: "arangodb" (default) | "neo4j"
-      - DATA_STORE=${DATA_STORE:-arangodb}
+      # DATA_STORE accepted values: "neo4j" (default) | "arangodb"
+      - DATA_STORE=${DATA_STORE:-neo4j}
 
       # ArangoDB (active when DATA_STORE=arangodb)
       - ARANGO_URL=http://arango:8529

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -1,17 +1,26 @@
 # PipesHub AI — unified, profile-driven Docker Compose
 #
 # Usage: run install.sh (in this directory) to generate .env and launch.
-# Manual quick-start:
-#   cp env.template .env && $EDITOR .env
-#   COMPOSE_PROFILES=graph-neo4j          docker compose -p pipeshub-ai up -d   # slim/neo4j/redis-streams
-#   COMPOSE_PROFILES=graph-arango,kv-etcd,broker-kafka \
-#     docker compose -p pipeshub-ai up -d                                        # full/arango/etcd/kafka
 #
-# Profile catalogue
-#   graph-neo4j   — start Neo4j (set DATA_STORE=neo4j in .env)
-#   graph-arango  — start ArangoDB (set DATA_STORE=arangodb in .env)
-#   kv-etcd       — start etcd (set KV_STORE_TYPE=etcd in .env; default is redis)
-#   broker-kafka  — start Zookeeper + Kafka (set MESSAGE_BROKER=kafka in .env; default is redis)
+# Manual quick-start — env.template ships a working slim stack (Neo4j, Redis
+# Streams, Redis KV). Set the passwords in it, then start:
+#
+#   cp env.template .env && $EDITOR .env      # set NEO4J_PASSWORD and MONGO_PASSWORD
+#   docker compose -p pipeshub-ai up -d
+#
+# Do not pass COMPOSE_PROFILES on the command line: it replaces the value in
+# .env rather than adding to it, so a profile set there would be dropped.
+# Change the stack by editing .env instead.
+#
+# Profile catalogue — each profile starts a container, and the variable beside it
+# tells the app to use it. Set both or neither.
+#   graph-neo4j   — Neo4j             (with DATA_STORE=neo4j)
+#   graph-arango  — ArangoDB          (with DATA_STORE=arangodb)
+#   kv-etcd       — etcd              (with KV_STORE_TYPE=etcd)
+#   broker-kafka  — Zookeeper + Kafka (with MESSAGE_BROKER=kafka)
+#
+# Full stack: DATA_STORE=neo4j, KV_STORE_TYPE=etcd, MESSAGE_BROKER=kafka and
+# COMPOSE_PROFILES=graph-neo4j,kv-etcd,broker-kafka
 #
 # Always-on: pipeshub-ai, redis, mongodb, qdrant, sandbox-image
 #

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -56,15 +56,28 @@ MONGO_PASSWORD=your_mongodb_password
 
 QDRANT_API_KEY=your_qdrant_api_key
 
-# KV store: use "redis" or "etcd"
+# ── Backend selection ────────────────────────────────────────────────────────
+# Each of these picks a backend. COMPOSE_PROFILES decides which containers
+# start. The two must agree: a backend whose profile is missing will not be
+# running, and a profile whose backend is not selected starts a container
+# nothing connects to.
+
+# Graph database: "neo4j" (default) or "arangodb"
+DATA_STORE=neo4j
+
+# KV store: "redis" (no extra container) or "etcd"
 KV_STORE_TYPE=redis
 
-# Message broker: "kafka" (default) or "redis" (uses Redis Streams)
+# Message broker: "kafka" or "redis" (uses Redis Streams, no extra container)
 MESSAGE_BROKER=kafka
-# When using Kafka, enable the kafka profile to start Kafka + Zookeeper containers:
-#   COMPOSE_PROFILES=kafka
-# When using Redis Streams, leave COMPOSE_PROFILES unset to skip Kafka/Zookeeper entirely.
-COMPOSE_PROFILES=kafka
+
+# Profiles for the selections above. Available profiles:
+#   graph-neo4j    Neo4j              (pairs with DATA_STORE=neo4j)
+#   graph-arango   ArangoDB           (pairs with DATA_STORE=arangodb)
+#   kv-etcd        etcd               (pairs with KV_STORE_TYPE=etcd)
+#   broker-kafka   Kafka + Zookeeper  (pairs with MESSAGE_BROKER=kafka)
+# redis, mongodb and qdrant always start and need no profile.
+COMPOSE_PROFILES=graph-neo4j,broker-kafka
 # Optional: isolate this copy from another PipesHub stack on the same Docker host.
 # The installer writes this; --stop / --uninstall read it. Default is pipeshub-ai.
 # COMPOSE_PROJECT_NAME=pipeshub-ai

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -15,6 +15,8 @@ SECRET_KEY=your_random_encryption_secret_key
 # Use Public URL (HTTPs only) to open web page
 FRONTEND_PUBLIC_URL=
 
+# Graph database passwords. Set the one matching DATA_STORE below.
+NEO4J_PASSWORD=your_neo4j_password
 ARANGO_PASSWORD=your_arangodb_password
 
 REDIS_PASSWORD=
@@ -68,8 +70,8 @@ DATA_STORE=neo4j
 # KV store: "redis" (no extra container) or "etcd"
 KV_STORE_TYPE=redis
 
-# Message broker: "kafka" or "redis" (uses Redis Streams, no extra container)
-MESSAGE_BROKER=kafka
+# Message broker: "redis" (Redis Streams, no extra container) or "kafka"
+MESSAGE_BROKER=redis
 
 # Profiles for the selections above. Available profiles:
 #   graph-neo4j    Neo4j              (pairs with DATA_STORE=neo4j)
@@ -77,7 +79,12 @@ MESSAGE_BROKER=kafka
 #   kv-etcd        etcd               (pairs with KV_STORE_TYPE=etcd)
 #   broker-kafka   Kafka + Zookeeper  (pairs with MESSAGE_BROKER=kafka)
 # redis, mongodb and qdrant always start and need no profile.
-COMPOSE_PROFILES=graph-neo4j,broker-kafka
+#
+# The values below are the slim stack, matching IMAGE_TAG=slim above: Neo4j for
+# the graph, Redis Streams for the broker, Redis for the key-value store. For the
+# full stack set MESSAGE_BROKER=kafka, KV_STORE_TYPE=etcd and
+# COMPOSE_PROFILES=graph-neo4j,broker-kafka,kv-etcd together.
+COMPOSE_PROFILES=graph-neo4j
 # Optional: isolate this copy from another PipesHub stack on the same Docker host.
 # The installer writes this; --stop / --uninstall read it. Default is pipeshub-ai.
 # COMPOSE_PROJECT_NAME=pipeshub-ai


### PR DESCRIPTION
## What goes wrong today

At the top of `docker-compose.yml` there are instructions for setting PipesHub up by hand, without the installer:

```bash
cp env.template .env && $EDITOR .env
COMPOSE_PROFILES=graph-neo4j docker compose -p pipeshub-ai up -d
```

If you follow them, PipesHub starts but does not work. It has nowhere to store its knowledge graph and no message broker to process documents through, and the errors you get point at network connections rather than at the real cause.

You can see the problem without running anything, by asking Compose which containers it would create:

```
$ docker compose --env-file env.template config --services
mongodb pipeshub-ai qdrant redis sandbox-image
```

No graph database, no broker. Meanwhile the application has been told to use both — Kafka as the broker, and ArangoDB as the graph database. It spends its life trying to reach two things that were never launched.

## Why it happens

Several separate mistakes line up, and each one alone is enough to break the setup.

**The template asks for a profile that does not exist.** Compose uses "profiles" to decide which optional containers to start. `env.template` asks for `kafka`, but the Kafka and Zookeeper containers are labelled `broker-kafka` (`docker-compose.yml:499,517`). The name does not match, so neither starts — while the same file tells the application to use Kafka anyway.

**The template never says which graph database to use.** It has a value for the key-value store, the broker and the profiles, but nothing for `DATA_STORE`, so no graph container is requested either.

**When nothing states a preference, Compose filled in the wrong one.** `docker-compose.yml:111` fell back to `arangodb`, while everywhere else in the project picks Neo4j — `install.sh:842,844`, `backend/env.template:33`, and `values.yaml:546`.

**The template had no Neo4j password.** It carried `ARANGO_PASSWORD` only. The compose file builds Neo4j's credentials as `NEO4J_AUTH=neo4j/${NEO4J_PASSWORD:-}` (`docker-compose.yml:441`) with no fallback, and the Neo4j image refuses to start without a password:

```
$ docker run -e NEO4J_AUTH=neo4j/ neo4j:5.26.0
Invalid value for NEO4J_AUTH: 'neo4j/'
exited (1)
```

**The instructions overrode the template.** The command above passes `COMPOSE_PROFILES` on the command line, and Compose treats that as a replacement for the value in `.env`, not an addition to it. So even a correct profile list in `.env` was discarded.

## What this changes

`env.template` now describes one coherent setup: Neo4j for the graph, Redis Streams for the broker, Redis for the key-value store. That is the "slim" shape the file already claimed with `IMAGE_TAG=slim`, and the same one `install.sh` produces for a slim install (`install.sh:844`). It gains a `NEO4J_PASSWORD` line beside `ARANGO_PASSWORD`, asks for profile names that exist, and lists all four profiles next to the settings they pair with.

The fallback in `docker-compose.yml` becomes `neo4j`, so every route into PipesHub now picks the same graph database.

The header instructions no longer pass profiles on the command line, and explain why you should not: it replaces what is in `.env` rather than adding to it.

Running the documented command now gives a setup where everything the application asks for is actually running:

```
services:  mongodb neo4j pipeshub-ai qdrant redis sandbox-image
app wants: DATA_STORE=neo4j  KV_STORE_TYPE=redis  MESSAGE_BROKER=redis
NEO4J_AUTH: neo4j/your_neo4j_password
```

`neo4j:5.26.0` starts successfully with that value.

## Before you upgrade

Almost nobody needs to do anything.

**If you installed with `install.sh`** — no action. It always writes `DATA_STORE` into your `.env` (`install.sh:1113`), so the fallback never applied to you. This is why the problem went unnoticed.

**If you copied `env.template`** — no action either. The old template never started a graph database at all, so there is no ArangoDB data to strand.

**One narrow case needs a change.** If you hand-wrote your own `.env` with `COMPOSE_PROFILES=graph-arango` but no `DATA_STORE` line, you have been running on ArangoDB through the old fallback. Add an explicit line before upgrading, or PipesHub will look for Neo4j and not find your data:

```bash
DATA_STORE=arangodb
```

## Anything else affected?

No. Compose already treats both graph databases as optional when working out start-up order, and no other container assumes one graph database over the other.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Neo4j remains the default graph database for Docker Compose deployments.
  - Added a centralized setting to choose between Neo4j and ArangoDB.
  - Redis is now the default message broker.
  - Updated default Compose profiles for a slim Neo4j and Redis stack.
  - Documented available profiles and full-stack combinations.
  - Added matching Neo4j password configuration.
  - Clarified environment-file setup and cautioned against overriding Compose profiles from the command line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->