### PR TITLE
Feature: filter OS metadata files

### DIFF
--- a/backend/python/app/events/events.py
+++ b/backend/python/app/events/events.py
@@ -51,6 +51,7 @@ from app.services.vector_db.strategy import (
     resolve_write_collection_name,
 )
 from app.utils.cpu_offload import offload_if_large
+from app.utils.file_signatures import match_metadata_file_signature
 from app.utils.libreoffice_convert import convert_with_libreoffice
 from app.utils.time_conversion import get_epoch_timestamp_in_ms
 
@@ -98,30 +99,6 @@ def shutdown_pdf_ocr_pool() -> bool:
     _get_pdf_ocr_detection_pool().shutdown(wait=False, cancel_futures=True)
     _get_pdf_ocr_detection_pool.cache_clear()
     return True
-
-
-# OS/filesystem metadata "files" that connectors might occasionally hand us wearing
-# a real document's extension/MIME type.
-_METADATA_FILE_SIGNATURES: dict[str, bytes] = {
-    "AppleDouble": b"\x00\x05\x16\x07",
-    "AppleSingle": b"\x00\x05\x16\x00",
-    "DS_Store": b"\x00\x00\x00\x01BAB1",
-    "BinaryPlist": b"bplist",
-    "OLE_Compound_ThumbsDB": b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",
-    "WindowsLnk": b"\x4c\x00\x00\x00\x01\x14\x02\x00",
-    "VimSwap": b"Vim!",
-}
-
-
-def _match_metadata_file_signature(file_content: bytes) -> str | None:
-    """Name of the matched signature if *file_content* is OS/filesystem
-    metadata masquerading as a real document, else None."""
-    if not isinstance(file_content, (bytes, bytearray)):
-        return None
-    for name, magic in _METADATA_FILE_SIGNATURES.items():
-        if file_content.startswith(magic):
-            return name
-    return None
 
 
 def _detect_pdf_needs_ocr(file_content: bytes) -> bool:
@@ -974,7 +951,7 @@ class EventProcessor:
                 yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=record_id))
                 return
 
-            metadata_file_match = _match_metadata_file_signature(file_content)
+            metadata_file_match = match_metadata_file_signature(file_content)
             if metadata_file_match:
                 self.logger.info(
                     "❌ Skipping OS metadata file (%s): %s",

--- a/backend/python/app/events/events.py
+++ b/backend/python/app/events/events.py
@@ -100,6 +100,30 @@ def shutdown_pdf_ocr_pool() -> bool:
     return True
 
 
+# OS/filesystem metadata "files" that connectors might occasionally hand us wearing
+# a real document's extension/MIME type.
+_METADATA_FILE_SIGNATURES: dict[str, bytes] = {
+    "AppleDouble": b"\x00\x05\x16\x07",
+    "AppleSingle": b"\x00\x05\x16\x00",
+    "DS_Store": b"\x00\x00\x00\x01BAB1",
+    "BinaryPlist": b"bplist",
+    "OLE_Compound_ThumbsDB": b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1",
+    "WindowsLnk": b"\x4c\x00\x00\x00\x01\x14\x02\x00",
+    "VimSwap": b"Vim!",
+}
+
+
+def _match_metadata_file_signature(file_content: bytes) -> str | None:
+    """Name of the matched signature if *file_content* is OS/filesystem
+    metadata masquerading as a real document, else None."""
+    if not isinstance(file_content, (bytes, bytearray)):
+        return None
+    for name, magic in _METADATA_FILE_SIGNATURES.items():
+        if file_content.startswith(magic):
+            return name
+    return None
+
+
 def _detect_pdf_needs_ocr(file_content: bytes) -> bool:
     logger = logging.getLogger(__name__)
 
@@ -946,6 +970,18 @@ class EventProcessor:
 
             if not file_content or file_content == b"":
                 await self.mark_record_status(doc, ProgressStatus.EMPTY)
+                yield PipelineEvent(event=IndexingEvent.PARSING_COMPLETE, data=PipelineEventData(record_id=record_id))
+                yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=record_id))
+                return
+
+            metadata_file_match = _match_metadata_file_signature(file_content)
+            if metadata_file_match:
+                self.logger.info(
+                    "❌ Skipping OS metadata file (%s): %s",
+                    metadata_file_match,
+                    record_name,
+                )
+                await self.mark_record_status(doc, ProgressStatus.FILE_TYPE_NOT_SUPPORTED)
                 yield PipelineEvent(event=IndexingEvent.PARSING_COMPLETE, data=PipelineEventData(record_id=record_id))
                 yield PipelineEvent(event=IndexingEvent.INDEXING_COMPLETE, data=PipelineEventData(record_id=record_id))
                 return

--- a/backend/python/app/events/events.py
+++ b/backend/python/app/events/events.py
@@ -538,7 +538,10 @@ class EventProcessor:
                 else None
             ),
         }
-        await self.update_record_fields(doc, fields)
+        success = await self.update_record_fields(doc, fields)
+        self._require_persisted(
+            success, f"Failed to persist status {status.value} for record", doc
+        )
         self.logger.debug(
             f"🔍 Record {record_id}: Successfully updated status to {status.value}"
         )

--- a/backend/python/app/events/processor.py
+++ b/backend/python/app/events/processor.py
@@ -460,8 +460,10 @@ class Processor:
                         self.logger.debug(f"⏭️ Skipping empty page {page_number}")
                         continue
 
-                    # Parse each page through DoclingProcessor (no LLM calls)
-                    page_filename = f"{Path(recordName).stem}_page_{page_number}.md"
+                    # Parse each page through DoclingProcessor (no LLM calls).
+                    # Strip leading dots from the stem
+                    safe_stem = Path(recordName).stem.lstrip(".") or "document"
+                    page_filename = f"{safe_stem}_page_{page_number}.md"
                     md_bytes = page_markdown.encode('utf-8')
 
                     try:

--- a/backend/python/app/utils/file_signatures.py
+++ b/backend/python/app/utils/file_signatures.py
@@ -1,0 +1,38 @@
+"""Content-based detection of OS/filesystem metadata "files".
+
+Connectors and manual uploads occasionally hand the indexing pipeline files
+like macOS AppleDouble sidecars (``._name.ext``) or Windows shortcuts that
+carry a real document's extension/MIME type but are not valid documents of
+that type — parsers fail on them with cryptic errors instead of a clean
+"unsupported" status.
+
+Detect these by content, not filename: a sidecar can be renamed, and a
+filename convention (like a leading ``._``) alone is not proof either way.
+
+Only add signatures here that cannot collide with a real, supported document
+format. In particular, do not add generic container magic numbers (e.g. the
+OLE2/CFBF header shared by legacy ``.doc``/``.xls``/``.ppt`` — see
+``_MAGIC_OLE2`` in ``app/agents/actions/util/parse_file.py``) — those would
+misclassify real documents as junk.
+"""
+from __future__ import annotations
+
+METADATA_FILE_SIGNATURES: dict[str, bytes] = {
+    "AppleDouble": b"\x00\x05\x16\x07",
+    "AppleSingle": b"\x00\x05\x16\x00",
+    "DS_Store": b"\x00\x00\x00\x01Bud1",
+    "BinaryPlist": b"bplist",
+    "WindowsLnk": b"\x4c\x00\x00\x00\x01\x14\x02\x00",
+    "VimSwap": b"b0VIM",
+}
+
+
+def match_metadata_file_signature(file_content: bytes) -> str | None:
+    """Name of the matched signature if *file_content* is OS/filesystem
+    metadata masquerading as a real document, else None."""
+    if not isinstance(file_content, (bytes, bytearray)):
+        return None
+    for name, magic in METADATA_FILE_SIGNATURES.items():
+        if file_content.startswith(magic):
+            return name
+    return None

--- a/backend/python/tests/unit/events/test_events.py
+++ b/backend/python/tests/unit/events/test_events.py
@@ -203,6 +203,26 @@ class TestMarkRecordStatusEdgeCases:
         with pytest.raises(Exception, match="fail"):
             await ep.mark_record_status(doc, ProgressStatus.EMPTY)
 
+    @pytest.mark.asyncio
+    async def test_silent_write_failure_raises_indexing_error(self):
+        """A write that fails without raising (update_node returns False,
+        e.g. a transient graph DB write failure) must not be swallowed.
+
+        Without this, mark_record_status would report success on a status
+        that was never actually persisted — leaving the record stuck at its
+        prior status forever, since reconciliation only revisits QUEUED/
+        IN_PROGRESS records and the caller would still yield completion
+        events as if the write had succeeded.
+        """
+        from app.exceptions.indexing_exceptions import IndexingError  # noqa: PLC0415
+
+        ep, _, _, gp = _make_event_processor()
+        gp.update_node = AsyncMock(return_value=False)
+        doc = {"_key": "k8"}
+
+        with pytest.raises(IndexingError):
+            await ep.mark_record_status(doc, ProgressStatus.FILE_TYPE_NOT_SUPPORTED)
+
 
 # ===========================================================================
 # _check_duplicate_by_md5 - Additional Edge Cases

--- a/backend/python/tests/unit/events/test_orchestrator_flow.py
+++ b/backend/python/tests/unit/events/test_orchestrator_flow.py
@@ -484,6 +484,61 @@ async def test_apple_double_sidecar_is_skipped_before_parsing() -> None:
 
 
 @pytest.mark.asyncio
+@patch.dict(os.environ, {"USE_PARSING_SERVICE": "true"})
+async def test_apple_double_sidecar_does_not_complete_if_status_write_fails() -> None:
+    """If persisting FILE_TYPE_NOT_SUPPORTED fails (update_node returns
+    False, not an exception), on_event must raise instead of yielding
+    PARSING_COMPLETE/INDEXING_COMPLETE — otherwise the message would be
+    treated as handled while the record is stuck at its prior status with
+    nothing left to ever revisit it."""
+    parsing_client = MagicMock()
+    parsing_client.circuit_open = False
+    parsing_client.parse = AsyncMock(return_value=_make_parse_result())
+
+    graph_provider = MagicMock()
+    graph_provider.get_document = AsyncMock(return_value={
+        "_key": "rec-1",
+        "orgId": "org-1",
+        "recordName": "._Report.pdf",
+        "recordType": "FILE",
+        "indexingStatus": "NOT_STARTED",
+        "mimeType": "application/pdf",
+        "connectorName": None,
+        "origin": "UPLOAD",
+        "externalRecordId": "ext-rec-1",
+        "connectorId": "connector-1",
+        "createdAtTimestamp": 1000000,
+        "updatedAtTimestamp": 1000000,
+    })
+    graph_provider.get_departments = AsyncMock(return_value=[])
+    graph_provider.batch_upsert_nodes = AsyncMock(return_value=True)
+    graph_provider.batch_update_nodes = AsyncMock(return_value=True)
+    graph_provider.find_duplicate_records = AsyncMock(return_value=[])
+    graph_provider.update_node = AsyncMock(return_value=False)  # simulate write failure
+
+    ep = _make_event_processor(
+        parsing_client=parsing_client,
+        graph_provider=graph_provider,
+    )
+
+    event_data = _make_event_data()
+    event_data["payload"]["recordName"] = "._Report.pdf"
+    event_data["payload"]["buffer"] = b"\x00\x05\x16\x07" + b"\x00" * 32
+
+    from app.exceptions.indexing_exceptions import IndexingError  # noqa: PLC0415
+
+    events = []
+    with pytest.raises(IndexingError):
+        async for event in ep.on_event(event_data):
+            events.append(event)
+
+    # No completion event was yielded before the failed write was surfaced.
+    event_types = [e.event for e in events]
+    assert IndexingEvent.INDEXING_COMPLETE not in event_types
+    parsing_client.parse.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_apple_double_sidecar_is_skipped_in_legacy_pipeline() -> None:
     """Same guard applies when USE_PARSING_SERVICE is unset (legacy dispatch) —
     the check runs before the service/legacy branch, so neither PDF handler

--- a/backend/python/tests/unit/events/test_orchestrator_flow.py
+++ b/backend/python/tests/unit/events/test_orchestrator_flow.py
@@ -440,3 +440,111 @@ async def test_duplicate_record_skips_service_pipeline() -> None:
     parsing_client.parse.assert_not_awaited()
     # Events still yielded for status reporting
     assert len(events) >= 1
+
+
+# ---------------------------------------------------------------------------
+# AppleDouble / OS-metadata sidecar guard (content-based, not filename-based)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, {"USE_PARSING_SERVICE": "true"})
+async def test_apple_double_sidecar_is_skipped_before_parsing() -> None:
+    """A macOS AppleDouble sidecar (detected by magic bytes, not filename)
+    must be marked FILE_TYPE_NOT_SUPPORTED and never reach the parser."""
+    parsing_client = MagicMock()
+    parsing_client.circuit_open = False
+    parsing_client.parse = AsyncMock(return_value=_make_parse_result())
+
+    sink_orchestrator = MagicMock()
+    sink_orchestrator.index = AsyncMock()
+    sink_orchestrator.enrich = AsyncMock()
+
+    ep = _make_event_processor(
+        parsing_client=parsing_client,
+        sink_orchestrator=sink_orchestrator,
+    )
+
+    event_data = _make_event_data()
+    event_data["payload"]["recordName"] = "._Report.pdf"
+    event_data["payload"]["buffer"] = b"\x00\x05\x16\x07" + b"\x00" * 32
+
+    events = []
+    async for event in ep.on_event(event_data):
+        events.append(event)
+
+    parsing_client.parse.assert_not_awaited()
+    sink_orchestrator.index.assert_not_awaited()
+
+    event_types = [e.event for e in events]
+    assert event_types == [IndexingEvent.PARSING_COMPLETE, IndexingEvent.INDEXING_COMPLETE]
+
+    updates = [call.args[2] for call in ep.graph_provider.update_node.await_args_list]
+    assert any(update.get("indexingStatus") == "FILE_TYPE_NOT_SUPPORTED" for update in updates)
+
+
+@pytest.mark.asyncio
+async def test_apple_double_sidecar_is_skipped_in_legacy_pipeline() -> None:
+    """Same guard applies when USE_PARSING_SERVICE is unset (legacy dispatch) —
+    the check runs before the service/legacy branch, so neither PDF handler
+    should ever be invoked."""
+    mock_processor = MagicMock()
+    mock_processor.indexing_pipeline = AsyncMock()
+    mock_processor.process_pdf_with_docling = AsyncMock(return_value=_noop_gen())
+    mock_processor.process_pdf_document_with_ocr = AsyncMock(return_value=_noop_gen())
+
+    ep = _make_event_processor(processor=mock_processor)
+
+    event_data = _make_event_data()
+    event_data["payload"]["recordName"] = "._Report.pdf"
+    event_data["payload"]["buffer"] = b"\x00\x05\x16\x07" + b"\x00" * 32
+
+    events = []
+    async for event in ep.on_event(event_data):
+        events.append(event)
+
+    mock_processor.process_pdf_with_docling.assert_not_called()
+    mock_processor.process_pdf_document_with_ocr.assert_not_called()
+
+    event_types = [e.event for e in events]
+    assert event_types == [IndexingEvent.PARSING_COMPLETE, IndexingEvent.INDEXING_COMPLETE]
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, {"USE_PARSING_SERVICE": "true"})
+async def test_real_pdf_named_with_leading_dot_is_not_skipped() -> None:
+    """A real PDF whose *filename* happens to start with '._' (not an actual
+    AppleDouble sidecar) must still be parsed normally — the guard keys off
+    content magic bytes, never off the filename convention."""
+    parsing_client = MagicMock()
+    parsing_client.circuit_open = False
+    parsing_client.parse = AsyncMock(return_value=_make_parse_result())
+
+    extraction_client = MagicMock()
+    extraction_client.classify = AsyncMock(return_value=None)
+
+    sink_orchestrator = MagicMock()
+    sink_orchestrator.index = AsyncMock()
+    sink_orchestrator.enrich = AsyncMock()
+
+    ep = _make_event_processor(
+        parsing_client=parsing_client,
+        extraction_client=extraction_client,
+        sink_orchestrator=sink_orchestrator,
+    )
+
+    event_data = _make_event_data()
+    event_data["payload"]["recordName"] = "._John_Carter_Report.pdf"
+    event_data["payload"]["buffer"] = b"%PDF-1.7\n" + b"rest of a real pdf"
+
+    events = []
+    async for event in ep.on_event(event_data):
+        events.append(event)
+
+    parsing_client.parse.assert_awaited_once()
+    sink_orchestrator.index.assert_awaited_once()
+
+    updates = [call.args[2] for call in ep.graph_provider.update_node.await_args_list]
+    assert not any(
+        update.get("indexingStatus") == "FILE_TYPE_NOT_SUPPORTED" for update in updates
+    )

--- a/backend/python/tests/unit/utils/test_file_signatures.py
+++ b/backend/python/tests/unit/utils/test_file_signatures.py
@@ -1,0 +1,104 @@
+"""Unit tests for app.utils.file_signatures."""
+
+import pytest
+
+from app.utils.file_signatures import (
+    METADATA_FILE_SIGNATURES,
+    match_metadata_file_signature,
+)
+
+# The OLE2/CFBF container header shared by legacy .doc/.xls/.ppt (and other
+# real formats). Regression guard: this must never be added as a metadata
+# signature, since it would misclassify real documents as junk — see the
+# module docstring in app.utils.file_signatures.
+_OLE2_MAGIC = b"\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1"
+_PDF_MAGIC = b"%PDF-1.7\n"
+_ZIP_MAGIC = b"PK\x03\x04"  # DOCX/XLSX/PPTX (OOXML) container header
+
+
+class TestMetadataFileSignatures:
+    """Structural tests for the signature table itself."""
+
+    def test_is_dict_of_bytes(self):
+        assert isinstance(METADATA_FILE_SIGNATURES, dict)
+        for name, magic in METADATA_FILE_SIGNATURES.items():
+            assert isinstance(name, str)
+            assert isinstance(magic, bytes)
+            assert len(magic) > 0
+
+    def test_apple_double_magic(self):
+        assert METADATA_FILE_SIGNATURES["AppleDouble"] == b"\x00\x05\x16\x07"
+
+    def test_apple_single_magic(self):
+        assert METADATA_FILE_SIGNATURES["AppleSingle"] == b"\x00\x05\x16\x00"
+
+    def test_ds_store_magic_is_bud1_not_bab1(self):
+        # Regression: the real .DS_Store header is "...Bud1", a prior version
+        # of this table had a "BAB1" typo that could never match a real file.
+        assert METADATA_FILE_SIGNATURES["DS_Store"] == b"\x00\x00\x00\x01Bud1"
+
+    def test_no_signature_collides_with_ole2_container(self):
+        # OLE2/CFBF is shared by legacy Office formats; a signature here
+        # that matches it (or is a prefix of it) would silently drop real
+        # .doc/.xls/.ppt documents as unsupported.
+        for magic in METADATA_FILE_SIGNATURES.values():
+            assert not _OLE2_MAGIC.startswith(magic)
+
+    def test_no_signature_collides_with_pdf_or_ooxml(self):
+        for magic in METADATA_FILE_SIGNATURES.values():
+            assert not _PDF_MAGIC.startswith(magic)
+            assert not _ZIP_MAGIC.startswith(magic)
+
+
+class TestMatchMetadataFileSignature:
+    @pytest.mark.parametrize(
+        ("content", "expected_name"),
+        [
+            (b"\x00\x05\x16\x07", "AppleDouble"),
+            (b"\x00\x05\x16\x07\x00\x02\x00\x00" + b"\x00" * 16, "AppleDouble"),
+            (b"\x00\x05\x16\x00", "AppleSingle"),
+            (b"\x00\x00\x00\x01Bud1" + b"\x00" * 32, "DS_Store"),
+            (b"bplist00" + b"\x00" * 10, "BinaryPlist"),
+            (b"\x4c\x00\x00\x00\x01\x14\x02\x00" + b"\x00" * 8, "WindowsLnk"),
+            (b"b0VIM" + b" 8.2\n" + b"\x00" * 10, "VimSwap"),
+        ],
+    )
+    def test_known_signatures_are_matched(self, content, expected_name):
+        assert match_metadata_file_signature(content) == expected_name
+
+    def test_full_multibyte_magic_is_checked_not_just_first_4_bytes(self):
+        # match_metadata_file_signature uses startswith(magic), which checks
+        # the *entire* magic value regardless of its length — there is no
+        # hardcoded 4-byte prefix comparison anywhere in this module. Prove
+        # it for BinaryPlist's 6-byte magic: content sharing only the first
+        # 4 bytes ("bpli") must NOT match, only content sharing all 6 does.
+        assert len(METADATA_FILE_SIGNATURES["BinaryPlist"]) == 6
+        assert match_metadata_file_signature(b"bpliXX" + b"\x00" * 10) is None
+        assert match_metadata_file_signature(b"bplist" + b"\x00" * 10) == "BinaryPlist"
+
+    def test_real_pdf_is_not_matched(self):
+        assert match_metadata_file_signature(_PDF_MAGIC + b"rest of pdf content") is None
+
+    def test_real_ooxml_docx_is_not_matched(self):
+        assert match_metadata_file_signature(_ZIP_MAGIC + b"rest of docx content") is None
+
+    def test_real_ole2_doc_is_not_matched(self):
+        # The exact scenario this table must never regress into matching.
+        assert match_metadata_file_signature(_OLE2_MAGIC + b"rest of doc content") is None
+
+    def test_plain_text_is_not_matched(self):
+        assert match_metadata_file_signature(b"Hello, world!") is None
+
+    def test_empty_bytes_returns_none(self):
+        assert match_metadata_file_signature(b"") is None
+
+    def test_content_shorter_than_magic_returns_none(self):
+        # Truncated/partial AppleDouble magic must not false-match.
+        assert match_metadata_file_signature(b"\x00\x05\x16") is None
+
+    def test_bytearray_input_is_supported(self):
+        assert match_metadata_file_signature(bytearray(b"\x00\x05\x16\x07")) == "AppleDouble"
+
+    @pytest.mark.parametrize("non_bytes", [None, "not bytes", 12345, {}, [], object()])
+    def test_non_bytes_input_returns_none(self, non_bytes):
+        assert match_metadata_file_signature(non_bytes) is None


### PR DESCRIPTION
## Description

metadata files coming from connector source like appleDouble might still carry with them their sibling's mimetype and extension but will fail on parsing. Added a filter to compare the inital bytes of a file with magic bytes of these metadata files and skip them if they match.

Fix Docling ConversionError: File format not allowed for records whose name starts with ._/.: the per-page OCR filename inherited the leading dot, and Docling's DocumentStream format-guesser (unlike its Path-based one) blanks the extension for any name starting with ., causing an ambiguous MIME guess. Now strips leading dots from the stem before building the synthetic page filename (processor.py).

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes. Provide instructions so we can reproduce.]

### Test Configuration

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [ ] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [ ] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

<img width="1917" height="1137" alt="image" src="https://github.com/user-attachments/assets/4f4e784e-4890-4308-ac51-1e638fb4f20d" />
skipping appleDouble files

<img width="1632" height="980" alt="image" src="https://github.com/user-attachments/assets/3c3d1c02-6750-4213-b139-95645c323f7a" />
now marked as filetype not supported

<img width="1635" height="436" alt="image" src="https://github.com/user-attachments/assets/0827ea5b-5804-4463-b251-3b465c7ce25d" />
<img width="1632" height="692" alt="image" src="https://github.com/user-attachments/assets/6befd3ae-5a85-45f4-8f67-44a9bec987b3" />

valid files with just name starting with "._" indexing 

normal files also indexed
<img width="1631" height="927" alt="image" src="https://github.com/user-attachments/assets/7396165a-d7ed-492a-a3df-828432004e57" />

<img width="1631" height="1026" alt="image" src="https://github.com/user-attachments/assets/97579585-a408-4533-90d5-f24516c86fd1" />
Query working

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported operating-system metadata files are now detected and skipped during document processing, preventing unnecessary parsing and indexing.
  * Valid documents with similar filenames continue to be processed normally.
  * OCR-generated page filenames now handle hidden files more reliably and use a fallback name when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->