### PR TITLE
docs: make the playbook's connector boilerplate constructible

### DIFF
--- a/CONNECTOR_INTEGRATION_PLAYBOOK.md
+++ b/CONNECTOR_INTEGRATION_PLAYBOOK.md
@@ -679,15 +679,22 @@ class YourConnector(BaseConnector):
         logger: Logger,
         data_entities_processor: DataSourceEntitiesProcessor,
         data_store_provider: DataStoreProvider,
-        config_service: ConfigurationService
+        config_service: ConfigurationService,
+        connector_id: str,
+        scope: str,
+        created_by: str,
     ) -> None:
         super().__init__(
-            YourConnectorApp(),
+            YourConnectorApp(connector_id),
             logger,
             data_entities_processor,
             data_store_provider,
             config_service,
+            connector_id,
+            scope,
+            created_by,
         )
+        self.connector_id = connector_id
 
         # TODO: Initialize your external API client reference
         self.external_client: Optional[Any] = None
@@ -695,7 +702,7 @@ class YourConnector(BaseConnector):
         # Initialize sync point for delta sync
         # See: https://github.com/pipeshub-ai/pipeshub-ai/blob/main/backend/python/app/connectors/core/base/sync_point/sync_point.py
         self.sync_point = SyncPoint(
-            connector_name=Connectors.YOUR_CONNECTOR,
+            connector_id=connector_id,
             org_id=self.data_entities_processor.org_id,
             sync_data_point_type=SyncDataPointType.RECORDS,
             data_store_provider=self.data_store_provider
@@ -1094,15 +1101,19 @@ from app.connectors.sources.{vendor}.{connector_name}.connector import YourConne
 def _make_connector() -> YourConnector:
     """Build a connector with every dependency mocked.
 
-    The four arguments match `YourConnector.__init__` from Step 6.2. The
-    entities processor cannot be omitted: its `org_id` is read while the
-    connector is being constructed, to build the SyncPoint.
+    The arguments match `YourConnector.__init__` from Step 6.2, which in
+    turn matches `BaseConnector`. The entities processor cannot be omitted:
+    its `org_id` is read while the connector is being constructed, to build
+    the SyncPoint.
     """
     return YourConnector(
         logger=MagicMock(),
         data_entities_processor=MagicMock(org_id="org-1"),
         data_store_provider=MagicMock(),
         config_service=MagicMock(),
+        connector_id="yourconnector-1",
+        scope="team",
+        created_by="test-user",
     )
 
 
@@ -1174,18 +1185,9 @@ pytest tests/unit/connectors/sources/
 Testing YourConnector
 ==================================================
 
-1. Creating connector instance...
-✅ Connector instance created
+tests/unit/connectors/sources/test_yourconnector_connector.py ...      [100%]
 
-2. Initializing connector...
-✅ Connector initialized successfully
-
-3. Testing connection...
-✅ Connection test passed
-
-==================================================
-All tests passed! ✅
-==================================================
+3 passed in 0.42s
 ```
 
 ### Step 8.3: Test with Full System

--- a/CONNECTOR_INTEGRATION_PLAYBOOK.md
+++ b/CONNECTOR_INTEGRATION_PLAYBOOK.md
@@ -567,17 +567,14 @@ Record (Email 1) ←─ recordRelations (SIBLING) ─→ Record (Email 2)
 See example: [Microsoft apps.py](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/backend/python/app/connectors/sources/microsoft/common/apps.py)
 
 ```python
-from app.config.constants.arangodb import Connectors
-from app.connectors.core.interfaces.connector.apps import App, AppGroup
+from app.config.constants.arangodb import AppGroups, Connectors
+from app.connectors.core.interfaces.connector.apps import App
 
 class YourConnectorApp(App):
     """App definition for YourConnector."""
 
-    def __init__(self) -> None:
-        super().__init__(
-            app_name=Connectors.YOUR_CONNECTOR,  # This will be defined in Step 7.1
-            app_group=AppGroup.YOUR_VENDOR  # e.g., AppGroup.MICROSOFT_365
-        )
+    def __init__(self, connector_id: str) -> None:
+        super().__init__(Connectors.YOUR_CONNECTOR, AppGroups.YOUR_VENDOR, connector_id)
 ```
 
 ### Step 6.2: Create Connector Class (Boilerplate)
@@ -842,21 +839,27 @@ class YourConnector(BaseConnector):
         cls,
         logger: Logger,
         data_store_provider: DataStoreProvider,
-        config_service: ConfigurationService
+        config_service: ConfigurationService,
+        connector_id: str,
+        scope: str,
+        created_by: str,
+        data_entities_processor: DataSourceEntitiesProcessor,
+        **kwargs,
     ) -> 'YourConnector':
-        """Factory method to create and initialize connector."""
-        data_entities_processor = DataSourceEntitiesProcessor(
-            logger,
-            data_store_provider,
-            config_service
-        )
-        await data_entities_processor.initialize()
+        """Factory method used by ConnectorFactory.create_connector().
 
+        The factory builds and initialises the entities processor itself and
+        passes it in, along with connector_id, scope and created_by. Accept
+        **kwargs so future additions do not break this signature.
+        """
         return YourConnector(
             logger,
             data_entities_processor,
             data_store_provider,
-            config_service
+            config_service,
+            connector_id,
+            scope,
+            created_by,
         )
 ```
 
@@ -1185,8 +1188,7 @@ pytest tests/unit/connectors/sources/
 Testing YourConnector
 ==================================================
 
-tests/unit/connectors/sources/test_yourconnector_connector.py ...      [100%]
-
+...                                                                    [100%]
 3 passed in 0.42s
 ```
 


### PR DESCRIPTION
## The problem

The connector template in Step 6.2 of `CONNECTOR_INTEGRATION_PLAYBOOK.md` cannot be instantiated. Copy it, fill in your service, and it raises a `TypeError` before any of your own code runs.

Two of its calls do not match the classes it builds on.

**`super().__init__` is missing three arguments.** `BaseConnector.__init__` (`connector_service.py:56`) takes eight; the template passes five, leaving out `connector_id`, `scope` and `created_by`.

**`SyncPoint` is given the wrong keyword.** `SyncPoint.__init__` (`sync_point.py:32`) takes `connector_id`. The template passes `connector_name`, so once the first problem is fixed construction fails on the next line instead.

The unit-test helper added in Step 8.1 has the same gap, because it was written against the template rather than against the base class.

## The change

The template's signature now takes `connector_id`, `scope` and `created_by` and forwards them, matching how the shipped connectors do it — see `sources/linear/connector.py:76`. The `SyncPoint` call uses `connector_id`. The test helper passes all seven arguments.

Step 8.2's "Expected Output" also still showed the banner printed by a `__main__` script that is no longer in the document. It now shows what `pytest` actually prints.

## Verification

Rather than reading the signatures by eye, I extracted them and compared:

```
BaseConnector expects : app, logger, data_entities_processor, data_store_provider,
                        config_service, connector_id, scope, created_by
template super() sends: app, logger, data_entities_processor, data_store_provider,
                        config_service, connector_id, scope, created_by
                        -> order and count match

SyncPoint expects     : connector_id, org_id, sync_data_point_type, data_store_provider
template passes       : connector_id, org_id, sync_data_point_type, data_store_provider
                        -> match
```

## Note

`connector_name` is still passed to `FileRecord` further down the playbook. That one is correct — `Record` genuinely has a `connector_name` field (`models/entities.py:224`). Only the `SyncPoint` call was wrong.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector setup now supports explicit connector identifiers, scopes, and creator information.
  * Synchronization tracking is associated with the configured connector ID.
  * Connector creation accepts a preconfigured data processor and additional setup options.

* **Tests**
  * Updated test setup to use the new connector configuration requirements.
  * Refreshed sample output to show automated test execution with three passing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->