### PR TITLE
Harden JWT and cookie signing secret generation to 256-bit keys (GHSA-g8xh-pw7m-h5cr)

### DIFF
--- a/backend/nodejs/apps/src/modules/tokens_manager/services/cm.service.ts
+++ b/backend/nodejs/apps/src/modules/tokens_manager/services/cm.service.ts
@@ -1,4 +1,4 @@
-import { randomInt } from 'crypto';
+import { randomBytes } from 'crypto';
 
 import { EncryptionService } from '../../../libs/encryptor/encryptor';
 import { ARANGO_DB_NAME, MONGO_DB_NAME } from '../../../libs/enums/db.enum';
@@ -17,15 +17,7 @@ export interface SmtpConfig {
   fromEmail: string;
 }
 
-export const randomKeyGenerator = () => {
-  const chars =
-    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-  let result = '';
-  for (let i = 0; i < 20; i++) {
-    result += chars.charAt(randomInt(chars.length));
-  }
-  return result;
-};
+export const randomKeyGenerator = (): string => randomBytes(32).toString('hex');
 
 export interface KafkaConfig {
   brokers: string[];

--- a/backend/nodejs/apps/tests/modules/tokens_manager/services/cm.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/tokens_manager/services/cm.service.test.ts
@@ -26,19 +26,11 @@ describe('tokens_manager/services/cm.service', () => {
   // randomKeyGenerator
   // =========================================================================
   describe('randomKeyGenerator', () => {
-    it('should generate a string of length 20', () => {
-      const key = randomKeyGenerator()
-      expect(key).to.have.lengthOf(20)
-    })
-
-    it('should return a string', () => {
+    it('should generate a 64-char hex string (256 bits, HS256 minimum per RFC 7518)', () => {
       const key = randomKeyGenerator()
       expect(key).to.be.a('string')
-    })
-
-    it('should only contain alphanumeric characters', () => {
-      const key = randomKeyGenerator()
-      expect(key).to.match(/^[A-Za-z0-9]+$/)
+      expect(key).to.have.lengthOf(64)
+      expect(key).to.match(/^[0-9a-f]{64}$/)
     })
 
     it('should generate different keys on consecutive calls', () => {
@@ -48,27 +40,24 @@ describe('tokens_manager/services/cm.service', () => {
       expect(key1).to.not.equal(key2)
     })
 
-    it('should generate keys from the expected character set', () => {
-      const validChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
-      const key = randomKeyGenerator()
-      for (const char of key) {
-        expect(validChars).to.include(char)
-      }
-    })
-
     it('should not use Math.random (signing secrets must come from a CSPRNG)', () => {
       const mathRandomSpy = sinon.spy(Math, 'random')
       randomKeyGenerator()
       expect(mathRandomSpy.called).to.be.false
     })
 
-    it('should draw every character via crypto.randomInt over the full charset', () => {
-      const randomIntStub = sinon.stub<[number], number>().returns(0)
-      sinon.replace(crypto, 'randomInt', randomIntStub as typeof crypto.randomInt)
+    it('should draw 32 bytes from crypto.randomBytes', () => {
+      const randomBytesStub = sinon
+        .stub<[number], Buffer>()
+        .callsFake((size: number) => Buffer.alloc(size, 0xab))
+      sinon.replace(
+        crypto,
+        'randomBytes',
+        randomBytesStub as unknown as typeof crypto.randomBytes,
+      )
       const key = randomKeyGenerator()
-      expect(key).to.equal('A'.repeat(20))
-      expect(randomIntStub.callCount).to.equal(20)
-      expect(randomIntStub.alwaysCalledWithExactly(62)).to.be.true
+      expect(randomBytesStub.calledOnceWithExactly(32)).to.be.true
+      expect(key).to.equal('ab'.repeat(32))
     })
   })
 
@@ -273,7 +262,7 @@ describe('tokens_manager/services/cm.service', () => {
       for (let i = 0; i < 50; i++) {
         keys.add(randomKeyGenerator())
       }
-      // With 62^20 possible keys, 50 should all be unique
+      // With 2^256 possible keys, 50 should all be unique
       expect(keys.size).to.equal(50)
     })
 
@@ -414,15 +403,15 @@ describe('tokens_manager/services/cm.service', () => {
   // randomKeyGenerator stress tests
   // =========================================================================
   describe('randomKeyGenerator (stress)', () => {
-    it('should always produce length 20 across 100 iterations', () => {
+    it('should always produce a 64-char hex string across 100 iterations', () => {
       for (let i = 0; i < 100; i++) {
         const key = randomKeyGenerator()
-        expect(key).to.have.lengthOf(20)
+        expect(key).to.match(/^[0-9a-f]{64}$/)
       }
     })
 
     it('should contain at least 3 distinct characters', () => {
-      // A random 20-char alphanumeric string should have variety
+      // A random 64-char hex string should have variety
       const key = randomKeyGenerator()
       const uniqueChars = new Set(key.split(''))
       expect(uniqueChars.size).to.be.at.least(3)
@@ -943,7 +932,7 @@ describe('tokens_manager/services/cm.service', () => {
         mockKvStore.get.resolves(null)
         const result = await configService.getJwtSecret()
         expect(result).to.be.a('string')
-        expect(result).to.have.lengthOf(20)
+        expect(result).to.have.lengthOf(64)
         expect(mockKvStore.set.calledOnce).to.be.true
       })
 
@@ -952,7 +941,7 @@ describe('tokens_manager/services/cm.service', () => {
         mockKvStore.get.resolves('encrypted:' + JSON.stringify(secretData))
         const result = await configService.getJwtSecret()
         expect(result).to.be.a('string')
-        expect(result).to.have.lengthOf(20)
+        expect(result).to.have.lengthOf(64)
       })
     })
 
@@ -968,7 +957,7 @@ describe('tokens_manager/services/cm.service', () => {
         mockKvStore.get.resolves(null)
         const result = await configService.getScopedJwtSecret()
         expect(result).to.be.a('string')
-        expect(result).to.have.lengthOf(20)
+        expect(result).to.have.lengthOf(64)
       })
     })
 
@@ -984,7 +973,7 @@ describe('tokens_manager/services/cm.service', () => {
         mockKvStore.get.resolves(null)
         const result = await configService.getCookieSecret()
         expect(result).to.be.a('string')
-        expect(result).to.have.lengthOf(20)
+        expect(result).to.have.lengthOf(64)
       })
     })
 
@@ -1889,7 +1878,7 @@ describe('ConfigService - coverage', () => {
 
       const result = await service.getJwtSecret()
       expect(result).to.be.a('string')
-      expect(result).to.have.lengthOf(20)
+      expect(result).to.have.lengthOf(64)
       expect(mockKvStore.set.called).to.be.true
     })
 
@@ -1900,7 +1889,7 @@ describe('ConfigService - coverage', () => {
 
       const result = await service.getJwtSecret()
       expect(result).to.be.a('string')
-      expect(result).to.have.lengthOf(20)
+      expect(result).to.have.lengthOf(64)
     })
   })
 
@@ -1922,7 +1911,7 @@ describe('ConfigService - coverage', () => {
 
       const result = await service.getScopedJwtSecret()
       expect(result).to.be.a('string')
-      expect(result).to.have.lengthOf(20)
+      expect(result).to.have.lengthOf(64)
       expect(mockKvStore.set.called).to.be.true
     })
   })
@@ -1945,7 +1934,7 @@ describe('ConfigService - coverage', () => {
 
       const result = await service.getCookieSecret()
       expect(result).to.be.a('string')
-      expect(result).to.have.lengthOf(20)
+      expect(result).to.have.lengthOf(64)
     })
   })
 


### PR DESCRIPTION
## Summary

Addresses the advisory **GHSA-g8xh-pw7m-h5cr** — *"JWT and cookie signing secrets are generated with `Math.random()`, making issued tokens forgeable"* (High, CWE-338 / CWE-330).

The headline issue — `Math.random()` as the entropy source for `jwtSecret`, `scopedJwtSecret`, and `cookieSecret` — was already fixed in `6653eba71` (#3102), which switched `randomKeyGenerator` to `crypto.randomInt` (a CSPRNG). The state-reconstruction attack described in the advisory no longer applies on `main`.

This PR closes the **residual weakness**: the generated key was still only 20 alphanumeric characters — ~119 bits of entropy and a 160-bit key. All three secrets sign HS256 JWTs (`jsonwebtoken` in Node, PyJWT in Python), and **RFC 7518 §3.2 requires an HS256 key of at least 256 bits**.

## Changes

- **`backend/nodejs/apps/src/modules/tokens_manager/services/cm.service.ts`** — `randomKeyGenerator` now returns `crypto.randomBytes(32).toString('hex')`: 256 bits of CSPRNG entropy encoded as a 64-char hex string (the advisory's suggested fix). The old charset loop is removed.
- **`backend/nodejs/apps/tests/modules/tokens_manager/services/cm.service.test.ts`** — updated unit tests:
  - asserts the new 64-char lowercase-hex format and length,
  - guards that `Math.random` is never called during key generation,
  - verifies exactly 32 bytes are drawn from `crypto.randomBytes`,
  - uniqueness/stress tests and all secret-getter length assertions updated to the new format.

## Compatibility analysis

**No consumer breaks.** Every reader of these secrets treats them as an opaque string secret for HMAC signing — nothing hex-decodes, slices, or assumes a fixed length:

- **Node:** `libs/utils/jwtConfig.ts`, `libs/services/authtoken.service.ts`, `libs/utils/createJwt.ts`, `modules/auth/controller/userAccount.controller.ts` (all `jwt.sign` with the string secret), `modules/auth/routes/saml.routes.ts` (cookie secret), slack-bot token generation.
- **Python** (reads the same values from the KV store at `/services/secretKeys`): `api/middlewares/auth.py`, `utils/jwt.py`, `core/signed_url.py`, `agents/actions/util/blob_staging.py`, `services/record_content/strategies.py`, `modules/transformers/blob_storage.py` — all pass the value straight to PyJWT as an HS256 string secret.

**Platform-agnostic.** `crypto.randomBytes` is Node core (no new dependency), backed by the OS CSPRNG on Linux (incl. Alpine/Docker images), macOS, and Windows. Output is plain ASCII hex — no locale, endianness, or encoding sensitivity; it round-trips identically through JSON, the encryption layer, etcd/Redis, and Python's UTF-8 `str` handling.

## Impact on existing deployments

**Upgrading is a non-event for these secrets.** The getters (`getJwtSecret` / `getScopedJwtSecret` / `getCookieSecret`) only generate a value when the key is *missing* from `/services/secretKeys`. Existing deployments already have all three stored, so after upgrading they keep their current secrets byte-for-byte:

- No tokens are invalidated, no sessions drop, nobody is logged out.
- Node and Python continue to agree on the same secrets.
- The new 256-bit generation only fires on fresh installs (or after deliberate rotation, below).

**Docker specifics:** the secrets live in the KV store's named volume (`redis_data` / `etcd_data` in `deployment/docker-compose/docker-compose.yml`), not in any image. A standard `docker compose pull && docker compose up -d` recreates the app containers but reattaches those volumes untouched — existing secrets survive, everything keeps working. New secrets are only generated on a fresh install (new volumes) or after `docker compose down -v`, which wipes all data and is a full reset, not a rotation.

**The flip side:** upgrading alone does **not** remediate existing weak secrets:

- Deployments first initialized **before `6653eba71`** still hold `Math.random()`-derived secrets — the population the advisory is about. They remain potentially predictable until rotated.
- Deployments initialized **after `6653eba71` but before this PR** hold 20-char `crypto.randomInt` secrets (~119 bits of CSPRNG entropy) — below the RFC 7518 ideal but not practically brute-forceable; rotation is nice-to-have, not urgent.

## Rotation procedure (operator decision — deliberately not automated)

To move an existing deployment to 256-bit secrets: remove `jwtSecret`, `scopedJwtSecret`, and `cookieSecret` from the encrypted blob at `/services/secretKeys` in the KV store (etcd/Redis) and restart the Node service — the getters regenerate them at the new strength.

Consequences to plan for:

- Every issued JWT and session cookie becomes invalid → **all users must log in again**.
- In-flight signed URLs and scoped/service tokens break at that moment (Python signs/verifies with the same `scopedJwtSecret`).
- Best done in a maintenance window with **all services restarted together** so Node and Python agree on the new values.

Auto-rotating on upgrade was deliberately not done here: silently logging out every user of every deployment is an operator decision, not something the code should force. A possible follow-up is a startup warning when a stored secret is shorter than 64 chars, pointing at this procedure — happy to add if maintainers want it.

## Verification

- Full Node test suite: **9683 passing, 0 failing**.
- `tsc --noEmit`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Improved generated security keys with stronger, cryptographically secure random values.
  * Generated keys are now 64-character hexadecimal strings, providing increased protection for authentication tokens, scoped tokens, and cookies.
  * Updated secret generation to meet modern security requirements for HS256-based authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->