### PR TITLE
fix(indexing): never discard a record event without a terminal status

### DIFF
--- a/backend/python/app/events/events.py
+++ b/backend/python/app/events/events.py
@@ -30,7 +30,7 @@ from app.config.constants.arangodb import (
     normalize_file_extension,
 )
 from app.events.processor import Processor
-from app.exceptions.indexing_exceptions import IndexingError
+from app.exceptions.indexing_exceptions import IndexingError, ProcessingError
 from app.modules.parsers.pdf.ocr_handler import OCRStrategy
 from app.modules.transformers.pipeline import IndexingPipeline
 from app.events.dedup import DedupDecision, select_duplicate
@@ -857,10 +857,20 @@ class EventProcessor:
             event_type = event_data.get(
                 "eventType", EventTypes.NEW_RECORD.value
             )  # default to create
+            # The three guards below used to `return` bare, yielding neither
+            # PARSING_COMPLETE nor INDEXING_COMPLETE. The consumers read that as
+            # a handler that failed for an unknown reason and retried it to the
+            # dead-letter ceiling — three deliveries, no diagnosis, and on Kafka
+            # not even a status write, because the handler took its no-error
+            # path on the way out. A malformed envelope cannot come good on a
+            # retry, so the first two raise a TERMINAL error and are reported
+            # once; the third is a real race and drains instead.
             payload = event_data.get("payload")
             if payload is None:
-                self.logger.error("❌ No payload in event data")
-                return
+                raise ProcessingError(
+                    "Event has no payload",
+                    details={"event_type": event_type},
+                )
             event_data = payload
             record_id = event_data.get("recordId")
             org_id = event_data.get("orgId")
@@ -868,15 +878,28 @@ class EventProcessor:
             self.logger.debug(f"📥 Processing event: {event_type}: for record {record_id} with virtual_record_id {virtual_record_id}")
 
             if not record_id:
-                self.logger.error("❌ No record ID provided in event data")
-                return
+                raise ProcessingError(
+                    "Event has no recordId",
+                    details={"event_type": event_type},
+                )
 
             record = await self.graph_provider.get_document(
                 record_id, CollectionNames.RECORDS.value
             )
 
             if record is None:
+                # Legitimately reachable: a record can be deleted between an
+                # event being published and consumed. There is nothing to index
+                # and nothing to fail, so drain the message rather than retry it.
                 self.logger.error("❌ Record %s not found", record_id)
+                yield PipelineEvent(
+                    event=IndexingEvent.PARSING_COMPLETE,
+                    data=PipelineEventData(record_id=record_id),
+                )
+                yield PipelineEvent(
+                    event=IndexingEvent.INDEXING_COMPLETE,
+                    data=PipelineEventData(record_id=record_id),
+                )
                 return
 
             if virtual_record_id is None:

--- a/backend/python/app/indexing_main.py
+++ b/backend/python/app/indexing_main.py
@@ -500,6 +500,18 @@ async def recover_in_progress_records(
         )
         total_records += queued_swept
 
+        # The counterpart for *live* connectors: a row whose event was lost or
+        # never published is invisible to both the scan above and the sweep.
+        # Off unless STRANDED_RECORD_REPUBLISH_AFTER_SECONDS is set.
+        total_records += await _republish_stranded_records(
+            graph_provider=graph_provider,
+            logger=logger,
+            producer=retry_producer,
+            run_coordination=run_coordination,
+            concurrency_manager=concurrency_manager,
+            page_size=page_size,
+        )
+
         # Vectors whose last referencing record was repointed elsewhere are
         # reachable from neither the record scan above nor the membership
         # backfill (both walk records, and this VRID has none). Left alone they
@@ -766,6 +778,214 @@ async def _sweep_queued_records_for_inactive_connectors(
     return swept
 
 
+async def _republish_stranded_records(
+    *,
+    graph_provider,
+    logger,
+    producer,
+    run_coordination,
+    concurrency_manager,
+    page_size: int,
+) -> int:
+    """Re-publish records that have been waiting on an event that never came.
+
+    The sweep above only rescues rows on connectors that are gone; the main
+    stale scan only looks at IN_PROGRESS. A row on a *live* connector whose
+    event was lost — dropped by the broker, discarded by a consumer, or never
+    published because the send failed after the transaction committed — is
+    reachable by neither, so it waits for ever.
+
+    Keyed on age rather than on what QUEUED is supposed to mean. That status is
+    written both by the upsert that precedes publishing and by the publish
+    itself, so it cannot distinguish "the event is on the broker" from "the
+    event was never sent"; age can, and it recovers the row either way.
+
+    Off by default. Enable with STRANDED_RECORD_REPUBLISH_AFTER_SECONDS, set
+    comfortably longer than the worst backlog the broker is expected to carry,
+    or healthy records still queued behind it will be re-sent.
+
+    Re-publishing is safe to repeat: the handler skips a record that is already
+    COMPLETED, and the per-record exclusivity lease stops a republished event
+    racing one already in flight.
+    """
+    after_seconds = messaging_env.stranded_record_republish_after_seconds
+    if after_seconds <= 0:
+        return 0
+
+    cutoff_ms = get_epoch_timestamp_in_ms() - int(after_seconds * 1000)
+    connector_active: dict[str, bool] = {}
+    republished = 0
+
+    async def _is_active(connector_id: str) -> bool:
+        if connector_id not in connector_active:
+            instance = await graph_provider.get_document(
+                connector_id, CollectionNames.APPS.value
+            )
+            connector_active[connector_id] = bool(
+                instance and instance.get("isActive", False)
+            )
+        return connector_active[connector_id]
+
+    for status_value in (
+        ProgressStatus.QUEUED.value,
+        ProgressStatus.NOT_STARTED.value,
+    ):
+        offset = 0
+        while True:
+            page = await graph_provider.get_documents_paginated(
+                CollectionNames.RECORDS.value,
+                skip=offset,
+                limit=page_size,
+                filters={"indexingStatus": status_value},
+                sort_field="_key",
+                raise_on_error=False,
+            )
+            if not page:
+                break
+
+            for record in page:
+                record_key = record.get("_key") or record.get("id")
+                connector_id = record.get("connectorId")
+                if (
+                    not record_key
+                    or not connector_id
+                    or record.get("origin") != OriginTypes.CONNECTOR.value
+                ):
+                    continue
+
+                # Two clocks, both of which must be older than the cutoff.
+                # updatedAt moves on every write to the row, so a record still
+                # being touched by a sync is never old enough to qualify.
+                # lastRepublishedAt is our own: publishing changes nothing about
+                # the row, so without it a record stays eligible and every tick
+                # sends another copy of the same event -- worst precisely when
+                # the consumer is backlogged, which is the case this sweep
+                # exists for.
+                updated_at = record.get("updatedAtTimestamp") or record.get(
+                    "createdAtTimestamp"
+                )
+                last_republished_at = record.get("lastRepublishedAt")
+                try:
+                    if updated_at is None or float(updated_at) > cutoff_ms:
+                        continue
+                    if (
+                        last_republished_at is not None
+                        and float(last_republished_at) > cutoff_ms
+                    ):
+                        continue
+                except (TypeError, ValueError):
+                    continue
+
+                if not await _is_active(connector_id):
+                    # The sweep above owns these; moving them here would race it.
+                    continue
+
+                # A duplicate parked behind an in-flight twin is legitimately
+                # QUEUED with its message already acked — it is released by the
+                # twin's completion, not by us.
+                if record.get("md5Checksum") and record.get("virtualRecordId"):
+                    continue
+
+                record_owner = f"stranded:{uuid4().hex}"
+                record_pool = f"record:{record_key}"
+                lock_held = False
+                try:
+                    if concurrency_manager is not None:
+                        lock_held = await concurrency_manager.try_acquire(
+                            record_pool,
+                            record_owner,
+                            1,
+                            messaging_env.concurrency_lease_seconds,
+                        )
+                        if not lock_held:
+                            # Someone is working on it after all.
+                            continue
+
+                    payload = {
+                        "recordId": record_key,
+                        "recordName": record.get("recordName"),
+                        "orgId": record.get("orgId"),
+                        "version": record.get("version", 0),
+                        "connectorName": record.get("connectorName"),
+                        "connectorId": connector_id,
+                        "extension": record.get("extension"),
+                        "mimeType": record.get("mimeType"),
+                        "origin": record.get("origin"),
+                        "recordType": record.get("recordType"),
+                        "virtualRecordId": record.get("virtualRecordId"),
+                    }
+                    version = int(payload.get("version", 0) or 0)
+                    event_type = (
+                        EventTypes.REINDEX_RECORD.value
+                        if version > 0 and payload.get("virtualRecordId")
+                        else EventTypes.NEW_RECORD.value
+                    )
+                    await run_coordination(
+                        producer.send_event(
+                            topic=Topic.RECORD_EVENTS.value,
+                            event_type=event_type,
+                            payload=payload,
+                            key=str(record_key),
+                        )
+                    )
+                    republished += 1
+                    # Recorded before the lease is released, so the cutoff above
+                    # excludes this record until another full interval passes.
+                    # Deliberately not updatedAtTimestamp: that field means "when
+                    # the record last changed" and connectors write it, so a
+                    # recovery sweep must not move it.
+                    marked = await graph_provider.update_node(
+                        record_key,
+                        CollectionNames.RECORDS.value,
+                        {"lastRepublishedAt": get_epoch_timestamp_in_ms()},
+                    )
+                    if not marked:
+                        logger.error(
+                            "Re-published stranded record %s but could not mark "
+                            "it; it will be re-published again next tick",
+                            record_key,
+                        )
+                    logger.warning(
+                        "Re-published stranded record %s (%s, status %s, "
+                        "untouched for %.0fs)",
+                        record_key,
+                        record.get("recordName"),
+                        status_value,
+                        (get_epoch_timestamp_in_ms() - float(updated_at)) / 1000,
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "Failed to re-publish stranded record %s: %s",
+                        record_key,
+                        exc,
+                    )
+                finally:
+                    if lock_held and concurrency_manager is not None:
+                        try:
+                            await concurrency_manager.release(
+                                record_pool, record_owner
+                            )
+                        except Exception as release_exc:
+                            logger.warning(
+                                "Failed to release stranded-record lease for %s: %s",
+                                record_key,
+                                release_exc,
+                            )
+
+            if len(page) < page_size:
+                break
+            # Republished rows keep their status, so the filtered result does
+            # not shrink under the cursor — advance over the whole page.
+            offset += len(page)
+
+    if republished:
+        logger.warning(
+            "Re-published %d stranded record(s) whose events never arrived",
+            republished,
+        )
+    return republished
+
+
 async def run_stale_recovery_loop(
     app_container: IndexingAppContainer,
     graph_provider: IGraphDBProvider,
@@ -849,6 +1069,14 @@ async def start_kafka_consumers(
         await retry_producer.initialize()
         logger.info("✅ Retry producer initialized for %s", broker_type.value)
 
+        # Built before the consumer because it is both the message handler and
+        # the consumer's abandonment sink: when a message is discarded without
+        # being processed, this is what puts the record into a terminal status
+        # instead of leaving it on one no recovery sweep revisits.
+        record_event_handler = await KafkaUtils.create_record_event_handler(
+            app_container, producer=retry_producer
+        )
+
         # Same process-wide singleton the ParsingClient/DoclingClient/
         # EmbeddingServerEmbeddings instances used by this consumer's
         # pipeline default to (see app.services.messaging.backpressure) —
@@ -864,11 +1092,14 @@ async def start_kafka_consumers(
             concurrency_manager=concurrency_manager,
             governor=governor,
             backpressure_coordinator=get_default_backpressure_coordinator(),
+            disposition_sink=record_event_handler,
         )
         consumers.append(("record", record_kafka_consumer, retry_producer))
 
         record_message_handler = await KafkaUtils.create_record_message_handler(
-            app_container, producer=retry_producer
+            app_container,
+            producer=retry_producer,
+            record_event_service=record_event_handler,
         )
         await record_kafka_consumer.start(record_message_handler)  # type: ignore[arg-type]
         logger.info("✅ Record message consumer started")

--- a/backend/python/app/services/messaging/config.py
+++ b/backend/python/app/services/messaging/config.py
@@ -337,6 +337,19 @@ class MessagingEnvConfig:
         return int(os.getenv("STALE_INDEXING_RECOVERY_PAGE_SIZE", "100"))
 
     @property
+    def stranded_record_republish_after_seconds(self) -> float:
+        """How long a record may sit unqueued before its event is re-sent.
+
+        Zero disables the sweep. Guards the gap no other recovery path covers:
+        a record on a live connector whose event was lost or never published is
+        invisible to the stale scan (which only looks at IN_PROGRESS) and to the
+        inactive-connector sweep. Set it well above the largest backlog the
+        broker is expected to carry, or records legitimately waiting their turn
+        will be published a second time.
+        """
+        return _env_seconds("STRANDED_RECORD_REPUBLISH_AFTER_SECONDS", 0.0)
+
+    @property
     def vector_membership_backfill_interval_seconds(self) -> float:
         return float(os.getenv("VECTOR_MEMBERSHIP_BACKFILL_INTERVAL_SECONDS", "30"))
 
@@ -483,6 +496,21 @@ class MessagingEnvConfig:
         raw = os.getenv("FAIR_SCHEDULING_LANED_TOPICS", Topic.RECORD_EVENTS.value)
         topics = tuple(part.strip() for part in raw.split(",") if part.strip())
         return topics or (Topic.RECORD_EVENTS.value,)
+
+    @property
+    def fair_scheduling_metrics_per_connector(self) -> bool:
+        """Label the dispatch counter by connector as well as org.
+
+        Off by default because it multiplies that metric's series count by
+        the number of connector instances, which is unbounded. Worth turning
+        on for a single-org install, where labelling by org alone collapses
+        every connector into one series and the per-connector share -- the
+        thing fair scheduling exists to produce -- becomes invisible.
+        """
+        return (
+            os.getenv("FAIR_SCHEDULING_METRICS_PER_CONNECTOR", "false").lower()
+            == "true"
+        )
 
     @property
     def fair_scheduling_max_dwell_seconds(self) -> float:

--- a/backend/python/app/services/messaging/disposition.py
+++ b/backend/python/app/services/messaging/disposition.py
@@ -1,0 +1,90 @@
+"""What happens to a message when a consumer gives up on it.
+
+The rule this module exists to enforce: a message is never abandoned silently.
+Whenever a consumer discards a message it must first tell the
+``AbandonedMessageSink``, so whatever the message referred to is left in a
+terminal, visible state instead of sitting in a status nothing ever revisits.
+
+Without that, a discarded record event left its record on the status it was
+created with — QUEUED — which neither the stale-record scan (IN_PROGRESS only)
+nor the inactive-connector sweep looks at, so the record waited for ever. The
+only log line named the broker's message id, which is unresolvable once the
+entry is gone, so there was no way to tell afterwards which records were lost.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from logging import Logger
+
+    from app.services.messaging.config import StreamMessage
+
+
+@runtime_checkable
+class AbandonedMessageSink(Protocol):
+    """Notified when a consumer abandons a message for good.
+
+    Implemented by whoever owns the state the message refers to — for record
+    events that is ``RecordEventHandler``, which puts the record into a terminal
+    status. Consumers depend on this protocol rather than on records, so they
+    stay broker-generic and domain-free.
+    """
+
+    async def on_message_abandoned(
+        self,
+        message: StreamMessage | None,
+        *,
+        reason: str,
+        attempts: int,
+    ) -> None:
+        """Handle a message that will never be processed.
+
+        ``message`` is ``None`` when the envelope could not even be parsed.
+        Implementations must not raise: abandonment happens on the way to an
+        acknowledgement that has to go through regardless.
+        """
+        ...
+
+
+async def notify_abandoned(
+    sink: AbandonedMessageSink | None,
+    logger: Logger,
+    message: StreamMessage | None,
+    *,
+    reason: str,
+    attempts: int,
+) -> None:
+    """Tell the sink a message is being given up on, without ever raising.
+
+    Every caller is on its way to an acknowledgement it cannot skip — leaving
+    the entry pending because the notification failed would stall the consumer,
+    which is worse than the missing status write. So the failure is logged
+    loudly and swallowed.
+    """
+    if sink is None:
+        return
+    try:
+        await sink.on_message_abandoned(message, reason=reason, attempts=attempts)
+    except Exception as e:
+        logger.error(
+            "Failed to record abandonment of a message (%s): %s",
+            reason,
+            e,
+            exc_info=True,
+        )
+
+
+def describe_message(message: StreamMessage | None) -> str:
+    """Short identifier for logs: the record the message is about, if any.
+
+    Dead-letter logs carried only the broker's own message id, which cannot be
+    resolved back to a record once the entry is gone.
+    """
+    if message is None:
+        return "record=<unparseable>"
+    payload = message.payload or {}
+    record_id = payload.get("recordId")
+    if record_id:
+        return f"record={record_id} event={message.eventType}"
+    return f"record=<none> event={message.eventType}"

--- a/backend/python/app/services/messaging/kafka/consumer/indexing_consumer.py
+++ b/backend/python/app/services/messaging/kafka/consumer/indexing_consumer.py
@@ -25,6 +25,11 @@ from app.services.messaging.config import (
     compute_retry_backoff_seconds,
     messaging_env,
 )
+from app.services.messaging.disposition import (
+    AbandonedMessageSink,
+    describe_message,
+    notify_abandoned,
+)
 from app.services.messaging.distributed_concurrency import DistributedLeaseSet
 from app.services.messaging.error_classifier import (
     MessageErrorClassifier,
@@ -163,6 +168,7 @@ class IndexingKafkaConsumer(IMessagingConsumer):
         fair_scheduler_config: FairSchedulerConfig | None = None,
         key_extractor: FairnessKeyExtractor | None = None,
         weight_provider: WeightProvider | None = None,
+        disposition_sink: Optional[AbandonedMessageSink] = None,
     ) -> None:
         self.logger = logger
         self.consumer: AIOKafkaConsumer | None = None
@@ -170,6 +176,9 @@ class IndexingKafkaConsumer(IMessagingConsumer):
         self.kafka_config = kafka_config
         self.consume_task = None
         self.retry_manager = retry_manager
+        # Told about every message this consumer gives up on, before the commit
+        # that makes it unrecoverable — see disposition.AbandonedMessageSink.
+        self.disposition_sink = disposition_sink
         self.producer = producer
         self.concurrency_manager = concurrency_manager
         # When set, node-local parsing/indexing admission is delegated to the
@@ -1707,6 +1716,38 @@ class IndexingKafkaConsumer(IMessagingConsumer):
             self.logger.error(f"Failed to re-queue message to {topic}: {e}")
             raise
 
+    async def __abandon_message(
+        self,
+        message_id: str,
+        tracking_id: str,
+        parsed_message: StreamMessage | None,
+        *,
+        reason: str,
+        attempts: int,
+    ) -> None:
+        """Give up on a message: tell the sink, then drop its tracking.
+
+        The caller commits immediately afterwards, which is final — so a record
+        whose message is dropped without this notification is left on whatever
+        status it happened to hold, which no recovery sweep revisits, and the
+        log names only an offset that explains nothing.
+        """
+        await notify_abandoned(
+            self.disposition_sink,
+            self.logger,
+            parsed_message,
+            reason=reason,
+            attempts=attempts,
+        )
+        self.logger.warning(
+            "Dead-lettered %s (%s, tracking id %s): %s",
+            message_id,
+            describe_message(parsed_message),
+            tracking_id,
+            reason,
+        )
+        await self._clear_retry_tracking(tracking_id)
+
     async def __commit_if_appropriate(
         self,
         message: ConsumerRecord,
@@ -1737,15 +1778,30 @@ class IndexingKafkaConsumer(IMessagingConsumer):
             self.logger.info(f"Message {message_id} processed successfully")
             await self._clear_retry_tracking(stable_message_id)
         elif is_terminal_error:
-            self.logger.warning(f"Terminal error for {message_id}, committing without retry")
-            await self._clear_retry_tracking(stable_message_id)
+            # Route it through the sink as well — the handler usually wrote
+            # FAILED on its way out, in which case this is a no-op, but an
+            # error raised before it ever ran (a malformed envelope, a missing
+            # orgId) leaves no trace at all otherwise.
+            await self.__abandon_message(
+                message_id,
+                stable_message_id,
+                parsed_message,
+                reason="terminal error",
+                attempts=1,
+            )
         elif self.retry_manager and parsed_message:
             count, should_dead_letter = await self._increment_retry_and_check(stable_message_id)
             if should_dead_letter:
-                self.logger.warning(
-                    f"Dead-lettering {message_id} (tracking ID: {stable_message_id}) after {count} transient failures"
+                await self.__abandon_message(
+                    message_id,
+                    stable_message_id,
+                    parsed_message,
+                    reason=(
+                        f"{count} transient failures "
+                        f"(max {messaging_env.max_delivery_attempts})"
+                    ),
+                    attempts=count,
                 )
-                await self._clear_retry_tracking(stable_message_id)
             else:
                 # RE-QUEUE: Publish back to same topic for retry
                 try:
@@ -2139,6 +2195,19 @@ class IndexingKafkaConsumer(IMessagingConsumer):
             )
             return success
 
+        except asyncio.CancelledError:
+            # A BaseException, so the recovery below cannot see it: no failure
+            # is counted, nothing is re-queued and nothing is committed. That is
+            # the correct outcome — the offset resolves as redeliver — but it
+            # has to be visible, and it has to name the record, because the
+            # handler has already written a status on the way out.
+            self.logger.warning(
+                "Processing of %s (%s) was cancelled; leaving the offset "
+                "uncommitted for redelivery",
+                message_id,
+                describe_message(parsed_message),
+            )
+            raise
         except Exception as e:
             # Log the full exception chain for debugging
             exception_chain = format_exception_chain(e)

--- a/backend/python/app/services/messaging/kafka/handlers/record.py
+++ b/backend/python/app/services/messaging/kafka/handlers/record.py
@@ -28,6 +28,7 @@ from app.services.messaging.config import (
     IndexingEvent,
     PipelineEvent,
     PipelineEventData,
+    StreamMessage,
     Topic,
 )
 from app.services.messaging.error_classifier import (
@@ -60,6 +61,144 @@ class RecordEventHandler(BaseEventService):
 
         self.event_processor : EventProcessor = event_processor
         self.producer = producer
+
+    # Statuses that already describe a finished record. Abandoning a duplicate
+    # delivery of one of these must not rewrite it as a failure. FAILED is
+    # included so that when the handler ran and recorded its own specific
+    # reason, this does not overwrite it with the generic one — while a record
+    # whose handler never ran still gets marked here.
+    _SETTLED_STATUSES = frozenset({
+        ProgressStatus.COMPLETED.value,
+        ProgressStatus.EMPTY.value,
+        ProgressStatus.AUTO_INDEX_OFF.value,
+        ProgressStatus.FILE_TYPE_NOT_SUPPORTED.value,
+        ProgressStatus.FAILED.value,
+    })
+
+    async def on_message_abandoned(
+        self,
+        message: StreamMessage | None,
+        *,
+        reason: str,
+        attempts: int,
+    ) -> None:
+        """Put a record into a terminal state when its message is discarded.
+
+        Implements ``AbandonedMessageSink``. Without this a discarded message
+        leaves its record on whatever status it was created with — QUEUED —
+        which no recovery path revisits, so the record is stranded silently and
+        for ever.
+
+        Never raises: the caller is on its way to an acknowledgement that has to
+        happen either way.
+        """
+        if message is None:
+            self.logger.error(
+                "Discarded an unparseable message (%s); no record could be identified",
+                reason,
+            )
+            return
+
+        payload = message.payload or {}
+        record_id = payload.get("recordId")
+        if not record_id:
+            # Bulk-delete, membership-sync and collection-delete events carry no
+            # record; there is nothing to mark.
+            self.logger.warning(
+                "Discarded %s message with no recordId after %d attempt(s): %s",
+                message.eventType,
+                attempts,
+                reason,
+            )
+            return
+
+        record_id = str(record_id)
+        try:
+            record = await self.event_processor.graph_provider.get_document(
+                record_id, CollectionNames.RECORDS.value
+            )
+            if record is None:
+                self.logger.warning(
+                    "Discarded message for record %s after %d attempt(s); "
+                    "record no longer exists: %s",
+                    record_id,
+                    attempts,
+                    reason,
+                )
+                return
+
+            current_status = record.get("indexingStatus")
+            if current_status in self._SETTLED_STATUSES:
+                self.logger.info(
+                    "Discarded message for record %s after %d attempt(s); "
+                    "leaving settled status %s untouched: %s",
+                    record_id,
+                    attempts,
+                    current_status,
+                    reason,
+                )
+                return
+
+            # The check above is a read, so it cannot stand on its own: a
+            # concurrent delivery can finish the record between that read and
+            # this write, and an unconditional write would bury a COMPLETED
+            # record as FAILED. Claim the transition from the exact status we
+            # saw instead -- if anything moved it in the meantime the swap
+            # misses, and whatever it became is not ours to overwrite.
+            claimed = await self.event_processor.graph_provider.compare_and_set_indexing_status(
+                [record_id],
+                current_status,
+                ProgressStatus.FAILED.value,
+            )
+            if not claimed:
+                self.logger.info(
+                    "Discarded message for record %s after %d attempt(s); it "
+                    "moved on from %s before it could be marked, leaving it "
+                    "alone: %s",
+                    record_id,
+                    attempts,
+                    current_status,
+                    reason,
+                )
+                return
+
+            # The record is ours now (nothing else can swap out of FAILED), so
+            # fill in the remaining fields through the usual writer, which also
+            # preserves a completed extraction and mirrors parsingStatus.
+            updated = await self.__update_document_status(
+                record_id=record_id,
+                indexing_status=ProgressStatus.FAILED.value,
+                extraction_status=ProgressStatus.FAILED.value,
+                reason=f"Message discarded after {attempts} attempt(s): {reason}",
+            )
+            if updated is None:
+                # The status write is the only trace this record will ever get,
+                # so a silent failure here recreates the bug this method exists
+                # to fix.
+                self.logger.error(
+                    "Failed to mark record %s FAILED after its message was "
+                    "discarded (%s); it may remain in %s",
+                    record_id,
+                    reason,
+                    current_status,
+                )
+                return
+
+            self.logger.error(
+                "Record %s marked FAILED: message discarded after %d attempt(s): %s",
+                record_id,
+                attempts,
+                reason,
+            )
+        except Exception as e:
+            self.logger.error(
+                "Error while marking record %s FAILED after its message was "
+                "discarded (%s): %s",
+                record_id,
+                reason,
+                e,
+                exc_info=True,
+            )
 
     async def _propagate_primary_failure_to_queued_duplicates(
         self,
@@ -377,6 +516,7 @@ class RecordEventHandler(BaseEventService):
         error_occurred = False
         error_msg = None
         last_exception: Exception | None = None
+        cancelled = False
         record = None
         try:
             if not event_type:
@@ -922,10 +1062,12 @@ class RecordEventHandler(BaseEventService):
             # (set by the consumer before we started) still governs whether
             # this becomes a terminal FAILED or a QUEUED retry below.
             error_occurred = True
+            cancelled = True
             error_msg = "Record processing was cancelled (handler closed)"
             raise
         except asyncio.CancelledError as ce:
             error_occurred = True
+            cancelled = True
             error_msg = "Record processing was cancelled"
             last_exception = ce
             raise
@@ -972,7 +1114,20 @@ class RecordEventHandler(BaseEventService):
                     )
                     is_final = True
                     
-                if is_final:
+                if cancelled:
+                    # Checked before is_final: a cancellation is not a verdict
+                    # on the record. The broker entry was never acknowledged
+                    # (Redis) or committed (Kafka), so it comes back regardless
+                    # of how many attempts it had used. Writing FAILED here --
+                    # which the is_final branch would do, clearing
+                    # processingStartedAt with it -- would both misreport the
+                    # record and drop the one marker the stale-record scan
+                    # needs to recover it if this process never returns.
+                    self.logger.info(
+                        f"🔄 Record {record_id} cancelled mid-flight; leaving it "
+                        f"IN_PROGRESS for redelivery or stale recovery"
+                    )
+                elif is_final:
                     # Traceback logged once here (not on every transient retry attempt)
                     # so final, unrecoverable failures remain fully debuggable.
                     self.logger.error(

--- a/backend/python/app/services/messaging/kafka/utils/utils.py
+++ b/backend/python/app/services/messaging/kafka/utils/utils.py
@@ -178,9 +178,33 @@ class KafkaUtils:
         return handle_entity_message
 
     @staticmethod
+    async def create_record_event_handler(
+        app_container: IndexingAppContainer,
+        producer: Any = None,
+    ) -> RecordEventHandler:
+        """Build the record event handler.
+
+        Separate from ``create_record_message_handler`` because the consumer
+        needs this same instance as its ``AbandonedMessageSink`` — it is what
+        puts a record into a terminal status when its message is discarded — and
+        two instances would mean two graph clients for one job.
+        """
+        logger = app_container.logger()
+        event_processor = getattr(app_container, '_event_processor', None)
+        if not event_processor:
+            event_processor = await app_container.event_processor()
+        return RecordEventHandler(
+            logger=logger,
+            config_service=app_container.config_service(),
+            event_processor=event_processor,
+            producer=producer,
+        )
+
+    @staticmethod
     async def create_record_message_handler(
         app_container: IndexingAppContainer,
         producer: Any = None,
+        record_event_service: RecordEventHandler | None = None,
     ) -> IndexingMessageHandler:
         """Create a message handler for record events.
 
@@ -188,19 +212,16 @@ class KafkaUtils:
         next queued duplicate); pass the same producer used for retries so we
         don't spin up a second Kafka connection.
 
+        Pass `record_event_service` to reuse an instance already built for the
+        consumer's abandonment sink.
+
         Returns an async generator function that yields PipelineEvent during processing.
         """
         logger = app_container.logger()
-        event_processor = getattr(app_container, '_event_processor', None)
-        if not event_processor:
-            event_processor = await app_container.event_processor()
-        config_service = app_container.config_service()
-        record_event_service = RecordEventHandler(
-            logger=logger,
-            config_service=config_service,
-            event_processor=event_processor,
-            producer=producer,
-        )
+        if record_event_service is None:
+            record_event_service = await KafkaUtils.create_record_event_handler(
+                app_container, producer
+            )
 
         async def handle_record_message(message: StreamMessage) -> AsyncGenerator[PipelineEvent, None]:
             try:

--- a/backend/python/app/services/messaging/messaging_factory.py
+++ b/backend/python/app/services/messaging/messaging_factory.py
@@ -41,6 +41,7 @@ from app.services.messaging.scheduling.key_extractors import CompositeKeyExtract
 
 if TYPE_CHECKING:
     from app.services.messaging.backpressure import BackpressureCoordinator
+    from app.services.messaging.disposition import AbandonedMessageSink
     from app.services.resource_governor import ResourceGovernor
 
 
@@ -182,6 +183,7 @@ class MessagingFactory:
         fair_scheduler_config: FairSchedulerConfig | None = None,
         key_extractor: FairnessKeyExtractor | None = None,
         weight_provider: WeightProvider | None = None,
+        disposition_sink: "AbandonedMessageSink | None" = None,
     ) -> IMessagingConsumer:
         """Create a messaging consumer based on broker type.
 
@@ -245,6 +247,7 @@ class MessagingFactory:
                     fair_scheduler_config=effective_fair_config,
                     key_extractor=effective_key_extractor,
                     weight_provider=weight_provider,
+                    disposition_sink=disposition_sink,
                 )
             return KafkaMessagingConsumer(logger, config, retry_manager)
         else:
@@ -266,5 +269,6 @@ class MessagingFactory:
                     fair_scheduler_config=effective_fair_config,
                     key_extractor=effective_key_extractor,
                     weight_provider=weight_provider,
+                    disposition_sink=disposition_sink,
                 )
             return RedisStreamsConsumer(logger, config, retry_manager)

--- a/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
+++ b/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
@@ -166,6 +166,10 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
         self._consecutive_empty_polls = 0
         self._idle_threshold = 3  # Drain pending after N consecutive empty polls
         self._in_flight_message_ids: set[str] = set()
+        # Keyed by recordId, not by entry id. Two entries can carry the same
+        # record -- the original and one the stranded sweep re-published -- and
+        # the message-id set above cannot see that they are the same work.
+        self._in_flight_record_ids: set[str] = set()
         self._in_flight_lock = threading.Lock()
 
         # Absent config disables fair scheduling and keeps this consumer on
@@ -468,6 +472,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
             self._active_futures.clear()
         with self._in_flight_lock:
             self._in_flight_message_ids.clear()
+            self._in_flight_record_ids.clear()
 
     def _wait_for_active_futures(self) -> None:
         """Wait for all active futures to complete, bounded by ONE shared timeout.
@@ -520,6 +525,27 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
     def _unmark_in_flight(self, message_id: str) -> None:
         with self._in_flight_lock:
             self._in_flight_message_ids.discard(message_id)
+
+    def _claim_record(self, record_id: str) -> bool:
+        """Take this process's claim on a record, or report it already taken.
+
+        The distributed ``record:`` lease is the cross-replica guard, but it is
+        only taken when a concurrency manager is configured. Without one there
+        was nothing keyed by record at all in this consumer -- entries are
+        tracked by stream id -- so two deliveries carrying the same record (the
+        original, and one the stranded sweep re-published) could run at the same
+        time and race each other's status writes. The Kafka consumer already
+        keeps the equivalent set; this is its counterpart.
+        """
+        with self._in_flight_lock:
+            if record_id in self._in_flight_record_ids:
+                return False
+            self._in_flight_record_ids.add(record_id)
+        return True
+
+    def _release_record(self, record_id: str) -> None:
+        with self._in_flight_lock:
+            self._in_flight_record_ids.discard(record_id)
 
     async def _cleanup_empty_consumers(
         self,
@@ -1878,6 +1904,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
         - TERMINAL: ACK immediately (parsing errors, validation errors)
         - TRANSIENT: Don't ACK, let PEL retry
         """
+        record_claim_held = False
         parsing_held = False
         indexing_held = False
         indexing_complete = False
@@ -1951,6 +1978,19 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                 message_id,
             )
             return False
+
+        # Claimed after the backoff wait and the ownership check, so a message
+        # that is only sleeping or is not ours never holds one.
+        if not self._claim_record(record_lock_id):
+            self.logger.debug(
+                "Skipping %s: another in-flight delivery in this process "
+                "already holds record %s. Left un-acked so it is redelivered "
+                "once that one finishes.",
+                message_id,
+                record_lock_id,
+            )
+            return False
+        record_claim_held = True
 
         # Route the active-pipeline permit by tier, from the record event's own
         # extension/mimeType. The permit is held for the record's whole
@@ -2272,6 +2312,13 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
 
             return False
         finally:
+            # First, and deliberately: this is a plain set discard with no
+            # await, so unlike everything below it cannot be skipped by a
+            # cancellation landing inside this block. A stranded claim would
+            # block every later delivery of the record for the life of the
+            # process.
+            if record_claim_held:
+                self._release_record(record_lock_id)
             if renewal_task is not None:
                 renewal_task.cancel()
                 await asyncio.gather(renewal_task, return_exceptions=True)

--- a/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
+++ b/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
@@ -5,6 +5,8 @@ import threading
 import time
 import uuid
 from collections import deque
+from collections.abc import Awaitable, Callable
+from concurrent.futures import CancelledError as FuturesCancelledError
 from concurrent.futures import Future, ThreadPoolExecutor
 from concurrent.futures import wait as futures_wait
 from logging import Logger
@@ -21,6 +23,11 @@ from app.services.messaging.config import (
     StreamMessage,
     compute_retry_backoff_seconds,
     messaging_env,
+)
+from app.services.messaging.disposition import (
+    AbandonedMessageSink,
+    describe_message,
+    notify_abandoned,
 )
 from app.services.messaging.distributed_concurrency import DistributedLeaseSet
 from app.services.messaging.error_classifier import (
@@ -113,6 +120,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
         fair_scheduler_config: FairSchedulerConfig | None = None,
         key_extractor: FairnessKeyExtractor | None = None,
         weight_provider: WeightProvider | None = None,
+        disposition_sink: Optional[AbandonedMessageSink] = None,
     ) -> None:
         self.logger = logger
         self.config = config
@@ -120,6 +128,9 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
         # lets one process re-read another process's still-active messages.
         self.consumer_name = f"{config.client_id}-{uuid.uuid4().hex}"
         self.retry_manager = retry_manager
+        # Told about every message this consumer gives up on, before the XACK
+        # that makes it unrecoverable — see disposition.AbandonedMessageSink.
+        self.disposition_sink = disposition_sink
         self.producer = producer
         self.concurrency_manager = concurrency_manager
         # When set, node-local parsing/indexing admission is delegated to the
@@ -565,6 +576,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
         topic: str,
         message_id: str,
         stable_message_id: str | None = None,
+        parsed_message: StreamMessage | None = None,
     ) -> bool:
         """Check if message should be dead-lettered based on failure retry count.
 
@@ -605,13 +617,18 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                 self.logger.error("Error checking app-tracked retry count: %s", e)
             else:
                 if failure_count >= max_attempts:
-                    await self.redis.xack(topic, self.config.group_id, message_id)  # type: ignore
-                    await self._clear_retry_tracking(tracking_id)
-                    self.logger.warning(
-                        "Dead-lettered %s after %d transient failures (max %d)",
+                    await self._abandon_message(
                         message_id,
-                        failure_count,
-                        max_attempts,
+                        tracking_id,
+                        parsed_message,
+                        reason=(
+                            f"exhausted {failure_count} of {max_attempts} "
+                            "allowed failures"
+                        ),
+                        attempts=failure_count,
+                        ack=lambda: self.redis.xack(  # type: ignore[union-attr]
+                            topic, self.config.group_id, message_id
+                        ),
                     )
                     return True
                 # Fall through to the times_delivered backstop below: the
@@ -631,19 +648,65 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
             if details:
                 times_delivered = details[0].get("times_delivered", 0)
                 if times_delivered >= delivery_backstop:
-                    await self.redis.xack(topic, self.config.group_id, message_id)  # type: ignore
-                    await self._clear_retry_tracking(tracking_id)
-                    self.logger.warning(
-                        "Dead-lettered %s after %d transient failures (max %d)",
+                    await self._abandon_message(
                         message_id,
-                        times_delivered,
-                        delivery_backstop,
+                        tracking_id,
+                        parsed_message,
+                        reason=(
+                            f"delivered {times_delivered} times "
+                            f"(backstop {delivery_backstop}); likely crashing "
+                            "the consumer before the failure counter is written"
+                        ),
+                        attempts=times_delivered,
+                        ack=lambda: self.redis.xack(  # type: ignore[union-attr]
+                            topic, self.config.group_id, message_id
+                        ),
                     )
                     return True
         except Exception as e:
             self.logger.error("Error checking delivery count: %s", e)
 
         return False
+
+    async def _abandon_message(
+        self,
+        message_id: str,
+        tracking_id: str,
+        parsed_message: StreamMessage | None,
+        *,
+        reason: str,
+        attempts: int,
+        ack: Callable[[], Awaitable[Any]],
+    ) -> None:
+        """Give up on a message: tell the sink, then acknowledge it.
+
+        The notification comes first and on every path. An XACK is final — the
+        entry leaves the PEL and nothing redelivers it — so a record whose
+        message is dropped without this is left on whatever status it happened
+        to hold, which no recovery sweep revisits, and the log names only a
+        stream id that no longer resolves to anything.
+
+        ``ack`` is supplied by the caller because acknowledging is loop-bound:
+        the drain loop owns ``self.redis`` directly, while the processing
+        wrapper runs on the worker loop and has to bridge back (see
+        ``_ack_message``).
+        """
+        await notify_abandoned(
+            self.disposition_sink,
+            self.logger,
+            parsed_message,
+            reason=reason,
+            attempts=attempts,
+        )
+        self.logger.warning(
+            "Dead-lettered %s (%s, tracking id %s): %s",
+            message_id,
+            describe_message(parsed_message),
+            tracking_id,
+            reason,
+        )
+        await ack()
+        await self._clear_retry_tracking(tracking_id)
 
     async def _wait_out_backpressure(self) -> None:
         """Block while any downstream service has an active 429+Retry-After
@@ -727,7 +790,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                             if self.__already_held(message_id):
                                 continue
                             if await self._should_dead_letter(
-                                topic, message_id, stable_message_id
+                                topic, message_id, stable_message_id, parsed_message
                             ):
                                 continue
                             processed_any = True
@@ -812,7 +875,7 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                                 if self.__already_held(message_id):
                                     continue
                                 if await self._should_dead_letter(
-                                    topic, message_id, stable_message_id
+                                    topic, message_id, stable_message_id, parsed_message
                                 ):
                                     continue
                                 processed_any = True
@@ -1090,10 +1153,25 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
         """Parse a freshly read entry and hand it to the scheduler."""
         parsed = await self._parse_message(message_id, fields)
         if parsed is None:
+            # No recordId can be recovered from an envelope that would not
+            # parse. The entry itself is not logged: it carries the whole
+            # record payload, and XACK leaves it in the stream, so XRANGE on
+            # the id below retrieves it without putting customer data in the
+            # logs. The size is here because a truncated write is the usual
+            # cause.
             self.logger.warning(
-                "Unparseable message %s from stream %s; acknowledging without retry",
+                "Unparseable message %s from stream %s (%d byte payload); "
+                "acknowledging without retry",
                 message_id,
                 stream_name,
+                len(fields.get(_MESSAGE_VALUE_FIELD, "") or ""),
+            )
+            await notify_abandoned(
+                self.disposition_sink,
+                self.logger,
+                None,
+                reason=f"unparseable envelope on {stream_name}",
+                attempts=1,
             )
             try:
                 await self._ack_message(stream_name, message_id)
@@ -1550,6 +1628,15 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                 self._active_futures.discard(f)
             try:
                 _ = f.result()
+            except FuturesCancelledError:
+                # Shutdown cancelled the task. The entry was never ACKed, so it
+                # stays in the PEL and is redelivered — this is a normal
+                # outcome, not the unhandled-exception case below.
+                self.logger.info(
+                    "Processing task for %s was cancelled; entry left for "
+                    "redelivery",
+                    message_id,
+                )
             except Exception as exc:
                 self.logger.error("Task completed with unhandled exception: %s", exc)
 
@@ -1823,10 +1910,18 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
             parsed_message = await self._parse_message(message_id, fields)
         if parsed_message is None:
             self.logger.warning(
-                "Unparseable message %s from stream %s; "
+                "Unparseable message %s from stream %s (%d byte payload); "
                 "acknowledging without retry",
                 message_id,
                 stream_name,
+                len(fields.get(_MESSAGE_VALUE_FIELD, "") or ""),
+            )
+            await notify_abandoned(
+                self.disposition_sink,
+                self.logger,
+                None,
+                reason=f"unparseable envelope on {stream_name}",
+                attempts=1,
             )
             try:
                 await self._ack_message(stream_name, message_id)
@@ -2071,6 +2166,19 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
 
             return True
 
+        except asyncio.CancelledError:
+            # A BaseException, so the recovery below cannot see it: no failure
+            # is counted, nothing is re-queued and nothing is ACKed. That is the
+            # correct outcome — the entry stays in the PEL and is redelivered —
+            # but it has to be visible, and it has to name the record, because
+            # the handler has already written a status on the way out.
+            self.logger.warning(
+                "Processing of %s (%s) was cancelled; leaving it un-acked for "
+                "redelivery",
+                message_id,
+                describe_message(parsed_message),
+            )
+            raise
         except RedisAcknowledgementError as e:
             self.logger.warning("%s", e)
             return False
@@ -2100,31 +2208,38 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
                 # Update is_final_failure for terminal errors
                 if parsed_message:
                     parsed_message.is_final_failure = True
-                # Terminal error: ACK immediately to skip this message
-                self.logger.warning(
-                    "Terminal error for %s, ACK'ing to skip: %s",
+                # Terminal error: ACK immediately to skip this message. Route
+                # it through the sink too — the handler usually wrote FAILED on
+                # its way out, in which case this is a no-op, but an error
+                # raised before it ever ran (a malformed envelope, a missing
+                # orgId) leaves no trace at all otherwise.
+                await self._abandon_message(
                     message_id,
-                    type(e).__name__,
+                    stable_message_id,
+                    parsed_message,
+                    reason=f"terminal error: {type(e).__name__}",
+                    attempts=1,
+                    ack=lambda: self._ack_message(stream_name, message_id),
                 )
-                await self._ack_message(stream_name, message_id)
                 acked = True
-                await self._clear_retry_tracking(stable_message_id)
             elif self.retry_manager is not None and parsed_message:
                 failure_count, should_dead_letter = (
                     await self._increment_retry_and_check(stable_message_id)
                 )
                 if should_dead_letter:
-                    await self._ack_message(stream_name, message_id)
-                    acked = True
-                    await self._clear_retry_tracking(stable_message_id)
-                    self.logger.warning(
-                        "Dead-lettered %s (tracking ID: %s) after %d transient failures (max %d): %s",
+                    await self._abandon_message(
                         message_id,
                         stable_message_id,
-                        failure_count,
-                        messaging_env.max_delivery_attempts,
-                        type(e).__name__,
+                        parsed_message,
+                        reason=(
+                            f"{failure_count} transient failures "
+                            f"(max {messaging_env.max_delivery_attempts}), "
+                            f"last was {type(e).__name__}"
+                        ),
+                        attempts=failure_count,
+                        ack=lambda: self._ack_message(stream_name, message_id),
                     )
+                    acked = True
                 else:
                     # RE-QUEUE: Publish back to same stream for retry, then ACK
                     try:

--- a/backend/python/tests/unit/events/test_events.py
+++ b/backend/python/tests/unit/events/test_events.py
@@ -18,6 +18,7 @@ from app.config.constants.arangodb import (
     ProgressStatus,
 )
 from app.events.events import DedupDecision, EventProcessor
+from app.exceptions.indexing_exceptions import ProcessingError
 from app.services.messaging.config import (
     IndexingEvent,
     PipelineEvent,
@@ -1445,30 +1446,47 @@ class TestOnEventEarlyReturns:
     """Test on_event early return edge cases."""
 
     @pytest.mark.asyncio
-    async def test_no_payload_returns_early(self):
-        """No payload in event data (lines 244-245)."""
-        ep, logger, _, _ = _make_event_processor()
+    async def test_no_payload_raises_terminal_error(self):
+        """A malformed envelope must fail loudly and once.
+
+        Returning bare here yielded neither completion event, which the
+        consumers read as an unexplained failure and retried to the dead-letter
+        ceiling — three deliveries and no diagnosis for something no retry can
+        fix.
+        """
+        ep, _logger, _, _ = _make_event_processor()
         event_data = {"eventType": "NEW_RECORD"}  # no payload key
-        events = await _drain(ep.on_event(event_data))
-        assert events == []
-        logger.error.assert_called()
+
+        with pytest.raises(ProcessingError):
+            await _drain(ep.on_event(event_data))
 
     @pytest.mark.asyncio
-    async def test_no_record_id_returns_early(self):
-        """No recordId in payload (lines 253-254)."""
-        ep, logger, _, _ = _make_event_processor()
+    async def test_no_record_id_raises_terminal_error(self):
+        """A payload with no recordId can never come good on a retry."""
+        ep, _logger, _, _ = _make_event_processor()
         event_data = {"payload": {"orgId": "org-1"}}  # no recordId
-        events = await _drain(ep.on_event(event_data))
-        assert events == []
+
+        with pytest.raises(ProcessingError):
+            await _drain(ep.on_event(event_data))
 
     @pytest.mark.asyncio
-    async def test_record_not_found_returns_early(self):
-        """Record not found in DB (lines 261-262)."""
-        ep, logger, _, gp = _make_event_processor()
+    async def test_record_not_found_drains_the_message(self):
+        """A deleted record is drained, not retried.
+
+        Unlike the two malformed cases above this is legitimately reachable —
+        a record can be deleted between an event being published and consumed —
+        so it completes the pipeline rather than raising.
+        """
+        ep, _logger, _, gp = _make_event_processor()
         gp.get_document.return_value = None
         event_data = _make_event_payload()
+
         events = await _drain(ep.on_event(event_data))
-        assert events == []
+
+        assert [e.event for e in events] == [
+            IndexingEvent.PARSING_COMPLETE,
+            IndexingEvent.INDEXING_COMPLETE,
+        ]
 
     @pytest.mark.asyncio
     async def test_no_buffer_proceeds_with_none_content(self):

--- a/backend/python/tests/unit/services/messaging/test_disposition.py
+++ b/backend/python/tests/unit/services/messaging/test_disposition.py
@@ -1,0 +1,83 @@
+"""Tests for app.services.messaging.disposition.
+
+The rule these guard: a consumer never abandons a message silently. Before this
+existed, a discarded record event left its record on the status it was created
+with — QUEUED — which neither the stale-record scan nor the connector sweep
+looks at, and the only log line named a stream id that no longer resolved to
+anything once the entry was gone.
+"""
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from app.services.messaging.config import StreamMessage
+from app.services.messaging.disposition import (
+    AbandonedMessageSink,
+    describe_message,
+    notify_abandoned,
+)
+
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    return logging.getLogger("test.disposition")
+
+
+def _message(record_id: str | None = "rec-1") -> StreamMessage:
+    payload = {"recordId": record_id} if record_id else {"orgId": "org-1"}
+    return StreamMessage(eventType="newRecord", payload=payload)
+
+
+class TestNotifyAbandoned:
+    @pytest.mark.asyncio
+    async def test_forwards_reason_and_attempts(self, logger):
+        sink = AsyncMock()
+        message = _message()
+
+        await notify_abandoned(sink, logger, message, reason="poison", attempts=4)
+
+        sink.on_message_abandoned.assert_awaited_once_with(
+            message, reason="poison", attempts=4
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_failing_sink_never_propagates(self, logger):
+        """The caller is on its way to an ack it cannot skip.
+
+        Losing the status write is bad; wedging the stream behind it is worse.
+        """
+        sink = AsyncMock()
+        sink.on_message_abandoned = AsyncMock(side_effect=Exception("graph down"))
+
+        await notify_abandoned(sink, logger, _message(), reason="poison", attempts=1)
+
+    @pytest.mark.asyncio
+    async def test_no_sink_is_a_no_op(self, logger):
+        await notify_abandoned(None, logger, _message(), reason="poison", attempts=1)
+
+
+class TestDescribeMessage:
+    """These strings are the only handle an operator has on what was discarded."""
+
+    def test_names_the_record(self):
+        assert "rec-1" in describe_message(_message())
+
+    def test_marks_a_record_less_event(self):
+        described = describe_message(_message(record_id=None))
+        assert "none" in described
+        assert "newRecord" in described
+
+    def test_marks_an_unparseable_envelope(self):
+        assert "unparseable" in describe_message(None)
+
+
+class TestSinkProtocol:
+    def test_record_handler_shaped_object_satisfies_the_protocol(self):
+        """Consumers duck-type the sink; this is the shape they require."""
+
+        class Handler:
+            async def on_message_abandoned(self, message, *, reason, attempts):
+                return None
+
+        assert isinstance(Handler(), AbandonedMessageSink)

--- a/backend/python/tests/unit/services/messaging/test_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_indexing_consumer.py
@@ -2023,3 +2023,94 @@ class TestConsumeLoop:
         mock_consumer.getmany = mock_getmany
         consumer.consumer = mock_consumer
         await consumer._IndexingKafkaConsumer__consume_loop()
+
+
+# ===================================================================
+# Abandonment: nothing is discarded without a terminal record status
+# ===================================================================
+
+
+class TestKafkaAbandonmentNotifiesTheSink:
+    """A committed-away message must leave its record in a terminal state.
+
+    Committing past an offset is final. If the record's status is not made
+    terminal first, no recovery sweep revisits it — the stale scan filters on
+    IN_PROGRESS and the connector sweep only touches connectors that are gone —
+    so the record waits for ever with only an offset in the logs to explain it.
+    """
+
+    @staticmethod
+    def _parsed():
+        return StreamMessage(eventType="newRecord", payload={"recordId": "r1"})
+
+    @pytest.mark.asyncio
+    async def test_dead_letter_notifies_the_sink_before_committing(self, consumer):
+        sink = AsyncMock()
+        consumer.disposition_sink = sink
+        consumer.retry_manager = AsyncMock()
+        consumer.retry_manager.increment_and_check = AsyncMock(
+            return_value=(3, True)
+        )
+        order = []
+        sink.on_message_abandoned = AsyncMock(
+            side_effect=lambda *a, **kw: order.append("sink")
+        )
+        consumer._commit_offset = AsyncMock(
+            side_effect=lambda *a, **kw: order.append("commit")
+        )
+
+        await consumer._IndexingKafkaConsumer__commit_if_appropriate(
+            _make_message(offset=7), self._parsed(), success=False
+        )
+
+        assert order == ["sink", "commit"]
+        assert (
+            sink.on_message_abandoned.await_args.args[0].payload["recordId"] == "r1"
+        )
+
+    @pytest.mark.asyncio
+    async def test_terminal_error_also_notifies_the_sink(self, consumer):
+        """An error raised before the handler body ran wrote no status itself."""
+        sink = AsyncMock()
+        consumer.disposition_sink = sink
+        consumer._commit_offset = AsyncMock()
+
+        await consumer._IndexingKafkaConsumer__commit_if_appropriate(
+            _make_message(offset=7),
+            self._parsed(),
+            success=False,
+            is_terminal_error=True,
+        )
+
+        sink.on_message_abandoned.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_sink_does_not_stop_the_commit(self, consumer):
+        """A stalled partition would be a worse failure than the lost status."""
+        sink = AsyncMock()
+        sink.on_message_abandoned = AsyncMock(side_effect=Exception("graph down"))
+        consumer.disposition_sink = sink
+        consumer.retry_manager = AsyncMock()
+        consumer.retry_manager.increment_and_check = AsyncMock(
+            return_value=(3, True)
+        )
+        consumer._commit_offset = AsyncMock()
+
+        await consumer._IndexingKafkaConsumer__commit_if_appropriate(
+            _make_message(offset=7), self._parsed(), success=False
+        )
+
+        consumer._commit_offset.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_success_never_notifies_the_sink(self, consumer):
+        sink = AsyncMock()
+        consumer.disposition_sink = sink
+        consumer.retry_manager = AsyncMock()
+        consumer._commit_offset = AsyncMock()
+
+        await consumer._IndexingKafkaConsumer__commit_if_appropriate(
+            _make_message(offset=7), self._parsed(), success=True
+        )
+
+        sink.on_message_abandoned.assert_not_awaited()

--- a/backend/python/tests/unit/services/messaging/test_record_handler.py
+++ b/backend/python/tests/unit/services/messaging/test_record_handler.py
@@ -20,6 +20,7 @@ from app.services.messaging.config import (
     IndexingEvent,
     PipelineEvent,
     PipelineEventData,
+    StreamMessage,
 )
 from app.services.messaging.error_classifier import MessageErrorType
 from app.services.vector_db.rebuild_state import PHASE_FAILED, PHASE_READY
@@ -1971,7 +1972,80 @@ class TestProcessEventErrors:
         assert updates.get("indexingStatus") == ProgressStatus.QUEUED.value
 
     @pytest.mark.asyncio
-    async def test_cancellation_reverts_all_in_progress_statuses(self):
+    async def test_cancellation_on_the_final_attempt_still_writes_nothing(self):
+        """Cancellation is checked before is_final, and this is why.
+
+        is_final_failure is set from the retry count before the handler runs,
+        so a record on its last attempt that is then cancelled by a shutdown
+        used to take the FAILED branch -- misreporting a record the broker is
+        about to redeliver, and clearing the processingStartedAt the stale scan
+        needs to recover it.
+        """
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(
+            return_value={
+                "_key": "r1",
+                "virtualRecordId": "vr1",
+                "parsingStatus": ProgressStatus.IN_PROGRESS.value,
+                "indexingStatus": ProgressStatus.IN_PROGRESS.value,
+                "mimeType": "application/pdf",
+            }
+        )
+        gp.update_node = AsyncMock(return_value=True)
+        gp.batch_update_nodes = AsyncMock(return_value=True)
+
+        entered_processor = asyncio.Event()
+        never_complete = asyncio.Event()
+
+        async def blocked_events(_event_data):
+            entered_processor.set()
+            await never_complete.wait()
+            if False:
+                yield None
+
+        handler.event_processor.on_event = blocked_events
+        payload = {
+            "recordId": "r1",
+            "virtualRecordId": "vr1",
+            "orgId": "org-1",
+            "mimeType": "application/pdf",
+            "extension": "pdf",
+            "signedUrl": "https://example.com/file.pdf",
+            # the difference from the test below
+            "is_final_failure": True,
+        }
+
+        with patch.object(
+            handler,
+            "_download_from_signed_url",
+            new=AsyncMock(return_value=b"pdf"),
+        ):
+            event_generator = handler.process_event(
+                EventTypes.NEW_RECORD.value,
+                payload,
+            )
+            processing = asyncio.create_task(anext(event_generator))
+            await asyncio.wait_for(entered_processor.wait(), timeout=1)
+            processing.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await processing
+            await event_generator.aclose()
+
+        gp.update_node.assert_not_awaited()
+        gp.batch_update_nodes.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_leaves_the_record_in_progress(self):
+        """A cancelled record must stay IN_PROGRESS, not fall back to QUEUED.
+
+        The revert-to-QUEUED path exists because the consumer re-queues the
+        message; a cancellation schedules no such retry — the broker entry is
+        simply left unacknowledged and redelivered. Writing QUEUED here put the
+        record in the one state no sweep reconciles, so if the process never
+        came back it was stranded for ever. IN_PROGRESS with its
+        processingStartedAt intact is what the stale-record scan looks for.
+        """
         handler = _make_handler()
         gp = handler.event_processor.graph_provider
         record = {
@@ -2021,10 +2095,7 @@ class TestProcessEventErrors:
                 await processing
             await event_generator.aclose()
 
-        updates = gp.update_node.await_args.args[2]
-        assert updates["parsingStatus"] == ProgressStatus.NOT_STARTED.value
-        assert updates["indexingStatus"] == ProgressStatus.QUEUED.value
-        assert updates["processingStartedAt"] is None
+        gp.update_node.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_transient_failure_after_completed_does_not_downgrade(self):
@@ -3653,3 +3724,181 @@ class TestTerminalConditionsDrain:
             IndexingEvent.INDEXING_COMPLETE,
         ]
 
+
+
+# ===========================================================================
+# on_message_abandoned — the terminal status a discarded message leaves behind
+# ===========================================================================
+
+
+class TestOnMessageAbandoned:
+    """The handler's AbandonedMessageSink implementation.
+
+    This is what stops a discarded message from stranding its record. Before it
+    existed, a consumer that gave up on a message acknowledged it and wrote
+    nothing, so the record kept the status it was created with — QUEUED — which
+    the stale scan (IN_PROGRESS only) and the connector sweep (inactive
+    connectors only) both ignore. It sat there for ever, and the only log line
+    named the broker's message id, not the record.
+    """
+
+    @staticmethod
+    def _message(record_id="r1", event_type="newRecord"):
+        payload = {"recordId": record_id} if record_id else {"orgId": "org-1"}
+        return StreamMessage(eventType=event_type, payload=payload)
+
+    @pytest.mark.asyncio
+    async def test_marks_the_record_failed_with_a_reason(self):
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(
+            return_value={
+                "_key": "r1",
+                "indexingStatus": ProgressStatus.QUEUED.value,
+                "parsingStatus": ProgressStatus.NOT_STARTED.value,
+            }
+        )
+        gp.update_node = AsyncMock(return_value=True)
+        gp.compare_and_set_indexing_status = AsyncMock(return_value=["r1"])
+
+        await handler.on_message_abandoned(
+            self._message(), reason="4 transient failures", attempts=4
+        )
+
+        updates = gp.update_node.await_args.args[2]
+        assert updates["indexingStatus"] == ProgressStatus.FAILED.value
+        assert updates["extractionStatus"] == ProgressStatus.FAILED.value
+        assert updates["processingStartedAt"] is None
+        assert "4 transient failures" in updates["reason"]
+        assert "4 attempt" in updates["reason"]
+
+    @pytest.mark.parametrize(
+        "settled_status",
+        [
+            ProgressStatus.COMPLETED.value,
+            ProgressStatus.EMPTY.value,
+            ProgressStatus.AUTO_INDEX_OFF.value,
+            ProgressStatus.FILE_TYPE_NOT_SUPPORTED.value,
+            ProgressStatus.FAILED.value,
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_never_downgrades_a_settled_record(self, settled_status):
+        """A duplicate delivery of a finished record must not be rewritten.
+
+        AUTO_INDEX_OFF matters most here: the connector parked that record
+        deliberately, and turning it into a failure would misreport it. FAILED
+        is in the list so the specific reason the handler recorded survives —
+        this path only has a generic one to offer.
+        """
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(
+            return_value={"_key": "r1", "indexingStatus": settled_status}
+        )
+        gp.update_node = AsyncMock(return_value=True)
+
+        await handler.on_message_abandoned(
+            self._message(), reason="poison", attempts=3
+        )
+
+        gp.update_node.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_tolerates_a_deleted_record(self):
+        """A record can be deleted between the event and the abandonment."""
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(return_value=None)
+        gp.update_node = AsyncMock(return_value=True)
+
+        await handler.on_message_abandoned(
+            self._message(), reason="poison", attempts=3
+        )
+
+        gp.update_node.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_op_for_record_less_events(self):
+        """Bulk-delete and membership-sync events carry no recordId."""
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock()
+
+        await handler.on_message_abandoned(
+            self._message(record_id=None, event_type="bulkDeleteRecords"),
+            reason="poison",
+            attempts=3,
+        )
+
+        gp.get_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_op_for_an_unparseable_envelope(self):
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock()
+
+        await handler.on_message_abandoned(None, reason="unparseable", attempts=1)
+
+        gp.get_document.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_record_that_completes_concurrently_is_not_buried(self):
+        """The settled check is a read; the write has to be conditional.
+
+        A concurrent delivery can finish the record between the two, and an
+        unconditional write would bury a COMPLETED record as FAILED. The swap
+        is claimed from the exact status that was read, so a record that moved
+        on is left alone.
+        """
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(
+            return_value={"_key": "r1", "indexingStatus": ProgressStatus.QUEUED.value}
+        )
+        # Nothing swapped: someone else moved the record first.
+        gp.compare_and_set_indexing_status = AsyncMock(return_value=[])
+        gp.update_node = AsyncMock(return_value=True)
+
+        await handler.on_message_abandoned(
+            self._message(), reason="poison", attempts=3
+        )
+
+        gp.compare_and_set_indexing_status.assert_awaited_once_with(
+            ["r1"], ProgressStatus.QUEUED.value, ProgressStatus.FAILED.value
+        )
+        gp.update_node.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_never_raises_when_the_graph_is_down(self):
+        """The caller is mid-acknowledgement and cannot handle an exception."""
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(side_effect=Exception("graph down"))
+        gp.compare_and_set_indexing_status = AsyncMock(return_value=["r1"])
+
+        await handler.on_message_abandoned(
+            self._message(), reason="poison", attempts=3
+        )
+
+    @pytest.mark.asyncio
+    async def test_reports_a_write_that_did_not_land(self):
+        """update_node returns False rather than raising.
+
+        This is the record's last write; a silently dropped one recreates the
+        bug this method exists to fix, so it has to be logged as an error.
+        """
+        handler = _make_handler()
+        gp = handler.event_processor.graph_provider
+        gp.get_document = AsyncMock(
+            return_value={"_key": "r1", "indexingStatus": ProgressStatus.QUEUED.value}
+        )
+        gp.update_node = AsyncMock(return_value=False)
+        gp.compare_and_set_indexing_status = AsyncMock(return_value=["r1"])
+
+        await handler.on_message_abandoned(
+            self._message(), reason="poison", attempts=3
+        )
+
+        assert handler.logger.error.called

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -2812,3 +2812,78 @@ class TestModuleConstants:
 
     def test_message_value_field_constant(self):
         assert _MESSAGE_VALUE_FIELD == "value"
+
+
+# ===================================================================
+# Abandonment: nothing is discarded without a terminal record status
+# ===================================================================
+
+
+class TestAbandonmentNotifiesTheSink:
+    """A discarded message must leave its record in a terminal, visible state.
+
+    An XACK is final — the entry leaves the PEL and nothing redelivers it. If
+    the record's status is not made terminal first, no recovery sweep revisits
+    it: the stale scan filters on IN_PROGRESS and the connector sweep only
+    touches connectors that are gone. That is how records sat in QUEUED for
+    ever with nothing in the logs but a stream id.
+    """
+
+    @staticmethod
+    def _with_counters(consumer, *, failures):
+        consumer.retry_manager = AsyncMock()
+        consumer.retry_manager.get_count = AsyncMock(return_value=failures)
+        consumer.redis = AsyncMock()
+        consumer.redis.xack = AsyncMock()
+
+    @pytest.mark.asyncio
+    async def test_sink_hears_about_it_before_the_ack(self, consumer):
+        self._with_counters(consumer, failures=99)
+        calls = []
+        sink = AsyncMock()
+        sink.on_message_abandoned = AsyncMock(
+            side_effect=lambda *a, **kw: calls.append("sink")
+        )
+        consumer.disposition_sink = sink
+        consumer.redis.xack = AsyncMock(
+            side_effect=lambda *a, **kw: calls.append("xack")
+        )
+        message = StreamMessage(
+            eventType="newRecord", payload={"recordId": "rec-1"}
+        )
+
+        result = await consumer._should_dead_letter(
+            "topic-a", "1-0", None, message
+        )
+
+        assert result is True
+        assert calls == ["sink", "xack"]
+        assert sink.on_message_abandoned.await_args.args[0] is message
+
+    @pytest.mark.asyncio
+    async def test_a_failing_sink_does_not_block_the_ack(self, consumer):
+        """Losing the status write is bad; stalling the stream is worse."""
+        self._with_counters(consumer, failures=99)
+        sink = AsyncMock()
+        sink.on_message_abandoned = AsyncMock(side_effect=Exception("graph down"))
+        consumer.disposition_sink = sink
+
+        result = await consumer._should_dead_letter("topic-a", "1-0")
+
+        assert result is True
+        consumer.redis.xack.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_a_healthy_message_is_not_abandoned(self, consumer):
+        self._with_counters(consumer, failures=0)
+        sink = AsyncMock()
+        consumer.disposition_sink = sink
+        consumer.redis.xpending_range = AsyncMock(
+            return_value=[{"times_delivered": 2}]
+        )
+
+        result = await consumer._should_dead_letter("topic-a", "1-0")
+
+        assert result is False
+        sink.on_message_abandoned.assert_not_awaited()
+        consumer.redis.xack.assert_not_awaited()

--- a/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
+++ b/backend/python/tests/unit/services/messaging/test_redis_streams_indexing_consumer.py
@@ -2887,3 +2887,97 @@ class TestAbandonmentNotifiesTheSink:
         assert result is False
         sink.on_message_abandoned.assert_not_awaited()
         consumer.redis.xack.assert_not_awaited()
+
+
+class TestProcessLocalRecordClaim:
+    """Two entries can carry the same record; the entry-id set cannot see that.
+
+    The stranded sweep re-publishes a record whose event went missing, so the
+    original entry and the new one both name it. The cross-replica guard is the
+    distributed `record:` lease, but that is only taken when a concurrency
+    manager is configured — without one there was nothing keyed by record at
+    all, and the two deliveries could race each other's status writes.
+    """
+
+    def test_a_record_can_only_be_claimed_once(self, consumer):
+        assert consumer._claim_record("rec-1") is True
+        assert consumer._claim_record("rec-1") is False
+
+    def test_releasing_lets_the_next_delivery_through(self, consumer):
+        consumer._claim_record("rec-1")
+        consumer._release_record("rec-1")
+        assert consumer._claim_record("rec-1") is True
+
+    def test_different_records_do_not_block_each_other(self, consumer):
+        assert consumer._claim_record("rec-1") is True
+        assert consumer._claim_record("rec-2") is True
+
+    def test_releasing_an_unheld_record_is_harmless(self, consumer):
+        consumer._release_record("never-claimed")
+
+    @pytest.mark.asyncio
+    async def test_a_duplicate_delivery_is_left_for_redelivery(self, consumer):
+        """The loser is not acked: it comes back once the winner finishes.
+
+        Dropping it instead would discard a genuinely different event for the
+        same record — a create and its update are not interchangeable.
+        """
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        consumer.main_loop = asyncio.get_running_loop()
+        consumer.message_handler = MagicMock()
+        # Another delivery of this record is already running in this process.
+        consumer._claim_record("r1")
+
+        result = await consumer._process_message_wrapper(
+            "s", "1-0", _valid_fields(payload={"recordId": "r1"})
+        )
+
+        assert result is False
+        consumer.message_handler.assert_not_called()
+        consumer.redis.xack.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_claim_is_released_when_processing_finishes(self, consumer):
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        consumer.main_loop = asyncio.get_running_loop()
+
+        async def handler(msg):
+            yield PipelineEvent(
+                event=IndexingEvent.PARSING_COMPLETE,
+                data=PipelineEventData(record_id="r1"),
+            )
+            yield PipelineEvent(
+                event=IndexingEvent.INDEXING_COMPLETE,
+                data=PipelineEventData(record_id="r1"),
+            )
+
+        consumer.message_handler = handler
+
+        await consumer._process_message_wrapper(
+            "s", "1-0", _valid_fields(payload={"recordId": "r1"})
+        )
+
+        assert consumer._claim_record("r1") is True
+
+    @pytest.mark.asyncio
+    async def test_the_claim_is_released_when_the_handler_raises(self, consumer):
+        consumer.parsing_semaphore = asyncio.Semaphore(1)
+        consumer.indexing_semaphore = asyncio.Semaphore(1)
+        consumer.redis = AsyncMock()
+        consumer.main_loop = asyncio.get_running_loop()
+
+        async def handler(msg):
+            raise RuntimeError("boom")
+            yield  # pragma: no cover - makes this an async generator
+
+        consumer.message_handler = handler
+
+        await consumer._process_message_wrapper(
+            "s", "1-0", _valid_fields(payload={"recordId": "r1"})
+        )
+
+        assert consumer._claim_record("r1") is True

--- a/backend/python/tests/unit/test_indexing_main.py
+++ b/backend/python/tests/unit/test_indexing_main.py
@@ -1,14 +1,20 @@
 """Comprehensive unit tests for app.indexing_main module."""
 
 import asyncio
+import os
 import time
-from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from unittest.mock import ANY, AsyncMock, MagicMock, patch, PropertyMock
 
 import pytest
 from fastapi.responses import JSONResponse
 
-from app.config.constants.arangodb import CollectionNames, ProgressStatus
+from app.config.constants.arangodb import (
+    CollectionNames,
+    EventTypes,
+    ProgressStatus,
+)
 from app.services.messaging.config import MessageBrokerType
+from app.utils.time_conversion import get_epoch_timestamp_in_ms
 
 
 @pytest.fixture(autouse=True)
@@ -1889,3 +1895,259 @@ class TestSweepOrphanedVirtualRecordMappings:
         )
 
         assert m._orphan_sweep_cursor == 0
+
+
+# ===================================================================
+# _republish_stranded_records
+# ===================================================================
+
+
+def _stranded_env(after_seconds=3600.0):
+    """Set the sweep's threshold; 0 (the default) disables it entirely.
+
+    Patches the environment rather than the property because messaging_env
+    re-reads os.getenv on every access by design.
+    """
+    return patch.dict(
+        os.environ,
+        {"STRANDED_RECORD_REPUBLISH_AFTER_SECONDS": str(after_seconds)},
+    )
+
+
+async def _run_stranded(graph, producer=None, concurrency_manager=None):
+    from app.indexing_main import _republish_stranded_records
+
+    async def run_coordination(coro):
+        return await coro
+
+    return await _republish_stranded_records(
+        graph_provider=graph,
+        logger=MagicMock(),
+        producer=producer or AsyncMock(),
+        run_coordination=run_coordination,
+        concurrency_manager=concurrency_manager,
+        page_size=100,
+    )
+
+
+class TestRepublishStrandedRecords:
+    """The net for records whose event was lost.
+
+    A row on a live connector is invisible to both other sweeps: the stale scan
+    filters on IN_PROGRESS, and the connector sweep only touches connectors that
+    are gone. That gap is how records sat in QUEUED for ever after their event
+    was discarded.
+    """
+
+    @staticmethod
+    def _old_record(**overrides):
+        record = {
+            "_key": "r1",
+            "connectorId": "live",
+            "origin": "CONNECTOR",
+            "recordName": "PA-1 Something",
+            "orgId": "org-1",
+            "version": 0,
+            "updatedAtTimestamp": 1,  # epoch ms — far older than any cutoff
+        }
+        record.update(overrides)
+        return record
+
+    @pytest.mark.asyncio
+    async def test_disabled_by_default(self):
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record()]}, active_ids={"live"}
+        )
+        producer = AsyncMock()
+
+        with _stranded_env(0.0):
+            assert await _run_stranded(graph, producer) == 0
+
+        producer.send_event.assert_not_awaited()
+        graph.get_documents_paginated.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_republishes_a_stranded_row_on_a_live_connector(self):
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record()]}, active_ids={"live"}
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 1
+
+        kwargs = producer.send_event.await_args.kwargs
+        assert kwargs["payload"]["recordId"] == "r1"
+        assert kwargs["event_type"] == EventTypes.NEW_RECORD.value
+        assert kwargs["key"] == "r1"
+
+    @pytest.mark.asyncio
+    async def test_an_already_indexed_row_reindexes_instead(self):
+        """A record with a version and a VRID has been indexed before."""
+        graph = _sweep_graph(
+            {
+                ProgressStatus.QUEUED.value: [
+                    self._old_record(version=2, virtualRecordId="vr-1")
+                ]
+            },
+            active_ids={"live"},
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            await _run_stranded(graph, producer)
+
+        assert (
+            producer.send_event.await_args.kwargs["event_type"]
+            == EventTypes.REINDEX_RECORD.value
+        )
+
+    @pytest.mark.asyncio
+    async def test_a_recently_touched_row_is_left_alone(self):
+        """Its event may legitimately still be queued behind a backlog."""
+        graph = _sweep_graph(
+            {
+                ProgressStatus.QUEUED.value: [
+                    self._old_record(updatedAtTimestamp=get_epoch_timestamp_in_ms())
+                ]
+            },
+            active_ids={"live"},
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 0
+
+        producer.send_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_inactive_connector_rows_belong_to_the_other_sweep(self):
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record()]}, active_ids=set()
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 0
+
+        producer.send_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_dedup_parked_duplicate_is_left_to_its_twin(self):
+        """A record parked behind an in-flight md5 twin is legitimately QUEUED.
+
+        It is released when the twin completes, not by re-publishing it.
+        """
+        graph = _sweep_graph(
+            {
+                ProgressStatus.QUEUED.value: [
+                    self._old_record(md5Checksum="abc", virtualRecordId="vr-1")
+                ]
+            },
+            active_ids={"live"},
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 0
+
+        producer.send_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_uploads_are_not_swept(self):
+        """Only connector-origin records are re-published from here."""
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record(origin="UPLOAD")]},
+            active_ids={"live"},
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 0
+
+        producer.send_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_republishing_marks_the_row(self):
+        """Publishing changes nothing about the record on its own.
+
+        Without a marker the row stays eligible and every sweep tick sends
+        another copy of the same event — worst exactly when the consumer is
+        backlogged, which is the case this sweep exists for.
+        """
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record()]}, active_ids={"live"}
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            await _run_stranded(graph, producer)
+
+        key, collection, fields = graph.update_node.await_args.args
+        assert key == "r1"
+        assert collection == CollectionNames.RECORDS.value
+        assert "lastRepublishedAt" in fields
+        # updatedAtTimestamp means "when the record last changed" and belongs
+        # to the connectors; a recovery sweep must not move it.
+        assert "updatedAtTimestamp" not in fields
+
+    @pytest.mark.asyncio
+    async def test_a_recently_republished_row_is_skipped(self):
+        """At most one republish per threshold window, per record."""
+        graph = _sweep_graph(
+            {
+                ProgressStatus.QUEUED.value: [
+                    self._old_record(lastRepublishedAt=get_epoch_timestamp_in_ms())
+                ]
+            },
+            active_ids={"live"},
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 0
+
+        producer.send_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_old_republish_does_not_block_a_retry(self):
+        """A second lost event is still recoverable once the window passes."""
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record(lastRepublishedAt=1)]},
+            active_ids={"live"},
+        )
+        producer = AsyncMock()
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_contended_record_lease_skips_the_row(self):
+        """Somebody is working on it after all."""
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record()]}, active_ids={"live"}
+        )
+        producer = AsyncMock()
+        manager = AsyncMock()
+        manager.try_acquire = AsyncMock(return_value=False)
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer, manager) == 0
+
+        producer.send_event.assert_not_awaited()
+        manager.release.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_the_record_lease_is_always_released(self):
+        graph = _sweep_graph(
+            {ProgressStatus.QUEUED.value: [self._old_record()]}, active_ids={"live"}
+        )
+        producer = AsyncMock()
+        producer.send_event = AsyncMock(side_effect=Exception("broker down"))
+        manager = AsyncMock()
+        manager.try_acquire = AsyncMock(return_value=True)
+
+        with _stranded_env():
+            assert await _run_stranded(graph, producer, manager) == 0
+
+        manager.release.assert_awaited_once_with("record:r1", ANY)


### PR DESCRIPTION
A consumer that gives up on a message acknowledged it and wrote nothing, so the record kept the status it was created with -- QUEUED. Nothing revisits that: the stale-record scan filters on IN_PROGRESS, and the connector sweep only touches connectors that are gone. The record waited for ever, and the only log line named the broker's message id, which no longer resolves to anything once the entry is gone -- so there was no way to tell afterwards which records had been lost.

Adds an AbandonedMessageSink the consumers notify before every ack or commit they make without having processed the message. RecordEventHandler implements it by putting the record into FAILED with a reason and the attempt count, refusing to downgrade a record that already settled, and never raising -- the caller is on its way to an acknowledgement it cannot skip, so a broken sink must not wedge the stream. Consumers depend on the protocol, not on records, so they stay broker-generic.

Also closes the paths that fed the same silence:

- asyncio.CancelledError is a BaseException, so the wrappers' `except Exception` recovery never saw it: no failure counted, nothing re-queued, nothing acked, while the handler had already reverted the record to QUEUED expecting a retry. Both consumers now catch it explicitly and name the record; the handler leaves a cancelled record IN_PROGRESS with its processingStartedAt intact, which is the one state the stale scan can recover.

- Three guards in on_event returned bare, yielding neither completion event. The consumers read that as an unexplained failure and retried to the dead-letter ceiling. A missing payload or recordId cannot come good on a retry, so they raise a TERMINAL error and are reported once; a deleted record is a real race and drains instead.

- Adds an opt-in sweep that re-publishes records stranded on live connectors, keyed on age rather than on what QUEUED is taken to mean, since that status cannot distinguish "the event is on the broker" from "the event was never sent". Off unless STRANDED_RECORD_REPUBLISH_AFTER_SECONDS is set.

Carries one unrelated config property that was in flight in the same working tree, fair_scheduling_metrics_per_connector, included here rather than left uncommitted.


Claude-Session: https://claude.ai/code/session_01GkV49MyjrgyTkgcQw1VZ42

## Description

[Provide a brief description of the changes in this PR]

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes. Provide instructions so we can reproduce.]

### Test Configuration

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [ ] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [ ] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed events and missing records are now handled explicitly instead of being silently ignored.
  - Failed or abandoned messages are reported, with associated records marked as failed when appropriate.
  - Cancelled processing remains recoverable through redelivery or recovery scans.

- **Reliability**
  - Lost events on active connectors can now be recovered automatically.
  - Duplicate processing is prevented, improving consistency during message redelivery.
  - Diagnostics are improved for unparseable messages, abandoned processing, and terminal failures.
  - Acknowledgements continue safely even when failure notifications encounter errors.
  - Recovery timing and connector-level scheduling metrics are configurable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->