### PR TITLE
fix(arango): agent-template soft delete passes the wrong arguments to update_node

### DIFF
--- a/backend/python/app/services/graph_db/arango/arango_http_provider.py
+++ b/backend/python/app/services/graph_db/arango/arango_http_provider.py
@@ -21856,8 +21856,12 @@ class ArangoHTTPProvider(IGraphDBProvider):
             }
 
             # Soft delete the template using update_node
-            template_path = f"{CollectionNames.AGENT_TEMPLATES.value}/{template_id}"
-            result = await self.update_node(template_path, update_data, transaction=transaction)
+            result = await self.update_node(
+                template_id,
+                CollectionNames.AGENT_TEMPLATES.value,
+                update_data,
+                transaction=transaction,
+            )
 
             if not result:
                 self.logger.error(f"Failed to delete template {template_id}")


### PR DESCRIPTION
## Problem

Soft-deleting an agent template always fails. `ArangoHTTPProvider.update_node` is:

```python
async def update_node(
    self,
    key: str,
    collection: str,
    updates: dict,
    transaction: str | None = None
) -> bool:
```

but the delete path calls it with a document *path* as `key`, the update payload as `collection`, and no `updates` at all:

```python
template_path = f"{CollectionNames.AGENT_TEMPLATES.value}/{template_id}"
result = await self.update_node(template_path, update_data, transaction=transaction)
```

which raises:

```
TypeError: update_node() missing 1 required positional argument: 'updates'
```

## Fix

The correct shape is already in this very method, a few lines above — `get_document` takes the same `(id, collection, transaction=...)` triple:

```python
template = await self.get_document(template_id, CollectionNames.AGENT_TEMPLATES.value, transaction=transaction)
```

so this passes `template_id` and the collection name separately and hands `update_data` to `updates`. The `template_path` local becomes unused and is dropped. This matches every other `update_node` caller in the repo, e.g.:

- `app/api/routes/entity.py:340` — `update_node(team_id, CollectionNames.TEAMS.value, updates)`
- `app/agents/agent_loop/skills/graph_store.py:418` — `update_node(self._key(skill_name), _SKILLS, {...})`

Note that even had `updates` been supplied, `key` would have been wrong: `update_node` forwards to `http_client.update_document(collection, key, updates, ...)`, which wants a bare document key, not `collection/key`.

## Verification

I replayed the call sites against a stub extracted from the real file with `ast` and bound via `inspect.Signature.bind`, using two known-good callers as controls:

```
### pipeshub-ai  ArangoHTTPProvider.update_node
  signature: (self, key, collection, updates, transaction=None)
  OK    entity.py:340 (control)
  OK    graph_store.py:418 (control)
  RAISE arango_http_provider soft-delete (flagged): TypeError: missing a required argument: 'updates'
  OK    proposed fix
```

The green controls confirm the harness is exercising the real signature, so the failure is specific to this call site.

`ruff check` output on the file is byte-identical before and after the change (the file has 34 pre-existing findings, none added or removed), so this introduces no new lint findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed template soft deletion so templates are correctly updated in the agent-template collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->