### PR TITLE
refactor(chat): split messages out of conversations/agentConversation…

### DIFF
--- a/backend/env.template
+++ b/backend/env.template
@@ -80,6 +80,13 @@ REDIS_KV_PREFIX=pipeshub:kv:
 MONGO_URI=mongodb://admin:password@localhost:27017/
 MONGO_DB_NAME=enterprise-search
 
+# Phase 2 one-time backfill: number of legacy `conversations` /
+# `agentconversations` documents copied into chatSessions/chatSessionMessages
+# per batch on Node boot. Runs in the background after the KB-filters
+# migration completes; lower this if legacy documents are large enough that
+# BATCH_SIZE x document size becomes memory pressure. Default: 10.
+# CHAT_SESSIONS_MIGRATION_BATCH_SIZE=10
+
 QDRANT_API_KEY=your_qdrant_secret_api_key
 QDRANT_HOST=localhost
 QDRANT_GRPC_PORT=6334

--- a/backend/nodejs/apps/src/libs/services/mongo.service.ts
+++ b/backend/nodejs/apps/src/libs/services/mongo.service.ts
@@ -31,6 +31,8 @@ const REQUIRED_COLLECTIONS = [
   'authorizationCodes',
   'conversations',
   'agentconversations',
+  'chatSessions',
+  'chatSessionMessages',
   'connectorsConfig',
   'citation',
   'citations',

--- a/backend/nodejs/apps/src/modules/configuration_manager/paths/paths.ts
+++ b/backend/nodejs/apps/src/modules/configuration_manager/paths/paths.ts
@@ -45,6 +45,9 @@ export const configPaths = {
   chatKbFiltersMigration: '/migrations/chat_kb_filters_v1',
   adminRoleMigration: '/migrations/admin_role_v1',
   documentOrgIdMigration: '/migrations/document_orgid_v1',
+  // Value: JSON.stringify({ conversationsMigrated, agentConversationsMigrated, ... }).
+  // See chat_sessions.migration.ts.
+  chatSessionsMigration: '/migrations/chat_sessions_v1',
   // Python-owned flag (backend/python/app/migrations/kb_apps_migration.py) — read-only from Node.
   kbAppsMigrationDone: '/migrations/kb_apps_v1',
   webSearch: '/services/webSearch',

--- a/backend/nodejs/apps/src/modules/configuration_manager/services/migration.service.ts
+++ b/backend/nodejs/apps/src/modules/configuration_manager/services/migration.service.ts
@@ -101,11 +101,14 @@ export class MigrationService {
   async chatSessionsMigration(): Promise<void> {
     this.logger.info('Migrating legacy conversations into chatSessions');
     try {
-      const batchSize = parseInt(
-        process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE ||
-          String(DEFAULT_CHAT_SESSIONS_MIGRATION_BATCH_SIZE),
+      const configuredBatchSize = Number.parseInt(
+        process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE ?? '',
         10,
       );
+      const batchSize =
+        Number.isInteger(configuredBatchSize) && configuredBatchSize > 0
+          ? configuredBatchSize
+          : DEFAULT_CHAT_SESSIONS_MIGRATION_BATCH_SIZE;
       const result = await new ChatSessionsMigration(
         this.logger,
         this.keyValueStoreService,

--- a/backend/nodejs/apps/src/modules/configuration_manager/services/migration.service.ts
+++ b/backend/nodejs/apps/src/modules/configuration_manager/services/migration.service.ts
@@ -14,7 +14,10 @@ import { ScheduledJobsBackfillMigration } from './migrations/scheduled_jobs_back
 import { ChatKbFiltersMigration } from './migrations/chat_kb_filters.migration';
 import { AdminRoleMigration } from './migrations/admin_role.migration';
 import { DocumentOrgIdBackfillMigration } from './migrations/document_orgid_backfill.migration';
+import { ChatSessionsMigration } from './migrations/chat_sessions.migration';
 import { Org } from '../../user_management/schema/org.schema';
+
+const DEFAULT_CHAT_SESSIONS_MIGRATION_BATCH_SIZE = 10;
 
 export interface MigrationDependencies {
   scheduler: CrawlingSchedulerService;
@@ -41,6 +44,7 @@ export class MigrationService {
     // await this.aiModelsMigration();  NO LONGER NEEDED
     await this.connectorSyncScheduleMigration(deps.scheduler, deps.appConfig);
     await this.chatKbFiltersMigration();
+    await this.chatSessionsMigration();
     await this.adminRoleMigration();
     await this.documentOrgIdMigration();
     this.logger.info('✅ Migration completed');
@@ -89,6 +93,35 @@ export class MigrationService {
       }
     } catch (error) {
       this.logger.error('Chat KB-filters migration failed', {
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+
+  async chatSessionsMigration(): Promise<void> {
+    this.logger.info('Migrating legacy conversations into chatSessions');
+    try {
+      const batchSize = parseInt(
+        process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE ||
+          String(DEFAULT_CHAT_SESSIONS_MIGRATION_BATCH_SIZE),
+        10,
+      );
+      const result = await new ChatSessionsMigration(
+        this.logger,
+        this.keyValueStoreService,
+        batchSize,
+      ).run();
+
+      if (result.errored > 0) {
+        this.logger.warn(
+          '⚠️  Chat sessions migration finished with errors — will retry unmigrated documents on next boot',
+          result,
+        );
+      } else {
+        this.logger.info('✅ Chat sessions migrated', result);
+      }
+    } catch (error) {
+      this.logger.error('Chat sessions migration failed', {
         error: error instanceof Error ? error.message : 'Unknown error',
       });
     }

--- a/backend/nodejs/apps/src/modules/configuration_manager/services/migrations/chat_sessions.migration.ts
+++ b/backend/nodejs/apps/src/modules/configuration_manager/services/migrations/chat_sessions.migration.ts
@@ -176,11 +176,18 @@ export class ChatSessionsMigration {
     let messagesMigrated = 0;
     let errored = 0;
 
-    // No `skip` — a successfully migrated document is flagged and drops out
-    // of this same filter, so the next iteration naturally advances.
+    // Advance by `_id` rather than relying on the `isMigrated` flag alone to
+    // drop rows out of the filter: a document that fails is deliberately left
+    // unflagged, so without a cursor it sorts back to the front of the very
+    // next scan and this loop spins on it forever. Failures are retried on the
+    // next boot instead, when the cursor restarts from the beginning.
+    let lastId: unknown = null;
     for (;;) {
       const batch = await spec.legacyModel
-        .find({ isMigrated: { $ne: true } })
+        .find({
+          isMigrated: { $ne: true },
+          ...(lastId ? { _id: { $gt: lastId } } : {}),
+        })
         .sort({ _id: 1 })
         .limit(this.batchSize)
         .lean();
@@ -188,6 +195,16 @@ export class ChatSessionsMigration {
       if (batch.length === 0) {
         break;
       }
+
+      const batchLastId = batch[batch.length - 1]?._id;
+      if (!batchLastId) {
+        this.logger.error(
+          `Chat sessions migration for ${spec.legacyLabel} stopped: scanned a document without an _id, cannot advance the cursor safely`,
+        );
+        errored += 1;
+        break;
+      }
+      lastId = batchLastId;
 
       for (const doc of batch) {
         try {
@@ -258,6 +275,25 @@ export class ChatSessionsMigration {
     const messages: any[] = Array.isArray(doc.messages) ? doc.messages : [];
 
     if (messages.length > 0) {
+      // Both checks below have to happen before the bulkWrite: an `_id`-keyed
+      // upsert per message silently collapses duplicates (and, with a missing
+      // `_id`, collapses every message onto one `{_id: undefined}` filter),
+      // which is unrecoverable data loss once written.
+      const messageIds = messages.map((message) => message._id);
+      if (messageIds.some((id) => id === undefined || id === null)) {
+        throw new Error(
+          `Session ${String(doc._id)} has message(s) without an _id; refusing to copy (an _id-keyed upsert would collapse them)`,
+        );
+      }
+      const distinctMessageIdCount = new Set(
+        messageIds.map((id) => String(id)),
+      ).size;
+      if (distinctMessageIdCount !== messages.length) {
+        throw new Error(
+          `Session ${String(doc._id)} has duplicate message _id(s): ${messages.length} messages but only ${distinctMessageIdCount} distinct ids`,
+        );
+      }
+
       const messageOps = messages.map((message, index) => {
         const { _id, ...rest } = message;
         return {
@@ -281,18 +317,23 @@ export class ChatSessionsMigration {
         ordered: true,
       });
 
-      // Verify by counting actual stored documents for this session, not the
-      // bulkWrite result's matched/upserted counters: a duplicate message
-      // `_id` within one legacy array would still report as "written" via
-      // those counters (insert + a no-op matched upsert) while silently
-      // collapsing two messages into one stored row. Counting real rows for
-      // this sessionId catches that.
+      // Verify against actually stored rows rather than the bulkWrite
+      // result's matched/upserted counters, which report a no-op matched
+      // upsert as "written".
+      //
+      // Scoped to the ids just copied rather than every row for this
+      // sessionId: if an earlier attempt crashed after the ChatSession upsert
+      // but before the `isMigrated` write, that session is already live and
+      // may have accumulated newer messages. An unscoped count would then
+      // exceed messages.length on every retry and strand the document
+      // permanently unmigrated.
       const storedCount = await ChatSessionMessage.countDocuments({
         sessionId: doc._id,
+        _id: { $in: messageIds },
       });
       if (storedCount !== messages.length) {
         throw new Error(
-          `Message count mismatch for session ${doc._id}: expected ${messages.length}, found ${storedCount} (likely duplicate message _id in the legacy array)`,
+          `Message count mismatch for session ${String(doc._id)}: expected ${messages.length}, found ${storedCount}`,
         );
       }
     }

--- a/backend/nodejs/apps/src/modules/configuration_manager/services/migrations/chat_sessions.migration.ts
+++ b/backend/nodejs/apps/src/modules/configuration_manager/services/migrations/chat_sessions.migration.ts
@@ -1,0 +1,427 @@
+import { Model } from 'mongoose';
+import { Logger } from '../../../../libs/services/logger.service';
+import { KeyValueStoreService } from '../../../../libs/services/keyValueStore.service';
+import { configPaths } from '../../paths/paths';
+import { Conversation } from '../../../enterprise_search/schema/conversation.schema';
+import { AgentConversation } from '../../../enterprise_search/schema/agent.conversation.schema';
+import { ChatSession } from '../../../enterprise_search/schema/chat.session.schema';
+import { ChatSessionMessage } from '../../../enterprise_search/schema/chat.session.message.schema';
+
+type LegacyModel = Model<any>;
+
+const DEFAULT_BATCH_SIZE = 10;
+/** Bounded sample used for the pre-flight schema-drift key audit. */
+const SCHEMA_DRIFT_SAMPLE_SIZE = 50;
+
+interface ChatSessionsMigrationFlag {
+  conversationsMigrated?: boolean;
+  agentConversationsMigrated?: boolean;
+  migratedAt?: Partial<Record<'chat' | 'agent', string>>;
+  totals?: Partial<Record<'chat' | 'agent', { sessions: number; messages: number }>>;
+}
+
+interface CollectionSpec {
+  flagKey: 'conversationsMigrated' | 'agentConversationsMigrated';
+  sessionType: 'chat' | 'agent';
+  legacyModel: LegacyModel;
+  /** Actual Mongo collection name — 'agentconversations', lowercase, not 'agentConversations'. */
+  legacyLabel: string;
+}
+
+/**
+ * Phase 2: one-time backfill that copies every document out of the frozen
+ * legacy `conversations` / `agentconversations` collections into
+ * `chatSessions` + `chatSessionMessages` (the Phase 1 runtime model — see
+ * chat.session.schema.ts / chat.session.message.schema.ts). Phase 1 already
+ * stopped writing to the legacy collections, but `chatSessions` /
+ * `chatSessionMessages` are live the whole time this runs — Phase 1 sends
+ * every new chat straight there. That rules out any collection-level count
+ * comparison as a completion gate (`chatSessions.countDocuments({sessionType})`
+ * grows from ordinary live usage, independent of this migration, and a user
+ * can resume chatting on a session the instant it's migrated, growing
+ * `chatSessionMessages` past what the legacy array recorded). The only count
+ * check that holds under live traffic is per-document, immediately after
+ * that document's own write and before its session exists to be chattable —
+ * see the `storedCount` check in `migrateDocument`.
+ *
+ * Resumable at two granularities:
+ *   - per document, via an `isMigrated` flag on the legacy schema (crash
+ *     mid-run simply leaves some documents unflagged, retried next boot);
+ *   - per collection, via one KV flag object holding a boolean per legacy
+ *     collection, set once every document in that collection has been
+ *     copied with zero errors.
+ *
+ * Depends on `ChatKbFiltersMigration` having completed, since that migration
+ * rewrites `messages[].appliedFilters` on these same legacy documents — if
+ * this migration ran first, that fix would land on documents nobody reads
+ * any more. Node migrations run sequentially in `MigrationService`, but the
+ * KB-filters migration can defer for minutes waiting on a Python flag and
+ * return without completing, so this explicitly re-checks its flag rather
+ * than relying on call order alone.
+ */
+export class ChatSessionsMigration {
+  private readonly batchSize: number;
+
+  constructor(
+    private readonly logger: Logger,
+    private readonly kvStore: KeyValueStoreService,
+    batchSize?: number,
+  ) {
+    this.batchSize =
+      batchSize && batchSize > 0 ? batchSize : DEFAULT_BATCH_SIZE;
+  }
+
+  async run(): Promise<{
+    sessionsMigrated: number;
+    messagesMigrated: number;
+    errored: number;
+  }> {
+    const kbFiltersDone = await this.isKbFiltersMigrationDone();
+    if (!kbFiltersDone) {
+      this.logger.info(
+        'Chat KB-filters migration has not completed yet; deferring chat sessions migration to next boot',
+      );
+      return { sessionsMigrated: 0, messagesMigrated: 0, errored: 0 };
+    }
+
+    const flag = await this.readFlag();
+
+    const specs: CollectionSpec[] = [
+      {
+        flagKey: 'conversationsMigrated',
+        sessionType: 'chat',
+        legacyModel: Conversation,
+        legacyLabel: 'conversations',
+      },
+      {
+        flagKey: 'agentConversationsMigrated',
+        sessionType: 'agent',
+        legacyModel: AgentConversation,
+        legacyLabel: 'agentconversations',
+      },
+    ];
+
+    let sessionsMigrated = 0;
+    let messagesMigrated = 0;
+    let errored = 0;
+
+    for (const spec of specs) {
+      if (flag[spec.flagKey]) {
+        this.logger.info(
+          `Chat sessions migration for ${spec.legacyLabel} already completed; skipping`,
+        );
+        continue;
+      }
+
+      const result = await this.migrateCollection(spec);
+      sessionsMigrated += result.sessionsMigrated;
+      messagesMigrated += result.messagesMigrated;
+      errored += result.errored;
+
+      if (result.errored === 0) {
+        flag[spec.flagKey] = true;
+        flag.migratedAt = {
+          ...flag.migratedAt,
+          [spec.sessionType]: new Date().toISOString(),
+        };
+        flag.totals = {
+          ...flag.totals,
+          [spec.sessionType]: {
+            sessions: result.sessionsMigrated,
+            messages: result.messagesMigrated,
+          },
+        };
+        await this.writeFlag(flag);
+      }
+    }
+
+    return { sessionsMigrated, messagesMigrated, errored };
+  }
+
+  // ---------------------------------------------------------------------
+  // Per-collection orchestration
+  // ---------------------------------------------------------------------
+
+  private async migrateCollection(spec: CollectionSpec): Promise<{
+    sessionsMigrated: number;
+    messagesMigrated: number;
+    errored: number;
+  }> {
+    this.logger.info(
+      `Starting chat sessions migration for ${spec.legacyLabel}`,
+    );
+    const startedAt = Date.now();
+
+    // Pre-flight: a document with no orgId would migrate to messages with no
+    // orgId, invisible to org-scoped content search and impossible to detect
+    // after the fact via the native-driver copy. Hard-stop instead.
+    const missingOrgIdCount = await spec.legacyModel.countDocuments({
+      $or: [{ orgId: { $exists: false } }, { orgId: null }],
+    });
+    if (missingOrgIdCount > 0) {
+      this.logger.error(
+        `Chat sessions migration aborted for ${spec.legacyLabel}: ${missingOrgIdCount} document(s) missing orgId`,
+        { legacyLabel: spec.legacyLabel, missingOrgIdCount },
+      );
+      return {
+        sessionsMigrated: 0,
+        messagesMigrated: 0,
+        errored: missingOrgIdCount,
+      };
+    }
+
+    await this.auditSchemaDrift(spec);
+
+    let sessionsMigrated = 0;
+    let messagesMigrated = 0;
+    let errored = 0;
+
+    // No `skip` — a successfully migrated document is flagged and drops out
+    // of this same filter, so the next iteration naturally advances.
+    for (;;) {
+      const batch = await spec.legacyModel
+        .find({ isMigrated: { $ne: true } })
+        .sort({ _id: 1 })
+        .limit(this.batchSize)
+        .lean();
+
+      if (batch.length === 0) {
+        break;
+      }
+
+      for (const doc of batch) {
+        try {
+          const migratedMessageCount = await this.migrateDocument(doc, spec);
+          sessionsMigrated += 1;
+          messagesMigrated += migratedMessageCount;
+        } catch (error) {
+          errored += 1;
+          this.logger.error(
+            `Failed to migrate a ${spec.legacyLabel} document — left unmigrated, will retry on next boot`,
+            {
+              documentId: doc._id?.toString(),
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      }
+
+      this.logger.info(`Chat sessions migration progress for ${spec.legacyLabel}`, {
+        sessionsMigrated,
+        messagesMigrated,
+        errored,
+        elapsedMs: Date.now() - startedAt,
+      });
+    }
+
+    if (errored > 0) {
+      this.logger.warn(
+        `Chat sessions migration for ${spec.legacyLabel} finished with errors — completion flag NOT written, unmigrated documents retried on next boot`,
+        { sessionsMigrated, messagesMigrated, errored },
+      );
+      return { sessionsMigrated, messagesMigrated, errored };
+    }
+
+    this.logger.info(`✅ Chat sessions migration for ${spec.legacyLabel} complete`, {
+      sessionsMigrated,
+      messagesMigrated,
+      elapsedMs: Date.now() - startedAt,
+    });
+
+    return { sessionsMigrated, messagesMigrated, errored };
+  }
+
+  // ---------------------------------------------------------------------
+  // Per-document copy
+  // ---------------------------------------------------------------------
+
+  /**
+   * Copies one legacy document's messages then the session itself, via the
+   * native driver (never `new ChatSession(doc)` / `new ChatSessionMessage(doc)`
+   * — Mongoose strict mode silently drops any path not declared on the
+   * target schema, which would be silent data loss here). `.lean()` reads
+   * mean the values are already BSON-correct going back out.
+   *
+   * Write order is messages, then session, then the `isMigrated` flag: a
+   * crash between steps leaves an interrupted document simply invisible
+   * (no session row yet) rather than visible with missing history.
+   *
+   * Every write is an `_id`-keyed `$setOnInsert` upsert, never `$set` /
+   * `replaceOne` — users keep chatting on already-migrated sessions, so a
+   * stray re-run must not revert `status`, `lastActivityAt`, or title edits
+   * made after the copy.
+   */
+  private async migrateDocument(
+    doc: any,
+    spec: CollectionSpec,
+  ): Promise<number> {
+    const messages: any[] = Array.isArray(doc.messages) ? doc.messages : [];
+
+    if (messages.length > 0) {
+      const messageOps = messages.map((message, index) => {
+        const { _id, ...rest } = message;
+        return {
+          updateOne: {
+            filter: { _id },
+            update: {
+              $setOnInsert: {
+                ...rest,
+                _id,
+                sessionId: doc._id,
+                orgId: doc.orgId,
+                seq: index + 1, // array order, not createdAt — see plan fix #2
+              },
+            },
+            upsert: true,
+          },
+        };
+      });
+
+      await ChatSessionMessage.collection.bulkWrite(messageOps, {
+        ordered: true,
+      });
+
+      // Verify by counting actual stored documents for this session, not the
+      // bulkWrite result's matched/upserted counters: a duplicate message
+      // `_id` within one legacy array would still report as "written" via
+      // those counters (insert + a no-op matched upsert) while silently
+      // collapsing two messages into one stored row. Counting real rows for
+      // this sessionId catches that.
+      const storedCount = await ChatSessionMessage.countDocuments({
+        sessionId: doc._id,
+      });
+      if (storedCount !== messages.length) {
+        throw new Error(
+          `Message count mismatch for session ${doc._id}: expected ${messages.length}, found ${storedCount} (likely duplicate message _id in the legacy array)`,
+        );
+      }
+    }
+
+    const { messages: _messages, isMigrated: _isMigrated, __v: _v, ...sessionFields } = doc;
+    await ChatSession.collection.updateOne(
+      { _id: doc._id },
+      {
+        $setOnInsert: {
+          ...sessionFields,
+          _id: doc._id,
+          sessionType: spec.sessionType,
+          nextSeq: messages.length,
+          __v: 0,
+        },
+      },
+      { upsert: true },
+    );
+
+    await spec.legacyModel.collection.updateOne(
+      { _id: doc._id },
+      { $set: { isMigrated: true } },
+    );
+
+    return messages.length;
+  }
+
+  // ---------------------------------------------------------------------
+  // Pre-flight audits
+  // ---------------------------------------------------------------------
+
+  /**
+   * Sample legacy documents and log any top-level field the chatSessions
+   * schema doesn't know about. A verbatim copy can't detect schema drift on
+   * its own — this is a warning, not a hard stop, since an unexpected field
+   * is still copied through (only fields explicitly excluded above are
+   * dropped on purpose).
+   */
+  private async auditSchemaDrift(spec: CollectionSpec): Promise<void> {
+    const sample = await spec.legacyModel
+      .find({})
+      .sort({ _id: -1 })
+      .limit(SCHEMA_DRIFT_SAMPLE_SIZE)
+      .lean();
+
+    if (sample.length === 0) {
+      return;
+    }
+
+    const known = new Set<string>();
+    for (const path of Object.keys(ChatSession.schema.paths)) {
+      known.add(path.split('.')[0] || path);
+    }
+    known.add('messages'); // handled separately, excluded from the session copy on purpose
+    known.add('isMigrated'); // legacy-only bookkeeping, excluded from the session copy on purpose
+
+    const unknown = new Set<string>();
+    for (const legacyDoc of sample) {
+      for (const key of Object.keys(legacyDoc)) {
+        if (!known.has(key)) {
+          unknown.add(key);
+        }
+      }
+    }
+
+    if (unknown.size > 0) {
+      this.logger.warn(
+        `Chat sessions migration: sampled ${spec.legacyLabel} documents contain fields not present on the chatSessions schema`,
+        {
+          legacyLabel: spec.legacyLabel,
+          unknownFields: Array.from(unknown),
+          sampleSize: sample.length,
+        },
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // KV flags
+  // ---------------------------------------------------------------------
+
+  private async isKbFiltersMigrationDone(): Promise<boolean> {
+    try {
+      const flag = await this.kvStore.get<string>(
+        configPaths.chatKbFiltersMigration,
+      );
+      return flag === 'true';
+    } catch (error) {
+      this.logger.warn(
+        'Failed to read chat KB-filters migration flag; deferring chat sessions migration to next boot',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return false;
+    }
+  }
+
+  private async readFlag(): Promise<ChatSessionsMigrationFlag> {
+    try {
+      const raw = await this.kvStore.get<string>(
+        configPaths.chatSessionsMigration,
+      );
+      if (!raw) {
+        return {};
+      }
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') {
+        return {};
+      }
+      return parsed as ChatSessionsMigrationFlag;
+    } catch (error) {
+      this.logger.warn(
+        'Failed to read/parse chat sessions migration flag; treating both collections as not-yet-migrated',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+      return {};
+    }
+  }
+
+  private async writeFlag(flag: ChatSessionsMigrationFlag): Promise<void> {
+    try {
+      await this.kvStore.set(
+        configPaths.chatSessionsMigration,
+        JSON.stringify(flag),
+      );
+    } catch (error) {
+      this.logger.warn(
+        'Chat sessions migration succeeded but failed to persist the completion flag; will retry on next boot',
+        { error: error instanceof Error ? error.message : String(error) },
+      );
+    }
+  }
+}

--- a/backend/nodejs/apps/src/modules/enterprise_search/constants/constants.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/constants/constants.ts
@@ -58,6 +58,14 @@ export const REASONING_EFFORT_VALUES = [
 
 export type ReasoningEffort = (typeof REASONING_EFFORT_VALUES)[number];
 
+// `chatSessions` discriminator predicates. Applied at buildFilter /
+// buildAgentConversationFilter call sites and at every id-only mutation
+// (findByIdAndUpdate → findOneAndUpdate) now that both session types share
+// one collection — without this, a plain-chat route could mutate an agent
+// session (or vice versa) purely by guessing/reusing an _id.
+export const EXCLUDE_AGENT = { sessionType: 'chat' } as const;
+export const ONLY_AGENT = { sessionType: 'agent' } as const;
+
 export const PIPESHUB_CHAT_MODE = {
   WEB_SEARCH: 'web_search',
   INTERNAL_SEARCH: 'internal_search',

--- a/backend/nodejs/apps/src/modules/enterprise_search/controller/es_controller.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/controller/es_controller.ts
@@ -47,13 +47,15 @@ import {
   IAgentConversation,
   IAIModel,
   IAIResponse,
-  IConversationDocument,
+  IChatSession,
+  IChatSessionDocument,
   IMessage,
   IMessageCitation,
   IMessageDocument,
 } from '../types/conversation.interfaces';
 import { IConversation } from '../types/conversation.interfaces';
-import { Conversation } from '../schema/conversation.schema';
+import { ChatSession } from '../schema/chat.session.schema';
+import { ChatSessionMessage } from '../schema/chat.session.message.schema';
 import { HTTP_STATUS } from '../../../libs/enums/http-status.enum';
 import {
   addComputedFields,
@@ -71,6 +73,12 @@ import {
   getPaginationParams,
   sortMessages,
   attachPopulatedCitations,
+  appendMessages,
+  getMessages,
+  attachMessages,
+  appendMessageFeedback,
+  findSessionIdsMatchingContent,
+  validateAndEscapeSearch,
 } from '../utils/utils';
 import {
   AGUIEventType,
@@ -88,11 +96,11 @@ import Citation, {
   AiSearchResponse,
   ICitation,
 } from '../schema/citation.schema';
-import { CONVERSATION_STATUS } from '../constants/constants';
 import {
-  AgentConversation,
-  IAgentConversationDocument,
-} from '../schema/agent.conversation.schema';
+  CONVERSATION_STATUS,
+  EXCLUDE_AGENT,
+  ONLY_AGENT,
+} from '../constants/constants';
 import { Users } from '../../user_management/schema/users.schema';
 import { KeyValueStoreService } from '../../../libs/services/keyValueStore.service';
 import { AuthTokenService } from '../../../libs/services/authtoken.service';
@@ -784,7 +792,7 @@ export const streamChat =
     const orgId = req.user?.orgId;
 
     let session: ClientSession | null = null;
-    let savedConversation: IConversationDocument | null = null;
+    let savedConversation: IChatSessionDocument | null = null;
 
     const modelInfo = extractModelInfo(req.body);
     const protocol = resolveProtocol(
@@ -815,28 +823,39 @@ export const streamChat =
         req.body.attachments,
       );
 
-      const userConversationData: Partial<IConversation> = {
+      const userConversationData: Partial<IChatSession> = {
         orgId,
         userId,
         initiator: userId,
         title: req.body.query.slice(0, 100),
-        messages: [userQueryMessage] as IMessageDocument[],
         lastActivityAt: Date.now(),
         status: CONVERSATION_STATUS.INPROGRESS,
         // Store model and mode information
         modelInfo: modelInfo,
+        sessionType: 'chat',
       };
 
       // Start transaction if replica set is available
       if (rsAvailable) {
         session = await mongoose.startSession();
         await session.withTransaction(async () => {
-          const conversation = new Conversation(userConversationData);
+          const conversation = new ChatSession(userConversationData);
           savedConversation = await conversation.save({ session });
+          await appendMessages(
+            savedConversation._id as mongoose.Types.ObjectId,
+            orgId as mongoose.Types.ObjectId,
+            [userQueryMessage],
+            session,
+          );
         });
       } else {
-        const conversation = new Conversation(userConversationData);
+        const conversation = new ChatSession(userConversationData);
         savedConversation = await conversation.save();
+        await appendMessages(
+          savedConversation._id as mongoose.Types.ObjectId,
+          orgId as mongoose.Types.ObjectId,
+          [userQueryMessage],
+        );
       }
 
       if (!savedConversation) {
@@ -990,7 +1009,7 @@ export const streamChat =
                 upstreamAiErrorEventForwarded = true;
                 if (savedConversation) {
                   void markConversationFailed(
-                    savedConversation as IConversationDocument,
+                    savedConversation,
                     errorMessage,
                     session,
                     'streaming_error',
@@ -1045,7 +1064,7 @@ export const streamChat =
                       ? new Map(Object.entries(errorData.metadata as Record<string, unknown>))
                       : undefined;
                   void markConversationFailed(
-                    savedConversation as IConversationDocument,
+                    savedConversation,
                     errorMessage,
                     session,
                     'streaming_error',
@@ -1069,7 +1088,7 @@ export const streamChat =
                 if (savedConversation) {
                   const parseFailMsg = `Failed to parse error event: ${parseError.message}`;
                   void markConversationFailed(
-                    savedConversation as IConversationDocument,
+                    savedConversation,
                     parseFailMsg,
                     session,
                     'parse_error',
@@ -1097,9 +1116,10 @@ export const streamChat =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void Conversation.findByIdAndUpdate(
-                    savedConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    savedConversation._id as mongoose.Types.ObjectId,
+                    savedConversation.orgId,
+                    [toolCallMessage],
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -1129,9 +1149,10 @@ export const streamChat =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void Conversation.findByIdAndUpdate(
-                    savedConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    savedConversation._id as mongoose.Types.ObjectId,
+                    savedConversation.orgId,
+                    [toolCallMessage],
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -1201,12 +1222,14 @@ export const streamChat =
             );
           } else if (!upstreamAiErrorEventForwarded) {
             // Mark as failed if no complete data received (and AI did not already send error SSE)
-            await markConversationFailed(
-              savedConversation as IConversationDocument,
-              'No complete response received from AI service',
-              session,
-              'incomplete_response',
-            );
+            if (savedConversation) {
+              await markConversationFailed(
+                savedConversation,
+                'No complete response received from AI service',
+                session,
+                'incomplete_response',
+              );
+            }
 
             // Send error event
             res.write(
@@ -1229,7 +1252,7 @@ export const streamChat =
 
           if (savedConversation) {
             await markConversationFailed(
-              savedConversation as IConversationDocument,
+              savedConversation,
               `Failed to save conversation: ${dbError.message}`,
               session,
               'database_error',
@@ -1260,7 +1283,7 @@ export const streamChat =
           // Mark conversation as failed
           if (savedConversation) {
             await markConversationFailed(
-              savedConversation as IConversationDocument,
+              savedConversation,
               `Stream error: ${error.message}`,
               session,
               'stream_error',
@@ -1294,7 +1317,7 @@ export const streamChat =
         // Mark conversation as failed if it was created
         if (savedConversation) {
           await markConversationFailed(
-            savedConversation as IConversationDocument,
+            savedConversation,
             error.message || 'Internal server error',
             session,
             'internal_error',
@@ -1452,24 +1475,30 @@ export const createConversation =
         req.body.attachments,
       );
 
-      const userConversationData: Partial<IConversation> = {
+      const userConversationData: Partial<IChatSession> = {
         orgId,
         userId,
         initiator: userId,
         title: req.body.query.slice(0, 100),
-        messages: [userQueryMessage] as IMessageDocument[],
         lastActivityAt: Date.now(),
         status: CONVERSATION_STATUS.INPROGRESS,
         modelInfo: modelInfo,
+        sessionType: 'chat',
       };
 
-      const conversation = new Conversation(userConversationData);
+      const conversation = new ChatSession(userConversationData);
       const savedConversation = session
         ? await conversation.save({ session })
         : await conversation.save();
       if (!savedConversation) {
         throw new InternalServerError('Failed to create conversation');
       }
+      await appendMessages(
+        savedConversation._id as mongoose.Types.ObjectId,
+        savedConversation.orgId,
+        [userQueryMessage],
+        session,
+      );
 
       const aiCommandOptions: AICommandOptions = {
         uri: `${appConfig.aiBackend}/api/v1/chat`,
@@ -1540,9 +1569,14 @@ export const createConversation =
           aiResponseData,
           citations,
           modelInfo,
-        ) as IMessageDocument;
+        );
         // Add the AI message to the conversation
-        savedConversation.messages.push(aiResponseMessage);
+        const [insertedAiMessage] = await appendMessages(
+          savedConversation._id as mongoose.Types.ObjectId,
+          savedConversation.orgId,
+          [aiResponseMessage],
+          session,
+        );
         savedConversation.lastActivityAt = Date.now();
         savedConversation.status = CONVERSATION_STATUS.COMPLETE; // Successful conversation
 
@@ -1554,10 +1588,9 @@ export const createConversation =
           throw new InternalServerError('Failed to update conversation');
         }
         const responseConversation = await attachPopulatedCitations(
-          updatedConversation._id as mongoose.Types.ObjectId,
-          updatedConversation.toObject() as IConversation,
+          updatedConversation.toObject(),
+          [insertedAiMessage!.toObject()],
           citations,
-          false,
           session,
         );
         return {
@@ -1578,9 +1611,13 @@ export const createConversation =
             error.message || 'Unknown error occurred';
         }
         // persist and serve the error message to the user.
-        const failedMessage =
-          buildAIFailureResponseMessage() as IMessageDocument;
-        savedConversation.messages.push(failedMessage);
+        const failedMessage = buildAIFailureResponseMessage();
+        await appendMessages(
+          savedConversation._id as mongoose.Types.ObjectId,
+          savedConversation.orgId,
+          [failedMessage],
+          session,
+        );
         savedConversation.lastActivityAt = Date.now();
 
         const savedWithError = session
@@ -1744,11 +1781,12 @@ export const addMessage =
       // Extract common operations into a helper function.
       async function performAddMessage(session?: ClientSession | null) {
         // Get existing conversation
-        const conversation = await Conversation.findOne({
+        const conversation = await ChatSession.findOne({
           _id: req.params.conversationId,
           orgId,
           userId,
           isDeleted: false,
+          ...EXCLUDE_AGENT,
         });
 
         if (!conversation) {
@@ -1763,7 +1801,11 @@ export const addMessage =
         // in case of bot_response message
         // Format previous conversations for context
         const previousConversations = formatPreviousConversations(
-          conversation.messages,
+          (await getMessages(
+            conversation._id as mongoose.Types.ObjectId,
+            {},
+            session,
+          )) as IMessage[],
         );
         logger.debug('Previous conversations', {
           previousConversations,
@@ -1776,7 +1818,12 @@ export const addMessage =
           req.body.attachments,
         );
         // First, add the user message to the existing conversation
-        conversation.messages.push(userQueryMessage as IMessageDocument);
+        await appendMessages(
+          conversation._id as mongoose.Types.ObjectId,
+          conversation.orgId,
+          [userQueryMessage],
+          session,
+        );
         conversation.lastActivityAt = Date.now();
 
         // Save the user message to the existing conversation first
@@ -1892,9 +1939,14 @@ export const addMessage =
             aiResponseData,
             savedCitations,
             modelInfo,
-          ) as IMessageDocument;
+          );
           // Add the AI message to the existing conversation
-          savedConversation.messages.push(aiResponseMessage);
+          const [insertedAiMessage] = await appendMessages(
+            savedConversation._id as mongoose.Types.ObjectId,
+            savedConversation.orgId,
+            [aiResponseMessage],
+            session,
+          );
           savedConversation.lastActivityAt = Date.now();
           savedConversation.status = CONVERSATION_STATUS.COMPLETE;
 
@@ -1911,10 +1963,9 @@ export const addMessage =
 
           // Return the updated conversation with new messages.
           const responseConversation = await attachPopulatedCitations(
-            updatedConversation._id as mongoose.Types.ObjectId,
-            updatedConversation.toObject() as IConversation,
+            updatedConversation.toObject(),
+            [insertedAiMessage!.toObject()],
             savedCitations,
-            false,
             session,
           );
           return {
@@ -1930,9 +1981,13 @@ export const addMessage =
           conversation.failReason = error.message || 'Unknown error occurred';
 
           // persist and serve the error message to the user.
-          const failedMessage =
-            buildAIFailureResponseMessage() as IMessageDocument;
-          conversation.messages.push(failedMessage);
+          const failedMessage = buildAIFailureResponseMessage();
+          await appendMessages(
+            conversation._id as mongoose.Types.ObjectId,
+            conversation.orgId,
+            [failedMessage],
+            session,
+          );
           conversation.lastActivityAt = Date.now();
           const saveGeneralError = session
             ? await conversation.save({ session })
@@ -2011,7 +2066,7 @@ export const addMessageStream =
     const { conversationId } = req.params;
 
     let session: ClientSession | null = null;
-    let existingConversation: IConversationDocument | null = null;
+    let existingConversation: IChatSessionDocument | null = null;
 
     const modelInfo = extractModelInfo(req.body);
     const protocol = resolveProtocol(
@@ -2028,11 +2083,12 @@ export const addMessageStream =
       session?: ClientSession | null,
     ): Promise<void> {
       // Get existing conversation
-      const conversation = await Conversation.findOne({
+      const conversation = await ChatSession.findOne({
         _id: conversationId,
         orgId,
         userId,
         isDeleted: false,
+        ...EXCLUDE_AGENT,
       });
 
       if (!conversation) {
@@ -2060,13 +2116,18 @@ export const addMessageStream =
       }
 
       // First, add the user message to the existing conversation
-      conversation.messages.push(
-        buildUserQueryMessage(
-          req.body.query,
-          req.body.appliedFilters,
-          req.body.chatMode,
-          req.body.attachments,
-        ) as IMessageDocument,
+      await appendMessages(
+        conversation._id as mongoose.Types.ObjectId,
+        conversation.orgId,
+        [
+          buildUserQueryMessage(
+            req.body.query,
+            req.body.appliedFilters,
+            req.body.chatMode,
+            req.body.attachments,
+          ),
+        ],
+        session,
       );
       conversation.lastActivityAt = Date.now();
 
@@ -2132,13 +2193,16 @@ export const addMessageStream =
       if (!existingConversation) {
         throw new NotFoundError('Conversation not found');
       }
+      const confirmedConversation = existingConversation as IChatSessionDocument;
 
       // Format previous conversations for context (excluding the user message we just added)
+      const allMessagesSoFar = (await getMessages(
+        confirmedConversation._id as mongoose.Types.ObjectId,
+        {},
+        session,
+      )) as IMessage[];
       const previousConversations = formatPreviousConversations(
-        (existingConversation as IConversationDocument).messages.slice(
-          0,
-          -1,
-        ) as IMessage[],
+        allMessagesSoFar.slice(0, -1),
       );
 
       const { chatMode, agentMode } = parseChatMode(req.body.chatMode);
@@ -2254,18 +2318,20 @@ export const addMessageStream =
                 const errorData = JSON.parse(dataLine);
                 const errorMessage = errorData.message || 'Unknown error occurred';
                 upstreamAiErrorEventForwarded = true;
-                void markConversationFailed(
-                  existingConversation as IConversationDocument,
-                  errorMessage,
-                  session,
-                  'streaming_error',
-                  errorData.stack,
-                ).catch((markErr: any) => {
-                  logger.error('Failed to mark conversation from AI RUN_ERROR SSE', {
-                    requestId,
-                    error: markErr?.message,
+                if (existingConversation) {
+                  void markConversationFailed(
+                    existingConversation,
+                    errorMessage,
+                    session,
+                    'streaming_error',
+                    errorData.stack,
+                  ).catch((markErr: any) => {
+                    logger.error('Failed to mark conversation from AI RUN_ERROR SSE', {
+                      requestId,
+                      error: markErr?.message,
+                    });
                   });
-                });
+                }
                 filteredChunk += event + '\n\n';
               } catch (parseError: any) {
                 logger.error('Failed to parse RUN_ERROR event data', {
@@ -2303,21 +2369,23 @@ export const addMessageStream =
                   errorData.error ||
                   'Unknown error occurred';
                 upstreamAiErrorEventForwarded = true;
-                void markConversationFailed(
-                  existingConversation as IConversationDocument,
-                  errorMessage,
-                  session,
-                  'streaming_error',
-                  errorData.stack,
-                  errorData.metadata
-                    ? new Map(Object.entries(errorData.metadata))
-                    : undefined,
-                ).catch((markErr: any) => {
-                  logger.error('Failed to mark conversation from AI error SSE', {
-                    requestId,
-                    error: markErr?.message,
+                if (existingConversation) {
+                  void markConversationFailed(
+                    existingConversation,
+                    errorMessage,
+                    session,
+                    'streaming_error',
+                    errorData.stack,
+                    errorData.metadata
+                      ? new Map(Object.entries(errorData.metadata))
+                      : undefined,
+                  ).catch((markErr: any) => {
+                    logger.error('Failed to mark conversation from AI error SSE', {
+                      requestId,
+                      error: markErr?.message,
+                    });
                   });
-                });
+                }
                 filteredChunk += event + '\n\n';
               } catch (parseError: any) {
                 logger.error('Failed to parse error event data', {
@@ -2329,7 +2397,7 @@ export const addMessageStream =
                 const errorMessage = `Failed to parse error event: ${parseError.message}`;
                 if (existingConversation) {
                   void markConversationFailed(
-                    existingConversation as IConversationDocument,
+                    existingConversation,
                     errorMessage,
                     session,
                     'parse_error',
@@ -2357,9 +2425,11 @@ export const addMessageStream =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void Conversation.findByIdAndUpdate(
-                    existingConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    existingConversation._id as mongoose.Types.ObjectId,
+                    existingConversation.orgId,
+                    [toolCallMessage as unknown as IMessage],
+                    session,
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -2389,9 +2459,11 @@ export const addMessageStream =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void Conversation.findByIdAndUpdate(
-                    existingConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    existingConversation._id as mongoose.Types.ObjectId,
+                    existingConversation.orgId,
+                    [toolCallMessage as unknown as IMessage],
+                    session,
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -2451,7 +2523,14 @@ export const addMessageStream =
               ) as IMessageDocument;
 
               // Add the AI message to the existing conversation
-              existingConversation.messages.push(aiResponseMessage);
+              const insertedAiMessage = (
+                await appendMessages(
+                  existingConversation._id as mongoose.Types.ObjectId,
+                  existingConversation.orgId,
+                  [aiResponseMessage],
+                  session,
+                )
+              )[0];
               existingConversation.lastActivityAt = Date.now();
               existingConversation.status = CONVERSATION_STATUS.COMPLETE;
 
@@ -2468,10 +2547,9 @@ export const addMessageStream =
 
               // Return the updated conversation in the same format as addMessage
               const responseConversation = await attachPopulatedCitations(
-                updatedConversation._id as mongoose.Types.ObjectId,
-                updatedConversation.toObject() as IConversation,
+                updatedConversation.toObject(),
+                [insertedAiMessage!.toObject()],
                 savedCitations,
-                false,
                 session,
               );
 
@@ -2512,7 +2590,12 @@ export const addMessageStream =
                 // Add error message using existing utility
                 const failedMessage =
                   buildAIFailureResponseMessage() as IMessageDocument;
-                existingConversation.messages.push(failedMessage);
+                await appendMessages(
+                  existingConversation._id as mongoose.Types.ObjectId,
+                  existingConversation.orgId,
+                  [failedMessage],
+                  session,
+                );
                 existingConversation.lastActivityAt = Date.now();
 
                 const saveGeneralError = session
@@ -2599,7 +2682,7 @@ export const addMessageStream =
         try {
           if (existingConversation) {
             await markConversationFailed(
-              existingConversation as IConversationDocument,
+              existingConversation,
               error.message,
               session,
               'stream_error',
@@ -2636,33 +2719,31 @@ export const addMessageStream =
       try {
         // Mark conversation as failed if it exists
         if (existingConversation) {
-          (existingConversation as IConversationDocument).status =
-            CONVERSATION_STATUS.FAILED;
-          (existingConversation as IConversationDocument).failReason =
-            error.message || 'Internal server error';
+          const conv = existingConversation as IChatSessionDocument;
+          conv.status = CONVERSATION_STATUS.FAILED;
+          conv.failReason = error.message || 'Internal server error';
 
           // Add error message using existing utility
           const failedMessage =
             buildAIFailureResponseMessage() as IMessageDocument;
-          (existingConversation as IConversationDocument).messages.push(
-            failedMessage,
+          await appendMessages(
+            conv._id as mongoose.Types.ObjectId,
+            conv.orgId,
+            [failedMessage],
+            session,
           );
-          (existingConversation as IConversationDocument).lastActivityAt =
-            Date.now();
+          conv.lastActivityAt = Date.now();
 
           const saveGeneralError = session
-            ? await (existingConversation as IConversationDocument).save({
-                session,
-              })
-            : await (existingConversation as IConversationDocument).save();
+            ? await conv.save({ session })
+            : await conv.save();
 
           if (!saveGeneralError) {
             logger.error(
               'Failed to save conversation general error status in catch block',
               {
                 requestId,
-                conversationId: (existingConversation as IConversationDocument)
-                  ._id,
+                conversationId: conv._id,
               },
             );
           }
@@ -2745,27 +2826,38 @@ export const getAllConversations = async (
     const sortOptions = buildSortOptions(req);
 
     const isOwned = source === 'owned';
-    const filter = buildFilter(
-      req,
-      orgId,
-      userId,
-      conversationId as string,
-      isOwned,
-      !isOwned,
-    );
-    let selection = Conversation.find(filter)
+    let contentMatchIds: mongoose.Types.ObjectId[] | undefined;
+    if (req.query.search) {
+      const escapedSearch = validateAndEscapeSearch(req.query.search);
+      contentMatchIds = await findSessionIdsMatchingContent(
+        orgId,
+        escapedSearch,
+      );
+    }
+    const filter = {
+      ...buildFilter(
+        req,
+        orgId,
+        userId,
+        conversationId as string,
+        isOwned,
+        !isOwned,
+        contentMatchIds,
+      ),
+      ...EXCLUDE_AGENT,
+    };
+    let selection = ChatSession.find(filter)
       .sort(sortOptions as any)
       .skip(skip)
       .limit(limit)
-      .select('-__v')
-      .select('-messages');
+      .select('-__v');
     if (!isOwned) {
-      selection = selection.select('-sharedWith');
+      selection = selection.select('-sharedWith') as typeof selection;
     }
 
     const [conversations, totalCount] = await Promise.all([
       selection.lean().exec(),
-      Conversation.countDocuments(filter),
+      ChatSession.countDocuments(filter),
     ]);
 
     const processedConversations = conversations.map((conversation: any) =>
@@ -2827,7 +2919,23 @@ export const getConversationById = async (
     const { page, limit } = getPaginationParams(req);
 
     // Build the base filter with access control
-    const baseFilter = buildFilter(req, orgId, userId, conversationId);
+    let contentMatchIds: mongoose.Types.ObjectId[] | undefined;
+    if (req.query.search) {
+      const escapedSearch = validateAndEscapeSearch(req.query.search);
+      contentMatchIds = await findSessionIdsMatchingContent(
+        orgId,
+        escapedSearch,
+      );
+    }
+    const baseFilter = buildFilter(
+      req,
+      orgId,
+      userId,
+      conversationId,
+      true,
+      true,
+      contentMatchIds,
+    );
 
     // Build message filter
     const messageFilter = buildMessageFilter(req);
@@ -2838,25 +2946,11 @@ export const getConversationById = async (
       sortOrder as string,
     );
 
-    const countResult = await Conversation.aggregate([
-      { $match: baseFilter },
-      { $project: { messageCount: { $size: '$messages' } } },
-    ]);
-
-    if (!countResult.length) {
-      throw new NotFoundError('Conversation not found');
-    }
-
-    const totalMessages = countResult[0].messageCount;
-
-    // Calculate skip and limit for backward pagination
-    const skip = Math.max(0, totalMessages - page * limit);
-    const effectiveLimit = Math.min(limit, totalMessages - skip);
-
-    // Get conversation with paginated messages
-    const conversationWithMessages = await Conversation.findOne(baseFilter)
+    const session = await ChatSession.findOne({
+      ...baseFilter,
+      ...EXCLUDE_AGENT,
+    })
       .select({
-        messages: { $slice: [skip, effectiveLimit] },
         title: 1,
         initiator: 1,
         createdAt: 1,
@@ -2864,15 +2958,32 @@ export const getConversationById = async (
         sharedWith: 1,
         status: 1,
         failReason: 1,
-        modelInfo:1,
-      })
-      .populate({
-        path: 'messages.citations.citationId',
-        model: 'citation',
-        select: '-__v',
+        modelInfo: 1,
       })
       .lean()
       .exec();
+
+    if (!session) {
+      throw new NotFoundError('Conversation not found');
+    }
+
+    const sessionId = session._id as unknown as Types.ObjectId;
+
+    const totalMessages = await ChatSessionMessage.countDocuments({
+      sessionId,
+    });
+
+    // Calculate skip and limit for backward pagination
+    const skip = Math.max(0, totalMessages - page * limit);
+    const effectiveLimit = Math.min(limit, totalMessages - skip);
+
+    const messages = await getMessages(sessionId, {
+      skip,
+      limit: effectiveLimit,
+      populateCitations: true,
+    });
+
+    const conversationWithMessages = attachMessages(session, messages);
 
     // Sort messages using existing helper
     const sortedMessages = sortMessages(
@@ -2883,7 +2994,7 @@ export const getConversationById = async (
 
     // Build conversation response using existing helper
     const conversationResponse = buildConversationResponse(
-      conversationWithMessages as unknown as IConversationDocument,
+      conversationWithMessages as unknown as IChatSessionDocument,
       userId,
       {
         page,
@@ -2961,24 +3072,29 @@ export const deleteConversationById = async (
     // Common helper that performs the delete operation.
     async function performDeleteConversation(session?: ClientSession | null) {
       // Get conversation with access control
-      const conversation: IConversation | null = await Conversation.findOne({
-        _id: conversationId,
-        userId,
-        orgId,
-        isDeleted: false,
-        $or: [
-          { initiator: userId },
-          { 'sharedWith.userId': userId, 'sharedWith.accessLevel': 'write' },
-        ],
-      });
+      const conversation = await ChatSession.findOne(
+        {
+          _id: conversationId,
+          userId,
+          orgId,
+          isDeleted: false,
+          $or: [
+            { initiator: userId },
+            { 'sharedWith.userId': userId, 'sharedWith.accessLevel': 'write' },
+          ],
+          ...EXCLUDE_AGENT,
+        },
+        undefined,
+        { session },
+      );
 
       if (!conversation) {
         throw new NotFoundError('Conversation not found');
       }
 
       // Perform soft delete on the conversation
-      const updatedConversation = await Conversation.findByIdAndUpdate(
-        conversationId,
+      const updatedConversation = await ChatSession.findOneAndUpdate(
+        { _id: conversationId, ...EXCLUDE_AGENT },
         {
           $set: {
             isDeleted: true,
@@ -2997,10 +3113,16 @@ export const deleteConversationById = async (
         throw new InternalServerError('Failed to delete conversation');
       }
 
-      // Extract all citation IDs from messages
-      const citationIds = conversation.messages
-        .filter((msg: IMessage) => msg.citations && msg.citations.length)
-        .flatMap((msg: IMessage) =>
+      // Extract all citation IDs from messages (projected query, not the
+      // full document — message bodies are no longer embedded)
+      const sessionMessages = await ChatSessionMessage.find(
+        { sessionId: conversationId },
+        { citations: 1 },
+        { session: session || undefined },
+      ).lean();
+      const citationIds = sessionMessages
+        .filter((msg) => msg.citations && msg.citations.length)
+        .flatMap((msg) =>
           msg.citations?.map(
             (citation: IMessageCitation) => citation.citationId,
           ),
@@ -3114,12 +3236,13 @@ export const shareConversationById =
         }
 
         // Get conversation with access control
-        const conversation: IConversation | null = await Conversation.findOne({
+        const conversation = await ChatSession.findOne({
           _id: conversationId,
           orgId,
           userId,
           isDeleted: false,
           initiator: userId, // Only initiator can share
+          ...EXCLUDE_AGENT,
         });
 
         if (!conversation) {
@@ -3190,8 +3313,8 @@ export const shareConversationById =
         updateObject.sharedWith = mergedSharedWith;
 
         // Update the conversation
-        const updatedConversation = await Conversation.findByIdAndUpdate(
-          conversationId,
+        const updatedConversation = await ChatSession.findOneAndUpdate(
+          { _id: conversationId, ...EXCLUDE_AGENT },
           updateObject,
           {
             new: true,
@@ -3208,7 +3331,7 @@ export const shareConversationById =
         return updatedConversation;
       }
 
-      let updatedConversation: IConversationDocument | null = null;
+      let updatedConversation: IChatSessionDocument | null = null;
       if (rsAvailable) {
         session = await mongoose.startSession();
         session.startTransaction();
@@ -3220,10 +3343,14 @@ export const shareConversationById =
 
       // Grant READER permission edges on all attachments in this conversation
       // to every user it was just shared with.
+      const sessionMessages = await ChatSessionMessage.find(
+        { sessionId: conversationId },
+        { attachments: 1 },
+      ).lean();
       const attachmentRecordIds = [
         ...new Set(
-          (updatedConversation.messages ?? [])
-            .flatMap((msg: IMessage) => msg.attachments ?? [])
+          sessionMessages
+            .flatMap((msg) => msg.attachments ?? [])
             .map((att: any) => att.recordId as string | undefined)
             .filter((id): id is string => Boolean(id)),
         ),
@@ -3328,11 +3455,12 @@ export const unshareConversationById =
 
     async function performUnshareConversation(session?: ClientSession | null) {
       // Get conversation with access control
-      const conversation = await Conversation.findOne({
+      const conversation = await ChatSession.findOne({
         _id: conversationId,
         orgId,
         isDeleted: false,
         initiator: userId, // Only initiator can unshare
+        ...EXCLUDE_AGENT,
       });
 
       if (!conversation) {
@@ -3359,8 +3487,8 @@ export const unshareConversationById =
       }
 
       // Update the conversation
-      const updatedConversation = await Conversation.findByIdAndUpdate(
-        conversationId,
+      const updatedConversation = await ChatSession.findOneAndUpdate(
+        { _id: conversationId, ...EXCLUDE_AGENT },
         updateObject,
         {
           new: true,
@@ -3377,7 +3505,7 @@ export const unshareConversationById =
       return updatedConversation;
     }
 
-    let updatedConversation: IConversationDocument | null = null;
+    let updatedConversation: IChatSessionDocument | null = null;
     if (rsAvailable) {
       session = await mongoose.startSession();
       session.startTransaction();
@@ -3389,10 +3517,14 @@ export const unshareConversationById =
 
     // Revoke READER permission edges on all attachments in this conversation
     // for the users who were just removed from sharing.
+    const sessionMessages = await ChatSessionMessage.find(
+      { sessionId: conversationId },
+      { attachments: 1 },
+    ).lean();
     const attachmentRecordIds = [
       ...new Set(
-        (updatedConversation.messages ?? [])
-          .flatMap((msg: IMessage) => msg.attachments ?? [])
+        sessionMessages
+          .flatMap((msg) => msg.attachments ?? [])
           .map((att: any) => att.recordId as string | undefined)
           .filter((id): id is string => Boolean(id)),
       ),
@@ -3468,7 +3600,7 @@ export const unshareConversationById =
  * Configuration for regeneration function
  */
 interface RegenerationConfig {
-  conversationModel: typeof Conversation | typeof AgentConversation;
+  isAgentSession: boolean;
   buildQueryFilter: (
     conversationId: string,
     orgId: string | undefined,
@@ -3494,11 +3626,7 @@ async function regenerateAnswersInternal(
   const userId = req.user?.userId;
   const orgId = req.user?.orgId;
 
-  let existingConversation:
-    | IConversationDocument
-    | IAgentConversationDocument
-    | null = null;
-  let messageIndex = -1;
+  let existingConversation: IChatSessionDocument | null = null;
 
   const modelInfo = extractModelInfo(req.body);
   const protocol = resolveProtocol(
@@ -3509,7 +3637,7 @@ async function regenerateAnswersInternal(
   // Helper function to validate and get conversation
   async function performRegenerateAnswersValidation(
     session?: ClientSession | null,
-  ): Promise<IConversationDocument | IAgentConversationDocument> {
+  ): Promise<{ conversation: IChatSessionDocument; userQuery: IMessage }> {
     if (!conversationId) {
       throw new BadRequestError('Conversation ID is required');
     }
@@ -3522,8 +3650,7 @@ async function regenerateAnswersInternal(
       agentKey,
     );
 
-    // Type assertion needed because TypeScript can't infer the correct overload
-    const conversation = await (config.conversationModel as any).findOne(
+    const conversation = await ChatSession.findOne(
       queryFilter,
       null,
       session ? { session } : undefined,
@@ -3533,15 +3660,20 @@ async function regenerateAnswersInternal(
       throw new NotFoundError('Conversation not found or unauthorized');
     }
 
-    // Ensure there are messages
-    if (!conversation.messages || conversation.messages.length === 0) {
+    // Fetch the last 2 messages (newest first) to validate without positional
+    // addressing into a (now non-existent) embedded array.
+    const lastTwoMessages = (await getMessages(
+      conversation._id as mongoose.Types.ObjectId,
+      { limit: 2, sort: -1 },
+      session,
+    )) as Array<IMessage & { _id: mongoose.Types.ObjectId }>;
+
+    if (lastTwoMessages.length === 0) {
       throw new BadRequestError('No messages found in conversation');
     }
 
     // Get the last message and validate it
-    const lastMessage: IMessageDocument = conversation.messages[
-      conversation.messages.length - 1
-    ] as IMessageDocument;
+    const lastMessage = lastTwoMessages[0]!;
 
     if (lastMessage._id?.toString() !== messageId) {
       throw new BadRequestError(
@@ -3553,27 +3685,22 @@ async function regenerateAnswersInternal(
     }
 
     // Get user query from the previous message
-    if (conversation.messages.length < 2) {
+    if (lastTwoMessages.length < 2) {
       throw new BadRequestError('No user query found to regenerate response');
     }
-    const userQuery = conversation.messages[
-      conversation.messages.length - 2
-    ] as IMessageDocument;
+    const userQuery = lastTwoMessages[1]!;
     if (userQuery.messageType !== 'user_query') {
       throw new BadRequestError('Previous message must be a user query');
     }
-
-    messageIndex = conversation.messages.length - 1;
 
     logger.debug('Regenerate answers validation passed', {
       requestId,
       conversationId,
       messageId,
-      messageIndex,
       timestamp: new Date().toISOString(),
     });
 
-    return conversation;
+    return { conversation, userQuery };
   }
 
   try {
@@ -3588,27 +3715,34 @@ async function regenerateAnswersInternal(
     });
 
     // Validate conversation and message
+    let validationResult: {
+      conversation: IChatSessionDocument;
+      userQuery: IMessage;
+    } | null = null;
     if (rsAvailable) {
       session = await mongoose.startSession();
-      existingConversation = await session.withTransaction(() =>
+      validationResult = await session.withTransaction(() =>
         performRegenerateAnswersValidation(session),
       );
     } else {
-      existingConversation = await performRegenerateAnswersValidation();
+      validationResult = await performRegenerateAnswersValidation();
     }
 
-    if (!existingConversation || messageIndex === -1) {
+    if (!validationResult) {
       throw new NotFoundError('Conversation or message not found');
     }
+    existingConversation = validationResult.conversation;
+    const userQuery = validationResult.userQuery;
 
-    // Get user query from the previous message
-    const userQuery = existingConversation.messages[
-      messageIndex - 1
-    ] as IMessageDocument;
-
-    // Format previous conversations up to this message
+    // Format previous conversations up to this message (exclude last bot
+    // response and the user query that triggered it)
+    const allMessagesForRegen = (await getMessages(
+      existingConversation._id as mongoose.Types.ObjectId,
+      {},
+      session,
+    )) as IMessage[];
     const previousConversations = formatPreviousConversations(
-      existingConversation.messages.slice(0, -2), // Exclude last bot response and user query
+      allMessagesForRegen.slice(0, -2),
     );
 
     // For the assistant (non-agent-key) path, detect universal agent mode from chatMode
@@ -3677,7 +3811,7 @@ async function regenerateAnswersInternal(
         chunk,
         buffer,
         existingConversation,
-        messageIndex,
+        messageId || null,
         session,
         requestId || '',
         res,
@@ -3690,6 +3824,7 @@ async function regenerateAnswersInternal(
             citationsCount: completeData?.citations?.length || 0,
           });
         },
+        config.isAgentSession,
         protocol,
       );
     });
@@ -3704,7 +3839,7 @@ async function regenerateAnswersInternal(
               await handleRegenerationSuccess(
                 completeData,
                 existingConversation,
-                messageIndex,
+                messageId || '',
                 orgId || '',
                 session,
                 modelInfo,
@@ -3731,12 +3866,12 @@ async function regenerateAnswersInternal(
             );
           } catch (error: any) {
             // Update conversation status for general errors
-            if (existingConversation && messageIndex >= 0) {
+            if (existingConversation && messageId) {
               await handleRegenerationError(
                 res,
                 error,
                 existingConversation,
-                messageIndex,
+                messageId,
                 conversationId || '',
                 session,
                 requestId || '',
@@ -3755,23 +3890,31 @@ async function regenerateAnswersInternal(
           }
         } else {
           // Mark as failed if no complete data received
-          if (existingConversation && messageIndex >= 0) {
+          if (existingConversation && messageId) {
             const errorMessage =
               'No complete response received from AI service';
             await replaceMessageWithError(
               existingConversation,
-              messageIndex,
+              messageId,
               errorMessage,
               session,
               'incomplete_response',
             );
 
             // Reload conversation to get updated state
-            const updatedConversation = await (config.conversationModel as any).findById(
+            const updatedConversation = await ChatSession.findById(
               conversationId || '',
             );
             if (updatedConversation) {
-              const plainConversation = updatedConversation.toObject();
+              const messages = await getMessages(
+                updatedConversation._id as mongoose.Types.ObjectId,
+                {},
+                session,
+              );
+              const plainConversation = attachMessages(
+                updatedConversation.toObject(),
+                messages,
+              );
               await sendSSEErrorEvent(
                 res,
                 errorMessage,
@@ -3802,13 +3945,13 @@ async function regenerateAnswersInternal(
           },
         );
 
-        // Try to replace message with error if we have the index
-        if (existingConversation && messageIndex >= 0) {
+        // Try to replace message with error if we have the message id
+        if (existingConversation && messageId) {
           try {
             const errorMessage = `Failed to save regenerated AI response: ${dbError.message}`;
             await replaceMessageWithError(
               existingConversation,
-              messageIndex,
+              messageId,
               errorMessage,
               session,
               'database_error',
@@ -3816,11 +3959,19 @@ async function regenerateAnswersInternal(
             );
 
             // Reload conversation to get updated state
-            const updatedConversation = await (config.conversationModel as any).findById(
+            const updatedConversation = await ChatSession.findById(
               conversationId || '',
             );
             if (updatedConversation) {
-              const plainConversation = updatedConversation.toObject();
+              const messages = await getMessages(
+                updatedConversation._id as mongoose.Types.ObjectId,
+                {},
+                session,
+              );
+              const plainConversation = attachMessages(
+                updatedConversation.toObject(),
+                messages,
+              );
               await sendSSEErrorEvent(
                 res,
                 errorMessage,
@@ -3871,7 +4022,7 @@ async function regenerateAnswersInternal(
           res,
           error,
           existingConversation,
-          messageIndex,
+          messageId || null,
           conversationId || '',
           session,
           requestId || '',
@@ -3912,7 +4063,7 @@ async function regenerateAnswersInternal(
         res,
         error,
         existingConversation,
-        messageIndex,
+        messageId || null,
         conversationId || '',
         session,
         requestId || '',
@@ -3945,12 +4096,13 @@ export const regenerateAnswers =
   (appConfig: AppConfig) =>
   async (req: AuthenticatedUserRequest, res: Response) => {
     await regenerateAnswersInternal(appConfig, req, res, {
-      conversationModel: Conversation,
+      isAgentSession: false,
       buildQueryFilter: (conversationId, orgId, userId) => ({
         _id: conversationId,
         orgId,
         userId,
         isDeleted: false,
+        ...EXCLUDE_AGENT,
         $or: [
           { initiator: userId },
           { 'sharedWith.userId': userId },
@@ -3985,12 +4137,13 @@ export const updateTitle = async (
     });
 
     const applyTitleUpdate = async (txnSession: ClientSession | null) => {
-      const conv = await Conversation.findOne(
+      const conv = await ChatSession.findOne(
         {
           _id: conversationId,
           orgId,
           userId,
           isDeleted: false,
+          ...EXCLUDE_AGENT,
         },
         null,
         txnSession ? { session: txnSession } : {},
@@ -4050,7 +4203,6 @@ export const updateTitle = async (
 };
 
 async function performFeedbackUpdate(params: {
-  model: mongoose.Model<any>;
   query: Record<string, any>;
   conversationId: string;
   messageId: string;
@@ -4059,21 +4211,27 @@ async function performFeedbackUpdate(params: {
   userAgent: string | undefined;
   session?: ClientSession | null;
 }): Promise<{ updatedConversation: any; feedbackEntry: any }> {
-  const { model, query, conversationId, messageId, userId, body, userAgent, session } = params;
+  const { query, messageId, userId, body, userAgent, session } = params;
 
-  const conversation = await model.findOne(query);
+  const conversation = await ChatSession.findOne(
+    query,
+    null,
+    session ? { session } : undefined,
+  );
   if (!conversation) {
     throw new NotFoundError('Conversation not found');
   }
 
-  const messageIndex = conversation.messages.findIndex(
-    (msg: IMessageDocument) => msg._id?.toString() === messageId,
+  const message = await ChatSessionMessage.findOne(
+    { _id: messageId, sessionId: conversation._id },
+    null,
+    session ? { session } : undefined,
   );
-  if (messageIndex === -1) {
+  if (!message) {
     throw new NotFoundError('Message not found');
   }
 
-  if (conversation.messages[messageIndex]?.messageType !== 'bot_response') {
+  if (message.messageType !== 'bot_response') {
     throw new BadRequestError('Feedback is only allowed for bot responses');
   }
 
@@ -4082,25 +4240,23 @@ async function performFeedbackUpdate(params: {
     feedbackProvider: userId,
     timestamp: Date.now(),
     metrics: {
-      timeToFeedback:
-        Date.now() - Number(conversation.messages[messageIndex]?.createdAt),
+      timeToFeedback: Date.now() - Number(message.createdAt),
       userInteractionTime: body.metrics?.userInteractionTime,
       feedbackSessionId: body.metrics?.feedbackSessionId,
       userAgent,
     },
   };
 
-  const updatePath = `messages.${messageIndex}.feedback`;
-  const updatedConversation = await model.findByIdAndUpdate(
-    conversationId,
-    { $push: { [updatePath]: feedbackEntry } },
-    { new: true, session, runValidators: true },
+  const updatedMessage = await appendMessageFeedback(
+    messageId,
+    feedbackEntry,
+    session,
   );
-  if (!updatedConversation) {
+  if (!updatedMessage) {
     throw new InternalServerError('Failed to update feedback');
   }
 
-  return { updatedConversation, feedbackEntry };
+  return { updatedConversation: conversation, feedbackEntry };
 }
 
 export const updateFeedback = async (
@@ -4129,6 +4285,7 @@ export const updateFeedback = async (
       _id: conversationId,
       orgId,
       isDeleted: false,
+      ...EXCLUDE_AGENT,
       $or: [
         { initiator: userId },
         { 'sharedWith.userId': userId },
@@ -4141,13 +4298,13 @@ export const updateFeedback = async (
       session = await mongoose.startSession();
       ({ updatedConversation, feedbackEntry } = await session.withTransaction(
         () => performFeedbackUpdate({
-          model: Conversation, query, conversationId: conversationId!, messageId: messageId!,
+          query, conversationId: conversationId!, messageId: messageId!,
           userId: userId!, body: req.body, userAgent: req.headers['user-agent'], session,
         }),
       ));
     } else {
       ({ updatedConversation, feedbackEntry } = await performFeedbackUpdate({
-        model: Conversation, query, conversationId: conversationId!, messageId: messageId!,
+        query, conversationId: conversationId!, messageId: messageId!,
         userId: userId!, body: req.body, userAgent: req.headers['user-agent'],
       }));
     }
@@ -4210,11 +4367,12 @@ export const archiveConversation = async (
 
     async function performArchiveConversation(session?: ClientSession | null) {
       // Get conversation with access control
-      const conversation = await Conversation.findOne({
+      const conversation = await ChatSession.findOne({
         _id: conversationId,
         userId,
         orgId,
         isDeleted: false,
+        ...EXCLUDE_AGENT,
         $or: [
           { initiator: userId },
           { 'sharedWith.userId': userId, 'sharedWith.accessLevel': 'write' },
@@ -4232,9 +4390,9 @@ export const archiveConversation = async (
       }
 
       // Perform soft delete
-      const updatedConversation: IConversationDocument | null =
-        await Conversation.findByIdAndUpdate(
-          conversationId,
+      const updatedConversation: IChatSessionDocument | null =
+        await ChatSession.findOneAndUpdate(
+          { _id: conversationId, ...EXCLUDE_AGENT },
           {
             $set: {
               isArchived: true,
@@ -4256,7 +4414,7 @@ export const archiveConversation = async (
       return updatedConversation;
     }
 
-    let updatedConversation: IConversationDocument | null = null;
+    let updatedConversation: IChatSessionDocument | null = null;
     if (rsAvailable) {
       session = await mongoose.startSession();
       session.startTransaction();
@@ -4321,11 +4479,12 @@ export const unarchiveConversation = async (
       session?: ClientSession | null,
     ) {
       // Get conversation with access control
-      const conversation = await Conversation.findOne({
+      const conversation = await ChatSession.findOne({
         _id: conversationId,
         userId,
         orgId,
         isDeleted: false,
+        ...EXCLUDE_AGENT,
         $or: [
           { initiator: userId },
           { 'sharedWith.userId': userId, 'sharedWith.accessLevel': 'write' },
@@ -4343,9 +4502,9 @@ export const unarchiveConversation = async (
       }
 
       // Perform soft delete
-      const updatedConversation: IConversationDocument | null =
-        await Conversation.findByIdAndUpdate(
-          conversationId,
+      const updatedConversation: IChatSessionDocument | null =
+        await ChatSession.findOneAndUpdate(
+          { _id: conversationId, ...EXCLUDE_AGENT },
           {
             $set: {
               isArchived: false,
@@ -4366,7 +4525,7 @@ export const unarchiveConversation = async (
       return updatedConversation;
     }
 
-    let updatedConversation: IConversationDocument | null = null;
+    let updatedConversation: IChatSessionDocument | null = null;
     if (rsAvailable) {
       session = await mongoose.startSession();
       session.startTransaction();
@@ -4427,30 +4586,72 @@ export const listAllArchivesConversation = async (
     });
 
     const { skip, limit, page } = getPaginationParams(req);
+    let contentMatchIds: mongoose.Types.ObjectId[] | undefined;
+    if (req.query.search) {
+      const escapedSearch = validateAndEscapeSearch(req.query.search);
+      contentMatchIds = await findSessionIdsMatchingContent(
+        orgId,
+        escapedSearch,
+      );
+    }
     const filter = {
-      ...buildFilter(req, orgId, userId, conversationId as string),
+      ...buildFilter(
+        req,
+        orgId,
+        userId,
+        conversationId as string,
+        true,
+        true,
+        contentMatchIds,
+      ),
       isArchived: true, // Add archived filter
       archivedBy: { $exists: true }, // Ensure it was properly archived
     };
     const sortOptions = buildSortOptions(req);
+    const sessionFilter = { ...filter, ...EXCLUDE_AGENT };
 
     // Execute query
     const [conversations, totalCount] = await Promise.all([
-      Conversation.find(filter)
+      ChatSession.find(sessionFilter)
         .sort(sortOptions as any)
         .skip(skip)
         .limit(limit)
         .select('-__v')
-        .select('-citations')
         .lean()
         .exec(),
-      Conversation.countDocuments(filter),
+      ChatSession.countDocuments(sessionFilter),
     ]);
+
+    // Batch-fetch every message for the page in one query, grouped in
+    // memory by sessionId — never a per-row query.
+    const pageIds = conversations.map((c: any) => c._id);
+    const allMessages = await ChatSessionMessage.find({
+      sessionId: { $in: pageIds },
+    })
+      .sort({ seq: 1 })
+      .lean()
+      .exec();
+    const messagesBySession = new Map<string, any[]>();
+    for (const message of allMessages) {
+      const key = message.sessionId.toString();
+      const bucket = messagesBySession.get(key);
+      if (bucket) {
+        bucket.push(message);
+      } else {
+        messagesBySession.set(key, [message]);
+      }
+    }
 
     // Process results with computed fields and restructured citations
     const processedConversations = conversations.map((conversation: any) => {
+      const sessionMessages =
+        messagesBySession.get(conversation._id.toString()) || [];
+      const conversationWithMessages = attachMessages(
+        conversation,
+        sessionMessages,
+      );
       const conversationWithComputedFields = addComputedFields(
-        conversation as IConversation,
+        conversationWithMessages as IConversation,
         userId,
       );
 
@@ -4526,16 +4727,10 @@ export const searchArchivedConversations =
     if (!rawSearch || typeof rawSearch !== 'string' || !rawSearch.trim()) {
       throw new BadRequestError('search query parameter is required');
     }
-    if (Array.isArray(rawSearch)) {
-      throw new BadRequestError('Search parameter must be a string, not an array');
-    }
     const searchValue = rawSearch.trim();
-    validateNoXSS(searchValue, 'search parameter');
-    validateNoFormatSpecifiers(searchValue, 'search parameter');
-    if (searchValue.length > 1000) {
-      throw new BadRequestError('Search parameter too long (max 1000 characters)');
-    }
-    const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedSearch = validateAndEscapeSearch(searchValue, {
+      formatSpecifiers: true,
+    });
 
     // ── Pagination ─────────────────────────────────────────────────
     const { skip, limit, page } = getPaginationParams(req);
@@ -4552,19 +4747,24 @@ export const searchArchivedConversations =
     const orgOid = new mongoose.Types.ObjectId(`${orgId}`);
     const userOid = new mongoose.Types.ObjectId(`${userId}`);
 
-    const searchCondition = {
+    // Message content now lives in chatSessionMessages; resolve matching
+    // session ids up front instead of an inline `messages.content` regex.
+    const contentMatchIds = await findSessionIdsMatchingContent(
+      orgId,
+      escapedSearch,
+    );
+    const titleOrContentMatch = {
       $or: [
         { title: { $regex: escapedSearch, $options: 'i' } },
-        { 'messages.content': { $regex: escapedSearch, $options: 'i' } },
+        ...(contentMatchIds.length > 0
+          ? [{ _id: { $in: contentMatchIds } }]
+          : []),
       ],
     };
 
-    // ── Assistant (Conversation) filter ─────────────────────────────
-    const assistantFilter: any = {
-      orgId: orgOid,
-      isDeleted: false,
-      isArchived: true,
-      archivedBy: { $exists: true },
+    // ── Per-type access predicates (both now against chatSessions) ──
+    const assistantAccessPredicate: any = {
+      ...EXCLUDE_AGENT,
       $or: [
         { userId: userOid },
         {
@@ -4574,46 +4774,49 @@ export const searchArchivedConversations =
           ],
         },
       ],
-      $and: [searchCondition],
     };
 
-    // ── Agent (AgentConversation) filter ─────────────────────────────
-    const agentFilter: any = {
+    const agentAccessPredicate: any = {
+      ...ONLY_AGENT,
+      userId: userOid,
+    };
+    if (deletedAgentKeys !== null) {
+      agentAccessPredicate.agentKey = { $nin: deletedAgentKeys };
+    }
+
+    const baseFilter = {
       orgId: orgOid,
       isDeleted: false,
       isArchived: true,
       archivedBy: { $exists: true },
-      userId: userOid,
-      $and: [searchCondition],
+      $and: [titleOrContentMatch],
     };
-    if (deletedAgentKeys !== null) {
-      agentFilter.agentKey = { $nin: deletedAgentKeys };
-    }
 
-    // ── Execute queries: $unionWith aggregation + per-source counts ──
-    // $unionWith (Mongo 4.4+) merges both collections server-side so that
-    // sort, skip, and limit are pushed to MongoDB — avoiding unbounded
-    // in-memory loads when the search matches many documents.
+    // ── Execute: single $match ORing both per-type predicates, one
+    // combined aggregation replacing the old cross-collection $unionWith,
+    // and one countDocuments per predicate ──
     const [aggregateResult, assistantCount, agentCount] = await Promise.all([
-      Conversation.aggregate([
-        { $match: assistantFilter },
-        { $addFields: { source: 'assistant' } },
+      ChatSession.aggregate([
         {
-          $unionWith: {
-            coll: AgentConversation.collection.name,
-            pipeline: [
-              { $match: agentFilter },
-              { $addFields: { source: 'agent' } },
-            ],
+          $match: {
+            ...baseFilter,
+            $or: [assistantAccessPredicate, agentAccessPredicate],
+          },
+        },
+        {
+          $addFields: {
+            source: {
+              $cond: [{ $eq: ['$sessionType', 'agent'] }, 'agent', 'assistant'],
+            },
           },
         },
         { $sort: { lastActivityAt: -1 } },
         { $skip: skip },
         { $limit: limit },
-        { $project: { messages: 0, __v: 0 } },
+        { $project: { __v: 0, nextSeq: 0, sessionType: 0 } },
       ]),
-      Conversation.countDocuments(assistantFilter),
-      AgentConversation.countDocuments(agentFilter),
+      ChatSession.countDocuments({ ...baseFilter, ...assistantAccessPredicate }),
+      ChatSession.countDocuments({ ...baseFilter, ...agentAccessPredicate }),
     ]);
 
     const totalCount = assistantCount + agentCount;
@@ -5735,7 +5938,7 @@ export const deleteAgent =
     const { agentKey } = req.params;
 
     let session: ClientSession | null = null;
-    let savedConversation: IAgentConversationDocument | null = null;
+    let savedConversation: IChatSessionDocument | null = null;
 
     const modelInfo = extractModelInfo(req.body);
     const protocol = resolveProtocol(
@@ -5766,31 +5969,43 @@ export const deleteAgent =
         req.body.attachments,
       );
 
-      const userConversationData: Partial<IAgentConversation> = {
+      const userConversationData: Partial<IChatSession> = {
         orgId,
         userId,
         initiator: userId,
         title: req.body.query.slice(0, 100),
-        messages: [userQueryMessage] as IMessageDocument[],
         lastActivityAt: Date.now(),
         status: CONVERSATION_STATUS.INPROGRESS,
         agentKey,
         modelInfo,
+        sessionType: 'agent',
       };
 
       // Start transaction if replica set is available
       if (rsAvailable) {
         session = await mongoose.startSession();
         await session.withTransaction(async () => {
-          const conversation = new AgentConversation(userConversationData);
+          const conversation = new ChatSession(userConversationData);
           savedConversation = (await conversation.save({
             session,
-          })) as IAgentConversationDocument;
+          })) as IChatSessionDocument;
+          await appendMessages(
+            savedConversation._id as mongoose.Types.ObjectId,
+            savedConversation.orgId,
+            [userQueryMessage],
+            session,
+          );
         });
       } else {
-        const conversation = new AgentConversation(userConversationData);
+        const conversation = new ChatSession(userConversationData);
         savedConversation =
-          (await conversation.save()) as IAgentConversationDocument;
+          (await conversation.save()) as IChatSessionDocument;
+        await appendMessages(
+          savedConversation._id as mongoose.Types.ObjectId,
+          savedConversation.orgId,
+          [userQueryMessage],
+          session,
+        );
       }
 
       if (!savedConversation) {
@@ -5950,7 +6165,7 @@ export const deleteAgent =
                 upstreamAiErrorEventForwarded = true;
                 if (savedConversation) {
                   void markAgentConversationFailed(
-                    savedConversation as IAgentConversationDocument,
+                    savedConversation,
                     errorMessage,
                     session,
                     'streaming_error',
@@ -5985,9 +6200,11 @@ export const deleteAgent =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void AgentConversation.findByIdAndUpdate(
-                    savedConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    savedConversation._id as mongoose.Types.ObjectId,
+                    savedConversation.orgId,
+                    [toolCallMessage as unknown as IMessage],
+                    session,
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -6038,7 +6255,7 @@ export const deleteAgent =
                       ? new Map(Object.entries(errorData.metadata as Record<string, unknown>))
                       : undefined;
                   void markAgentConversationFailed(
-                    savedConversation as IAgentConversationDocument,
+                    savedConversation,
                     errorMessage,
                     session,
                     'streaming_error',
@@ -6062,7 +6279,7 @@ export const deleteAgent =
                 if (savedConversation) {
                   const parseFailMsg = `Failed to parse error event: ${parseError.message}`;
                   void markAgentConversationFailed(
-                    savedConversation as IAgentConversationDocument,
+                    savedConversation,
                     parseFailMsg,
                     session,
                     'parse_error',
@@ -6090,9 +6307,11 @@ export const deleteAgent =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void AgentConversation.findByIdAndUpdate(
-                    savedConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    savedConversation._id as mongoose.Types.ObjectId,
+                    savedConversation.orgId,
+                    [toolCallMessage as unknown as IMessage],
+                    session,
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -6163,11 +6382,13 @@ export const deleteAgent =
             );
           } else if (!upstreamAiErrorEventForwarded) {
             // Mark as failed if no complete data received (and AI did not already send error SSE)
-            await markAgentConversationFailed(
-              savedConversation as IAgentConversationDocument,
-              'No complete response received from AI service',
-              session,
-            );
+            if (savedConversation) {
+              await markAgentConversationFailed(
+                savedConversation,
+                'No complete response received from AI service',
+                session,
+              );
+            }
 
             // Send error event
             res.write(
@@ -6212,7 +6433,7 @@ export const deleteAgent =
           // Mark conversation as failed
           if (savedConversation) {
             await markAgentConversationFailed(
-              savedConversation as IAgentConversationDocument,
+              savedConversation,
               `Stream error: ${error.message}`,
               session,
             );
@@ -6245,7 +6466,7 @@ export const deleteAgent =
         // Mark conversation as failed if it was created
         if (savedConversation) {
           await markAgentConversationFailed(
-            savedConversation as IAgentConversationDocument,
+            savedConversation,
             error.message || 'Internal server error',
             session,
           );
@@ -6330,25 +6551,31 @@ export const createAgentConversation =
         req.body.attachments,
       );
 
-      const userConversationData: Partial<IAgentConversation> = {
+      const userConversationData: Partial<IChatSession> = {
         orgId,
         userId,
         initiator: userId,
         title: req.body.query.slice(0, 100),
-        messages: [userQueryMessage] as IMessageDocument[],
         lastActivityAt: Date.now(),
         status: CONVERSATION_STATUS.INPROGRESS,
         agentKey,
         modelInfo,
+        sessionType: 'agent',
       };
 
-      const conversation = new AgentConversation(userConversationData);
+      const conversation = new ChatSession(userConversationData);
       const savedConversation = session
         ? await conversation.save({ session })
-        : ((await conversation.save()) as IAgentConversationDocument);
+        : ((await conversation.save()) as IChatSessionDocument);
       if (!savedConversation) {
         throw new InternalServerError('Failed to create conversation');
       }
+      await appendMessages(
+        savedConversation._id as mongoose.Types.ObjectId,
+        savedConversation.orgId,
+        [userQueryMessage],
+        session,
+      );
 
       const aiPayload: Record<string, unknown> = {
         query: req.body.query,
@@ -6425,7 +6652,14 @@ export const createAgentConversation =
           modelInfo,
         ) as IMessageDocument;
         // Add the AI message to the conversation
-        savedConversation.messages.push(aiResponseMessage);
+        const insertedAiMessage = (
+          await appendMessages(
+            savedConversation._id as mongoose.Types.ObjectId,
+            savedConversation.orgId,
+            [aiResponseMessage],
+            session,
+          )
+        )[0];
         savedConversation.lastActivityAt = Date.now();
         savedConversation.status = CONVERSATION_STATUS.COMPLETE as any; // Successful conversation
 
@@ -6437,10 +6671,9 @@ export const createAgentConversation =
           throw new InternalServerError('Failed to update conversation');
         }
         const responseConversation = await attachPopulatedCitations(
-          updatedConversation._id as mongoose.Types.ObjectId,
-          updatedConversation.toObject() as IAgentConversation,
+          updatedConversation.toObject(),
+          [insertedAiMessage!.toObject()],
           citations,
-          true,
           session,
         );
         return {
@@ -6463,7 +6696,12 @@ export const createAgentConversation =
         // persist and serve the error message to the user.
         const failedMessage =
           buildAIFailureResponseMessage() as IMessageDocument;
-        savedConversation.messages.push(failedMessage);
+        await appendMessages(
+          savedConversation._id as mongoose.Types.ObjectId,
+          savedConversation.orgId,
+          [failedMessage],
+          session,
+        );
         savedConversation.lastActivityAt = Date.now();
 
         const savedWithError = session
@@ -6575,12 +6813,13 @@ export const createAgentConversation =
       // Extract common operations into a helper function.
       async function performAddMessage(session?: ClientSession | null) {
         // Get existing conversation
-        const conversation = await AgentConversation.findOne({
+        const conversation = await ChatSession.findOne({
           _id: req.params.conversationId,
           agentKey,
           orgId,
           userId,
           isDeleted: false,
+          ...ONLY_AGENT,
         });
 
         if (!conversation) {
@@ -6594,9 +6833,13 @@ export const createAgentConversation =
         // add previous conversations to the conversation
         // in case of bot_response message
         // Format previous conversations for context
-        const previousConversations = formatPreviousConversations(
-          conversation.messages,
-        );
+        const existingMessages = (await getMessages(
+          conversation._id as mongoose.Types.ObjectId,
+          {},
+          session,
+        )) as IMessage[];
+        const previousConversations =
+          formatPreviousConversations(existingMessages);
         logger.debug('Previous conversations', {
           previousConversations,
         });
@@ -6608,7 +6851,12 @@ export const createAgentConversation =
           req.body.attachments,
         );
         // First, add the user message to the existing conversation
-        conversation.messages.push(userQueryMessage as IMessageDocument);
+        await appendMessages(
+          conversation._id as mongoose.Types.ObjectId,
+          conversation.orgId,
+          [userQueryMessage],
+          session,
+        );
         conversation.lastActivityAt = Date.now();
 
         const fieldsToUpdate: Array<keyof IAIModel> = [
@@ -6629,7 +6877,7 @@ export const createAgentConversation =
         // Save the user message to the existing conversation first
         const savedConversation = session
           ? await conversation.save({ session })
-          : ((await conversation.save()) as IAgentConversationDocument);
+          : ((await conversation.save()) as IChatSessionDocument);
 
         if (!savedConversation) {
           throw new InternalServerError(
@@ -6747,7 +6995,14 @@ export const createAgentConversation =
             modelInfo,
           ) as IMessageDocument;
           // Add the AI message to the existing conversation
-          savedConversation.messages.push(aiResponseMessage);
+          const insertedAiMessage = (
+            await appendMessages(
+              savedConversation._id as mongoose.Types.ObjectId,
+              savedConversation.orgId,
+              [aiResponseMessage],
+              session,
+            )
+          )[0];
           savedConversation.lastActivityAt = Date.now();
           savedConversation.status = CONVERSATION_STATUS.COMPLETE as any;
 
@@ -6764,10 +7019,9 @@ export const createAgentConversation =
 
           // Return the updated conversation with new messages.
           const responseConversation = await attachPopulatedCitations(
-            updatedConversation._id as mongoose.Types.ObjectId,
-            updatedConversation.toObject() as IAgentConversation,
+            updatedConversation.toObject(),
+            [insertedAiMessage!.toObject()],
             savedCitations,
-            true,
             session,
           );
           return {
@@ -6785,7 +7039,12 @@ export const createAgentConversation =
           // persist and serve the error message to the user.
           const failedMessage =
             buildAIFailureResponseMessage() as IMessageDocument;
-          conversation.messages.push(failedMessage);
+          await appendMessages(
+            conversation._id as mongoose.Types.ObjectId,
+            conversation.orgId,
+            [failedMessage],
+            session,
+          );
           conversation.lastActivityAt = Date.now();
           const saveGeneralError = session
             ? await conversation.save({ session })
@@ -6880,7 +7139,7 @@ export const addMessageStreamToAgentConversation =
     const { conversationId, agentKey } = req.params;
 
     let session: ClientSession | null = null;
-    let existingConversation: IAgentConversationDocument | null = null;
+    let existingConversation: IChatSessionDocument | null = null;
 
     const modelInfo = extractModelInfo(req.body);
     const protocol = resolveProtocol(
@@ -6897,12 +7156,13 @@ export const addMessageStreamToAgentConversation =
       session?: ClientSession | null,
     ): Promise<void> {
       // Get existing conversation
-      const conversation = await AgentConversation.findOne({
+      const conversation = await ChatSession.findOne({
         _id: conversationId,
         agentKey,
         orgId,
         userId,
         isDeleted: false,
+        ...ONLY_AGENT,
       });
 
       if (!conversation) {
@@ -6929,20 +7189,25 @@ export const addMessageStreamToAgentConversation =
       }
 
       // First, add the user message to the existing conversation
-      conversation.messages.push(
-        buildUserQueryMessage(
-          req.body.query,
-          req.body.appliedFilters,
-          req.body.chatMode,
-          req.body.attachments,
-        ) as IMessageDocument,
+      await appendMessages(
+        conversation._id as mongoose.Types.ObjectId,
+        conversation.orgId,
+        [
+          buildUserQueryMessage(
+            req.body.query,
+            req.body.appliedFilters,
+            req.body.chatMode,
+            req.body.attachments,
+          ),
+        ],
+        session,
       );
       conversation.lastActivityAt = Date.now();
 
       // Save the user message to the existing conversation first
       const savedConversation = session
         ? await conversation.save({ session })
-        : ((await conversation.save()) as IAgentConversationDocument);
+        : ((await conversation.save()) as IChatSessionDocument);
 
       if (!savedConversation) {
         throw new InternalServerError(
@@ -7003,13 +7268,16 @@ export const addMessageStreamToAgentConversation =
       if (!existingConversation) {
         throw new NotFoundError('Conversation not found');
       }
+      const confirmedConversation = existingConversation as IChatSessionDocument;
 
       // Format previous conversations for context (excluding the user message we just added)
+      const allMessagesSoFar = (await getMessages(
+        confirmedConversation._id as mongoose.Types.ObjectId,
+        {},
+        session,
+      )) as IMessage[];
       const previousConversations = formatPreviousConversations(
-        (existingConversation as IConversationDocument).messages.slice(
-          0,
-          -1,
-        ) as IMessage[],
+        allMessagesSoFar.slice(0, -1),
       );
 
       // Prepare AI payload
@@ -7123,13 +7391,15 @@ export const addMessageStreamToAgentConversation =
                 const errorData = JSON.parse(dataLine);
                 const errorMessage = errorData.message || 'Unknown error occurred';
                 upstreamAiErrorEventForwarded = true;
-                markAgentConversationFailed(
-                  existingConversation as IAgentConversationDocument,
-                  errorMessage,
-                  session,
-                  'streaming_error',
-                  errorData.stack,
-                );
+                if (existingConversation) {
+                  markAgentConversationFailed(
+                    existingConversation,
+                    errorMessage,
+                    session,
+                    'streaming_error',
+                    errorData.stack,
+                  );
+                }
                 filteredChunk += event + '\n\n';
               } catch (parseError: any) {
                 logger.error('Failed to parse RUN_ERROR event data', {
@@ -7153,9 +7423,11 @@ export const addMessageStreamToAgentConversation =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void AgentConversation.findByIdAndUpdate(
-                    existingConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    existingConversation._id as mongoose.Types.ObjectId,
+                    existingConversation.orgId,
+                    [toolCallMessage as unknown as IMessage],
+                    session,
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -7199,16 +7471,18 @@ export const addMessageStreamToAgentConversation =
                   errorData.error ||
                   'Unknown error occurred';
                 upstreamAiErrorEventForwarded = true;
-                markAgentConversationFailed(
-                  existingConversation as IAgentConversationDocument,
-                  errorMessage,
-                  session,
-                  'streaming_error',
-                  errorData.stack,
-                  errorData.metadata
-                    ? new Map(Object.entries(errorData.metadata))
-                    : undefined,
-                );
+                if (existingConversation) {
+                  markAgentConversationFailed(
+                    existingConversation,
+                    errorMessage,
+                    session,
+                    'streaming_error',
+                    errorData.stack,
+                    errorData.metadata
+                      ? new Map(Object.entries(errorData.metadata))
+                      : undefined,
+                  );
+                }
                 filteredChunk += event + '\n\n';
               } catch (parseError: any) {
                 logger.error('Failed to parse error event data', {
@@ -7219,7 +7493,7 @@ export const addMessageStreamToAgentConversation =
                 upstreamAiErrorEventForwarded = true;
                 if (existingConversation) {
                   markAgentConversationFailed(
-                    existingConversation as IAgentConversationDocument,
+                    existingConversation,
                     `Failed to parse error event: ${parseError.message}`,
                     session,
                     'parse_error',
@@ -7242,9 +7516,11 @@ export const addMessageStreamToAgentConversation =
                     createdAt: new Date(),
                     updatedAt: new Date(),
                   };
-                  void AgentConversation.findByIdAndUpdate(
-                    existingConversation._id,
-                    { $push: { messages: toolCallMessage } },
+                  void appendMessages(
+                    existingConversation._id as mongoose.Types.ObjectId,
+                    existingConversation.orgId,
+                    [toolCallMessage as unknown as IMessage],
+                    session,
                   ).catch((saveErr: any) => {
                     logger.error('Failed to persist ask_user_question tool_call message', {
                       requestId,
@@ -7304,14 +7580,21 @@ export const addMessageStreamToAgentConversation =
               ) as IMessageDocument;
 
               // Add the AI message to the existing conversation
-              existingConversation.messages.push(aiResponseMessage);
+              const insertedAiMessage = (
+                await appendMessages(
+                  existingConversation._id as mongoose.Types.ObjectId,
+                  existingConversation.orgId,
+                  [aiResponseMessage],
+                  session,
+                )
+              )[0];
               existingConversation.lastActivityAt = Date.now();
               existingConversation.status = CONVERSATION_STATUS.COMPLETE as any;
 
               // Save the updated conversation with AI response
               const updatedConversation = session
                 ? await existingConversation.save({ session })
-                : ((await existingConversation.save()) as IAgentConversationDocument);
+                : ((await existingConversation.save()) as IChatSessionDocument);
 
               if (!updatedConversation) {
                 throw new InternalServerError(
@@ -7321,10 +7604,9 @@ export const addMessageStreamToAgentConversation =
 
               // Return the updated conversation in the same format as addMessage
               const responseConversation = await attachPopulatedCitations(
-                updatedConversation._id as mongoose.Types.ObjectId,
-                updatedConversation.toObject() as IAgentConversation,
+                updatedConversation.toObject(),
+                [insertedAiMessage!.toObject()],
                 savedCitations,
-                true,
                 session,
               );
 
@@ -7365,7 +7647,12 @@ export const addMessageStreamToAgentConversation =
                 // Add error message using existing utility
                 const failedMessage =
                   buildAIFailureResponseMessage() as IMessageDocument;
-                existingConversation.messages.push(failedMessage);
+                await appendMessages(
+                  existingConversation._id as mongoose.Types.ObjectId,
+                  existingConversation.orgId,
+                  [failedMessage],
+                  session,
+                );
                 existingConversation.lastActivityAt = Date.now();
 
                 const saveGeneralError = session
@@ -7401,7 +7688,7 @@ export const addMessageStreamToAgentConversation =
 
               const savedWithError = session
                 ? await existingConversation.save({ session })
-                : ((await existingConversation.save()) as IAgentConversationDocument);
+                : ((await existingConversation.save()) as IChatSessionDocument);
 
               if (!savedWithError) {
                 logger.error('Failed to save conversation error state', {
@@ -7452,7 +7739,7 @@ export const addMessageStreamToAgentConversation =
         try {
           if (existingConversation) {
             markAgentConversationFailed(
-              existingConversation as IAgentConversationDocument,
+              existingConversation,
               error.message,
               session,
             );
@@ -7489,34 +7776,31 @@ export const addMessageStreamToAgentConversation =
       try {
         // Mark conversation as failed if it exists
         if (existingConversation) {
-          (existingConversation as IAgentConversationDocument).status =
-            CONVERSATION_STATUS.FAILED as any;
-          (existingConversation as IAgentConversationDocument).failReason =
-            error.message || 'Internal server error';
+          const conv = existingConversation as IChatSessionDocument;
+          conv.status = CONVERSATION_STATUS.FAILED as any;
+          conv.failReason = error.message || 'Internal server error';
 
           // Add error message using existing utility
           const failedMessage =
             buildAIFailureResponseMessage() as IMessageDocument;
-          (existingConversation as IAgentConversationDocument).messages.push(
-            failedMessage,
+          await appendMessages(
+            conv._id as mongoose.Types.ObjectId,
+            conv.orgId,
+            [failedMessage],
+            session,
           );
-          (existingConversation as IAgentConversationDocument).lastActivityAt =
-            Date.now();
+          conv.lastActivityAt = Date.now();
 
           const saveGeneralError = session
-            ? await (existingConversation as IAgentConversationDocument).save({
-                session,
-              })
-            : await (existingConversation as IAgentConversationDocument).save();
+            ? await conv.save({ session })
+            : await conv.save();
 
           if (!saveGeneralError) {
             logger.error(
               'Failed to save conversation general error status in catch block',
               {
                 requestId,
-                conversationId: (
-                  existingConversation as IAgentConversationDocument
-                )._id,
+                conversationId: conv._id,
               },
             );
           }
@@ -7574,13 +7858,14 @@ export const regenerateAgentAnswers =
   (appConfig: AppConfig) =>
   async (req: AuthenticatedUserRequest, res: Response) => {
     await regenerateAnswersInternal(appConfig, req, res, {
-      conversationModel: AgentConversation,
+      isAgentSession: true,
       buildQueryFilter: (conversationId, orgId, userId, agentKey) => ({
         _id: conversationId,
         agentKey,
         orgId,
         userId,
         isDeleted: false,
+        ...ONLY_AGENT,
         $or: [
           { initiator: userId },
           { 'sharedWith.userId': userId },
@@ -7616,6 +7901,16 @@ export const getAllAgentConversations = async (
     });
 
     const { skip, limit, page } = getPaginationParams(req);
+    let contentMatchIds: mongoose.Types.ObjectId[] | undefined;
+    if (req.query.search) {
+      const escapedSearch = validateAndEscapeSearch(req.query.search, {
+        formatSpecifiers: true,
+      });
+      contentMatchIds = await findSessionIdsMatchingContent(
+        orgId,
+        escapedSearch,
+      );
+    }
     const filter = {
       ...buildAgentConversationFilter(
         req,
@@ -7623,6 +7918,7 @@ export const getAllAgentConversations = async (
         userId,
         agentKey as string,
         conversationId as string,
+        contentMatchIds,
       ),
       // Sidebar / chat list: omit archived threads (archived view uses a dedicated route).
       isArchived: { $ne: true },
@@ -7638,21 +7934,19 @@ export const getAllAgentConversations = async (
     // Execute query
     const [conversations, totalCount, sharedWithMeConversations] =
       await Promise.all([
-        AgentConversation.find(filter)
+        ChatSession.find(filter)
           .sort(sortOptions as any)
           .skip(skip)
           .limit(limit)
           .select('-__v')
-          .select('-messages')
           .lean()
           .exec(),
-        AgentConversation.countDocuments(filter),
-        AgentConversation.find(sharedWithMeFilter)
+        ChatSession.countDocuments(filter),
+        ChatSession.find(sharedWithMeFilter)
           .sort(sortOptions as any)
           .skip(skip)
           .limit(limit)
           .select('-__v')
-          .select('-messages')
           .select('-sharedWith')
           .lean()
           .exec(),
@@ -7735,12 +8029,23 @@ export const getAgentConversationById = async (
     const { page, limit } = getPaginationParams(req);
 
     // Build the base filter with access control
+    let contentMatchIds: mongoose.Types.ObjectId[] | undefined;
+    if (req.query.search) {
+      const escapedSearch = validateAndEscapeSearch(req.query.search, {
+        formatSpecifiers: true,
+      });
+      contentMatchIds = await findSessionIdsMatchingContent(
+        orgId,
+        escapedSearch,
+      );
+    }
     const baseFilter = buildAgentConversationFilter(
       req,
       orgId,
       userId,
       agentKey as string,
       conversationId as string,
+      contentMatchIds,
     );
 
     // Build message filter
@@ -7752,25 +8057,11 @@ export const getAgentConversationById = async (
       sortOrder as string,
     );
 
-    const countResult = await AgentConversation.aggregate([
-      { $match: baseFilter },
-      { $project: { messageCount: { $size: '$messages' } } },
-    ]);
-
-    if (!countResult.length) {
-      throw new NotFoundError('Conversation not found');
-    }
-
-    const totalMessages = countResult[0].messageCount;
-
-    // Calculate skip and limit for backward pagination
-    const skip = Math.max(0, totalMessages - page * limit);
-    const effectiveLimit = Math.min(limit, totalMessages - skip);
-
-    // Get conversation with paginated messages
-    const conversationWithMessages = await AgentConversation.findOne(baseFilter)
+    const session = await ChatSession.findOne({
+      ...baseFilter,
+      ...ONLY_AGENT,
+    })
       .select({
-        messages: { $slice: [skip, effectiveLimit] },
         title: 1,
         initiator: 1,
         createdAt: 1,
@@ -7780,13 +8071,30 @@ export const getAgentConversationById = async (
         failReason: 1,
         modelInfo: 1,
       })
-      .populate({
-        path: 'messages.citations.citationId',
-        model: 'citation',
-        select: '-__v',
-      })
       .lean()
       .exec();
+
+    if (!session) {
+      throw new NotFoundError('Conversation not found');
+    }
+
+    const sessionId = session._id as unknown as Types.ObjectId;
+
+    const totalMessages = await ChatSessionMessage.countDocuments({
+      sessionId,
+    });
+
+    // Calculate skip and limit for backward pagination
+    const skip = Math.max(0, totalMessages - page * limit);
+    const effectiveLimit = Math.min(limit, totalMessages - skip);
+
+    const messages = await getMessages(sessionId, {
+      skip,
+      limit: effectiveLimit,
+      populateCitations: true,
+    });
+
+    const conversationWithMessages = attachMessages(session, messages);
 
     // Sort messages using existing helper
     const sortedMessages = sortMessages(
@@ -7797,7 +8105,7 @@ export const getAgentConversationById = async (
 
     // Build conversation response using existing helper
     const conversationResponse = buildConversationResponse(
-      conversationWithMessages as unknown as IAgentConversationDocument,
+      conversationWithMessages as unknown as IChatSessionDocument,
       userId,
       {
         page,
@@ -7908,13 +8216,14 @@ export const archiveAgentConversation = async (
     });
 
     async function performArchive(s?: ClientSession | null) {
-      const conversation = await AgentConversation.findOne(
+      const conversation = await ChatSession.findOne(
         {
           _id: conversationId,
           userId,
           orgId,
           agentKey,
           isDeleted: false,
+          ...ONLY_AGENT,
         },
         null,
         { session: s },
@@ -7928,8 +8237,8 @@ export const archiveAgentConversation = async (
         throw new BadRequestError('Agent conversation already archived');
       }
 
-      const updated = await AgentConversation.findByIdAndUpdate(
-        conversationId,
+      const updated = await ChatSession.findOneAndUpdate(
+        { _id: conversationId, ...ONLY_AGENT },
         {
           $set: {
             isArchived: true,
@@ -8009,13 +8318,14 @@ export const unarchiveAgentConversation = async (
     });
 
     async function performUnarchive(s?: ClientSession | null) {
-      const conversation = await AgentConversation.findOne(
+      const conversation = await ChatSession.findOne(
         {
           _id: conversationId,
           userId,
           orgId,
           agentKey,
           isDeleted: false,
+          ...ONLY_AGENT,
         },
         null,
         { session: s },
@@ -8029,8 +8339,8 @@ export const unarchiveAgentConversation = async (
         throw new BadRequestError('Agent conversation is not archived');
       }
 
-      const updated = await AgentConversation.findByIdAndUpdate(
-        conversationId,
+      const updated = await ChatSession.findOneAndUpdate(
+        { _id: conversationId, ...ONLY_AGENT },
         {
           $set: {
             isArchived: false,
@@ -8103,23 +8413,39 @@ export const listAllArchivesAgentConversation = () =>
     });
 
     const { skip, limit, page } = getPaginationParams(req);
+    let contentMatchIds: mongoose.Types.ObjectId[] | undefined;
+    if (req.query.search) {
+      const escapedSearch = validateAndEscapeSearch(req.query.search, {
+        formatSpecifiers: true,
+      });
+      contentMatchIds = await findSessionIdsMatchingContent(
+        orgId,
+        escapedSearch,
+      );
+    }
     const filter = {
-      ...buildAgentConversationFilter(req, orgId, userId, agentKey as string),
+      ...buildAgentConversationFilter(
+        req,
+        orgId,
+        userId,
+        agentKey as string,
+        undefined,
+        contentMatchIds,
+      ),
       isArchived: true,
       archivedBy: { $exists: true },
     };
     const sortOptions = buildSortOptions(req);
 
     const [conversations, totalCount] = await Promise.all([
-      AgentConversation.find(filter)
+      ChatSession.find(filter)
         .sort(sortOptions as any)
         .skip(skip)
         .limit(limit)
         .select('-__v')
-        .select('-messages')
         .lean()
         .exec(),
-      AgentConversation.countDocuments(filter),
+      ChatSession.countDocuments(filter),
     ]);
 
     const processedConversations = conversations.map((conversation: any) => ({
@@ -8184,12 +8510,13 @@ export const updateAgentConversationTitle = async (
       timestamp: new Date().toISOString(),
     });
 
-    const conversation = await AgentConversation.findOne({
+    const conversation = await ChatSession.findOne({
       _id: conversationId,
       orgId,
       userId,
       agentKey,
       isDeleted: false,
+      ...ONLY_AGENT,
     });
 
     if (!conversation) {
@@ -8262,6 +8589,7 @@ export const updateAgentFeedback = async (
       userId,
       agentKey,
       isDeleted: false,
+      ...ONLY_AGENT,
     };
 
     let updatedConversation, feedbackEntry;
@@ -8269,13 +8597,13 @@ export const updateAgentFeedback = async (
       session = await mongoose.startSession();
       ({ updatedConversation, feedbackEntry } = await session.withTransaction(
         () => performFeedbackUpdate({
-          model: AgentConversation, query, conversationId: conversationId!, messageId: messageId!,
+          query, conversationId: conversationId!, messageId: messageId!,
           userId: userId!, body: req.body, userAgent: req.headers['user-agent'], session,
         }),
       ));
     } else {
       ({ updatedConversation, feedbackEntry } = await performFeedbackUpdate({
-        model: AgentConversation, query, conversationId: conversationId!, messageId: messageId!,
+        query, conversationId: conversationId!, messageId: messageId!,
         userId: userId!, body: req.body, userAgent: req.headers['user-agent'],
       }));
     }
@@ -8364,6 +8692,7 @@ export const listAllAgentsArchivedConversationsGrouped =
       isArchived: true,
       archivedBy: { $exists: true },
       isDeleted: false,
+      ...ONLY_AGENT,
     };
     if (deletedAgentKeys !== null) {
       filter.agentKey = { $nin: deletedAgentKeys };
@@ -8372,18 +8701,18 @@ export const listAllAgentsArchivedConversationsGrouped =
     // Amazon DocumentDB does not support the $facet stage (see AWS aggregation compatibility).
     // Use a cheap count pipeline + the full data pipeline instead of $facet.
     const [countRows, rawGroups] = await Promise.all([
-      AgentConversation.aggregate<{ totalAgentCount: number }>([
+      ChatSession.aggregate<{ totalAgentCount: number }>([
         { $match: filter },
         { $group: { _id: '$agentKey' } },
         { $count: 'totalAgentCount' },
       ]),
-      AgentConversation.aggregate([
+      ChatSession.aggregate([
         { $match: filter },
         // Sort by lastActivityAt desc — must match the per-agent archive endpoint's default sort
         // so that the initial 5 chats here align with page 1 of the per-agent pagination
         { $sort: { lastActivityAt: -1 as const } },
         // Exclude heavy fields before grouping
-        { $project: { __v: 0, messages: 0 } },
+        { $project: { __v: 0, messages: 0, nextSeq: 0, sessionType: 0 } },
         {
           $group: {
             _id: '$agentKey',

--- a/backend/nodejs/apps/src/modules/enterprise_search/controller/es_controller.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/controller/es_controller.ts
@@ -5979,6 +5979,9 @@ export const deleteAgent =
         agentKey,
         modelInfo,
         sessionType: 'agent',
+        // Set explicitly: the legacy agentConversations schema defaulted this,
+        // the unified chatSessions schema can't (it also backs plain chats).
+        conversationSource: 'agent_chat',
       };
 
       // Start transaction if replica set is available
@@ -6561,6 +6564,9 @@ export const createAgentConversation =
         agentKey,
         modelInfo,
         sessionType: 'agent',
+        // Set explicitly: the legacy agentConversations schema defaulted this,
+        // the unified chatSessions schema can't (it also backs plain chats).
+        conversationSource: 'agent_chat',
       };
 
       const conversation = new ChatSession(userConversationData);
@@ -7392,13 +7398,18 @@ export const addMessageStreamToAgentConversation =
                 const errorMessage = errorData.message || 'Unknown error occurred';
                 upstreamAiErrorEventForwarded = true;
                 if (existingConversation) {
-                  markAgentConversationFailed(
+                  void markAgentConversationFailed(
                     existingConversation,
                     errorMessage,
                     session,
                     'streaming_error',
                     errorData.stack,
-                  );
+                  ).catch((markErr: any) => {
+                    logger.error('Failed to mark agent conversation from AI RUN_ERROR SSE', {
+                      requestId,
+                      error: markErr?.message,
+                    });
+                  });
                 }
                 filteredChunk += event + '\n\n';
               } catch (parseError: any) {
@@ -7472,7 +7483,7 @@ export const addMessageStreamToAgentConversation =
                   'Unknown error occurred';
                 upstreamAiErrorEventForwarded = true;
                 if (existingConversation) {
-                  markAgentConversationFailed(
+                  void markAgentConversationFailed(
                     existingConversation,
                     errorMessage,
                     session,
@@ -7481,7 +7492,12 @@ export const addMessageStreamToAgentConversation =
                     errorData.metadata
                       ? new Map(Object.entries(errorData.metadata))
                       : undefined,
-                  );
+                  ).catch((markErr: any) => {
+                    logger.error('Failed to mark agent conversation from AI error SSE', {
+                      requestId,
+                      error: markErr?.message,
+                    });
+                  });
                 }
                 filteredChunk += event + '\n\n';
               } catch (parseError: any) {
@@ -7492,13 +7508,18 @@ export const addMessageStreamToAgentConversation =
                 });
                 upstreamAiErrorEventForwarded = true;
                 if (existingConversation) {
-                  markAgentConversationFailed(
+                  void markAgentConversationFailed(
                     existingConversation,
                     `Failed to parse error event: ${parseError.message}`,
                     session,
                     'parse_error',
                     parseError.stack,
-                  );
+                  ).catch((markErr: any) => {
+                    logger.error('Failed to mark agent conversation after error-event parse failure', {
+                      requestId,
+                      error: markErr?.message,
+                    });
+                  });
                 }
                 filteredChunk += event + '\n\n';
               }
@@ -7738,7 +7759,8 @@ export const addMessageStreamToAgentConversation =
         logger.error('Stream error', { requestId, error: error.message });
         try {
           if (existingConversation) {
-            markAgentConversationFailed(
+            // Awaited so the catch below actually observes a rejection.
+            await markAgentConversationFailed(
               existingConversation,
               error.message,
               session,

--- a/backend/nodejs/apps/src/modules/enterprise_search/schema/agent.conversation.schema.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/schema/agent.conversation.schema.ts
@@ -260,6 +260,13 @@ const agentConversationSchema = new Schema({
   compactedSummary: { type: String },
   compactedAtTurnIndex: { type: Number },
   compactedAtTimestamp: { type: Number },
+
+  // Phase 2 migration bookkeeping: set once this document has been copied
+  // into chatSessions/chatSessionMessages (see chat_sessions.migration.ts).
+  // Declared on the schema (not just written via the native driver) so
+  // `strictQuery` cannot silently drop the `{isMigrated: {$ne: true}}`
+  // scan filter or the completion write.
+  isMigrated: { type: Boolean, index: true },
 }, { timestamps: true });
 
 // Create indexes

--- a/backend/nodejs/apps/src/modules/enterprise_search/schema/chat.session.message.schema.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/schema/chat.session.message.schema.ts
@@ -1,15 +1,11 @@
 import mongoose, { Schema, Model } from 'mongoose';
 import {
-  IConversation,
-  IMessage,
+  IChatSessionMessageDocument,
   IFeedback,
-  IMessageCitation,
   IFollowUpQuestion,
+  IMessageCitation,
 } from '../types/conversation.interfaces';
-import {
-  CONFIDENCE_LEVELS,
-  REASONING_EFFORT_VALUES,
-} from '../constants/constants';
+import { CONFIDENCE_LEVELS, REASONING_EFFORT_VALUES } from '../constants/constants';
 
 const toolCallItemSchema = new Schema(
   {
@@ -40,7 +36,11 @@ const followUpQuestionSchema = new Schema<IFollowUpQuestion>(
 
 const messageCitationSchema = new Schema<IMessageCitation>(
   {
-    citationId: { type: Schema.Types.ObjectId, ref: 'citations' },
+    // Matches the actually-registered citation model name ('citation',
+    // singular — see citation.schema.ts). The old embedded schema says
+    // `ref: 'citations'` and every populate() call site compensates with an
+    // explicit `model: 'citation'`; fixed here instead of carried forward.
+    citationId: { type: Schema.Types.ObjectId, ref: 'citation' },
     relevanceScore: { type: Number, min: 0, max: 1 },
     excerpt: { type: String },
     context: { type: String },
@@ -80,7 +80,7 @@ const feedbackSchema = new Schema<IFeedback>(
     },
     citationFeedback: [
       {
-        citationId: { type: Schema.Types.ObjectId, ref: 'citations' },
+        citationId: { type: Schema.Types.ObjectId, ref: 'citation' },
         isRelevant: { type: Boolean },
         relevanceScore: { type: Number, min: 1, max: 5 },
         comment: { type: String },
@@ -140,8 +140,30 @@ const attachmentRefSchema = new Schema(
   { _id: false },
 );
 
-const messageSchema = new Schema<IMessage>(
+/**
+ * One message row. Formerly an embedded subdocument of `conversations` /
+ * `agentConversations`; now its own collection ordered by `seq` (see
+ * allocateSeq in utils.ts) rather than array position, so a session can
+ * exceed MongoDB's 16MB document limit and large threads don't have to be
+ * loaded/rewritten in full on every turn.
+ *
+ * `sessionId` / `orgId` / `seq` are internal addressing fields, not part of
+ * any documented response shape — attachMessages() strips them before a
+ * message ever reaches a response.
+ */
+const chatSessionMessageSchema = new Schema<IChatSessionMessageDocument>(
   {
+    sessionId: {
+      type: Schema.Types.ObjectId,
+      required: true,
+      ref: 'ChatSession',
+      index: true,
+    },
+    orgId: { type: Schema.Types.ObjectId, required: true, index: true },
+    // Per-session monotonic sort key allocated from the parent session's
+    // `nextSeq` counter. Gaps are legal; never treat this as a count or index.
+    seq: { type: Number, required: true },
+
     messageType: {
       type: String,
       enum: [
@@ -205,85 +227,23 @@ const messageSchema = new Schema<IMessage>(
     // Persisted chain-of-thought (additive, opt-out — see reasoningTurnSchema).
     reasoning: [reasoningTurnSchema],
     // Ordered agent-activity transcript (additive, `agui` protocol only) --
-    // now populated for internal_search/web_search/universal-agent turns
-    // too, since all three run through the same agent loop as agent-key
-    // conversations. `Mixed` for the same reason as agent.conversation.
-    // schema.ts's identical field: shape varies by `type`, and `sub_agent`
-    // nests the same shape recursively.
+    // Mixed for the same reason as the legacy schema's identical field:
+    // shape varies by `type`, and `sub_agent` nests the same shape recursively.
     parts: [Schema.Types.Mixed],
   },
-  { timestamps: true },
-);
-
-// Schema for the overall conversation/thread
-const conversationSchema = new Schema<IConversation>(
   {
-    userId: { type: Schema.Types.ObjectId, required: true, index: true },
-    orgId: { type: Schema.Types.ObjectId, required: true, index: true },
-    title: { type: String },
-    initiator: { type: Schema.Types.ObjectId, required: true, index: true },
-    messages: [messageSchema],
-    isShared: { type: Boolean, default: false },
-    shareLink: { type: String },
-    sharedWith: [
-      {
-        userId: { type: Schema.Types.ObjectId },
-        accessLevel: { type: String, enum: ['read', 'write'], default: 'read' },
-      },
-      { _id: false },
-    ],
-    isDeleted: { type: Boolean, default: false },
-    deletedBy: { type: Schema.Types.ObjectId },
-    isArchived: { type: Boolean, default: false },
-    archivedBy: { type: Schema.Types.ObjectId },
-    lastActivityAt: { type: Number, default: Date.now },
-    status: {
-      type: String,
-      enum: ['None', 'Inprogress', 'Complete', 'Failed'],
-    },
-    failReason: { type: String },
-    // Model information used for this conversation
-    modelInfo: {
-      modelKey: { type: String },
-      modelName: { type: String },
-      modelProvider: { type: String },
-      chatMode: { type: String, default: 'quick' },
-      modelFriendlyName: { type: String },
-      reasoningEffort: { type: String, enum: REASONING_EFFORT_VALUES },
-    },
-    // Errors array to track errors during conversation
-    conversationErrors: [
-      {
-        message: { type: String, required: true },
-        errorType: { type: String },
-        timestamp: { type: Date, default: Date.now },
-        messageId: { type: Schema.Types.ObjectId },
-        stack: { type: String },
-        metadata: { type: Map, of: Schema.Types.Mixed },
-      },
-    ],
-    // Additional metadata for useful information
-    metadata: {
-      type: Map,
-      of: Schema.Types.Mixed,
-    },
-    // Phase 2 migration bookkeeping: set once this document has been copied
-    // into chatSessions/chatSessionMessages (see chat_sessions.migration.ts).
-    // Declared on the schema (not just written via the native driver) so
-    // `strictQuery` cannot silently drop the `{isMigrated: {$ne: true}}`
-    // scan filter or the completion write.
-    isMigrated: { type: Boolean, index: true },
+    timestamps: true, // parity with the old embedded messageSchema
+    versionKey: false, // embedded subdocuments never had __v; a top-level one would be a new, leaking field
+    collection: 'chatSessionMessages',
   },
-  { timestamps: true },
 );
 
-// Create additional indexes as needed
-conversationSchema.index({ orgId: 1, initiator: 1 });
-conversationSchema.index({ isShared: 1 });
-conversationSchema.index({ 'messages.content': 'text' });
+// Serves both the seq-ordered read path and duplicate-seq protection —
+// the real backstop for allocateSeq's optimistic $inc allocation.
+chatSessionMessageSchema.index({ sessionId: 1, seq: 1 }, { unique: true });
 
-// Export the model
-export const Conversation: Model<IConversation> = mongoose.model<IConversation>(
-  'conversations',
-  conversationSchema,
-);
+export const ChatSessionMessage: Model<IChatSessionMessageDocument> =
+  mongoose.model<IChatSessionMessageDocument>(
+    'ChatSessionMessage',
+    chatSessionMessageSchema,
+  );

--- a/backend/nodejs/apps/src/modules/enterprise_search/schema/chat.session.schema.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/schema/chat.session.schema.ts
@@ -1,0 +1,113 @@
+import mongoose, { Schema, Model } from 'mongoose';
+import { IChatSessionDocument } from '../types/conversation.interfaces';
+import { REASONING_EFFORT_VALUES } from '../constants/constants';
+
+/**
+ * Single collection backing both plain chat and agent chat threads
+ * (`sessionType` discriminates). Replaces the separate `conversations` and
+ * `agentConversations` collections. `messages` lives in `ChatSessionMessage`
+ * (see chat.session.message.schema.ts) — not embedded here, to stay clear of
+ * MongoDB's 16MB document limit and keep session reads/writes small.
+ *
+ * `sessionType` and `nextSeq` are internal bookkeeping fields, not part of
+ * any documented API response shape, so they are `select: false` — this is
+ * the structural guard against leaking them into a response even from a
+ * `.lean()` query that forgets to project them out explicitly.
+ */
+const chatSessionSchema = new Schema<IChatSessionDocument>(
+  {
+    sessionType: {
+      type: String,
+      enum: ['chat', 'agent'],
+      required: true,
+      default: 'chat',
+      select: false,
+    },
+    // Monotonic counter used solely to allocate message `seq` values; never
+    // read as a message count (messages can be soft/hard-removed leaving gaps).
+    nextSeq: { type: Number, default: 0, select: false },
+
+    userId: { type: Schema.Types.ObjectId, required: true, index: true },
+    orgId: { type: Schema.Types.ObjectId, required: true, index: true },
+    title: { type: String },
+    initiator: { type: Schema.Types.ObjectId, required: true, index: true },
+    isShared: { type: Boolean, default: false },
+    shareLink: { type: String },
+    sharedWith: [
+      {
+        userId: { type: Schema.Types.ObjectId },
+        accessLevel: {
+          type: String,
+          enum: ['read', 'write'],
+          default: 'read',
+        },
+      },
+      { _id: false },
+    ],
+    isDeleted: { type: Boolean, default: false },
+    deletedBy: { type: Schema.Types.ObjectId },
+    isArchived: { type: Boolean, default: false },
+    archivedBy: { type: Schema.Types.ObjectId },
+    lastActivityAt: { type: Number, default: Date.now },
+    status: {
+      type: String,
+      enum: ['None', 'Inprogress', 'Complete', 'Failed'],
+    },
+    failReason: { type: String },
+    // Model information used for this session
+    modelInfo: {
+      modelKey: { type: String },
+      modelName: { type: String },
+      modelProvider: { type: String },
+      chatMode: { type: String, default: 'quick' },
+      modelFriendlyName: { type: String },
+      reasoningEffort: { type: String, enum: REASONING_EFFORT_VALUES },
+    },
+    // Errors array to track errors during the session
+    conversationErrors: [
+      {
+        message: { type: String, required: true },
+        errorType: { type: String },
+        timestamp: { type: Date, default: Date.now },
+        messageId: { type: Schema.Types.ObjectId },
+        stack: { type: String },
+        metadata: { type: Map, of: Schema.Types.Mixed },
+      },
+    ],
+    // Additional metadata for useful information
+    metadata: {
+      type: Map,
+      of: Schema.Types.Mixed,
+    },
+
+    // ---- Agent-only fields (undefined when sessionType === 'chat') ----
+    agentKey: { type: String, index: true }, // Reference to agent _key in ArangoDB
+    conversationSource: {
+      type: String,
+      enum: ['agent_chat'],
+    },
+    // Context compaction: deterministic summary of older turns, populated
+    // lazily by a background job or on session load when turn count
+    // exceeds a threshold.
+    compactedSummary: { type: String },
+    compactedAtTurnIndex: { type: Number },
+    compactedAtTimestamp: { type: Number },
+  },
+  { timestamps: true, collection: 'chatSessions' },
+);
+
+// Create additional indexes as needed
+chatSessionSchema.index({
+  sessionType: 1,
+  orgId: 1,
+  userId: 1,
+  lastActivityAt: -1,
+});
+chatSessionSchema.index({ sessionType: 1, orgId: 1, initiator: 1 });
+chatSessionSchema.index({ agentKey: 1, orgId: 1 });
+chatSessionSchema.index({ userId: 1, agentKey: 1 });
+chatSessionSchema.index({ isShared: 1 });
+chatSessionSchema.index({ lastActivityAt: -1 });
+
+export const ChatSession: Model<IChatSessionDocument> =
+  mongoose.model<IChatSessionDocument>('ChatSession', chatSessionSchema);

--- a/backend/nodejs/apps/src/modules/enterprise_search/types/conversation.interfaces.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/types/conversation.interfaces.ts
@@ -201,6 +201,8 @@ export interface IConversation {
   conversationSourceRecordType?: string;
   createdAt?: Date;
   updatedAt?: Date;
+  /** Phase 2 migration bookkeeping — see chat_sessions.migration.ts. Legacy schema/model only. */
+  isMigrated?: boolean;
   failReason?: String;
   status?: String;
   // Model information used for this conversation
@@ -235,6 +237,92 @@ export interface IConversationDocument extends Document, IConversation {
 
 export interface IConversationModel extends Model<IConversationDocument> {
   // Static methods go here
+}
+
+/**
+ * A single row in the `chatSessions` collection — the Phase 1 replacement
+ * for the separate `conversations` and `agentConversations` collections.
+ * `sessionType` is the discriminator ('chat' | 'agent'); the agent-only
+ * fields below are undefined on plain chat sessions. `messages` moved out
+ * entirely — see IChatSessionMessage — so this interface intentionally does
+ * NOT extend IConversation (which still declares `messages` as required,
+ * for the legacy schema/model kept around for the kb-filters migration).
+ *
+ * `conversationSource` here is deliberately narrower than IConversation's
+ * (which conflates a semantic "how was this conversation started" enum with
+ * the agent.conversation.schema.ts override `enum: ['agent_chat']`) — this
+ * type only ever needs the latter, written on agent sessions.
+ */
+export interface IChatSession {
+  userId: Types.ObjectId;
+  orgId: Types.ObjectId;
+  title?: string;
+  initiator: Types.ObjectId;
+  isShared?: boolean;
+  shareLink?: string;
+  sharedWith?: Array<{
+    userId: Types.ObjectId;
+    accessLevel: 'read' | 'write';
+  }>;
+  isDeleted?: boolean;
+  deletedBy?: Types.ObjectId;
+  isArchived?: boolean;
+  archivedBy?: Types.ObjectId;
+  lastActivityAt?: Number;
+  tags?: Types.ObjectId[];
+  createdAt?: Date;
+  updatedAt?: Date;
+  failReason?: String;
+  status?: String;
+  modelInfo?: IAIModel;
+  conversationErrors?: Array<{
+    message: string;
+    errorType?: string;
+    timestamp?: Date;
+    messageId?: Types.ObjectId;
+    stack?: string;
+    metadata?: Map<string, any>;
+  }>;
+  metadata?: Map<string, any>;
+
+  /** Discriminator. Internal (`select: false` in the schema) — never returned in a response. */
+  sessionType: 'chat' | 'agent';
+  /** Seq allocation counter. Internal (`select: false` in the schema) — never returned in a response. */
+  nextSeq?: number;
+
+  // ---- Agent-only fields, present only when sessionType === 'agent' ----
+  agentKey?: string;
+  conversationSource?: 'agent_chat';
+  compactedSummary?: string;
+  compactedAtTurnIndex?: number;
+  compactedAtTimestamp?: number;
+}
+
+export interface IChatSessionDocument extends Document, IChatSession {
+  // Document methods are inherited
+}
+
+/**
+ * A single row in the `chatSessionMessages` collection — the unwound,
+ * separately-stored `messages[]` entry that used to live embedded inside a
+ * conversation/agentConversation document. `IMessage` remains the shared,
+ * response-facing shape (see buildConversationResponse / attachMessages);
+ * this adds only the internal addressing fields, all stripped before a
+ * message reaches a response.
+ */
+export interface IChatSessionMessage extends IMessage {
+  /** Internal addressing field — never returned in a response. */
+  sessionId: Types.ObjectId;
+  /** Internal addressing field — never returned in a response. */
+  orgId: Types.ObjectId;
+  /** Internal sort key — never returned in a response; gaps are legal. */
+  seq: number;
+}
+
+export interface IChatSessionMessageDocument
+  extends Document,
+    IChatSessionMessage {
+  // Document methods are inherited
 }
 
 export interface AIServiceResponse<T> {

--- a/backend/nodejs/apps/src/modules/enterprise_search/utils/utils.ts
+++ b/backend/nodejs/apps/src/modules/enterprise_search/utils/utils.ts
@@ -1,11 +1,10 @@
 import {
   AIServiceResponse,
-  IAgentConversation,
   IAIModel,
   IAppliedFilterNode,
   IChatAttachmentRef,
-  IConversation,
-  IConversationDocument,
+  IChatSessionDocument,
+  IChatSessionMessageDocument,
   IMessage,
   IMessageCitation,
   IMessageDocument,
@@ -17,16 +16,14 @@ import { AuthenticatedUserRequest } from '../../../libs/middlewares/types';
 import {
   BadRequestError,
   InternalServerError,
+  NotFoundError,
 } from '../../../libs/errors/http.errors';
 import Citation, { ICitation } from '../schema/citation.schema';
-import { CONVERSATION_STATUS } from '../constants/constants';
+import { CONVERSATION_STATUS, ONLY_AGENT } from '../constants/constants';
 import { Logger } from '../../../libs/services/logger.service';
-import {
-  IAgentConversationDocument,
-  AgentConversation,
-} from '../schema/agent.conversation.schema';
 import { Response } from 'express';
-import { Conversation } from '../schema/conversation.schema';
+import { ChatSession } from '../schema/chat.session.schema';
+import { ChatSessionMessage } from '../schema/chat.session.message.schema';
 import { safeParsePagination } from '../../../utils/safe-integer';
 import {
   sanitizeForResponse,
@@ -115,6 +112,61 @@ function extractSearchParameter(searchParam: unknown): string {
   return searchParam;
 }
 
+/**
+ * Shared XSS-validation + regex-escaping for the title/content search param,
+ * used by both `buildFilter` and `buildAgentConversationFilter` (and by their
+ * callers' async content-match lookup — see `findSessionIdsMatchingContent`)
+ * so the two computations of "the escaped search term" can never drift.
+ */
+export const validateAndEscapeSearch = (
+  searchParam: unknown,
+  options: { formatSpecifiers?: boolean } = {},
+): string => {
+  const searchValue = extractSearchParameter(searchParam);
+
+  validateNoXSS(searchValue, 'search parameter');
+  if (options.formatSpecifiers) {
+    validateNoFormatSpecifiers(searchValue, 'search parameter');
+  }
+
+  if (searchValue.length > 1000) {
+    throw new BadRequestError(
+      'Search parameter too long (max 1000 characters)',
+    );
+  }
+
+  // Escape special regex characters to prevent regex injection
+  return searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+};
+
+/**
+ * Case-insensitive substring match against message content, scoped to one
+ * org. An unanchored `$regex` can't use an index, so this is a collection
+ * scan either way; `limit` bounds the result set (and therefore memory) at
+ * the cost of silently truncating pathological searches — see the Phase 1
+ * plan's "Search" section. Replacing this with a real text index is a
+ * Phase 2 follow-up.
+ */
+export const findSessionIdsMatchingContent = async (
+  orgId: string,
+  escapedSearch: string,
+  limit = 10000,
+): Promise<mongoose.Types.ObjectId[]> => {
+  const rows = await ChatSessionMessage.aggregate<{
+    _id: mongoose.Types.ObjectId;
+  }>([
+    {
+      $match: {
+        orgId: new mongoose.Types.ObjectId(orgId),
+        content: { $regex: escapedSearch, $options: 'i' },
+      },
+    },
+    { $group: { _id: '$sessionId' } },
+    { $limit: limit },
+  ]);
+  return rows.map((r) => r._id);
+};
+
 export const buildAIFailureResponseMessage = (): IMessage => ({
   messageType: 'error',
   content: 'Error Generating Response, Please try again',
@@ -123,8 +175,179 @@ export const buildAIFailureResponseMessage = (): IMessage => ({
   updatedAt: new Date(),
 });
 
+// ---------------------------------------------------------------------------
+// Core chatSessions / chatSessionMessages helpers (Phase 1)
+// ---------------------------------------------------------------------------
+
 /**
- * Attach populated citation documents across ALL messages of a conversation.
+ * Allocate a contiguous block of `n` sequence numbers for a session via an
+ * atomic `$inc` on the session's `nextSeq` counter. Race-free by
+ * construction (concurrent callers each get a disjoint block from the same
+ * counter); the unique `{sessionId, seq}` index on chatSessionMessages is
+ * the backstop. Returns the END of the allocated block — the block itself
+ * is `[end - n + 1 .. end]`. `seq` is a sort key only: never derive a count,
+ * an index, or a page offset from it, and never assume no gaps.
+ */
+export const allocateSeq = async (
+  sessionId: mongoose.Types.ObjectId | string,
+  n: number,
+  mongoSession?: ClientSession | null,
+): Promise<number> => {
+  const updated = await ChatSession.findOneAndUpdate(
+    { _id: sessionId },
+    { $inc: { nextSeq: n } },
+    {
+      new: true,
+      projection: { nextSeq: 1 }, // overrides the schema's `select: false` for this one read
+      session: mongoSession || undefined,
+    },
+  );
+  if (!updated) {
+    throw new NotFoundError(
+      'Chat session not found while allocating message sequence',
+    );
+  }
+  return updated.nextSeq as number;
+};
+
+/**
+ * Append one or more messages to a session's message collection. Allocates
+ * their `seq` block first, then inserts — see the Phase 1 plan's "Ordering"
+ * section for why (a crash between the two leaves nothing inconsistent: no
+ * message row exists yet). Returns the inserted documents (not `.lean()`)
+ * so callers can `.toObject()` them for `attachPopulatedCitations` fallback
+ * without a second query.
+ */
+export const appendMessages = async (
+  sessionId: mongoose.Types.ObjectId | string,
+  orgId: mongoose.Types.ObjectId | string,
+  messages: IMessage[],
+  mongoSession?: ClientSession | null,
+): Promise<IChatSessionMessageDocument[]> => {
+  if (messages.length === 0) {
+    return [];
+  }
+  const endSeq = await allocateSeq(sessionId, messages.length, mongoSession);
+  const startSeq = endSeq - messages.length + 1;
+  const toInsert = messages.map((message, i) => ({
+    ...message,
+    sessionId,
+    orgId,
+    seq: startSeq + i,
+  }));
+  return ChatSessionMessage.insertMany(toInsert, {
+    ordered: true,
+    session: mongoSession || undefined,
+  }) as unknown as Promise<IChatSessionMessageDocument[]>;
+};
+
+/**
+ * Wholesale-replace one message's content, preserving its `_id`/`sessionId`/
+ * `orgId`/`seq`. Mirrors the old `conversation.messages[index] = newMessage`
+ * array-element replacement (regeneration intentionally discards the prior
+ * message's citations/feedback/etc. — only its identity and position stay
+ * stable), so this is a full `findOneAndReplace`, not a `$set` merge (which
+ * would leave stale fields the new content doesn't mention).
+ */
+export const updateMessageById = async (
+  messageId: mongoose.Types.ObjectId | string,
+  newContent: IMessage,
+  mongoSession?: ClientSession | null,
+): Promise<IChatSessionMessageDocument | null> => {
+  const existing = await ChatSessionMessage.findById(messageId, undefined, {
+    session: mongoSession || undefined,
+  });
+  if (!existing) {
+    return null;
+  }
+  return ChatSessionMessage.findOneAndReplace(
+    { _id: messageId },
+    {
+      ...newContent,
+      sessionId: existing.sessionId,
+      orgId: existing.orgId,
+      seq: existing.seq,
+    },
+    { new: true, session: mongoSession || undefined, runValidators: true },
+  );
+};
+
+/** Append a feedback entry to one message's `feedback` array. */
+export const appendMessageFeedback = async (
+  messageId: mongoose.Types.ObjectId | string,
+  feedbackEntry: unknown,
+  mongoSession?: ClientSession | null,
+): Promise<IChatSessionMessageDocument | null> => {
+  return ChatSessionMessage.findOneAndUpdate(
+    { _id: messageId },
+    { $push: { feedback: feedbackEntry } },
+    { new: true, session: mongoSession || undefined, runValidators: true },
+  );
+};
+
+/**
+ * Fetch a session's messages, `seq`-ordered (ascending = chronological,
+ * matching the old embedded array's order). `.lean()`, matching every
+ * existing read path. Short-circuits to `[]` when `limit <= 0` — MongoDB's
+ * own `.limit(0)` means "no limit", the opposite of what a zero-message
+ * page must return.
+ */
+export const getMessages = async (
+  sessionId: mongoose.Types.ObjectId | string,
+  options: {
+    skip?: number;
+    limit?: number;
+    populateCitations?: boolean;
+    sort?: 1 | -1;
+  } = {},
+  mongoSession?: ClientSession | null,
+): Promise<any[]> => {
+  const { skip = 0, limit, populateCitations = false, sort = 1 } = options;
+  if (limit !== undefined && limit <= 0) {
+    return [];
+  }
+  let query = ChatSessionMessage.find({ sessionId }).sort({ seq: sort });
+  if (skip) {
+    query = query.skip(skip);
+  }
+  if (limit !== undefined) {
+    query = query.limit(limit);
+  }
+  if (populateCitations) {
+    query = query.populate({
+      path: 'citations.citationId',
+      model: 'citation',
+      select: '-__v',
+    });
+  }
+  if (mongoSession) {
+    query = query.session(mongoSession);
+  }
+  return query.lean().exec();
+};
+
+/**
+ * Reconstruct the legacy `{...session, messages: [...]}` response shape
+ * from a session object and an already-fetched messages array. Pure and
+ * synchronous — this is the structural leakage guard for in-memory
+ * `.toObject()` results that never passed through a query projection:
+ * strips `nextSeq`/`sessionType` from the session and `sessionId`/`orgId`/
+ * `seq` from each message, neither of which is part of any documented
+ * response shape.
+ */
+export const attachMessages = (session: any, messages: any[]): any => {
+  const { nextSeq, sessionType, ...cleanSession } = session ?? {};
+  return {
+    ...cleanSession,
+    messages: (messages || []).map((message: any) => {
+      const { sessionId, orgId, seq, ...rest } = message;
+      return rest;
+    }),
+  };
+};
+
+/**
+ * Attach populated citation documents across ALL messages of a session.
  *
  * Earlier implementations built a lookup map from ONLY the newly-created
  * citations for the current response and then applied it to every message in
@@ -136,101 +359,97 @@ export const buildAIFailureResponseMessage = (): IMessage => ({
  * `getConversationById` path correctly populates citations).
  *
  * Strategy:
- *   1. Re-fetch the conversation with `populate` on every citationId across
- *      all messages (matches the GET path).
+ *   1. Re-fetch ALL of the session's messages with `populate` on every
+ *      citationId (matches the GET path).
  *   2. For each message citation, if populate resolved to a full Citation
  *      document, use it. Otherwise fall back to the newly-created
  *      `fallbackCitations` array (handles transactional edge cases where the
  *      just-saved citation isn't visible to a follow-up query).
+ *
+ * `fallbackMessages` (typically just the message(s) the caller had in hand
+ * from the write it just performed) is used instead of the fresh fetch when
+ * Mongoose isn't connected (unit tests — see the readyState guard below) or
+ * the fetch throws; it will not include older history in that case, which is
+ * an accepted gap for the disconnected/test-only path (see the Phase 1
+ * plan's "Known Phase 2 items").
  */
-export const attachPopulatedCitations = async <
-  T extends IConversation | IAgentConversation,
->(
-  conversationId: mongoose.Types.ObjectId | string | undefined,
-  updatedConversationObject: T,
+export const attachPopulatedCitations = async (
+  session: any,
+  fallbackMessages: any[],
   fallbackCitations: ICitation[],
-  isAgent: boolean,
-  session?: ClientSession | null,
-): Promise<T> => {
-  let plainConversation: T = updatedConversationObject;
+  mongoSession?: ClientSession | null,
+): Promise<any> => {
+  const sessionId = session?._id;
+  let messages = fallbackMessages;
 
   // Only attempt the populate round-trip when Mongoose is actually connected.
   // In unit tests (and any environment without an active DB connection) the
   // default Mongoose buffering would hang this call for ~10s before failing,
-  // which is both slow and unnecessary — the fallback branch below handles
-  // those cases using the newly-created citations.
+  // which is both slow and unnecessary — the fallback branch handles those
+  // cases using the caller-supplied messages.
   const isConnected = mongoose.connection?.readyState === 1;
 
-  if (conversationId && isConnected) {
+  if (sessionId && isConnected) {
     try {
-      const Model = isAgent ? AgentConversation : Conversation;
-      const query = (Model as any).findById(conversationId).populate({
-        path: 'messages.citations.citationId',
-        model: 'citation',
-        select: '-__v',
-      });
-      if (session) {
-        query.session(session);
-      }
-      const populated = await query.lean().exec();
-      if (populated) {
-        plainConversation = populated as T;
-      }
+      messages = await getMessages(
+        sessionId,
+        { populateCitations: true },
+        mongoSession,
+      );
     } catch (err: any) {
       logger.warn(
         'Failed to populate citations for conversation response; falling back to newly-created citations only',
-        { conversationId: conversationId?.toString(), error: err?.message },
+        { conversationId: sessionId?.toString(), error: err?.message },
       );
     }
   }
 
+  const attached = attachMessages(session, messages);
   return {
-    ...plainConversation,
-    messages: (plainConversation.messages as IMessage[]).map(
-      (message: IMessage) => ({
-        ...message,
-        citations:
-          message.citations?.map((citation: IMessageCitation) => {
-            // After populate, `citationId` is the full Citation document;
-            // otherwise it's still an ObjectId / string reference. We must
-            // explicitly exclude ObjectId here because some bson versions
-            // expose inherited properties that make a plain `'_id' in x`
-            // check truthy on an ObjectId.
-            const populated = citation.citationId as unknown as
-              | (ICitation & { _id?: mongoose.Types.ObjectId })
-              | mongoose.Types.ObjectId
-              | string
-              | undefined;
-            const isPopulatedCitationDoc =
-              !!populated &&
-              typeof populated === 'object' &&
-              !(populated instanceof mongoose.Types.ObjectId) &&
-              (populated as any)._bsontype !== 'ObjectId' &&
-              '_id' in populated;
-            if (isPopulatedCitationDoc) {
-              const doc = populated as ICitation & {
-                _id?: mongoose.Types.ObjectId;
-              };
-              return {
-                ...citation,
-                citationId: doc._id,
-                citationData: doc as ICitation,
-              };
-            }
-            // Fallback to the newly-created citations for this response.
+    ...attached,
+    messages: attached.messages.map((message: IMessage) => ({
+      ...message,
+      citations:
+        message.citations?.map((citation: IMessageCitation) => {
+          // After populate, `citationId` is the full Citation document;
+          // otherwise it's still an ObjectId / string reference. We must
+          // explicitly exclude ObjectId here because some bson versions
+          // expose inherited properties that make a plain `'_id' in x`
+          // check truthy on an ObjectId.
+          const populated = citation.citationId as unknown as
+            | (ICitation & { _id?: mongoose.Types.ObjectId })
+            | mongoose.Types.ObjectId
+            | string
+            | undefined;
+          const isPopulatedCitationDoc =
+            !!populated &&
+            typeof populated === 'object' &&
+            !(populated instanceof mongoose.Types.ObjectId) &&
+            (populated as any)._bsontype !== 'ObjectId' &&
+            '_id' in populated;
+          if (isPopulatedCitationDoc) {
+            const doc = populated as ICitation & {
+              _id?: mongoose.Types.ObjectId;
+            };
             return {
               ...citation,
-              citationData: citation.citationId
-                ? fallbackCitations.find(
-                    (c: ICitation) =>
-                      c._id?.toString() === citation.citationId?.toString(),
-                  )
-                : undefined,
+              citationId: doc._id,
+              citationData: doc as ICitation,
             };
-          }) || [],
-      }),
-    ),
-  } as T;
+          }
+          // Fallback to the newly-created citations for this response.
+          return {
+            ...citation,
+            citationData: citation.citationId
+              ? fallbackCitations.find(
+                  (c: ICitation) =>
+                    c._id?.toString() === citation.citationId?.toString(),
+                )
+              : undefined,
+          };
+        }) || [],
+    })),
+  };
 };
 
 export const buildAIResponseMessage = (
@@ -425,8 +644,13 @@ export const buildSortOptions = (req: AuthenticatedUserRequest) => {
   };
 };
 
-export const addComputedFields = (
-  conversation: IConversation | IConversationDocument,
+export const addComputedFields = <
+  T extends {
+    initiator: { toString(): string };
+    sharedWith?: Array<{ userId: { toString(): string }; accessLevel: string }>;
+  },
+>(
+  conversation: T,
   userId: string,
 ) => {
   return {
@@ -440,13 +664,19 @@ export const addComputedFields = (
 };
 
 /**
- * Base access filter for conversations / enterprise searches in list and
+ * Base access filter for chat sessions / enterprise searches in list and
  * by-id flows. Matches either:
  * - rows owned by this user (`userId`), or
  * - rows explicitly shared with this user (`isShared` and `sharedWith` contains
  *   their id).
  *
  * The shared branch uses `$and` so `isShared: true` alone does not grant access.
+ *
+ * `contentMatchIds`, when provided, ORs an `_id: {$in: ...}` clause into the
+ * search predicate alongside the title regex — see
+ * `findSessionIdsMatchingContent`. Callers that don't pass it (the 8
+ * `EnterpriseSemanticSearch` call sites, whose documents have no `messages`)
+ * get exactly today's title-only search behaviour.
  */
 export const buildFilter = (
   req: AuthenticatedUserRequest,
@@ -455,6 +685,7 @@ export const buildFilter = (
   id?: string, // conversationId or searchId
   owned: boolean = true,
   shared: boolean = true,
+  contentMatchIds?: mongoose.Types.ObjectId[],
 ) => {
   if (!owned && !shared) {
     throw new BadRequestError('Either owned or shared must be true');
@@ -485,28 +716,16 @@ export const buildFilter = (
   }
 
   // Handle search with XSS validation
-  // Use helper function to safely extract and validate search parameter
   if (req.query.search) {
-    const searchValue = extractSearchParameter(req.query.search);
-
-    // Validate search parameter for XSS
-    validateNoXSS(searchValue, 'search parameter');
-
-    // Additional validation: limit search length
-    if (searchValue.length > 1000) {
-      throw new BadRequestError(
-        'Search parameter too long (max 1000 characters)',
-      );
-    }
-
-    // Escape special regex characters to prevent regex injection
-    const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedSearch = validateAndEscapeSearch(req.query.search);
 
     filter.$and = [
       {
         $or: [
           { title: { $regex: escapedSearch, $options: 'i' } },
-          { 'messages.content': { $regex: escapedSearch, $options: 'i' } },
+          ...(contentMatchIds && contentMatchIds.length > 0
+            ? [{ _id: { $in: contentMatchIds } }]
+            : []),
         ],
       },
     ];
@@ -826,7 +1045,7 @@ export const buildMessageSortOptions = (
 };
 
 export const buildConversationResponse = (
-  conversation: IConversationDocument,
+  conversation: IChatSessionDocument,
   userId: string,
   pagination: {
     page: number;
@@ -888,7 +1107,7 @@ export const buildConversationResponse = (
 
 // Helper function to save complete conversation
 export const saveCompleteConversation = async (
-  conversation: IConversationDocument,
+  conversation: IChatSessionDocument,
   completeData: IAIResponse,
   orgId: string,
   session?: ClientSession | null,
@@ -916,10 +1135,18 @@ export const saveCompleteConversation = async (
       { data: completeData, statusCode: 200 },
       citations,
       modelInfo,
-    ) as IMessageDocument;
+    );
 
-    // Update conversation
-    conversation.messages.push(aiResponseMessage);
+    // Insert it before flipping the session to Complete — see "Ordering" in
+    // the Phase 1 plan: a crash between the two leaves a persisted message
+    // under a stale (Inprogress) status, which is recoverable.
+    const [insertedMessage] = await appendMessages(
+      conversation._id as mongoose.Types.ObjectId,
+      conversation.orgId,
+      [aiResponseMessage],
+      session,
+    );
+
     if (modelInfo) {
       const fieldsToUpdate: Array<keyof IAIModel> = [
         'modelKey',
@@ -949,10 +1176,9 @@ export const saveCompleteConversation = async (
     }
 
     return attachPopulatedCitations(
-      updatedConversation._id as mongoose.Types.ObjectId,
-      updatedConversation.toObject() as IConversation,
+      updatedConversation.toObject(),
+      [insertedMessage!.toObject()],
       citations,
-      false,
       session,
     );
   } catch (error: any) {
@@ -964,10 +1190,9 @@ export const saveCompleteConversation = async (
   }
 };
 
-// Helper function to mark conversation as failed
 // Helper function to add error to conversation errors array
 export const addErrorToConversation = (
-  conversation: IConversationDocument | IAgentConversationDocument,
+  conversation: IChatSessionDocument,
   errorMessage: string,
   errorType?: string,
   messageId?: mongoose.Types.ObjectId,
@@ -988,7 +1213,7 @@ export const addErrorToConversation = (
 };
 
 export const markConversationFailed = async (
-  conversation: IConversationDocument,
+  conversation: IChatSessionDocument,
   failReason: string,
   session?: ClientSession | null,
   errorType?: string,
@@ -996,6 +1221,16 @@ export const markConversationFailed = async (
   metadata?: Map<string, any>,
 ): Promise<void> => {
   try {
+    // Insert the failure message first — see "Ordering" in the Phase 1 plan.
+    const failedMessage = buildAIFailureResponseMessage();
+    failedMessage.content = failReason;
+    await appendMessages(
+      conversation._id as mongoose.Types.ObjectId,
+      conversation.orgId,
+      [failedMessage],
+      session,
+    );
+
     conversation.status = CONVERSATION_STATUS.FAILED;
     conversation.failReason = failReason;
     conversation.lastActivityAt = Date.now();
@@ -1009,12 +1244,6 @@ export const markConversationFailed = async (
       stack,
       metadata,
     );
-
-    // Add failure message
-    const failedMessage = buildAIFailureResponseMessage() as IMessageDocument;
-    // Update the error message content with the exact error
-    failedMessage.content = failReason;
-    conversation.messages.push(failedMessage);
 
     // Save failed conversation
     const savedWithError = session
@@ -1042,11 +1271,13 @@ export const markConversationFailed = async (
 };
 
 /**
- * Replace a message at a specific index with an error message (used for regeneration)
+ * Replace a message (identified by its `_id`) with an error message — used
+ * for regeneration. Positional (`messageIndex`) addressing no longer applies
+ * once messages live in their own collection.
  */
 export const replaceMessageWithError = async (
-  conversation: IConversationDocument | IAgentConversationDocument,
-  messageIndex: number,
+  conversation: IChatSessionDocument,
+  messageId: mongoose.Types.ObjectId | string,
   errorMessage: string,
   session?: ClientSession | null,
   errorType?: string,
@@ -1054,35 +1285,39 @@ export const replaceMessageWithError = async (
   metadata?: Map<string, any>,
 ): Promise<void> => {
   try {
-    if (messageIndex < 0 || messageIndex >= conversation.messages.length) {
-      throw new InternalServerError(
-        'Invalid message index for error replacement',
-      );
-    }
-
     conversation.status = CONVERSATION_STATUS.FAILED;
     conversation.failReason = errorMessage;
     conversation.lastActivityAt = Date.now();
 
+    const messageObjectId =
+      typeof messageId === 'string'
+        ? new mongoose.Types.ObjectId(messageId)
+        : messageId;
+
     // Add error to errors array
-    const originalMessage = conversation.messages[
-      messageIndex
-    ] as IMessageDocument;
     addErrorToConversation(
       conversation,
       errorMessage,
       errorType,
-      originalMessage._id as mongoose.Types.ObjectId,
+      messageObjectId,
       stack,
       metadata,
     );
 
-    // Replace the message at the specified index with error message
-    const failedMessage = buildAIFailureResponseMessage() as IMessageDocument;
+    // Replace the message with an error message, preserving its _id/seq
+    const failedMessage = buildAIFailureResponseMessage();
     failedMessage.content = errorMessage;
-    // Preserve the original message ID
-    failedMessage._id = originalMessage._id;
-    conversation.messages[messageIndex] = failedMessage;
+    const updatedMessage = await updateMessageById(
+      messageId,
+      failedMessage,
+      session,
+    );
+    if (!updatedMessage) {
+      logger.error('Failed to replace message with error: message not found', {
+        conversationId: conversation._id,
+        messageId,
+      });
+    }
 
     // Save updated conversation
     const savedWithError = session
@@ -1092,20 +1327,20 @@ export const replaceMessageWithError = async (
     if (!savedWithError) {
       logger.error('Failed to replace message with error', {
         conversationId: conversation._id,
-        messageIndex,
+        messageId,
         errorMessage,
       });
     }
 
     logger.debug('Message replaced with error', {
       conversationId: conversation._id,
-      messageIndex,
+      messageId,
       errorMessage,
     });
   } catch (error: any) {
     logger.error('Error replacing message with error', {
       conversationId: conversation._id,
-      messageIndex,
+      messageId,
       error: error.message,
     });
     throw error;
@@ -1116,7 +1351,7 @@ export const replaceMessageWithError = async (
  * Save complete agent conversation data to database
  */
 export const saveCompleteAgentConversation = async (
-  conversation: IAgentConversationDocument,
+  conversation: IChatSessionDocument,
   completeData: IAIResponse,
   orgId: string,
   session?: ClientSession | null,
@@ -1144,10 +1379,15 @@ export const saveCompleteAgentConversation = async (
       { data: completeData, statusCode: 200 },
       citations,
       modelInfo,
-    ) as IMessageDocument;
+    );
 
-    // Update conversation
-    conversation.messages.push(aiResponseMessage);
+    const [insertedMessage] = await appendMessages(
+      conversation._id as mongoose.Types.ObjectId,
+      conversation.orgId,
+      [aiResponseMessage],
+      session,
+    );
+
     if (modelInfo) {
       const fieldsToUpdate: Array<keyof IAIModel> = [
         'modelKey',
@@ -1177,10 +1417,9 @@ export const saveCompleteAgentConversation = async (
     }
 
     return attachPopulatedCitations(
-      updatedConversation._id as mongoose.Types.ObjectId,
-      updatedConversation.toObject() as IAgentConversation,
+      updatedConversation.toObject(),
+      [insertedMessage!.toObject()],
       citations,
-      true,
       session,
     );
   } catch (error: any) {
@@ -1197,7 +1436,7 @@ export const saveCompleteAgentConversation = async (
  * Mark agent conversation as failed
  */
 export const markAgentConversationFailed = async (
-  conversation: IAgentConversationDocument,
+  conversation: IChatSessionDocument,
   failReason: string,
   session?: ClientSession | null,
   errorType?: string,
@@ -1205,6 +1444,14 @@ export const markAgentConversationFailed = async (
   metadata?: Map<string, any>,
 ): Promise<void> => {
   try {
+    const failedMessage = buildAIFailureResponseMessage();
+    await appendMessages(
+      conversation._id as mongoose.Types.ObjectId,
+      conversation.orgId,
+      [failedMessage],
+      session,
+    );
+
     conversation.status = CONVERSATION_STATUS.FAILED;
     conversation.failReason = failReason;
     conversation.lastActivityAt = Date.now();
@@ -1217,10 +1464,6 @@ export const markAgentConversationFailed = async (
       stack,
       metadata,
     );
-
-    // Add failure message
-    const failedMessage = buildAIFailureResponseMessage() as IMessageDocument;
-    conversation.messages.push(failedMessage);
 
     // Save failed conversation
     const savedWithError = session
@@ -1251,17 +1494,20 @@ export const markAgentConversationFailed = async (
 };
 
 /**
- * Build filter for agent conversations
+ * Build filter for agent conversations. `ONLY_AGENT` is applied here (in
+ * addition to always requiring a concrete `agentKey`) as defense-in-depth
+ * now that agent and plain-chat sessions share one collection.
  */
-
 export const buildAgentConversationFilter = (
   req: any,
   orgId: string,
   userId: string,
   agentKey: string,
   conversationId?: string,
+  contentMatchIds?: mongoose.Types.ObjectId[],
 ) => {
   const filter: any = {
+    ...ONLY_AGENT,
     agentKey,
     orgId: new mongoose.Types.ObjectId(orgId),
     $or: [{ userId: new mongoose.Types.ObjectId(userId) }],
@@ -1273,29 +1519,18 @@ export const buildAgentConversationFilter = (
   }
 
   // Handle search with XSS and format string validation
-  // Use helper function to safely extract and validate search parameter
   if (req.query.search) {
-    const searchValue = extractSearchParameter(req.query.search);
-
-    // Validate search parameter for XSS and format specifiers
-    validateNoXSS(searchValue, 'search parameter');
-    validateNoFormatSpecifiers(searchValue, 'search parameter');
-
-    // Additional validation: limit search length
-    if (searchValue.length > 1000) {
-      throw new BadRequestError(
-        'Search parameter too long (max 1000 characters)',
-      );
-    }
-
-    // Escape special regex characters to prevent regex injection
-    const escapedSearch = searchValue.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const escapedSearch = validateAndEscapeSearch(req.query.search, {
+      formatSpecifiers: true,
+    });
 
     filter.$and = [
       {
         $or: [
           { title: { $regex: escapedSearch, $options: 'i' } },
-          { 'messages.content': { $regex: escapedSearch, $options: 'i' } },
+          ...(contentMatchIds && contentMatchIds.length > 0
+            ? [{ _id: { $in: contentMatchIds } }]
+            : []),
         ],
       },
     ];
@@ -1344,6 +1579,7 @@ export const buildAgentSharedWithMeFilter = (
   agentKey: string,
 ) => {
   const filter: any = {
+    ...ONLY_AGENT,
     agentKey,
     orgId: new mongoose.Types.ObjectId(orgId),
     isDeleted: false,
@@ -1361,32 +1597,6 @@ export const buildAgentSharedWithMeFilter = (
   }
 
   return filter;
-};
-
-/**
- * Add computed fields for agent conversations
- */
-export const addAgentConversationComputedFields = (
-  conversation: any,
-  userId: string,
-) => {
-  return {
-    ...conversation,
-    isOwner: conversation.userId?.toString() === userId?.toString(),
-    canEdit:
-      conversation.userId?.toString() === userId?.toString() ||
-      conversation.sharedWith?.some(
-        (share: any) =>
-          share.userId?.toString() === userId?.toString() &&
-          share.accessLevel === 'write',
-      ),
-    canView: true, // User can view if they got this conversation in results
-    messageCount: conversation.messages?.length || 0,
-    lastMessage:
-      conversation.messages?.length > 0
-        ? conversation.messages[conversation.messages.length - 1]
-        : null,
-  };
 };
 
 /**
@@ -1410,9 +1620,10 @@ export const validateAgentConversationAccess = async (
   userId: string,
   orgId: string,
   accessLevel: 'read' | 'write' = 'read',
-): Promise<IAgentConversationDocument | null> => {
+): Promise<IChatSessionDocument | null> => {
   try {
-    const conversation = await AgentConversation.findOne({
+    const conversation = await ChatSession.findOne({
+      ...ONLY_AGENT,
       _id: conversationId,
       agentKey,
       orgId,
@@ -1441,192 +1652,6 @@ export const validateAgentConversationAccess = async (
 };
 
 /**
- * Get agent conversation statistics
- */
-export const getAgentConversationStats = async (
-  agentKey: string,
-  orgId: string,
-  userId: string,
-) => {
-  try {
-    const stats = await AgentConversation.aggregate([
-      {
-        $match: {
-          agentKey,
-          orgId,
-          userId,
-          isDeleted: false,
-        },
-      },
-      {
-        $group: {
-          _id: null,
-          totalConversations: { $sum: 1 },
-          completedConversations: {
-            $sum: { $cond: [{ $eq: ['$status', 'Complete'] }, 1, 0] },
-          },
-          failedConversations: {
-            $sum: { $cond: [{ $eq: ['$status', 'Failed'] }, 1, 0] },
-          },
-          inProgressConversations: {
-            $sum: { $cond: [{ $eq: ['$status', 'Inprogress'] }, 1, 0] },
-          },
-          totalMessages: { $sum: { $size: '$messages' } },
-          avgMessagesPerConversation: { $avg: { $size: '$messages' } },
-          lastActivity: { $max: '$lastActivityAt' },
-        },
-      },
-    ]);
-
-    return (
-      stats[0] || {
-        totalConversations: 0,
-        completedConversations: 0,
-        failedConversations: 0,
-        inProgressConversations: 0,
-        totalMessages: 0,
-        avgMessagesPerConversation: 0,
-        lastActivity: null,
-      }
-    );
-  } catch (error: any) {
-    logger.error('Error getting agent conversation stats', {
-      agentKey,
-      orgId,
-      userId,
-      error: error.message,
-    });
-    throw error;
-  }
-};
-
-/**
- * Search agent conversations
- */
-export const searchAgentConversations = async (
-  agentKey: string,
-  orgId: string,
-  userId: string,
-  searchQuery: string,
-  options: {
-    page?: number;
-    limit?: number;
-    sortBy?: string;
-    sortOrder?: 'asc' | 'desc';
-  } = {},
-) => {
-  try {
-    const {
-      page = 1,
-      limit = 20,
-      sortBy = 'lastActivityAt',
-      sortOrder = 'desc',
-    } = options;
-
-    const skip = (page - 1) * limit;
-    const sort: any = {};
-    sort[sortBy] = sortOrder === 'asc' ? 1 : -1;
-
-    const searchFilter = {
-      agentKey,
-      orgId,
-      userId,
-      isDeleted: false,
-      $or: [
-        { title: { $regex: searchQuery, $options: 'i' } },
-        { 'messages.content': { $regex: searchQuery, $options: 'i' } },
-      ],
-    };
-
-    const [conversations, totalCount] = await Promise.all([
-      AgentConversation.find(searchFilter)
-        .sort(sort)
-        .skip(skip)
-        .limit(limit)
-        .select('-messages') // Exclude messages for list view
-        .lean()
-        .exec(),
-      AgentConversation.countDocuments(searchFilter),
-    ]);
-
-    return {
-      conversations: conversations.map((conv) =>
-        addAgentConversationComputedFields(conv, userId),
-      ),
-      pagination: {
-        page,
-        limit,
-        total: totalCount,
-        pages: Math.ceil(totalCount / limit),
-        hasNextPage: page < Math.ceil(totalCount / limit),
-        hasPrevPage: page > 1,
-      },
-      searchQuery,
-    };
-  } catch (error: any) {
-    logger.error('Error searching agent conversations', {
-      agentKey,
-      orgId,
-      userId,
-      searchQuery,
-      error: error.message,
-    });
-    throw error;
-  }
-};
-
-/**
- * Archive/Unarchive agent conversation
- */
-export const toggleAgentConversationArchive = async (
-  conversationId: string,
-  agentKey: string,
-  userId: string,
-  orgId: string,
-  archive: boolean,
-): Promise<IAgentConversationDocument | null> => {
-  try {
-    const conversation = await validateAgentConversationAccess(
-      conversationId,
-      agentKey,
-      userId,
-      orgId,
-      'write',
-    );
-
-    if (!conversation) {
-      return null;
-    }
-
-    conversation.isArchived = archive;
-    conversation.archivedBy = archive ? (userId as any) : undefined;
-    conversation.lastActivityAt = Date.now();
-
-    const updatedConversation = await conversation.save();
-
-    logger.debug(`Agent conversation ${archive ? 'archived' : 'unarchived'}`, {
-      conversationId,
-      agentKey,
-      userId,
-      archived: archive,
-    });
-
-    return updatedConversation;
-  } catch (error: any) {
-    logger.error(
-      `Error ${archive ? 'archiving' : 'unarchiving'} agent conversation`,
-      {
-        conversationId,
-        agentKey,
-        userId,
-        error: error.message,
-      },
-    );
-    throw error;
-  }
-};
-
-/**
  * Delete agent conversation (soft delete)
  */
 export const deleteAgentConversation = async (
@@ -1634,7 +1659,7 @@ export const deleteAgentConversation = async (
   agentKey: string,
   userId: string,
   orgId: string,
-): Promise<IAgentConversationDocument | null> => {
+): Promise<IChatSessionDocument | null> => {
   try {
     const conversation = await validateAgentConversationAccess(
       conversationId,
@@ -1775,15 +1800,13 @@ export const sendSSECompleteEvent = (
 export const handleRegenerationStreamData = (
   chunk: Buffer,
   buffer: string,
-  existingConversation:
-    | IConversationDocument
-    | IAgentConversationDocument
-    | null,
-  messageIndex: number,
+  existingConversation: IChatSessionDocument | null,
+  messageId: mongoose.Types.ObjectId | string | null,
   session: ClientSession | null,
   requestId: string,
   res: Response,
   onCompleteData: (data: IAIResponse) => void,
+  isAgentSession: boolean,
   protocol?: SSEProtocol,
 ): string => {
   const chunkStr = chunk.toString();
@@ -1825,11 +1848,11 @@ export const handleRegenerationStreamData = (
       } else if (agui && eventType === AGUIEventType.RUN_ERROR && dataLine) {
         try {
           const errorData = JSON.parse(dataLine);
-          if (existingConversation && messageIndex >= 0) {
+          if (existingConversation && messageId) {
             const errorMessage = errorData.message || 'Unknown error occurred';
             replaceMessageWithError(
               existingConversation,
-              messageIndex,
+              messageId,
               errorMessage,
               session,
               'streaming_error',
@@ -1871,10 +1894,11 @@ export const handleRegenerationStreamData = (
               createdAt: new Date(),
               updatedAt: new Date(),
             };
-            if ('agentKey' in existingConversation) {
-              void AgentConversation.findByIdAndUpdate(
-                existingConversation._id,
-                { $push: { messages: toolCallMessage } },
+            if (isAgentSession) {
+              void appendMessages(
+                existingConversation._id as mongoose.Types.ObjectId,
+                existingConversation.orgId,
+                [toolCallMessage],
               ).catch((saveErr: any) => {
                 logger.error(
                   'Failed to persist ask_user_question tool_call message during regenerate',
@@ -1909,12 +1933,12 @@ export const handleRegenerationStreamData = (
       } else if (!agui && eventType === 'error' && dataLine) {
         try {
           const errorData = JSON.parse(dataLine);
-          if (existingConversation && messageIndex >= 0) {
+          if (existingConversation && messageId) {
             const errorMessage =
               errorData.error || errorData.message || 'Unknown error occurred';
             replaceMessageWithError(
               existingConversation,
-              messageIndex,
+              messageId,
               errorMessage,
               session,
               'streaming_error',
@@ -1936,11 +1960,11 @@ export const handleRegenerationStreamData = (
             parseError: parseError.message,
             dataLine,
           });
-          if (existingConversation && messageIndex >= 0) {
+          if (existingConversation && messageId) {
             const errorMessage = `Failed to parse error event: ${parseError.message}`;
             replaceMessageWithError(
               existingConversation,
-              messageIndex,
+              messageId,
               errorMessage,
               session,
               'parse_error',
@@ -1978,10 +2002,11 @@ export const handleRegenerationStreamData = (
               createdAt: new Date(),
               updatedAt: new Date(),
             };
-            if ('agentKey' in existingConversation) {
-              void AgentConversation.findByIdAndUpdate(
-                existingConversation._id,
-                { $push: { messages: toolCallMessage } },
+            if (isAgentSession) {
+              void appendMessages(
+                existingConversation._id as mongoose.Types.ObjectId,
+                existingConversation.orgId,
+                [toolCallMessage],
               ).catch((saveErr: any) => {
                 logger.error(
                   'Failed to persist ask_user_question tool_call message during regenerate',
@@ -2023,8 +2048,8 @@ export const handleRegenerationStreamData = (
  */
 export const handleRegenerationSuccess = async (
   completeData: IAIResponse,
-  existingConversation: IConversationDocument | IAgentConversationDocument,
-  messageIndex: number,
+  existingConversation: IChatSessionDocument,
+  messageId: mongoose.Types.ObjectId | string,
   orgId: string,
   session: ClientSession | null,
   modelInfo?: IAIModel,
@@ -2048,18 +2073,24 @@ export const handleRegenerationSuccess = async (
     }) || [],
   );
 
-  // Build AI response message
+  // Build AI response message and replace the original message with it,
+  // preserving the original's _id/seq (see updateMessageById).
   const aiResponseMessage = buildAIResponseMessage(
     { statusCode: 200, data: completeData },
     savedCitations,
     modelInfo,
-  ) as IMessageDocument;
+  );
 
-  // Preserve the original message ID
-  const originalMessage = existingConversation.messages[
-    messageIndex
-  ] as IMessageDocument;
-  aiResponseMessage._id = originalMessage._id;
+  const updatedMessage = await updateMessageById(
+    messageId,
+    aiResponseMessage,
+    session,
+  );
+  if (!updatedMessage) {
+    throw new InternalServerError(
+      'Failed to update conversation with regenerated response: message not found',
+    );
+  }
 
   if (modelInfo) {
     const fieldsToUpdate: Array<keyof IAIModel> = [
@@ -2078,8 +2109,6 @@ export const handleRegenerationSuccess = async (
     }
   }
 
-  // Update the conversation with the new message at the same index
-  existingConversation.messages[messageIndex] = aiResponseMessage;
   existingConversation.lastActivityAt = Date.now();
   existingConversation.status = CONVERSATION_STATUS.COMPLETE;
 
@@ -2097,13 +2126,10 @@ export const handleRegenerationSuccess = async (
   // Populate citationData across ALL messages so the frontend can rebuild its
   // citationMaps for the entire conversation. Otherwise previous messages lose
   // inline citation chips (see attachPopulatedCitations docstring).
-  const isAgent =
-    (updatedConversation as IAgentConversationDocument).agentKey !== undefined;
   const responseConversation = await attachPopulatedCitations(
-    updatedConversation._id as mongoose.Types.ObjectId,
-    updatedConversation.toObject() as IConversation | IAgentConversation,
+    updatedConversation.toObject(),
+    [updatedMessage.toObject()],
     savedCitations,
-    isAgent,
     session,
   );
 
@@ -2119,11 +2145,8 @@ export const handleRegenerationSuccess = async (
 export const handleRegenerationError = async (
   res: Response,
   error: Error | any,
-  existingConversation:
-    | IConversationDocument
-    | IAgentConversationDocument
-    | null,
-  messageIndex: number,
+  existingConversation: IChatSessionDocument | null,
+  messageId: mongoose.Types.ObjectId | string | null,
   conversationId: string,
   session: ClientSession | null,
   requestId: string,
@@ -2132,30 +2155,29 @@ export const handleRegenerationError = async (
 ): Promise<void> => {
   const errorMessage = error.message || 'Unknown error occurred';
 
-  if (existingConversation && messageIndex >= 0) {
+  if (existingConversation && messageId) {
     try {
       await replaceMessageWithError(
         existingConversation,
-        messageIndex,
+        messageId,
         errorMessage,
         session,
         errorType,
         error.stack,
       );
 
-      // Determine the model type from the conversation object itself
-      // Check if it's an AgentConversation by looking for agentKey property
-      // or by checking the constructor
-      const isAgentConversation =
-        'agentKey' in existingConversation ||
-        existingConversation.constructor === AgentConversation;
-
-      // Reload conversation to get updated state using the appropriate model
-      const updatedConversation = isAgentConversation
-        ? await AgentConversation.findById(conversationId)
-        : await Conversation.findById(conversationId);
+      // Reload conversation to get updated state
+      const updatedConversation = await ChatSession.findById(conversationId);
       if (updatedConversation) {
-        const plainConversation = updatedConversation.toObject();
+        const messages = await getMessages(
+          updatedConversation._id as mongoose.Types.ObjectId,
+          {},
+          session,
+        );
+        const plainConversation = attachMessages(
+          updatedConversation.toObject(),
+          messages,
+        );
         await sendSSEErrorEvent(
           res,
           errorMessage,

--- a/backend/nodejs/apps/tests/modules/configuration_manager/services/migration.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/configuration_manager/services/migration.service.test.ts
@@ -271,6 +271,24 @@ describe('MigrationService', () => {
       expect(capturedBatchSize).to.equal(10)
     })
 
+    it('should fall back to the default batch size when the env var is not a positive integer', async () => {
+      let capturedBatchSize: number | undefined
+      chatSessionsMigrationStub.callsFake(function (this: any) {
+        capturedBatchSize = this.batchSize
+        return Promise.resolve({ sessionsMigrated: 0, messagesMigrated: 0, errored: 0 })
+      })
+
+      for (const value of ['not-a-number', '0', '-5', '']) {
+        capturedBatchSize = undefined
+        process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE = value
+
+        const service = new MigrationService(mockLogger, mockKeyValueStore)
+        await service.chatSessionsMigration()
+
+        expect(capturedBatchSize, `env value ${JSON.stringify(value)}`).to.equal(10)
+      }
+    })
+
     it('should warn when migration finishes with errors', async () => {
       chatSessionsMigrationStub.resolves({
         sessionsMigrated: 3,

--- a/backend/nodejs/apps/tests/modules/configuration_manager/services/migration.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/configuration_manager/services/migration.service.test.ts
@@ -67,6 +67,7 @@ describe('MigrationService', () => {
       // Stub migrations so they don't make real HTTP calls or DB queries
       const connectorStub = sinon.stub(service, 'connectorSyncScheduleMigration' as any).resolves()
       const chatStub = sinon.stub(service, 'chatKbFiltersMigration' as any).resolves()
+      const chatSessionsStub = sinon.stub(service, 'chatSessionsMigration' as any).resolves()
       const adminStub = sinon.stub(service, 'adminRoleMigration' as any).resolves()
       const documentOrgIdStub = sinon.stub(service, 'documentOrgIdMigration' as any).resolves()
 
@@ -75,6 +76,8 @@ describe('MigrationService', () => {
       expect(mockLogger.info.calledWith('Running migration...')).to.be.true
       expect(connectorStub.calledOnce).to.be.true
       expect(chatStub.calledOnce).to.be.true
+      expect(chatSessionsStub.calledOnce).to.be.true
+      expect(chatStub.calledBefore(chatSessionsStub)).to.be.true
       expect(adminStub.calledOnce).to.be.true
       expect(documentOrgIdStub.calledOnce).to.be.true
       expect(mockLogger.info.calledWith('✅ Migration completed')).to.be.true
@@ -200,6 +203,104 @@ describe('MigrationService', () => {
 
       const service = new MigrationService(mockLogger, mockKeyValueStore)
       await service.adminRoleMigration()
+
+      expect(mockLogger.error.calledOnce).to.be.true
+      expect(mockLogger.error.firstCall.args[1].error).to.equal('Unknown error')
+    })
+  })
+
+  describe('chatSessionsMigration', () => {
+    let chatSessionsMigrationStub: sinon.SinonStub
+    let originalBatchSizeEnv: string | undefined
+
+    beforeEach(() => {
+      const ChatSessionsMigration = require('../../../../src/modules/configuration_manager/services/migrations/chat_sessions.migration').ChatSessionsMigration
+      chatSessionsMigrationStub = sinon.stub(ChatSessionsMigration.prototype, 'run')
+      originalBatchSizeEnv = process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE
+      delete process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE
+    })
+
+    afterEach(() => {
+      chatSessionsMigrationStub.restore()
+      if (originalBatchSizeEnv === undefined) {
+        delete process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE
+      } else {
+        process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE = originalBatchSizeEnv
+      }
+    })
+
+    it('should run chat sessions migration successfully with the default batch size', async () => {
+      chatSessionsMigrationStub.resolves({
+        sessionsMigrated: 5,
+        messagesMigrated: 12,
+        errored: 0,
+      })
+
+      const service = new MigrationService(mockLogger, mockKeyValueStore)
+      await service.chatSessionsMigration()
+
+      expect(chatSessionsMigrationStub.calledOnce).to.be.true
+      expect(mockLogger.info.calledWith('Migrating legacy conversations into chatSessions')).to.be.true
+      expect(mockLogger.info.calledWith('✅ Chat sessions migrated', sinon.match.object)).to.be.true
+    })
+
+    it('should read the batch size from CHAT_SESSIONS_MIGRATION_BATCH_SIZE', async () => {
+      process.env.CHAT_SESSIONS_MIGRATION_BATCH_SIZE = '42'
+      let capturedBatchSize: number | undefined
+      chatSessionsMigrationStub.callsFake(function (this: any) {
+        capturedBatchSize = this.batchSize
+        return Promise.resolve({ sessionsMigrated: 0, messagesMigrated: 0, errored: 0 })
+      })
+
+      const service = new MigrationService(mockLogger, mockKeyValueStore)
+      await service.chatSessionsMigration()
+
+      expect(capturedBatchSize).to.equal(42)
+    })
+
+    it('should fall back to the default batch size when the env var is unset', async () => {
+      let capturedBatchSize: number | undefined
+      chatSessionsMigrationStub.callsFake(function (this: any) {
+        capturedBatchSize = this.batchSize
+        return Promise.resolve({ sessionsMigrated: 0, messagesMigrated: 0, errored: 0 })
+      })
+
+      const service = new MigrationService(mockLogger, mockKeyValueStore)
+      await service.chatSessionsMigration()
+
+      expect(capturedBatchSize).to.equal(10)
+    })
+
+    it('should warn when migration finishes with errors', async () => {
+      chatSessionsMigrationStub.resolves({
+        sessionsMigrated: 3,
+        messagesMigrated: 8,
+        errored: 2,
+      })
+
+      const service = new MigrationService(mockLogger, mockKeyValueStore)
+      await service.chatSessionsMigration()
+
+      expect(mockLogger.warn.calledWith(
+        '⚠️  Chat sessions migration finished with errors — will retry unmigrated documents on next boot',
+        sinon.match.object,
+      )).to.be.true
+    })
+
+    it('should catch and log migration errors', async () => {
+      chatSessionsMigrationStub.rejects(new Error('DB connection failed'))
+
+      const service = new MigrationService(mockLogger, mockKeyValueStore)
+      await service.chatSessionsMigration()
+
+      expect(mockLogger.error.calledWith('Chat sessions migration failed', sinon.match.object)).to.be.true
+    })
+
+    it('should handle non-Error exceptions', async () => {
+      chatSessionsMigrationStub.rejects(42)
+
+      const service = new MigrationService(mockLogger, mockKeyValueStore)
+      await service.chatSessionsMigration()
 
       expect(mockLogger.error.calledOnce).to.be.true
       expect(mockLogger.error.firstCall.args[1].error).to.equal('Unknown error')

--- a/backend/nodejs/apps/tests/modules/configuration_manager/services/migrations/chat_sessions.migration.test.ts
+++ b/backend/nodejs/apps/tests/modules/configuration_manager/services/migrations/chat_sessions.migration.test.ts
@@ -74,13 +74,22 @@ function stubChatSession() {
 }
 
 function stubChatSessionMessage(
-  opts: { perDocCount?: (sessionId: any) => number } = {},
+  opts: {
+    perDocCount?: (sessionId: any) => number;
+    /** Full-filter variant, for asserting the `_id: {$in: [...]}` scoping. */
+    countByFilter?: (filter: any) => number;
+  } = {},
 ) {
   const countDocuments = sinon
     .stub(ChatSessionMessage, 'countDocuments')
-    .callsFake((filter: any) =>
-      Promise.resolve(opts.perDocCount ? opts.perDocCount(filter.sessionId) : 0),
-    );
+    .callsFake((filter: any) => {
+      if (opts.countByFilter) {
+        return Promise.resolve(opts.countByFilter(filter)) as any;
+      }
+      return Promise.resolve(
+        opts.perDocCount ? opts.perDocCount(filter.sessionId) : 0,
+      ) as any;
+    });
   const bulkWrite = sinon.stub(ChatSessionMessage.collection, 'bulkWrite').resolves({});
   return { countDocuments, bulkWrite };
 }
@@ -314,7 +323,7 @@ describe('ChatSessionsMigration', () => {
       batches: [[legacyDoc]],
     });
     const sessionStubs = stubChatSession();
-    // Simulate a duplicate message _id collapsing 2 messages into 1 stored row.
+    // Simulate one of the two copied rows failing to land.
     stubChatSessionMessage({ perDocCount: () => 1 });
 
     const result = await new ChatSessionsMigration(logger as any, kv as any).run();
@@ -327,6 +336,168 @@ describe('ChatSessionsMigration', () => {
     // At least one document still errored this boot -> completion flag withheld
     // even though the batch loop itself terminated (no unmigrated docs left to scan).
     expect(kv.set.called).to.equal(false);
+  });
+
+  it('terminates instead of rescanning a permanently-failing document forever', async () => {
+    // Regression: the scan filter is {isMigrated: {$ne: true}} and a failed
+    // document is deliberately left unflagged, so without an _id cursor it
+    // sorts back to the front of the very next scan and the loop spins on it
+    // for the rest of the boot. This stub models the real collection
+    // (honouring _id: {$gt: cursor}) so an unbounded loop would hang here.
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+
+    const failing = makeLegacyDoc({ messages: [makeMessage(), makeMessage()] });
+    const healthy = makeLegacyDoc({ messages: [makeMessage()] });
+    // _id order drives the cursor; make the failing document sort first.
+    const docs = [failing, healthy].sort((a, b) =>
+      a._id.toString() < b._id.toString() ? -1 : 1,
+    );
+
+    sinon.stub(Conversation, 'countDocuments').resolves(0 as any);
+    const find = sinon.stub(Conversation, 'find').callsFake((filter: any) => {
+      if (!filter?.isMigrated) {
+        return chain([]) as any;
+      }
+      const after = filter._id?.$gt;
+      const remaining = docs.filter(
+        (d) => !d.isMigrated && (!after || d._id.toString() > after.toString()),
+      );
+      return chain(remaining.slice(0, 1)) as any;
+    });
+    // Only successfully migrated documents get flagged, mirroring production.
+    sinon.stub(Conversation.collection, 'updateOne').callsFake((filter: any) => {
+      const target = docs.find((d) => d._id.toString() === filter._id.toString());
+      if (target) {
+        target.isMigrated = true;
+      }
+      return Promise.resolve({}) as any;
+    });
+    stubChatSession();
+    // One row lands per session: a match for the 1-message healthy document,
+    // one short for the 2-message failing one.
+    stubChatSessionMessage({ countByFilter: () => 1 });
+
+    const result = await new ChatSessionsMigration(
+      logger as any,
+      kv as any,
+      1,
+    ).run();
+
+    expect(result.errored).to.equal(1);
+    expect(result.sessionsMigrated).to.equal(1);
+    // Scans: failing doc, healthy doc, then the empty scan that ends the loop.
+    const scanCalls = find.getCalls().filter((c) => c.args[0]?.isMigrated);
+    expect(scanCalls).to.have.length(3);
+    // Errored document -> completion flag withheld, retried on the next boot.
+    expect(kv.set.called).to.equal(false);
+  });
+
+  it('still migrates a document whose session already accumulated newer live messages', async () => {
+    // Crash-recovery case: a previous attempt wrote the messages and the
+    // ChatSession but died before the isMigrated flag, so the session went
+    // live and users appended to it. Counting every row for the sessionId
+    // would now exceed messages.length on every retry and strand the
+    // document; the count must be scoped to the ids being copied.
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+    const legacyDoc = makeLegacyDoc({ messages: [makeMessage(), makeMessage()] });
+    const legacyIds = legacyDoc.messages.map((m: any) => m._id.toString());
+
+    const conversationStubs = stubLegacyModel(Conversation, {
+      batches: [[legacyDoc]],
+    });
+    stubChatSession();
+    const messageStubs = stubChatSessionMessage({
+      countByFilter: (filter: any) => {
+        // 5 rows exist for this session, only 2 of them are the copied ids.
+        const requested = filter._id?.$in;
+        if (!requested) {
+          return 5;
+        }
+        return requested.filter((id: any) =>
+          legacyIds.includes(id.toString()),
+        ).length;
+      },
+    });
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.deep.equal({
+      sessionsMigrated: 1,
+      messagesMigrated: 2,
+      errored: 0,
+    });
+    // The verification query must be scoped by the copied message ids.
+    const countFilter = messageStubs.countDocuments.firstCall.args[0] as any;
+    expect(countFilter._id?.$in).to.have.length(2);
+    expect(conversationStubs.collectionUpdateOne.calledOnce).to.equal(true);
+  });
+
+  it('refuses to copy a document with duplicate message _ids before any write happens', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+    const duplicated = makeMessage();
+    const legacyDoc = makeLegacyDoc({
+      messages: [duplicated, { ...duplicated, content: 'same _id' }],
+    });
+
+    const conversationStubs = stubLegacyModel(Conversation, {
+      batches: [[legacyDoc]],
+    });
+    const sessionStubs = stubChatSession();
+    const messageStubs = stubChatSessionMessage();
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result.errored).to.equal(1);
+    expect(result.sessionsMigrated).to.equal(0);
+    // An _id-keyed upsert would silently collapse the two rows, so nothing
+    // may be written at all.
+    expect(messageStubs.bulkWrite.called).to.equal(false);
+    expect(sessionStubs.collectionUpdateOne.called).to.equal(false);
+    expect(conversationStubs.collectionUpdateOne.called).to.equal(false);
+    expect(
+      logger.error.calledWith(sinon.match(/Failed to migrate a conversations document/)),
+    ).to.equal(true);
+  });
+
+  it('refuses to copy a document whose message is missing an _id', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+    const legacyDoc = makeLegacyDoc({
+      messages: [makeMessage(), { messageType: 'bot_response', content: 'no id' }],
+    });
+
+    stubLegacyModel(Conversation, { batches: [[legacyDoc]] });
+    const sessionStubs = stubChatSession();
+    const messageStubs = stubChatSessionMessage();
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result.errored).to.equal(1);
+    expect(messageStubs.bulkWrite.called).to.equal(false);
+    expect(sessionStubs.collectionUpdateOne.called).to.equal(false);
   });
 
   it('does not treat ordinary live traffic on chatSessions/chatSessionMessages as a migration failure', async () => {

--- a/backend/nodejs/apps/tests/modules/configuration_manager/services/migrations/chat_sessions.migration.test.ts
+++ b/backend/nodejs/apps/tests/modules/configuration_manager/services/migrations/chat_sessions.migration.test.ts
@@ -1,0 +1,405 @@
+import 'reflect-metadata';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import mongoose from 'mongoose';
+import { ChatSessionsMigration } from '../../../../../src/modules/configuration_manager/services/migrations/chat_sessions.migration';
+import { configPaths } from '../../../../../src/modules/configuration_manager/paths/paths';
+import { Conversation } from '../../../../../src/modules/enterprise_search/schema/conversation.schema';
+import { AgentConversation } from '../../../../../src/modules/enterprise_search/schema/agent.conversation.schema';
+import { ChatSession } from '../../../../../src/modules/enterprise_search/schema/chat.session.schema';
+import { ChatSessionMessage } from '../../../../../src/modules/enterprise_search/schema/chat.session.message.schema';
+
+const makeLogger = () => ({
+  info: sinon.stub(),
+  error: sinon.stub(),
+  debug: sinon.stub(),
+  warn: sinon.stub(),
+});
+
+const makeKvStore = (flags: Record<string, string | null> = {}) => ({
+  get: sinon
+    .stub()
+    .callsFake((path: string) => Promise.resolve(path in flags ? flags[path] : null)),
+  set: sinon.stub().resolves(),
+});
+
+/** A chainable query mock: .sort()/.limit()/.select() return itself, .lean() resolves. */
+function chain(result: any) {
+  const obj: any = {};
+  obj.sort = sinon.stub().returns(obj);
+  obj.limit = sinon.stub().returns(obj);
+  obj.select = sinon.stub().returns(obj);
+  obj.lean = sinon.stub().resolves(result);
+  return obj;
+}
+
+interface LegacyStubOptions {
+  missingOrgIdCount?: number;
+  /** Sequential batches returned by the isMigrated:{$ne:true} scan; [] ends the loop. */
+  batches?: any[][];
+  schemaDriftSample?: any[];
+}
+
+function stubLegacyModel(Model: any, opts: LegacyStubOptions = {}) {
+  const missingOrgIdCount = opts.missingOrgIdCount ?? 0;
+  const batches = opts.batches ?? [[]];
+  const schemaDriftSample = opts.schemaDriftSample ?? [];
+
+  let batchCall = 0;
+  const find = sinon.stub(Model, 'find').callsFake((filter: any) => {
+    if (filter && filter.isMigrated) {
+      const batch = batches[batchCall] ?? [];
+      batchCall++;
+      return chain(batch);
+    }
+    return chain(schemaDriftSample);
+  });
+
+  const countDocuments = sinon
+    .stub(Model, 'countDocuments')
+    .resolves(missingOrgIdCount);
+
+  const collectionUpdateOne = sinon
+    .stub(Model.collection, 'updateOne')
+    .resolves({});
+
+  return { find, countDocuments, collectionUpdateOne };
+}
+
+function stubChatSession() {
+  const collectionUpdateOne = sinon
+    .stub(ChatSession.collection, 'updateOne')
+    .resolves({});
+  return { collectionUpdateOne };
+}
+
+function stubChatSessionMessage(
+  opts: { perDocCount?: (sessionId: any) => number } = {},
+) {
+  const countDocuments = sinon
+    .stub(ChatSessionMessage, 'countDocuments')
+    .callsFake((filter: any) =>
+      Promise.resolve(opts.perDocCount ? opts.perDocCount(filter.sessionId) : 0),
+    );
+  const bulkWrite = sinon.stub(ChatSessionMessage.collection, 'bulkWrite').resolves({});
+  return { countDocuments, bulkWrite };
+}
+
+function makeMessage(overrides: Partial<any> = {}) {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    messageType: 'user_query',
+    content: 'hello',
+    ...overrides,
+  };
+}
+
+function makeLegacyDoc(overrides: Partial<any> = {}) {
+  return {
+    _id: new mongoose.Types.ObjectId(),
+    orgId: new mongoose.Types.ObjectId(),
+    userId: new mongoose.Types.ObjectId(),
+    initiator: new mongoose.Types.ObjectId(),
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe('ChatSessionsMigration', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('defers when the chat KB-filters migration has not completed', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({}); // chatKbFiltersMigration flag absent -> not 'true'
+    const conversationFindStub = sinon.stub(Conversation, 'find');
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.deep.equal({
+      sessionsMigrated: 0,
+      messagesMigrated: 0,
+      errored: 0,
+    });
+    expect(conversationFindStub.called).to.equal(false);
+    expect(kv.set.called).to.equal(false);
+  });
+
+  it('treats a KB-filters flag read failure as not-done and defers', async () => {
+    const logger = makeLogger();
+    const kv = {
+      get: sinon.stub().rejects(new Error('kv unavailable')),
+      set: sinon.stub().resolves(),
+    };
+    const conversationFindStub = sinon.stub(Conversation, 'find');
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.deep.equal({
+      sessionsMigrated: 0,
+      messagesMigrated: 0,
+      errored: 0,
+    });
+    expect(conversationFindStub.called).to.equal(false);
+    expect(logger.warn.called).to.equal(true);
+  });
+
+  it('skips both collections when both are already marked migrated', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        conversationsMigrated: true,
+        agentConversationsMigrated: true,
+      }),
+    });
+    const conversationFindStub = sinon.stub(Conversation, 'find');
+    const agentFindStub = sinon.stub(AgentConversation, 'find');
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.deep.equal({
+      sessionsMigrated: 0,
+      messagesMigrated: 0,
+      errored: 0,
+    });
+    expect(conversationFindStub.called).to.equal(false);
+    expect(agentFindStub.called).to.equal(false);
+    expect(kv.set.called).to.equal(false);
+  });
+
+  it('treats an unparseable chatSessions flag as not-yet-migrated for both collections', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: '{not valid json',
+    });
+    stubLegacyModel(Conversation);
+    stubLegacyModel(AgentConversation);
+    stubChatSession();
+    stubChatSessionMessage();
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.deep.equal({
+      sessionsMigrated: 0,
+      messagesMigrated: 0,
+      errored: 0,
+    });
+    expect(logger.warn.calledWith(sinon.match(/Failed to read\/parse/))).to.equal(true);
+    // Both collections attempted (empty -> zero errors); one flag write per
+    // successfully-completed collection, cumulative on the object.
+    expect(kv.set.callCount).to.equal(2);
+    const written = JSON.parse(kv.set.lastCall.args[1]);
+    expect(written.conversationsMigrated).to.equal(true);
+    expect(written.agentConversationsMigrated).to.equal(true);
+  });
+
+  it('aborts a collection and reports errored when documents are missing orgId', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({ [configPaths.chatKbFiltersMigration]: 'true' });
+    const legacyStubs = stubLegacyModel(Conversation, { missingOrgIdCount: 3 });
+    stubLegacyModel(AgentConversation); // agent collection is empty/healthy
+    stubChatSession();
+    stubChatSessionMessage();
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result.errored).to.equal(3);
+    expect(result.sessionsMigrated).to.equal(0);
+    // Neither the schema-drift audit nor the batch scan may run once the
+    // hard pre-flight check fails.
+    expect(legacyStubs.find.called).to.equal(false);
+    expect(logger.error.calledWith(sinon.match(/missing orgId/))).to.equal(true);
+    const written = kv.set.called ? JSON.parse(kv.set.firstCall.args[1]) : {};
+    expect(written.conversationsMigrated).to.not.equal(true);
+  });
+
+  it('migrates a document: seq = index + 1 and nextSeq = messages.length', async () => {
+    const logger = makeLogger();
+    // Agent collection pre-marked done so this test only exercises conversations.
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+
+    const orgId = new mongoose.Types.ObjectId();
+    const message0 = makeMessage({ content: 'first' });
+    const message1 = makeMessage({ content: 'second' });
+    const legacyDoc = makeLegacyDoc({ orgId, messages: [message0, message1] });
+
+    const conversationStubs = stubLegacyModel(Conversation, {
+      batches: [[legacyDoc]],
+    });
+    const agentFindStub = sinon.stub(AgentConversation, 'find');
+    const sessionStubs = stubChatSession();
+    const messageStubs = stubChatSessionMessage({ perDocCount: () => 2 });
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result.errored).to.equal(0);
+    expect(result.sessionsMigrated).to.equal(1);
+    expect(result.messagesMigrated).to.equal(2);
+
+    // Message ops: seq derived from array index (1-based), sessionId/orgId stamped.
+    expect(messageStubs.bulkWrite.calledOnce).to.equal(true);
+    const ops = messageStubs.bulkWrite.firstCall.args[0];
+    expect(ops).to.have.length(2);
+    expect(ops[0].updateOne.update.$setOnInsert.seq).to.equal(1);
+    expect(ops[0].updateOne.update.$setOnInsert.sessionId).to.equal(legacyDoc._id);
+    expect(ops[0].updateOne.update.$setOnInsert.orgId).to.equal(orgId);
+    expect(ops[0].updateOne.upsert).to.equal(true);
+    expect(ops[1].updateOne.update.$setOnInsert.seq).to.equal(2);
+
+    // Session upsert: nextSeq = message count, sessionType stamped, upsert-only.
+    expect(sessionStubs.collectionUpdateOne.calledOnce).to.equal(true);
+    const [sessionFilter, sessionUpdate, sessionOptions] =
+      sessionStubs.collectionUpdateOne.firstCall.args;
+    expect(sessionFilter).to.deep.equal({ _id: legacyDoc._id });
+    expect(sessionUpdate.$setOnInsert.nextSeq).to.equal(2);
+    expect(sessionUpdate.$setOnInsert.sessionType).to.equal('chat');
+    expect(sessionOptions).to.deep.equal({ upsert: true });
+
+    // Legacy flag write happens last, via $set (not $setOnInsert — it must take effect every run).
+    expect(conversationStubs.collectionUpdateOne.calledOnce).to.equal(true);
+    expect(conversationStubs.collectionUpdateOne.firstCall.args).to.deep.equal([
+      { _id: legacyDoc._id },
+      { $set: { isMigrated: true } },
+    ]);
+
+    // Zero errors -> completion flag written; agent's pre-existing true survives untouched.
+    expect(agentFindStub.called).to.equal(false);
+    expect(kv.set.calledOnce).to.equal(true);
+    const written = JSON.parse(kv.set.firstCall.args[1]);
+    expect(written.conversationsMigrated).to.equal(true);
+    expect(written.agentConversationsMigrated).to.equal(true);
+  });
+
+  it('migrates a zero-message conversation with nextSeq: 0 and skips the empty bulkWrite', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+    const legacyDoc = makeLegacyDoc({ messages: [] });
+
+    stubLegacyModel(Conversation, { batches: [[legacyDoc]] });
+    const sessionStubs = stubChatSession();
+    const messageStubs = stubChatSessionMessage();
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.include({ errored: 0, sessionsMigrated: 1, messagesMigrated: 0 });
+    expect(messageStubs.bulkWrite.called).to.equal(false);
+    const sessionUpdate = sessionStubs.collectionUpdateOne.firstCall.args[1];
+    expect(sessionUpdate.$setOnInsert.nextSeq).to.equal(0);
+  });
+
+  it('marks a document errored (not migrated) when the stored message count does not match', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+    const legacyDoc = makeLegacyDoc({ messages: [makeMessage(), makeMessage()] });
+
+    const conversationStubs = stubLegacyModel(Conversation, {
+      batches: [[legacyDoc]],
+    });
+    const sessionStubs = stubChatSession();
+    // Simulate a duplicate message _id collapsing 2 messages into 1 stored row.
+    stubChatSessionMessage({ perDocCount: () => 1 });
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result.errored).to.equal(1);
+    expect(result.sessionsMigrated).to.equal(0);
+    // Write order: on failure, neither the session nor the isMigrated flag is written.
+    expect(sessionStubs.collectionUpdateOne.called).to.equal(false);
+    expect(conversationStubs.collectionUpdateOne.called).to.equal(false);
+    // At least one document still errored this boot -> completion flag withheld
+    // even though the batch loop itself terminated (no unmigrated docs left to scan).
+    expect(kv.set.called).to.equal(false);
+  });
+
+  it('does not treat ordinary live traffic on chatSessions/chatSessionMessages as a migration failure', async () => {
+    // Regression test: verification used to compare legacy counts against
+    // ChatSession.countDocuments({sessionType}) / chatSessionMessages scoped
+    // by that sessionType — both of which grow from ordinary live usage
+    // while the migration is running, causing false-positive failures with
+    // zero real errored documents. There is no such comparison left to stub;
+    // a clean single-document migration must complete regardless of how
+    // much unrelated live data exists in chatSessions/chatSessionMessages.
+    const logger = makeLogger();
+    const kv = makeKvStore({
+      [configPaths.chatKbFiltersMigration]: 'true',
+      [configPaths.chatSessionsMigration]: JSON.stringify({
+        agentConversationsMigrated: true,
+      }),
+    });
+    const legacyDoc = makeLegacyDoc({ messages: [makeMessage()] });
+
+    stubLegacyModel(Conversation, { batches: [[legacyDoc]] });
+    stubChatSession();
+    stubChatSessionMessage({ perDocCount: () => 1 });
+    // No stubs on ChatSession.countDocuments/find or
+    // ChatSessionMessage.countDocuments({sessionId:{$in:...}}) — if the
+    // implementation regressed to calling either, these would throw against
+    // a disconnected Mongoose model and fail the test.
+
+    const result = await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    expect(result).to.deep.equal({
+      sessionsMigrated: 1,
+      messagesMigrated: 1,
+      errored: 0,
+    });
+    const written = JSON.parse(kv.set.firstCall.args[1]);
+    expect(written.conversationsMigrated).to.equal(true);
+  });
+
+  it('logs sampled unknown fields when a legacy document has keys absent from the chatSessions schema', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({ [configPaths.chatKbFiltersMigration]: 'true' });
+    const driftDoc = makeLegacyDoc({ legacyOnlyField: 'still here' });
+
+    stubLegacyModel(Conversation, { schemaDriftSample: [driftDoc] });
+    stubLegacyModel(AgentConversation);
+    stubChatSession();
+    stubChatSessionMessage();
+
+    await new ChatSessionsMigration(logger as any, kv as any).run();
+
+    const warnCall = logger.warn
+      .getCalls()
+      .find((c) => /fields not present on the chatSessions schema/.test(c.args[0]));
+    expect(warnCall).to.exist;
+    expect(warnCall!.args[1].unknownFields).to.include('legacyOnlyField');
+  });
+
+  it('reads CHAT_SESSIONS_MIGRATION_BATCH_SIZE-style explicit batch size and applies it to the scan', async () => {
+    const logger = makeLogger();
+    const kv = makeKvStore({ [configPaths.chatKbFiltersMigration]: 'true' });
+    const legacyStubs = stubLegacyModel(Conversation);
+    stubLegacyModel(AgentConversation);
+    stubChatSession();
+    stubChatSessionMessage();
+
+    await new ChatSessionsMigration(logger as any, kv as any, 25).run();
+
+    // First find() call is the schema-drift sample; the second is the batch scan.
+    const scanCallIndex = legacyStubs.find
+      .getCalls()
+      .findIndex((c) => c.args[0]?.isMigrated);
+    expect(scanCallIndex).to.be.greaterThan(-1);
+    const scanChain = legacyStubs.find.returnValues[scanCallIndex];
+    expect(scanChain.limit.calledWith(25)).to.equal(true);
+  });
+});

--- a/backend/nodejs/apps/tests/modules/enterprise_search/controller/es_controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/enterprise_search/controller/es_controller.test.ts
@@ -13,8 +13,10 @@ import {
   updateTitle,
   updateFeedback,
   archiveConversation,
+  archiveAgentConversation,
   unarchiveConversation,
   listAllArchivesConversation,
+  searchArchivedConversations,
   search,
   searchHistory,
   getSearchById,
@@ -47,12 +49,14 @@ import {
   addMessageStreamToAgentConversationInternal,
   regenerateAgentAnswers,
   updateAgentFeedback,
+  unarchiveAgentConversation,
+  updateAgentConversationTitle,
   uploadChatAttachments,
   uploadChatAttachmentsInternal,
   deleteChatAttachment,
 } from '../../../../src/modules/enterprise_search/controller/es_controller'
-import { Conversation } from '../../../../src/modules/enterprise_search/schema/conversation.schema'
-import { AgentConversation } from '../../../../src/modules/enterprise_search/schema/agent.conversation.schema'
+import { ChatSession } from '../../../../src/modules/enterprise_search/schema/chat.session.schema'
+import { ChatSessionMessage } from '../../../../src/modules/enterprise_search/schema/chat.session.message.schema'
 import EnterpriseSemanticSearch from '../../../../src/modules/enterprise_search/schema/search.schema'
 import Citation from '../../../../src/modules/enterprise_search/schema/citation.schema'
 import { AIServiceCommand } from '../../../../src/libs/commands/ai_service/ai.service.command'
@@ -132,6 +136,10 @@ function createMockSession(): any {
 
 /**
  * Helper to create a mock Mongoose document that supports .save(), .toObject(), etc.
+ * NOTE: `chatSessions` no longer embeds `messages` (see chat.session.schema.ts) — any
+ * `messages` override passed here is for legacy-test-shape convenience only and is
+ * ignored by the controller; use `stubAppendMessagesOnce`/`stubGetMessagesOnce` etc.
+ * below to control the separate `ChatSessionMessage` collection.
  */
 function createMockConversationDoc(overrides: Record<string, any> = {}): any {
   const doc: any = {
@@ -140,7 +148,6 @@ function createMockConversationDoc(overrides: Record<string, any> = {}): any {
     userId: new mongoose.Types.ObjectId(VALID_OID),
     initiator: new mongoose.Types.ObjectId(VALID_OID),
     title: 'Test conversation',
-    messages: [],
     lastActivityAt: Date.now(),
     status: 'complete',
     isDeleted: false,
@@ -159,10 +166,74 @@ function createMockConversationDoc(overrides: Record<string, any> = {}): any {
 }
 
 /**
+ * Helper to create a mock `ChatSessionMessage` document — a plain object with a
+ * `.toObject()` method, matching what `ChatSessionMessage.insertMany(...)` /
+ * `.findOneAndReplace(...)` etc. return (non-`.lean()` documents) at the call sites
+ * `appendMessages`/`updateMessageById` feed into `.toObject()`.
+ */
+function createMockMessageDoc(overrides: Record<string, any> = {}): any {
+  const doc: any = {
+    _id: new mongoose.Types.ObjectId(),
+    sessionId: new mongoose.Types.ObjectId(VALID_OID),
+    orgId: new mongoose.Types.ObjectId(VALID_OID2),
+    seq: 1,
+    messageType: 'user_query',
+    content: '',
+    contentFormat: 'MARKDOWN',
+    citations: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    toObject: sinon.stub(),
+    ...overrides,
+  }
+  doc.toObject.returns({ ...doc, toObject: undefined })
+  return doc
+}
+
+/**
+ * Stubs the two calls `appendMessages` makes so any controller code path that
+ * appends message(s) to a `ChatSession` (user query, AI response, error message,
+ * tool_call, etc.) resolves instantly instead of buffering against a real (absent)
+ * Mongo connection. Safe to call even when the test doesn't care about the
+ * inserted message shape — defaults to a single generic message doc.
+ */
+function restoreIfStubbed(obj: any, method: string) {
+  if (obj[method] && typeof obj[method].restore === 'function') {
+    obj[method].restore()
+  }
+}
+
+function stubAppendMessages(insertedMessages: any[] = [createMockMessageDoc()]): {
+  allocateSeqStub: sinon.SinonStub
+  insertManyStub: sinon.SinonStub
+} {
+  restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+  restoreIfStubbed(ChatSessionMessage, 'insertMany')
+  const allocateSeqStub = sinon
+    .stub(ChatSession, 'findOneAndUpdate')
+    .resolves({ nextSeq: insertedMessages.length || 1 } as any)
+  const insertManyStub = sinon
+    .stub(ChatSessionMessage, 'insertMany')
+    .resolves(insertedMessages as any)
+  return { allocateSeqStub, insertManyStub }
+}
+
+/**
+ * Stubs the `ChatSessionMessage.find().sort().skip().limit().populate().lean().exec()`
+ * chain that `getMessages` builds, for controller paths that read message history
+ * (previous-conversation formatting, regenerate validation, `getConversationById`, etc.).
+ */
+function stubGetMessages(model: typeof ChatSessionMessage, resolveValue: any[]): sinon.SinonStub {
+  restoreIfStubbed(model, 'find')
+  return stubMongooseFind(model, 'find', resolveValue)
+}
+
+/**
  * Stub model.findOne to return a thenable query that resolves to the given value.
  * Use this when the controller does `await model.findOne(query)` without calling `.exec()`.
  */
 function stubThenableFindOne(model: any, resolveValue: any): sinon.SinonStub {
+  restoreIfStubbed(model, 'findOne')
   const thenableQuery: any = {
     exec: sinon.stub().resolves(resolveValue),
     then(onFulfilled: any, onRejected?: any) {
@@ -175,10 +246,18 @@ function stubThenableFindOne(model: any, resolveValue: any): sinon.SinonStub {
   return sinon.stub(model, 'findOne').returns(thenableQuery)
 }
 
+/** Session + message lookups used by `performFeedbackUpdate`. */
+function stubFeedbackLookups(sessionDoc: any, messageDoc: any) {
+  stubThenableFindOne(ChatSession, sessionDoc)
+  restoreIfStubbed(ChatSessionMessage, 'findOne')
+  sinon.stub(ChatSessionMessage, 'findOne').resolves(messageDoc)
+}
+
 /**
  * Helper to stub Mongoose chaining methods for find operations.
  */
 function stubMongooseFind(model: any, methodName: string, resolveValue: any): sinon.SinonStub {
+  restoreIfStubbed(model, methodName)
   const chain: any = {
     sort: sinon.stub().returnsThis(),
     skip: sinon.stub().returnsThis(),
@@ -202,6 +281,39 @@ function createMockStream(): any {
 }
 
 describe('Enterprise Search Controller', () => {
+  beforeEach(() => {
+    // Default stubs so any code path that hits chatSessionMessages
+    // (appendMessages / getMessages / countDocuments / feedback) does not
+    // buffer against a real Mongo connection for 10s.
+    if (!(ChatSession.findOneAndUpdate as any).restore) {
+      sinon.stub(ChatSession, 'findOneAndUpdate').resolves({ nextSeq: 1 } as any)
+    }
+    if (!(ChatSessionMessage.insertMany as any).restore) {
+      sinon.stub(ChatSessionMessage, 'insertMany').resolves([createMockMessageDoc()] as any)
+    }
+    if (!(ChatSessionMessage.find as any).restore) {
+      stubMongooseFind(ChatSessionMessage, 'find', [])
+    }
+    if (!(ChatSessionMessage.countDocuments as any).restore) {
+      sinon.stub(ChatSessionMessage, 'countDocuments').resolves(0)
+    }
+    if (!(ChatSessionMessage.findOne as any).restore) {
+      sinon.stub(ChatSessionMessage, 'findOne').resolves(createMockMessageDoc({ messageType: 'bot_response' }))
+    }
+    if (!(ChatSessionMessage.findById as any).restore) {
+      sinon.stub(ChatSessionMessage, 'findById').resolves(createMockMessageDoc({ seq: 1 }))
+    }
+    if (!(ChatSessionMessage.findOneAndReplace as any).restore) {
+      sinon.stub(ChatSessionMessage, 'findOneAndReplace').resolves(createMockMessageDoc())
+    }
+    if (!(ChatSessionMessage.findOneAndUpdate as any).restore) {
+      sinon.stub(ChatSessionMessage, 'findOneAndUpdate').resolves(createMockMessageDoc())
+    }
+    if (!(ChatSessionMessage.aggregate as any).restore) {
+      sinon.stub(ChatSessionMessage, 'aggregate').resolves([])
+    }
+  })
+
   afterEach(() => {
     sinon.restore()
   })
@@ -275,8 +387,10 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      // Stub Conversation constructor + save
-      const constructorStub = sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      // Stub ChatSession constructor + save
+      const constructorStub = sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      // appendMessages (user query, then AI response) -> allocateSeq + insertMany
+      stubAppendMessages([createMockMessageDoc({ messageType: 'bot_response', content: 'world' })])
 
       // Stub AIServiceCommand.execute
       const aiResponse = {
@@ -321,7 +435,8 @@ describe('Enterprise Search Controller', () => {
           { messageType: 'bot_response', content: 'world', citations: [] },
         ],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubAppendMessages()
 
       let capturedBody: any
       sinon.stub(AIServiceCommand.prototype, 'execute').callsFake(function (this: any) {
@@ -358,7 +473,8 @@ describe('Enterprise Search Controller', () => {
           { messageType: 'bot_response', content: 'world', citations: [] },
         ],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubAppendMessages()
 
       let capturedBody: any
       sinon.stub(AIServiceCommand.prototype, 'execute').callsFake(function (this: any) {
@@ -388,7 +504,8 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubAppendMessages()
 
       sinon.stub(AIServiceCommand.prototype, 'execute').rejects(new Error('AI service down'))
 
@@ -411,7 +528,8 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubAppendMessages()
 
       const connError = new Error('fetch failed')
       ;(connError as any).cause = { code: 'ECONNREFUSED' }
@@ -470,7 +588,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -505,7 +623,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       let capturedBody: any
@@ -540,7 +658,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -571,7 +689,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(searchUtils, 'markConversationFailed').resolves()
 
       const mockStream = createMockStream()
@@ -614,7 +732,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(AIServiceCommand.prototype, 'executeStream').rejects(new Error('Stream start failed'))
 
       const req = createMockRequest({
@@ -640,13 +758,13 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
 
       // Stub Conversation.findOne for saveCompleteConversation
-      stubMongooseFind(Conversation, 'findOne', mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const req = createMockRequest({
         body: { query: 'hello' },
@@ -706,7 +824,7 @@ describe('Enterprise Search Controller', () => {
 
     it('should call next with error when conversationId is missing', async () => {
       const handler = addMessage(createMockAppConfig())
-      sinon.stub(Conversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
       const req = createMockRequest({
         params: {},
         body: { query: 'test' },
@@ -739,7 +857,7 @@ describe('Enterprise Search Controller', () => {
       const handler = addMessage(createMockAppConfig())
 
       // addMessage uses plain `await Conversation.findOne(...)` (thenable, no .lean().exec())
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(null),
       } as any)
 
@@ -771,7 +889,7 @@ describe('Enterprise Search Controller', () => {
       mockDoc.messages = [...mockDoc.messages]
 
       // addMessage uses plain `await Conversation.findOne(...)` (thenable)
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -814,7 +932,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -870,7 +988,7 @@ describe('Enterprise Search Controller', () => {
       mockDoc.messages = [...mockDoc.messages]
 
       // addMessageStream uses plain `await Conversation.findOne(...)`
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -907,7 +1025,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -936,7 +1054,7 @@ describe('Enterprise Search Controller', () => {
     it('should handle conversation not found', async () => {
       const handler = addMessageStream(createMockAppConfig())
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(null),
       } as any)
 
@@ -1016,8 +1134,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversations),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(1)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(1)
 
       const req = createMockRequest({
         query: { page: '1', limit: '10', source: 'owned' },
@@ -1045,8 +1163,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().rejects(new Error('DB error')),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: { source: 'owned' },
@@ -1073,7 +1191,12 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next when conversationId is missing', async () => {
-      sinon.stub(Conversation, 'aggregate').resolves([])
+      const findOneChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().resolves(null),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
       const req = createMockRequest({ params: {} })
       const res = createMockResponse()
       const next = createMockNext()
@@ -1087,21 +1210,20 @@ describe('Enterprise Search Controller', () => {
       const mockConversation = {
         _id: VALID_OID,
         title: 'Test',
-        messages: [{ messageType: 'user_query', content: 'hi' }],
         initiator: VALID_OID,
         isShared: false,
         sharedWith: [],
         status: 'complete',
       }
-
-      sinon.stub(Conversation, 'aggregate').resolves([{ messageCount: 1 }])
       const findOneChain: any = {
         select: sinon.stub().returnsThis(),
-        populate: sinon.stub().returnsThis(),
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(findOneChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
+      restoreIfStubbed(ChatSessionMessage, 'countDocuments')
+      sinon.stub(ChatSessionMessage, 'countDocuments').resolves(1)
+      stubGetMessages(ChatSessionMessage, [{ messageType: 'user_query', content: 'hi' }])
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1116,11 +1238,57 @@ describe('Enterprise Search Controller', () => {
       if (!next.called) {
         expect(res.status.calledWith(200)).to.be.true
         expect(res.json.calledOnce).to.be.true
+        const payload = res.json.firstCall.args[0]
+        expect(payload.conversation).to.not.have.property('sessionType')
+        expect(payload.conversation).to.not.have.property('nextSeq')
       }
     })
 
-    it('should call next with NotFoundError when aggregate returns empty', async () => {
-      sinon.stub(Conversation, 'aggregate').resolves([])
+    it('should return 200 with an empty messages array for a zero-message session', async () => {
+      const mockConversation = {
+        _id: VALID_OID,
+        title: 'Empty',
+        initiator: VALID_OID,
+        isShared: false,
+        sharedWith: [],
+        status: 'complete',
+      }
+      const findOneChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().resolves(mockConversation),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
+      restoreIfStubbed(ChatSessionMessage, 'countDocuments')
+      sinon.stub(ChatSessionMessage, 'countDocuments').resolves(0)
+      restoreIfStubbed(ChatSessionMessage, 'find')
+      const findStub = sinon.stub(ChatSessionMessage, 'find')
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID },
+        query: { page: '1', limit: '20' },
+        user: { userId: VALID_OID, orgId: VALID_OID2 },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+
+      await getConversationById(req, res, next)
+
+      expect(next.called).to.be.false
+      expect(res.status.calledWith(200)).to.be.true
+      expect(findStub.called).to.be.false
+      const payload = res.json.firstCall.args[0]
+      expect(payload.meta.messageCount).to.equal(0)
+      expect(payload.conversation.messages || []).to.have.lengthOf(0)
+    })
+
+    it('should call next with NotFoundError when the session does not exist', async () => {
+      const findOneChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().resolves(null),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1164,9 +1332,10 @@ describe('Enterprise Search Controller', () => {
         _id: VALID_OID,
         messages: [{ citations: [{ citationId: VALID_OID3 }] }],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      sinon.stub(ChatSession, 'findOneAndUpdate').resolves({
         _id: VALID_OID,
         updatedAt: new Date(),
       } as any)
@@ -1190,7 +1359,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next with NotFoundError when conversation not found', async () => {
-      sinon.stub(Conversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1261,16 +1430,30 @@ describe('Enterprise Search Controller', () => {
         sharedWith: [],
         isShared: false,
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      // shareConversationById does a bare `await ChatSession.findOne(...)` (no
+      // .exec()) — stubThenableFindOne matches that call shape; stubMongooseFind
+      // would leave `conversation` as the unresolved chain object.
+      const findOne = stubThenableFindOne(ChatSession, mockConversation)
 
       // Stub IAM user validation
       sinon.stub(IAMServiceCommand.prototype, 'execute').resolves({ statusCode: 200, data: { _id: VALID_OID2 } })
 
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      // The controller now calls ChatSession.findOneAndUpdate({_id, ...EXCLUDE_AGENT}, ...),
+      // never findByIdAndUpdate.
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      const update = sinon.stub(ChatSession, 'findOneAndUpdate').resolves({
         _id: VALID_OID,
         isShared: true,
         shareLink: undefined,
         sharedWith: [{ userId: VALID_OID2, accessLevel: 'read' }],
+      } as any)
+
+      // shareConversationById does a bare `await ChatSessionMessage.find(...).lean()`
+      // (no .exec()) — stubMongooseFind's `.lean()` returns the chain itself, not a
+      // promise, so it would resolve to a non-array here; return a real promise.
+      restoreIfStubbed(ChatSessionMessage, 'find')
+      const attachmentLookup = sinon.stub(ChatSessionMessage, 'find').returns({
+        lean: () => Promise.resolve([{ attachments: [{ recordId: 'rec-1' }] }]),
       } as any)
 
       const req = createMockRequest({
@@ -1283,7 +1466,18 @@ describe('Enterprise Search Controller', () => {
 
       await handler(req, res, next)
 
+      // Cross-type isolation: both the initiator lookup and the update must be
+      // scoped to chat sessions only (never able to touch an agent session).
+      expect(findOne.firstCall.args[0].sessionType).to.equal('chat')
+      expect(update.firstCall.args[0]).to.deep.equal({ _id: VALID_OID, sessionType: 'chat' })
+      // Attachment permission grant reads message attachments from the
+      // separate chatSessionMessages collection, not conversation.messages.
+      expect(attachmentLookup.calledWith({ sessionId: VALID_OID }, { attachments: 1 })).to.be.true
+
       if (!next.called) {
+        const response = res.json.firstCall.args[0]
+        expect(response.isShared).to.equal(true)
+        expect(response.sharedWith).to.deep.equal([{ userId: VALID_OID2, accessLevel: 'read' }])
         expect(res.status.calledWith(200)).to.be.true
       }
     })
@@ -1291,7 +1485,7 @@ describe('Enterprise Search Controller', () => {
     it('should call next when conversation not found', async () => {
       const handler = shareConversationById(createMockAppConfig())
 
-      sinon.stub(Conversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       sinon.stub(IAMServiceCommand.prototype, 'execute').resolves({ statusCode: 200, data: {} })
 
@@ -1372,8 +1566,8 @@ describe('Enterprise Search Controller', () => {
         _id: VALID_OID,
         sharedWith: [{ userId: new mongoose.Types.ObjectId(VALID_OID3), accessLevel: 'read' }],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         isShared: false,
         shareLink: undefined,
@@ -1399,7 +1593,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next with NotFoundError when conversation not found', async () => {
-      sinon.stub(Conversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1433,7 +1627,7 @@ describe('Enterprise Search Controller', () => {
     it('should call next when conversationId is missing', async () => {
       const mockSession = createMockSession()
       sinon.stub(mongoose, 'startSession').resolves(mockSession as any)
-      sinon.stub(Conversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const req = createMockRequest({ params: {}, body: { title: 'New title' } })
       const res = createMockResponse()
@@ -1449,7 +1643,7 @@ describe('Enterprise Search Controller', () => {
       sinon.stub(mongoose, 'startSession').resolves(mockSession as any)
 
       const mockDoc = createMockConversationDoc({ title: 'Old title' })
-      stubMongooseFind(Conversation, 'findOne', mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1470,7 +1664,7 @@ describe('Enterprise Search Controller', () => {
       const mockSession = createMockSession()
       sinon.stub(mongoose, 'startSession').resolves(mockSession as any)
 
-      stubMongooseFind(Conversation, 'findOne', null)
+      stubMongooseFind(ChatSession, 'findOne', null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1516,17 +1710,18 @@ describe('Enterprise Search Controller', () => {
 
     it('should update feedback successfully on happy path', async () => {
       const messageId = new mongoose.Types.ObjectId()
-      const mockConversation = {
-        _id: VALID_OID,
-        messages: [
-          { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
-        ],
-      }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
-        _id: VALID_OID,
-        messages: [{ _id: messageId, feedback: [{ rating: 'positive' }] }],
-      } as any)
+      const mockConversation = { _id: VALID_OID }
+      // performFeedbackUpdate does a bare `await ChatSession.findOne(query, null, opts)`
+      // (no .exec()) — stubThenableFindOne matches that call shape.
+      const findOne = stubThenableFindOne(ChatSession, mockConversation)
+      restoreIfStubbed(ChatSessionMessage, 'findOne')
+      sinon.stub(ChatSessionMessage, 'findOne').resolves(
+        createMockMessageDoc({ _id: messageId, messageType: 'bot_response' }),
+      )
+      restoreIfStubbed(ChatSessionMessage, 'findOneAndUpdate')
+      const feedbackUpdate = sinon.stub(ChatSessionMessage, 'findOneAndUpdate').resolves(
+        createMockMessageDoc({ _id: messageId, feedback: [{ rating: 'positive' }] }),
+      )
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -1538,13 +1733,20 @@ describe('Enterprise Search Controller', () => {
 
       await updateFeedback(req, res, next)
 
-      if (!next.called) {
-        expect(res.status.calledWith(200)).to.be.true
-      }
+      expect(next.called).to.be.false
+      expect(res.status.calledWith(200)).to.be.true
+      const response = res.json.firstCall.args[0]
+      expect(response.conversationId).to.equal(VALID_OID)
+      expect(response.messageId).to.equal(messageId.toString())
+      // Cross-type isolation: the session lookup must scope to chat sessions only.
+      expect(findOne.firstCall.args[0].sessionType).to.equal('chat')
+      // Feedback is appended via appendMessageFeedback (findOneAndUpdate on the
+      // message itself), not a positional $push on an embedded array.
+      expect(feedbackUpdate.calledWith({ _id: messageId.toString() })).to.be.true
     })
 
     it('should call next when conversation not found for feedback', async () => {
-      stubMongooseFind(Conversation, 'findOne', null)
+      stubThenableFindOne(ChatSession, null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -1566,7 +1768,7 @@ describe('Enterprise Search Controller', () => {
           { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubFeedbackLookups(mockConversation, null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -1589,7 +1791,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'user_query', content: 'question', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'user_query', content: 'question', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -1628,14 +1830,14 @@ describe('Enterprise Search Controller', () => {
 
     it('should archive conversation successfully on happy path', async () => {
       const mockConversation = { _id: VALID_OID, isArchived: false }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const execStub = sinon.stub().resolves({
         _id: VALID_OID,
         isArchived: true,
         updatedAt: new Date(),
       })
-      sinon.stub(Conversation, 'findByIdAndUpdate').returns({ exec: execStub } as any)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').returns({ exec: execStub } as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1655,7 +1857,7 @@ describe('Enterprise Search Controller', () => {
 
     it('should call next when conversation already archived', async () => {
       const mockConversation = { _id: VALID_OID, isArchived: true }
-      sinon.stub(Conversation, 'findOne').resolves(mockConversation as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConversation as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1670,7 +1872,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next when conversation not found', async () => {
-      sinon.stub(Conversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1708,14 +1910,14 @@ describe('Enterprise Search Controller', () => {
 
     it('should unarchive conversation successfully', async () => {
       const mockConversation = { _id: VALID_OID, isArchived: true }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const execStub = sinon.stub().resolves({
         _id: VALID_OID,
         isArchived: false,
         updatedAt: new Date(),
       })
-      sinon.stub(Conversation, 'findByIdAndUpdate').returns({ exec: execStub } as any)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').returns({ exec: execStub } as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1735,7 +1937,7 @@ describe('Enterprise Search Controller', () => {
 
     it('should call next when conversation not archived', async () => {
       const mockConversation = { _id: VALID_OID, isArchived: false }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1750,7 +1952,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next when conversation not found for unarchive', async () => {
-      stubMongooseFind(Conversation, 'findOne', null)
+      stubMongooseFind(ChatSession, 'findOne', null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -1789,8 +1991,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversations),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(1)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(1)
 
       const req = createMockRequest({
         query: {},
@@ -1828,7 +2030,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'old answer', createdAt: Date.now() },
         ],
       })
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -2842,7 +3044,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'test' }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
@@ -2875,7 +3077,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'test' }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       let capturedBody: any
       sinon.stub(AIServiceCommand.prototype, 'execute').callsFake(function (this: any) {
@@ -2906,7 +3108,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'test' }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').rejects(new Error('Agent AI failed'))
 
@@ -2986,7 +3188,7 @@ describe('Enterprise Search Controller', () => {
       mockDoc.messages = [...mockDoc.messages]
 
       // addMessageStreamToAgentConversation uses plain `await AgentConversation.findOne(...)`
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -3016,7 +3218,7 @@ describe('Enterprise Search Controller', () => {
     it('should handle conversation not found', async () => {
       const handler = addMessageStreamToAgentConversation(createMockAppConfig())
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(null),
       } as any)
 
@@ -3089,7 +3291,7 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversation),
       }
-      sinon.stub(AgentConversation, 'findOne').returns(findChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -3148,8 +3350,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversations),
       }
-      sinon.stub(AgentConversation, 'find').returns(findChain as any)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(1)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(1)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1' },
@@ -3178,8 +3380,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().rejects(new Error('DB error')),
       }
-      sinon.stub(AgentConversation, 'find').returns(findChain as any)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1' },
@@ -3224,21 +3426,21 @@ describe('Enterprise Search Controller', () => {
         _id: VALID_OID,
         title: 'Test',
         agentKey: 'agent-1',
-        messages: [{ messageType: 'user_query', content: 'hi' }],
         initiator: VALID_OID,
         isShared: false,
         sharedWith: [],
         status: 'complete',
       }
 
-      sinon.stub(AgentConversation, 'aggregate').resolves([{ messageCount: 1 }])
       const findOneChain: any = {
         select: sinon.stub().returnsThis(),
-        populate: sinon.stub().returnsThis(),
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversation),
       }
-      sinon.stub(AgentConversation, 'findOne').returns(findOneChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
+      restoreIfStubbed(ChatSessionMessage, 'countDocuments')
+      sinon.stub(ChatSessionMessage, 'countDocuments').resolves(1)
+      stubGetMessages(ChatSessionMessage, [{ messageType: 'user_query', content: 'hi' }])
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -3256,7 +3458,12 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next with NotFoundError when conversation not found', async () => {
-      sinon.stub(AgentConversation, 'aggregate').resolves([])
+      const findOneChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().resolves(null),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -3286,7 +3493,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should return 200 when conversation is not found', async () => {
-      sinon.stub(AgentConversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -3308,7 +3515,7 @@ describe('Enterprise Search Controller', () => {
         save: sinon.stub().resolves(),
       }
       mockConv.save.resolves(mockConv)
-      sinon.stub(AgentConversation, 'findOne').resolves(mockConv as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConv as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -3334,10 +3541,6 @@ describe('Enterprise Search Controller', () => {
         { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'hi', createdAt: new Date() },
       ]
 
-      // Mock aggregate for count
-      sinon.stub(Conversation, 'aggregate').resolves([{ messageCount: 2 }])
-
-      // Mock findOne for conversation data
       const findChain: any = {
         select: sinon.stub().returnsThis(),
         populate: sinon.stub().returnsThis(),
@@ -3345,7 +3548,6 @@ describe('Enterprise Search Controller', () => {
         exec: sinon.stub().resolves({
           _id: new mongoose.Types.ObjectId(VALID_OID),
           title: 'Test',
-          messages: mockMessages,
           initiator: new mongoose.Types.ObjectId(VALID_OID),
           isShared: false,
           sharedWith: [],
@@ -3354,7 +3556,10 @@ describe('Enterprise Search Controller', () => {
           createdAt: new Date(),
         }),
       }
-      sinon.stub(Conversation, 'findOne').returns(findChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
+      restoreIfStubbed(ChatSessionMessage, 'countDocuments')
+      sinon.stub(ChatSessionMessage, 'countDocuments').resolves(2)
+      stubGetMessages(ChatSessionMessage, mockMessages)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -3376,7 +3581,12 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next when aggregate returns no results', async () => {
-      sinon.stub(Conversation, 'aggregate').resolves([])
+      const findChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().resolves(null),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -3392,8 +3602,6 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should handle sort options from query params', async () => {
-      sinon.stub(Conversation, 'aggregate').resolves([{ messageCount: 1 }])
-
       const findChain: any = {
         select: sinon.stub().returnsThis(),
         populate: sinon.stub().returnsThis(),
@@ -3401,7 +3609,6 @@ describe('Enterprise Search Controller', () => {
         exec: sinon.stub().resolves({
           _id: new mongoose.Types.ObjectId(VALID_OID),
           title: 'Test',
-          messages: [{ _id: new mongoose.Types.ObjectId(), messageType: 'user_query', content: 'test', createdAt: new Date() }],
           initiator: new mongoose.Types.ObjectId(VALID_OID),
           isShared: false,
           sharedWith: [],
@@ -3410,7 +3617,12 @@ describe('Enterprise Search Controller', () => {
           createdAt: new Date(),
         }),
       }
-      sinon.stub(Conversation, 'findOne').returns(findChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
+      restoreIfStubbed(ChatSessionMessage, 'countDocuments')
+      sinon.stub(ChatSessionMessage, 'countDocuments').resolves(1)
+      stubGetMessages(ChatSessionMessage, [
+        { _id: new mongoose.Types.ObjectId(), messageType: 'user_query', content: 'test', createdAt: new Date() },
+      ])
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -3444,8 +3656,9 @@ describe('Enterprise Search Controller', () => {
       }
       mockConversation.save.resolves(mockConversation)
 
-      sinon.stub(Conversation, 'findOne').resolves(mockConversation as any)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves(mockConversation as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConversation as any)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      sinon.stub(ChatSession, 'findOneAndUpdate').resolves(mockConversation as any)
       sinon.stub(Citation, 'updateMany').resolves({} as any)
 
       const req = createMockRequest({
@@ -3477,9 +3690,9 @@ describe('Enterprise Search Controller', () => {
         isShared: true,
       }
 
-      sinon.stub(Conversation, 'findOne').resolves(mockConversation as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConversation as any)
       sinon.stub(IAMServiceCommand.prototype, 'execute').resolves({ statusCode: 200, data: {} })
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: mockConversation._id,
         isShared: true,
         sharedWith: [existingSharedUser],
@@ -3503,12 +3716,12 @@ describe('Enterprise Search Controller', () => {
     it('should call next when findByIdAndUpdate returns null', async () => {
       const handler = shareConversationById(createMockAppConfig())
 
-      sinon.stub(Conversation, 'findOne').resolves({
+      sinon.stub(ChatSession, 'findOne').resolves({
         _id: new mongoose.Types.ObjectId(VALID_OID),
         sharedWith: [],
       } as any)
       sinon.stub(IAMServiceCommand.prototype, 'execute').resolves({ statusCode: 200, data: {} })
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves(null)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -3531,9 +3744,9 @@ describe('Enterprise Search Controller', () => {
         sharedWith: [{ userId: new mongoose.Types.ObjectId(VALID_OID3), accessLevel: 'read' }],
       })
 
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
       sinon.stub(Users, 'find').resolves([{ _id: VALID_OID3, email: 'test@test.com' }] as any)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         isShared: false,
         sharedWith: [],
@@ -3567,9 +3780,9 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
       sinon.stub(Users, 'find').resolves([{ _id: VALID_OID3, email: 'test@test.com' }] as any)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         isShared: true,
         sharedWith: [{ userId: user4, accessLevel: 'write' }],
@@ -3602,7 +3815,7 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -3717,8 +3930,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversations),
       }
-      sinon.stub(Conversation, 'find').returns(findChain1 as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(1)
+      sinon.stub(ChatSession, 'find').returns(findChain1 as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(1)
 
       const req = createMockRequest({
         query: { page: '1', limit: '10', source: 'owned' },
@@ -3747,8 +3960,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves([]),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: { conversationId: VALID_OID, source: 'owned' },
@@ -3785,8 +3998,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockConversations),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(1)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(1)
 
       const req = createMockRequest({
         query: { page: '1', limit: '10', source: 'shared' },
@@ -3830,8 +4043,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves([]),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: {},
@@ -3865,7 +4078,7 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub(),
       }
-      const findStub = sinon.stub(AgentConversation, 'find')
+      const findStub = sinon.stub(ChatSession, 'find')
       findChain.exec.resolves(mockConversations)
       const findChain2: any = {
         sort: sinon.stub().returnsThis(),
@@ -3877,7 +4090,7 @@ describe('Enterprise Search Controller', () => {
       }
       findStub.onFirstCall().returns(findChain as any)
       findStub.onSecondCall().returns(findChain2 as any)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(1)
+      sinon.stub(ChatSession, 'countDocuments').resolves(1)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1' },
@@ -3905,7 +4118,7 @@ describe('Enterprise Search Controller', () => {
         { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'hi', createdAt: new Date() },
       ]
 
-      sinon.stub(AgentConversation, 'aggregate').resolves([{ messageCount: 2 }])
+      sinon.stub(ChatSession, 'aggregate').resolves([{ messageCount: 2 }])
 
       const findChain: any = {
         select: sinon.stub().returnsThis(),
@@ -3924,7 +4137,7 @@ describe('Enterprise Search Controller', () => {
           createdAt: new Date(),
         }),
       }
-      sinon.stub(AgentConversation, 'findOne').returns(findChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -3950,7 +4163,7 @@ describe('Enterprise Search Controller', () => {
       const handler = streamChat(createMockAppConfig())
 
       const mockConversation = createMockConversationDoc()
-      sinon.stub(Conversation.prototype, 'save').resolves(mockConversation)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockConversation)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -3991,7 +4204,7 @@ describe('Enterprise Search Controller', () => {
           { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'first answer' },
         ],
       })
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4019,7 +4232,7 @@ describe('Enterprise Search Controller', () => {
       const handler = createConversation(createMockAppConfig())
 
       const mockSaved = createMockConversationDoc()
-      sinon.stub(Conversation.prototype, 'save').resolves(mockSaved)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockSaved)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 500,
@@ -4056,7 +4269,7 @@ describe('Enterprise Search Controller', () => {
         status: 'failed',
         agentKey: 'agent-1',
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockSaved)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockSaved)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 500,
@@ -4252,7 +4465,7 @@ describe('Enterprise Search Controller', () => {
           { _id: new mongoose.Types.ObjectId(), messageType: 'user_query', content: 'hello' },
         ],
       })
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 400,
@@ -4282,7 +4495,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const connError = new Error('fetch failed')
       ;(connError as any).cause = { code: 'ECONNREFUSED' }
@@ -4447,7 +4660,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4487,7 +4700,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4554,7 +4767,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -4589,7 +4802,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4628,7 +4841,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -4665,10 +4878,10 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       // Stub findOne for saveCompleteConversation
-      stubMongooseFind(Conversation, 'findOne', mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4706,7 +4919,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4744,7 +4957,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -4794,7 +5007,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -4839,7 +5052,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -4875,11 +5088,11 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      const { insertManyStub } = stubAppendMessages([createMockMessageDoc({ messageType: 'tool_call' })])
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4904,11 +5117,11 @@ describe('Enterprise Search Controller', () => {
       mockStream.emit('data', Buffer.from(askChunk))
       await new Promise((resolve) => setTimeout(resolve, 50))
 
-      expect(findByIdAndUpdateStub.calledOnce).to.be.true
-      const updatePayload = findByIdAndUpdateStub.firstCall.args[1]
-      expect(updatePayload.$push.messages.messageType).to.equal('tool_call')
-      expect(updatePayload.$push.messages.tools[0].toolName).to.equal('ask_user_question')
-      expect(updatePayload.$push.messages.tools[0].toolResult).to.deep.equal(toolData)
+      const toolCallInsert = insertManyStub.getCalls().find((c: any) =>
+        c.args[0]?.some((m: any) => m.tools?.[0]?.toolName === 'ask_user_question'),
+      )
+      expect(toolCallInsert).to.exist
+      expect(toolCallInsert.args[0][0].tools[0].toolResult).to.deep.equal(toolData)
 
       const forwarded = res.write.args.map((a: any) => a[0]).join('')
       expect(forwarded).to.include('ask_user_question')
@@ -4927,11 +5140,11 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      const findByIdAndUpdateStub = sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({})
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -4967,11 +5180,11 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      const findByIdAndUpdateStub = sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({})
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5007,11 +5220,11 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').rejects(new Error('DB write failed'))
+      sinon.stub(ChatSession, 'findByIdAndUpdate').rejects(new Error('DB write failed'))
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5052,7 +5265,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -5081,7 +5294,7 @@ describe('Enterprise Search Controller', () => {
     it('should call next (via SSE error) when conversation not found', async () => {
       const handler = regenerateAnswers(createMockAppConfig())
 
-      stubMongooseFind(Conversation, 'findOne', null)
+      stubMongooseFind(ChatSession, 'findOne', null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -5114,7 +5327,11 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
+      stubGetMessages(ChatSessionMessage, [
+        { _id: messageId, messageType: 'bot_response', content: 'old answer', createdAt: Date.now() },
+        { _id: userQueryId, messageType: 'user_query', content: 'hello', createdAt: Date.now() },
+      ])
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5161,7 +5378,11 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(AgentConversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
+      stubGetMessages(ChatSessionMessage, [
+        { _id: messageId, messageType: 'bot_response', content: 'old answer', createdAt: Date.now() },
+        { _id: userQueryId, messageType: 'user_query', content: 'hello', createdAt: Date.now() },
+      ])
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5209,7 +5430,7 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const aiResponse = {
         statusCode: 200,
@@ -5260,8 +5481,8 @@ describe('Enterprise Search Controller', () => {
         ],
       }
 
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         updatedAt: new Date(),
       } as any)
@@ -5316,7 +5537,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5348,7 +5569,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5379,7 +5600,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(AIServiceCommand.prototype, 'executeStream').rejects(new Error('Agent stream start failed'))
 
       const req = createMockRequest({
@@ -5404,8 +5625,8 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
-      stubMongooseFind(AgentConversation, 'findOne', mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5443,8 +5664,8 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      const { insertManyStub } = stubAppendMessages([createMockMessageDoc({ messageType: 'tool_call' })])
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5469,10 +5690,11 @@ describe('Enterprise Search Controller', () => {
       mockStream.emit('data', Buffer.from(askChunk))
       await new Promise((resolve) => setTimeout(resolve, 50))
 
-      expect(findByIdAndUpdateStub.calledOnce).to.be.true
-      const updatePayload = findByIdAndUpdateStub.firstCall.args[1]
-      expect(updatePayload.$push.messages.tools[0].toolName).to.equal('ask_user_question')
-      expect(updatePayload.$push.messages.tools[0].toolResult).to.deep.equal(toolData)
+      const toolCallInsert = insertManyStub.getCalls().find((c: any) =>
+        c.args[0]?.some((m: any) => m.tools?.[0]?.toolName === 'ask_user_question'),
+      )
+      expect(toolCallInsert).to.exist
+      expect(toolCallInsert.args[0][0].tools[0].toolResult).to.deep.equal(toolData)
 
       const forwarded = res.write.args.map((a: any) => a[0]).join('')
       expect(forwarded).to.include('ask_user_question')
@@ -5488,8 +5710,8 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      const findByIdAndUpdateStub = sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({})
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5522,8 +5744,8 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').rejects(new Error('DB write failed'))
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').rejects(new Error('DB write failed'))
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5561,7 +5783,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5600,7 +5822,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       const executeStreamStub = sinon
@@ -5637,7 +5859,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       const executeStreamStub = sinon
@@ -5670,8 +5892,8 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
-      stubMongooseFind(AgentConversation, 'findOne', mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5709,7 +5931,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -5767,7 +5989,7 @@ describe('Enterprise Search Controller', () => {
     it('should call next with NotFoundError when conversation not found', async () => {
       const handler = addMessageToAgentConversation(createMockAppConfig())
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(null),
       } as any)
 
@@ -5799,7 +6021,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -5841,7 +6063,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -5870,7 +6092,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -5903,7 +6125,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -5955,7 +6177,7 @@ describe('Enterprise Search Controller', () => {
           { messageType: 'bot_response', content: 'world', citations: [] },
         ],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const aiResponse = {
         statusCode: 200,
@@ -6039,7 +6261,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -6175,7 +6397,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -6217,7 +6439,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -6257,7 +6479,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -6301,7 +6523,7 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -6334,7 +6556,7 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: differentId.toString() },
@@ -6366,7 +6588,7 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -6397,7 +6619,7 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -6429,7 +6651,7 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -6745,10 +6967,10 @@ describe('Enterprise Search Controller', () => {
   describe('archiveConversation (database error)', () => {
     it('should call next when findByIdAndUpdate returns null', async () => {
       const mockConversation = { _id: VALID_OID, isArchived: false }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const execStub = sinon.stub().resolves(null)
-      sinon.stub(Conversation, 'findByIdAndUpdate').returns({ exec: execStub } as any)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').returns({ exec: execStub } as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -6769,10 +6991,10 @@ describe('Enterprise Search Controller', () => {
   describe('unarchiveConversation (database error)', () => {
     it('should call next when findByIdAndUpdate returns null', async () => {
       const mockConversation = { _id: VALID_OID, isArchived: true }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const execStub = sinon.stub().resolves(null)
-      sinon.stub(Conversation, 'findByIdAndUpdate').returns({ exec: execStub } as any)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').returns({ exec: execStub } as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -6796,8 +7018,8 @@ describe('Enterprise Search Controller', () => {
         _id: VALID_OID,
         sharedWith: [{ userId: new mongoose.Types.ObjectId(VALID_OID3), accessLevel: 'read' }],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves(null)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -6824,8 +7046,9 @@ describe('Enterprise Search Controller', () => {
         isDeleted: false,
         messages: [],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves(null)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      sinon.stub(ChatSession, 'findOneAndUpdate').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -6850,7 +7073,7 @@ describe('Enterprise Search Controller', () => {
 
       const mockDoc = createMockConversationDoc({ title: 'Old title' })
       mockDoc.save.rejects(new Error('Save failed'))
-      stubMongooseFind(Conversation, 'findOne', mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -6878,8 +7101,9 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves(null)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() })
+      restoreIfStubbed(ChatSessionMessage, 'findOneAndUpdate')
+      sinon.stub(ChatSessionMessage, 'findOneAndUpdate').resolves(null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -6955,7 +7179,7 @@ describe('Enterprise Search Controller', () => {
         sharedWith: [],
         isShared: false,
       }
-      sinon.stub(Conversation, 'findOne').resolves(mockConversation as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConversation as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -6981,7 +7205,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -7027,7 +7251,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -7068,8 +7292,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().rejects(new Error('DB error')),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: {},
@@ -7088,8 +7312,13 @@ describe('Enterprise Search Controller', () => {
   // getAgentConversationById - database error
   // -----------------------------------------------------------------------
   describe('getAgentConversationById (database error)', () => {
-    it('should call next when aggregate throws', async () => {
-      sinon.stub(AgentConversation, 'aggregate').rejects(new Error('Aggregate failed'))
+    it('should call next when session lookup throws', async () => {
+      const findOneChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().rejects(new Error('Query failed')),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -7109,8 +7338,13 @@ describe('Enterprise Search Controller', () => {
   // getConversationById - database error
   // -----------------------------------------------------------------------
   describe('getConversationById (database error)', () => {
-    it('should call next when aggregate throws', async () => {
-      sinon.stub(Conversation, 'aggregate').rejects(new Error('Aggregate failed'))
+    it('should call next when session lookup throws', async () => {
+      const findOneChain: any = {
+        select: sinon.stub().returnsThis(),
+        lean: sinon.stub().returnsThis(),
+        exec: sinon.stub().rejects(new Error('Query failed')),
+      }
+      sinon.stub(ChatSession, 'findOne').returns(findOneChain as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID },
@@ -7135,7 +7369,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Bad Request')
       responseError.response = {
@@ -7160,7 +7394,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Unauthorized')
       responseError.response = {
@@ -7185,7 +7419,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Forbidden')
       responseError.response = {
@@ -7210,7 +7444,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Not Found')
       responseError.response = {
@@ -7235,7 +7469,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Bad Gateway')
       responseError.response = {
@@ -7260,7 +7494,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Service Unavailable')
       responseError.response = {
@@ -7285,7 +7519,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Gateway Timeout')
       responseError.response = {
@@ -7310,7 +7544,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Unknown')
       responseError.response = {
@@ -7335,7 +7569,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const requestError: any = new Error('No response')
       requestError.request = {}
@@ -7357,7 +7591,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const detailError: any = new Error('error')
       detailError.detail = 'Custom detail error'
@@ -7379,7 +7613,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const fetchError = new Error('fetch failed')
       sinon.stub(AIServiceCommand.prototype, 'execute').rejects(fetchError)
@@ -7402,7 +7636,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const responseError: any = new Error('Error')
       responseError.response = {
@@ -7443,7 +7677,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
         data: { answer: 'world', citations: [], followUpQuestions: [] },
@@ -7518,7 +7752,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -7553,7 +7787,7 @@ describe('Enterprise Search Controller', () => {
     it('should not call writeHead when headersSent is true', async () => {
       const handler = streamChat(createMockAppConfig())
 
-      sinon.stub(Conversation.prototype, 'save').rejects(new Error('DB crash'))
+      sinon.stub(ChatSession.prototype, 'save').rejects(new Error('DB crash'))
 
       const req = createMockRequest({
         body: { query: 'hello' },
@@ -7581,7 +7815,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -7620,7 +7854,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -7665,7 +7899,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -7706,7 +7940,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -7751,7 +7985,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -7792,7 +8026,7 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
         data: { answer: 'world', citations: [], followUpQuestions: [] },
@@ -8075,7 +8309,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -8133,8 +8367,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves([]),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: {
@@ -8182,7 +8416,7 @@ describe('Enterprise Search Controller', () => {
       const mockConversation = createMockConversationDoc({
         messages: [],
       })
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -8210,7 +8444,7 @@ describe('Enterprise Search Controller', () => {
           { _id: msgId2, messageType: 'bot_response', content: 'answer', createdAt: new Date() },
         ],
       })
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: msgId1.toString() },
@@ -8236,7 +8470,7 @@ describe('Enterprise Search Controller', () => {
           { _id: msgId, messageType: 'user_query', content: 'hello', createdAt: new Date() },
         ],
       })
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: msgId.toString() },
@@ -8268,7 +8502,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const connError: any = new Error('fetch failed')
       connError.cause = { code: 'ECONNREFUSED' }
@@ -8297,7 +8531,7 @@ describe('Enterprise Search Controller', () => {
       const handler = streamChat(createMockAppConfig())
 
       // Make save return null to simulate failed creation
-      sinon.stub(Conversation.prototype, 'save').resolves(null as any)
+      sinon.stub(ChatSession.prototype, 'save').resolves(null as any)
 
       const req = createMockRequest({
         body: { query: 'hello' },
@@ -8321,7 +8555,7 @@ describe('Enterprise Search Controller', () => {
     it('should skip markAgentConversationFailed when savedConversation is null', async () => {
       const handler = streamAgentConversation(createMockAppConfig())
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(null as any)
+      sinon.stub(ChatSession.prototype, 'save').resolves(null as any)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1' },
@@ -8346,7 +8580,7 @@ describe('Enterprise Search Controller', () => {
     it('should not call writeHead when headersSent is true in catch block', async () => {
       const handler = addMessageStream(createMockAppConfig())
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (_resolve: any, reject: any) => { throw new Error('DB crash') },
       } as any)
 
@@ -8375,7 +8609,7 @@ describe('Enterprise Search Controller', () => {
     it('should not call writeHead when headersSent is true', async () => {
       const handler = addMessageStreamToAgentConversation(createMockAppConfig())
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: () => { throw new Error('DB crash') },
       } as any)
 
@@ -8403,7 +8637,7 @@ describe('Enterprise Search Controller', () => {
     it('should not call writeHead when headersSent is true', async () => {
       const handler = streamAgentConversation(createMockAppConfig())
 
-      sinon.stub(AgentConversation.prototype, 'save').rejects(new Error('DB crash'))
+      sinon.stub(ChatSession.prototype, 'save').rejects(new Error('DB crash'))
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1' },
@@ -8432,7 +8666,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
       // First save succeeds (creating conversation), but findOne fails later
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -8447,7 +8681,7 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().rejects(new Error('DB save failed')),
       }
-      sinon.stub(Conversation, 'findOne').returns(findChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
 
       const req = createMockRequest({
         body: { query: 'hello' },
@@ -8482,7 +8716,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.rejects(new Error('Save failed in markConversationFailed'))
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -8656,7 +8890,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -8697,7 +8931,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -8743,7 +8977,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -8786,7 +9020,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -8831,7 +9065,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -8874,7 +9108,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -8918,7 +9152,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -8964,7 +9198,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9011,7 +9245,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9049,7 +9283,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -9085,7 +9319,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -9111,7 +9345,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -9152,7 +9386,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -9198,7 +9432,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9241,7 +9475,7 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
         data: {
@@ -9277,7 +9511,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'test' }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const connError = new Error('fetch failed')
       ;(connError as any).cause = { code: 'ECONNREFUSED' }
@@ -9319,7 +9553,7 @@ describe('Enterprise Search Controller', () => {
           { messageType: 'bot_response', content: 'response', citations: [] },
         ],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
@@ -9358,7 +9592,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9394,7 +9628,7 @@ describe('Enterprise Search Controller', () => {
         sharedWith: [],
         isShared: false,
       }
-      sinon.stub(Conversation, 'findOne').resolves(mockConversation as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConversation as any)
       sinon.stub(IAMServiceCommand.prototype, 'execute').resolves({ statusCode: 404, data: null })
 
       const req = createMockRequest({
@@ -9476,9 +9710,9 @@ describe('Enterprise Search Controller', () => {
         sharedWith: [],
         isShared: false,
       }
-      sinon.stub(Conversation, 'findOne').resolves(mockConversation as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConversation as any)
       sinon.stub(IAMServiceCommand.prototype, 'execute').resolves({ statusCode: 200, data: {} })
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         isShared: true,
         sharedWith: [{ userId: VALID_OID2, accessLevel: 'read' }],
@@ -9551,7 +9785,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9598,7 +9832,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: '123', citations: [] }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
         data: { answer: 'answer', citations: [], followUpQuestions: [] },
@@ -9628,7 +9862,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9664,7 +9898,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.messages = [...mockDoc.messages]
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -9702,7 +9936,7 @@ describe('Enterprise Search Controller', () => {
         _id: mockDoc._id,
         messages: [{ messageType: 'user_query', content: '42', citations: [] }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 200,
@@ -9742,8 +9976,8 @@ describe('Enterprise Search Controller', () => {
       const thenableResult: any = {
         then: (resolve: any) => resolve(mockConversation),
       }
-      sinon.stub(Conversation, 'findOne').returns(thenableResult)
-      sinon.stub(Conversation, 'findById').resolves(mockConversation)
+      sinon.stub(ChatSession, 'findOne').returns(thenableResult)
+      sinon.stub(ChatSession, 'findById').resolves(mockConversation)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -9777,7 +10011,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'test' }],
       })
-      sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
         statusCode: 400,
@@ -9883,8 +10117,8 @@ describe('Enterprise Search Controller', () => {
         ],
       }
 
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         updatedAt: new Date(),
       } as any)
@@ -9917,8 +10151,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves([]),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         context: undefined,
@@ -9946,7 +10180,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -9998,7 +10232,7 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const aiResponse = {
         statusCode: 200,
@@ -10062,7 +10296,7 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves(mockDoc),
       }
-      sinon.stub(Conversation, 'findOne').returns(findChain as any)
+      sinon.stub(ChatSession, 'findOne').returns(findChain as any)
 
       const aiResponse = {
         statusCode: 200,
@@ -10106,7 +10340,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const error: any = new Error('fail')
       error.response = { status: 400, data: { reason: 'Bad input data' } }
@@ -10131,7 +10365,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const error: any = new Error('fail')
       error.response = { status: 500, data: { message: 'Server error' } }
@@ -10156,7 +10390,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const error: any = new Error('fail')
       error.response = { status: 503, data: {} }
@@ -10186,7 +10420,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const error: any = new Error('fail')
       error.detail = 'Detailed error info'
@@ -10216,7 +10450,7 @@ describe('Enterprise Search Controller', () => {
       })
       mockDoc.save.resolves(mockDoc)
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const error: any = new Error('Request sent but no response')
       error.request = {}
@@ -10255,7 +10489,7 @@ describe('Enterprise Search Controller', () => {
         ],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       // AI returns non-200 to trigger error save path
       sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
@@ -10287,7 +10521,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
 
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -10320,7 +10554,7 @@ describe('Enterprise Search Controller', () => {
     it('should handle error without message in outer catch block', async () => {
       const handler = streamChat(createMockAppConfig())
 
-      sinon.stub(Conversation.prototype, 'save').rejects({ stack: 'error stack' })
+      sinon.stub(ChatSession.prototype, 'save').rejects({ stack: 'error stack' })
 
       const req = createMockRequest({
         body: { query: 'hello' },
@@ -10381,8 +10615,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves([]),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: {
@@ -10415,8 +10649,8 @@ describe('Enterprise Search Controller', () => {
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().resolves([]),
       }
-      sinon.stub(Conversation, 'find').returns(findChain as any)
-      sinon.stub(Conversation, 'countDocuments').resolves(0)
+      sinon.stub(ChatSession, 'find').returns(findChain as any)
+      sinon.stub(ChatSession, 'countDocuments').resolves(0)
 
       const req = createMockRequest({
         query: { source: 'owned' },
@@ -10483,7 +10717,7 @@ describe('Enterprise Search Controller', () => {
         lastActivityAt: null,
         save: sinon.stub().rejects(new Error('DB write error')),
       }
-      sinon.stub(AgentConversation, 'findOne').resolves(mockConv as any)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConv as any)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, agentKey: 'agent-1' },
@@ -10542,7 +10776,7 @@ describe('Enterprise Search Controller', () => {
       const handler = addMessageStreamToAgentConversation(createMockAppConfig())
       const mockDoc = buildMockDocPair('null')
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
       // Make executeStream throw so the outer catch is triggered after existingConversation is set
@@ -10571,7 +10805,7 @@ describe('Enterprise Search Controller', () => {
       const handler = addMessageStreamToAgentConversation(createMockAppConfig())
       const mockDoc = buildMockDocPair('throw')
 
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
       sinon.stub(AIServiceCommand.prototype, 'executeStream').rejects(new Error('AI unavailable'))
@@ -10600,7 +10834,7 @@ describe('Enterprise Search Controller', () => {
 
       // Return null from findOne so existingConversation stays undefined and the
       // outer catch hits the !res.headersSent branch (line 6149-6151)
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(null),
       } as any)
       sinon.stub(AIServiceCommand.prototype, 'executeStream').rejects(new Error('early fail'))
@@ -10635,7 +10869,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'test query' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       let capturedBody: any = null
       let capturedUri: string = ''
@@ -10674,7 +10908,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'test query' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       let capturedBody: any = null
       let capturedUri: string = ''
@@ -10713,7 +10947,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'test query' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       let capturedBody: any = null
       let capturedUri: string = ''
@@ -10752,7 +10986,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'test query' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       let capturedBody: any = null
       let capturedUri: string = ''
@@ -10791,7 +11025,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'test query' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       let capturedBody: any = null
       let capturedUri: string = ''
@@ -10857,7 +11091,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next when agent conversation is not found', async () => {
-      stubMongooseFind(AgentConversation, 'findOne', null)
+      stubThenableFindOne(ChatSession, null)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -10879,7 +11113,7 @@ describe('Enterprise Search Controller', () => {
           { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(AgentConversation, 'findOne', mockConversation)
+      stubFeedbackLookups(mockConversation, null)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -10902,7 +11136,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'user_query', content: 'question', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(AgentConversation, 'findOne', mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'user_query', content: 'question', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: messageId.toString() },
@@ -10925,8 +11159,9 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(AgentConversation, 'findOne', mockConversation)
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves(null)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() })
+      restoreIfStubbed(ChatSessionMessage, 'findOneAndUpdate')
+      sinon.stub(ChatSessionMessage, 'findOneAndUpdate').resolves(null)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: messageId.toString() },
@@ -10949,8 +11184,8 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(AgentConversation, 'findOne', mockConversation)
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         messages: [{ _id: messageId, feedback: [{ rating: 'positive' }] }],
       } as any)
@@ -10987,8 +11222,8 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         messages: [{ _id: messageId, feedback: [{ isHelpful: false, categories: ['incorrect_information'] }] }],
       } as any)
@@ -11019,8 +11254,8 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         messages: [{ _id: messageId, feedback: [{ isHelpful: false }] }],
       } as any)
@@ -11055,8 +11290,8 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt },
         ],
       }
-      stubMongooseFind(Conversation, 'findOne', mockConversation)
-      sinon.stub(Conversation, 'findByIdAndUpdate').resolves({
+      stubMongooseFind(ChatSession, 'findOne', mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         messages: [{ _id: messageId, feedback: [{}] }],
       } as any)
@@ -11098,7 +11333,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'system', content: 'system msg', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(Conversation, mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'system', content: 'system msg', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -11124,7 +11359,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'error', content: 'error msg', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(Conversation, mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'error', content: 'error msg', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -11150,7 +11385,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'tool_call', content: 'tool output', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(Conversation, mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'tool_call', content: 'tool output', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: messageId.toString() },
@@ -11177,7 +11412,7 @@ describe('Enterprise Search Controller', () => {
     afterEach(() => { sinon.restore() })
 
     it('should call next with NotFoundError when conversation is null', async () => {
-      stubThenableFindOne(Conversation, null)
+      stubThenableFindOne(ChatSession, null)
 
       const req = createMockRequest({
         params: { conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -11211,8 +11446,8 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(AgentConversation, mockConversation)
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({
+      stubThenableFindOne(ChatSession, mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         messages: [{ _id: messageId, feedback: [{ isHelpful: false, categories: ['missing_information'], comments: { negative: 'Missing key details' } }] }],
       } as any)
@@ -11249,7 +11484,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'system', content: 'system msg', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(AgentConversation, mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'system', content: 'system msg', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: messageId.toString() },
@@ -11275,8 +11510,8 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'bot_response', content: 'answer', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(AgentConversation, mockConversation)
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({
+      stubThenableFindOne(ChatSession, mockConversation)
+      sinon.stub(ChatSession, 'findByIdAndUpdate').resolves({
         _id: VALID_OID,
         messages: [{ _id: messageId, feedback: [{ isHelpful: true }] }],
       } as any)
@@ -11308,7 +11543,7 @@ describe('Enterprise Search Controller', () => {
           { _id: messageId, messageType: 'error', content: 'error msg', createdAt: Date.now() },
         ],
       }
-      stubThenableFindOne(AgentConversation, mockConversation)
+      stubFeedbackLookups(mockConversation, { _id: messageId, messageType: 'error', content: 'error msg', createdAt: Date.now() })
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: messageId.toString() },
@@ -11327,7 +11562,7 @@ describe('Enterprise Search Controller', () => {
     })
 
     it('should call next when agent conversation not found (thenable)', async () => {
-      stubThenableFindOne(AgentConversation, null)
+      stubThenableFindOne(ChatSession, null)
 
       const req = createMockRequest({
         params: { agentKey: 'agent-1', conversationId: VALID_OID, messageId: VALID_OID3 },
@@ -11363,7 +11598,7 @@ describe('Enterprise Search Controller', () => {
         const mockDoc = createMockConversationDoc({
           messages: [{ messageType: 'user_query', content: 'hello' }],
         })
-        sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+        sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
         sinon.stub(AIServiceCommand.prototype, 'executeStream').callsFake(function (this: any) {
           ;(mockStream as any)._capturedBody = JSON.parse(this.body)
           return Promise.resolve(mockStream)
@@ -11466,7 +11701,7 @@ describe('Enterprise Search Controller', () => {
           modelInfo: {},
         })
         mockDoc.messages = [...mockDoc.messages]
-        sinon.stub(Conversation, 'findOne').returns({
+        sinon.stub(ChatSession, 'findOne').returns({
           then: (resolve: any) => resolve(mockDoc),
         } as any)
         sinon.stub(AIServiceCommand.prototype, 'executeStream').callsFake(function (this: any) {
@@ -11547,7 +11782,7 @@ describe('Enterprise Search Controller', () => {
     describe('streamAgentConversation', () => {
       function stubStreamAgentConversationDeps(mockStream: any) {
         const mockDoc = createMockConversationDoc({ agentKey: 'agent-1' })
-        sinon.stub(AgentConversation.prototype, 'save').resolves(mockDoc)
+        sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
         sinon.stub(AIServiceCommand.prototype, 'executeStream').callsFake(function (this: any) {
           ;(mockStream as any)._capturedBody = JSON.parse(this.body)
           return Promise.resolve(mockStream)
@@ -11637,7 +11872,7 @@ describe('Enterprise Search Controller', () => {
           modelInfo: {},
         })
         mockDoc.messages = [...mockDoc.messages]
-        sinon.stub(AgentConversation, 'findOne').returns({
+        sinon.stub(ChatSession, 'findOne').returns({
           then: (resolve: any) => resolve(mockDoc),
         } as any)
         return mockDoc
@@ -11735,7 +11970,7 @@ describe('Enterprise Search Controller', () => {
           modelInfo: {},
         })
         mockDoc.messages = [...mockDoc.messages]
-        sinon.stub(AgentConversation, 'findOne').returns({
+        sinon.stub(ChatSession, 'findOne').returns({
           then: (resolve: any) => resolve(mockDoc),
         } as any)
         sinon.stub(AIServiceCommand.prototype, 'executeStream').callsFake(function (this: any) {
@@ -11951,7 +12186,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       const executeStreamStub = sinon
@@ -11985,7 +12220,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       const executeStreamStub = sinon
@@ -12015,8 +12250,8 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
-      stubMongooseFind(Conversation, 'findOne', mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
+      stubMongooseFind(ChatSession, 'findOne', mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -12051,7 +12286,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation.prototype, 'save').resolves(mockDoc)
+      sinon.stub(ChatSession.prototype, 'save').resolves(mockDoc)
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -12087,7 +12322,7 @@ describe('Enterprise Search Controller', () => {
       const mockDoc = createMockConversationDoc({
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
       mockDoc.save.resolves(mockDoc)
@@ -12126,7 +12361,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
       mockDoc.messages = [...mockDoc.messages]
-      sinon.stub(Conversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -12167,7 +12402,7 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
       mockDoc.save.resolves(mockDoc)
@@ -12207,7 +12442,7 @@ describe('Enterprise Search Controller', () => {
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
       mockDoc.messages = [...mockDoc.messages]
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
 
@@ -12246,10 +12481,11 @@ describe('Enterprise Search Controller', () => {
         agentKey: 'agent-1',
         messages: [{ messageType: 'user_query', content: 'hello' }],
       })
-      sinon.stub(AgentConversation, 'findOne').returns({
+      sinon.stub(ChatSession, 'findOne').returns({
         then: (resolve: any) => resolve(mockDoc),
       } as any)
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves(mockDoc)
+      stubAppendMessages()
+      stubGetMessages(ChatSessionMessage, [])
 
       const mockStream = createMockStream()
       sinon.stub(AIServiceCommand.prototype, 'executeStream').resolves(mockStream)
@@ -12273,10 +12509,344 @@ describe('Enterprise Search Controller', () => {
       mockStream.emit('data', Buffer.from(`event: CUSTOM\ndata: ${customPayload}\n\n`))
       await new Promise((resolve) => setTimeout(resolve, 50))
 
-      expect((AgentConversation.findByIdAndUpdate as sinon.SinonStub).called).to.be.true
+      expect((ChatSessionMessage.insertMany as sinon.SinonStub).called).to.be.true
 
       mockStream.emit('end')
       await new Promise((resolve) => setTimeout(resolve, 50))
     })
   })
+  describe('cross-type isolation on id-only mutation routes', () => {
+    it('archiveConversation scopes the update to sessionType chat', async () => {
+      const mockConversation = createMockConversationDoc({ isArchived: false })
+      const findOne = sinon.stub(ChatSession, 'findOne').resolves(mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      const update = sinon.stub(ChatSession, 'findOneAndUpdate').returns({
+        exec: sinon.stub().resolves({ _id: VALID_OID, updatedAt: new Date() }),
+      } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID },
+        user: { userId: VALID_OID, orgId: VALID_OID2 },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await archiveConversation(req, res, next)
+
+      expect(findOne.called).to.be.true
+      const filter = findOne.firstCall.args[0] as any
+      expect(filter.sessionType).to.equal('chat')
+      if (update.called) {
+        expect((update.firstCall.args[0] as any).sessionType).to.equal('chat')
+      }
+    })
+
+    it('archiveAgentConversation scopes the update to sessionType agent', async () => {
+      const mockConversation = createMockConversationDoc({ isArchived: false, agentKey: 'a1' })
+      const findOne = sinon.stub(ChatSession, 'findOne').resolves(mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      sinon.stub(ChatSession, 'findOneAndUpdate').returns({
+        exec: sinon.stub().resolves({ _id: VALID_OID, updatedAt: new Date() }),
+      } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, agentKey: 'a1' },
+        user: { userId: VALID_OID, orgId: VALID_OID2 },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await archiveAgentConversation(req, res, next)
+
+      expect(findOne.called).to.be.true
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('agent')
+    })
+
+    it('deleteConversationById scopes both the lookup and the soft-delete to sessionType chat', async () => {
+      const mockConversation = { _id: VALID_OID }
+      const findOne = stubThenableFindOne(ChatSession, mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      const update = sinon.stub(ChatSession, 'findOneAndUpdate').resolves({
+        _id: VALID_OID,
+        updatedAt: new Date(),
+      } as any)
+      // deleteConversationById reads citations via a bare `.find(...).lean()`
+      // (no .exec()); the default beforeEach stub's `.lean()` returns the
+      // chain itself, not an array, so give it a real resolving promise.
+      restoreIfStubbed(ChatSessionMessage, 'find')
+      sinon.stub(ChatSessionMessage, 'find').returns({ lean: () => Promise.resolve([]) } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await deleteConversationById(req, res, next)
+
+      expect(next.called).to.be.false
+      expect(findOne.firstCall.args[0].sessionType).to.equal('chat')
+      expect((update.firstCall.args[0] as any).sessionType).to.equal('chat')
+    })
+
+    it('unshareConversationById scopes both the lookup and the update to sessionType chat', async () => {
+      const handler = unshareConversationById(createMockAppConfig())
+      const mockConversation = { _id: VALID_OID, sharedWith: [] }
+      const findOne = stubThenableFindOne(ChatSession, mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      const update = sinon.stub(ChatSession, 'findOneAndUpdate').resolves({
+        _id: VALID_OID,
+        sharedWith: [],
+      } as any)
+      // unshareConversationById revokes attachment permissions via a bare
+      // `.find(...).lean()` (no .exec()); give it a real resolving promise.
+      restoreIfStubbed(ChatSessionMessage, 'find')
+      sinon.stub(ChatSessionMessage, 'find').returns({ lean: () => Promise.resolve([]) } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID },
+        body: { userIds: [VALID_OID3] },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await handler(req, res, next)
+
+      expect(next.called).to.be.false
+      expect(findOne.firstCall.args[0].sessionType).to.equal('chat')
+      expect((update.firstCall.args[0] as any).sessionType).to.equal('chat')
+    })
+
+    it('updateTitle scopes the lookup to sessionType chat', async () => {
+      const mockConversation = createMockConversationDoc({ title: 'old title' })
+      const findOne = stubThenableFindOne(ChatSession, mockConversation)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID },
+        body: { title: 'new title' },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await updateTitle(req, res, next)
+
+      expect(findOne.firstCall.args[0].sessionType).to.equal('chat')
+    })
+
+    it('unarchiveConversation scopes both the lookup and the update to sessionType chat', async () => {
+      const mockConversation = createMockConversationDoc({ isArchived: true })
+      const findOne = sinon.stub(ChatSession, 'findOne').resolves(mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      const update = sinon.stub(ChatSession, 'findOneAndUpdate').returns({
+        exec: sinon.stub().resolves({ _id: VALID_OID, updatedAt: new Date() }),
+      } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await unarchiveConversation(req, res, next)
+
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('chat')
+      expect((update.firstCall.args[0] as any).sessionType).to.equal('chat')
+    })
+
+    it('addMessageToAgentConversation scopes the lookup to sessionType agent', async () => {
+      const handler = addMessageToAgentConversation(createMockAppConfig())
+      const mockConversation = createMockConversationDoc({ agentKey: 'agent-1' })
+      const findOne = sinon.stub(ChatSession, 'findOne').returns({
+        then: (resolve: any) => resolve(mockConversation),
+      } as any)
+      sinon.stub(AIServiceCommand.prototype, 'execute').rejects(new Error('boom'))
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, agentKey: 'agent-1' },
+        body: { query: 'test question' },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await handler(req, res, next)
+
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('agent')
+    })
+
+    it('unarchiveAgentConversation scopes both the lookup and the update to sessionType agent', async () => {
+      const mockConversation = createMockConversationDoc({ isArchived: true, agentKey: 'agent-1' })
+      const findOne = sinon.stub(ChatSession, 'findOne').resolves(mockConversation)
+      restoreIfStubbed(ChatSession, 'findOneAndUpdate')
+      const update = sinon.stub(ChatSession, 'findOneAndUpdate').returns({
+        exec: sinon.stub().resolves({ _id: VALID_OID, updatedAt: new Date() }),
+      } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, agentKey: 'agent-1' },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await unarchiveAgentConversation(req, res, next)
+
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('agent')
+      expect((update.firstCall.args[0] as any).sessionType).to.equal('agent')
+    })
+
+    it('updateAgentConversationTitle scopes the lookup to sessionType agent', async () => {
+      const mockConversation = createMockConversationDoc({ agentKey: 'agent-1', title: 'old title' })
+      const findOne = sinon.stub(ChatSession, 'findOne').resolves(mockConversation)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, agentKey: 'agent-1' },
+        body: { title: 'new title' },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await updateAgentConversationTitle(req, res, next)
+
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('agent')
+    })
+
+    it('updateAgentFeedback scopes the session lookup to sessionType agent', async () => {
+      const messageId = new mongoose.Types.ObjectId()
+      const mockConversation = { _id: VALID_OID }
+      const findOne = stubThenableFindOne(ChatSession, mockConversation)
+      restoreIfStubbed(ChatSessionMessage, 'findOne')
+      sinon.stub(ChatSessionMessage, 'findOne').resolves(
+        createMockMessageDoc({ _id: messageId, messageType: 'bot_response' }),
+      )
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, agentKey: 'agent-1', messageId: messageId.toString() },
+        body: { rating: 'positive' },
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      const next = createMockNext()
+      await updateAgentFeedback(req, res, next)
+
+      expect(findOne.firstCall.args[0].sessionType).to.equal('agent')
+    })
+
+    it('regenerateAnswers scopes the buildQueryFilter lookup to sessionType chat', async () => {
+      const handler = regenerateAnswers(createMockAppConfig())
+      const messageId = new mongoose.Types.ObjectId()
+      const findOne = sinon.stub(ChatSession, 'findOne').returns({
+        then: (resolve: any) => resolve(null),
+      } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, messageId: messageId.toString() },
+        body: {},
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      res.flush = sinon.stub()
+      await handler(req, res)
+
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('chat')
+    })
+
+    it('regenerateAgentAnswers scopes the buildQueryFilter lookup to sessionType agent', async () => {
+      const handler = regenerateAgentAnswers(createMockAppConfig())
+      const messageId = new mongoose.Types.ObjectId()
+      const findOne = sinon.stub(ChatSession, 'findOne').returns({
+        then: (resolve: any) => resolve(null),
+      } as any)
+
+      const req = createMockRequest({
+        params: { conversationId: VALID_OID, agentKey: 'agent-1', messageId: messageId.toString() },
+        body: {},
+        user: { userId: new mongoose.Types.ObjectId(VALID_OID), orgId: new mongoose.Types.ObjectId(VALID_OID2) },
+      })
+      const res = createMockResponse()
+      res.flush = sinon.stub()
+      await handler(req, res)
+
+      expect((findOne.firstCall.args[0] as any).sessionType).to.equal('agent')
+    })
+  })
+
+  // -----------------------------------------------------------------------
+  // searchArchivedConversations (previously untested) — merges assistant and
+  // agent archived matches from a single ChatSession aggregation.
+  // -----------------------------------------------------------------------
+  describe('searchArchivedConversations', () => {
+    it('should call next with BadRequestError when search query parameter is missing', async () => {
+      const handler = searchArchivedConversations(createMockAppConfig())
+      const req = createMockRequest({ query: {} })
+      const res = createMockResponse()
+      const next = createMockNext()
+
+      await handler(req, res, next)
+
+      expect(next.calledOnce).to.be.true
+      expect(next.firstCall.args[0].message).to.include('search query parameter is required')
+    })
+
+    it('should call next with BadRequestError when user is not authenticated', async () => {
+      const handler = searchArchivedConversations(createMockAppConfig())
+      const req = createMockRequest({ query: { search: 'hello' }, user: undefined })
+      const res = createMockResponse()
+      const next = createMockNext()
+
+      await handler(req, res, next)
+
+      expect(next.calledOnce).to.be.true
+    })
+
+    it('merges assistant and agent archived matches by sessionType, wiring content search and per-type counts', async () => {
+      const handler = searchArchivedConversations(createMockAppConfig())
+      sinon.stub(AIServiceCommand.prototype, 'execute').resolves({
+        statusCode: 200,
+        data: { agents: [], pagination: { hasNext: false } },
+      })
+
+      const contentMatchId = new mongoose.Types.ObjectId()
+      restoreIfStubbed(ChatSessionMessage, 'aggregate')
+      sinon.stub(ChatSessionMessage, 'aggregate').resolves([{ _id: contentMatchId }])
+
+      const assistantDoc = {
+        _id: VALID_OID, title: 'assistant match', updatedAt: new Date(), archivedBy: VALID_OID,
+        initiator: VALID_OID, sharedWith: [], isShared: false, source: 'assistant',
+      }
+      const agentDoc = {
+        _id: VALID_OID3, title: 'agent match', agentKey: 'agent-1', updatedAt: new Date(), archivedBy: VALID_OID,
+        initiator: VALID_OID, sharedWith: [], isShared: false, source: 'agent',
+      }
+      const aggregate = sinon.stub(ChatSession, 'aggregate').resolves([assistantDoc, agentDoc])
+      const countDocuments = sinon.stub(ChatSession, 'countDocuments')
+      countDocuments.onFirstCall().resolves(1)
+      countDocuments.onSecondCall().resolves(1)
+
+      const req = createMockRequest({ query: { search: 'hello', page: '1', limit: '20' } })
+      const res = createMockResponse()
+      const next = createMockNext()
+
+      await handler(req, res, next)
+
+      expect(next.called).to.be.false
+      expect(res.status.calledWith(200)).to.be.true
+      const response = res.json.firstCall.args[0]
+      expect(response.summary).to.deep.equal({
+        totalMatches: 2,
+        assistantMatches: 1,
+        agentMatches: 1,
+        searchQuery: 'hello',
+      })
+      expect(response.conversations).to.have.length(2)
+      expect(response.conversations[0].source).to.equal('assistant')
+      expect(response.conversations[1].source).to.equal('agent')
+      expect(response.conversations[1].agentKey).to.equal('agent-1')
+
+      // Content search: matched chatSessionMessages ids feed into the $match.
+      const matchStage = (aggregate.firstCall.args[0][0] as any).$match
+      expect(matchStage.$and[0].$or[1]).to.deep.equal({ _id: { $in: [contentMatchId] } })
+      // Cross-type isolation: assistant/agent predicates stay mutually
+      // exclusive by sessionType even though merged into one aggregation.
+      expect(matchStage.$or[0].sessionType).to.equal('chat')
+      expect(matchStage.$or[1].sessionType).to.equal('agent')
+    })
+  })
+
 })

--- a/backend/nodejs/apps/tests/modules/enterprise_search/utils/utils.test.ts
+++ b/backend/nodejs/apps/tests/modules/enterprise_search/utils/utils.test.ts
@@ -23,16 +23,21 @@ import {
   sendSSECompleteEvent,
   buildAgentConversationFilter,
   buildAgentSharedWithMeFilter,
-  addAgentConversationComputedFields,
   buildAgentConversationSortOptions,
   addErrorToConversation,
   handleRegenerationStreamData,
+  allocateSeq,
+  appendMessages,
+  updateMessageById,
+  getMessages,
+  attachMessages,
+  findSessionIdsMatchingContent,
 } from '../../../../src/modules/enterprise_search/utils/utils'
-import { handleRegenerationError, markConversationFailed, replaceMessageWithError, saveCompleteConversation, saveCompleteAgentConversation, markAgentConversationFailed, deleteAgentConversation, handleRegenerationSuccess, attachPopulatedCitations } from '../../../../src/modules/enterprise_search/utils/utils';
+import { handleRegenerationError, markConversationFailed, replaceMessageWithError, markAgentConversationFailed, deleteAgentConversation, attachPopulatedCitations } from '../../../../src/modules/enterprise_search/utils/utils';
 import { InternalServerError, BadRequestError } from '../../../../src/libs/errors/http.errors'
 import Citation from '../../../../src/modules/enterprise_search/schema/citation.schema'
-import { Conversation } from '../../../../src/modules/enterprise_search/schema/conversation.schema'
-import { AgentConversation } from '../../../../src/modules/enterprise_search/schema/agent.conversation.schema'
+import { ChatSession } from '../../../../src/modules/enterprise_search/schema/chat.session.schema'
+import { ChatSessionMessage } from '../../../../src/modules/enterprise_search/schema/chat.session.message.schema'
 import { AGUI_PROTOCOL, LEGACY_PROTOCOL } from '../../../../src/modules/enterprise_search/utils/agui'
 
 // ---------------------------------------------------------------------------
@@ -69,6 +74,40 @@ function createMockResponse(): any {
   res.json.returns(res)
   res.end.returns(res)
   return res
+}
+
+/** Stub the `ChatSession.findOneAndUpdate` `$inc` call inside `allocateSeq()`. */
+function stubAllocateSeq(nextSeq: number): sinon.SinonStub {
+  return sinon.stub(ChatSession, 'findOneAndUpdate').resolves({ nextSeq } as any)
+}
+
+/** Stub the two calls `appendMessages()` makes: `allocateSeq()` then `ChatSessionMessage.insertMany()`. */
+function stubAppendMessages(insertedDocs: any[] = [{ _id: new mongoose.Types.ObjectId() }]) {
+  const allocateSeqStub = stubAllocateSeq(insertedDocs.length)
+  const insertManyStub = sinon.stub(ChatSessionMessage, 'insertMany').resolves(insertedDocs as any)
+  return { allocateSeqStub, insertManyStub }
+}
+
+/** Stub the two calls `updateMessageById()` makes: `ChatSessionMessage.findById()` then `.findOneAndReplace()`. */
+function stubUpdateMessageById(existingDoc: any, updatedDoc: any = existingDoc) {
+  const findByIdStub = sinon.stub(ChatSessionMessage, 'findById').resolves(existingDoc)
+  const findOneAndReplaceStub = sinon.stub(ChatSessionMessage, 'findOneAndReplace').resolves(updatedDoc)
+  return { findByIdStub, findOneAndReplaceStub }
+}
+
+/** Stub the chainable `ChatSessionMessage.find(...).sort()...lean().exec()` query used by `getMessages()`. */
+function stubGetMessagesChain(resolvedMessages: any[] = []) {
+  const chain: any = {
+    sort: sinon.stub().returnsThis(),
+    skip: sinon.stub().returnsThis(),
+    limit: sinon.stub().returnsThis(),
+    populate: sinon.stub().returnsThis(),
+    session: sinon.stub().returnsThis(),
+    lean: sinon.stub().returnsThis(),
+    exec: sinon.stub().resolves(resolvedMessages),
+  }
+  const findStub = sinon.stub(ChatSessionMessage, 'find').returns(chain)
+  return { findStub, chain }
 }
 
 describe('Enterprise Search Utils', () => {
@@ -595,6 +634,20 @@ describe('Enterprise Search Utils', () => {
       expect(result.$or[0].$and[0]).to.deep.include({ isShared: true })
       expect(result.$or[0].$and[1]).to.have.property('sharedWith.userId')
     })
+
+    it('should OR in a contentMatchIds branch alongside the title regex when provided', () => {
+      const req = createMockRequest({ query: { search: 'test' } })
+      const contentMatchIds = [new mongoose.Types.ObjectId()]
+      const result = buildFilter(req, VALID_OID2, VALID_OID, undefined, true, true, contentMatchIds)
+      expect(result.$and[0].$or).to.have.lengthOf(2)
+      expect(result.$and[0].$or[1]).to.deep.equal({ _id: { $in: contentMatchIds } })
+    })
+
+    it('should only match on title when contentMatchIds is empty or absent', () => {
+      const req = createMockRequest({ query: { search: 'test' } })
+      const result = buildFilter(req, VALID_OID2, VALID_OID, undefined, true, true, [])
+      expect(result.$and[0].$or).to.have.lengthOf(1)
+    })
   })
 
   // -----------------------------------------------------------------------
@@ -1069,6 +1122,12 @@ describe('Enterprise Search Utils', () => {
       expect(result).to.have.property('$or')
     })
 
+    it('should scope the filter to agent sessions (sessionType: agent)', () => {
+      const req = createMockRequest()
+      const result = buildAgentConversationFilter(req, VALID_OID2, VALID_OID, 'agent-key-1')
+      expect(result).to.have.property('sessionType', 'agent')
+    })
+
     it('should include conversationId when provided', () => {
       const req = createMockRequest()
       const convId = new mongoose.Types.ObjectId().toString()
@@ -1130,62 +1189,6 @@ describe('Enterprise Search Utils', () => {
       const req = createMockRequest({ query: { isArchived: 'false' } })
       const result = buildAgentSharedWithMeFilter(req, VALID_OID2, VALID_OID, 'agent-key-1')
       expect(result).to.have.property('isArchived', false)
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // addAgentConversationComputedFields
-  // -----------------------------------------------------------------------
-  describe('addAgentConversationComputedFields', () => {
-    it('should add computed fields for owner', () => {
-      const conversation = {
-        userId: VALID_OID,
-        messages: [{ content: 'hi' }, { content: 'hello' }],
-        sharedWith: [],
-      }
-      const result = addAgentConversationComputedFields(conversation, VALID_OID)
-      expect(result.isOwner).to.be.true
-      expect(result.canEdit).to.be.true
-      expect(result.canView).to.be.true
-      expect(result.messageCount).to.equal(2)
-      expect(result.lastMessage).to.deep.equal({ content: 'hello' })
-    })
-
-    it('should add computed fields for non-owner', () => {
-      const otherUserId = new mongoose.Types.ObjectId().toString()
-      const conversation = {
-        userId: VALID_OID,
-        messages: [],
-        sharedWith: [],
-      }
-      const result = addAgentConversationComputedFields(conversation, otherUserId)
-      expect(result.isOwner).to.be.false
-      expect(result.canEdit).to.be.false
-      expect(result.messageCount).to.equal(0)
-      expect(result.lastMessage).to.be.null
-    })
-
-    it('should detect write access for shared user', () => {
-      const otherUserId = new mongoose.Types.ObjectId().toString()
-      const conversation = {
-        userId: VALID_OID,
-        messages: [{ content: 'msg' }],
-        sharedWith: [{ userId: otherUserId, accessLevel: 'write' }],
-      }
-      const result = addAgentConversationComputedFields(conversation, otherUserId)
-      expect(result.isOwner).to.be.false
-      expect(result.canEdit).to.be.true
-    })
-
-    it('should not give edit access for read-only shared user', () => {
-      const otherUserId = new mongoose.Types.ObjectId().toString()
-      const conversation = {
-        userId: VALID_OID,
-        messages: [],
-        sharedWith: [{ userId: otherUserId, accessLevel: 'read' }],
-      }
-      const result = addAgentConversationComputedFields(conversation, otherUserId)
-      expect(result.canEdit).to.be.false
     })
   })
 
@@ -1274,11 +1277,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         (data) => { capturedData = data },
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1296,11 +1300,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         (d) => { capturedData = d },
+        false,
       )
 
       expect(capturedData).to.not.be.null
@@ -1317,11 +1322,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       // Incomplete event should be kept in buffer
@@ -1337,11 +1343,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       // Should forward because parse failed
@@ -1357,11 +1364,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1369,31 +1377,32 @@ describe('Enterprise Search Utils', () => {
       expect(writeArg).to.include('error')
     })
 
-    it('should handle error events with conversation and message index', () => {
+    it('should handle error events with conversation and messageId', () => {
       const res = createMockResponse()
       const errorData = JSON.stringify({ error: 'AI failed' })
       const chunk = Buffer.from(`event: error\ndata: ${errorData}\n\n`)
+      const messageId = new mongoose.Types.ObjectId()
 
       const mockConversation: any = {
         _id: 'conv-1',
         status: 'Inprogress',
-        messages: [
-          { _id: new mongoose.Types.ObjectId(), messageType: 'user_query', content: 'hi' },
-          { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'old' },
-        ],
         conversationErrors: [],
         save: sinon.stub().resolves({}),
       }
+      // The error branch fires-and-forgets `replaceMessageWithError`, which
+      // calls `updateMessageById` -> `ChatSessionMessage.findById`/`.findOneAndReplace`.
+      stubUpdateMessageById({ _id: messageId, sessionId: 'conv-1', orgId: 'org-1', seq: 2 })
 
       handleRegenerationStreamData(
         chunk,
         '',
         mockConversation,
-        1,
+        messageId,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1407,11 +1416,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1427,11 +1437,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         '',
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1448,11 +1459,12 @@ describe('Enterprise Search Utils', () => {
         chunk,
         previousBuffer,
         null,
-        -1,
+        null,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1466,26 +1478,26 @@ describe('Enterprise Search Utils', () => {
         metadata: { retryCount: 3, region: 'us-east' },
       })
       const chunk = Buffer.from(`event: error\ndata: ${errorData}\n\n`)
+      const messageId = new mongoose.Types.ObjectId()
 
       const mockConversation: any = {
         _id: 'conv-1',
         status: 'Inprogress',
-        messages: [
-          { _id: new mongoose.Types.ObjectId(), messageType: 'bot_response', content: 'old' },
-        ],
         conversationErrors: [],
         save: sinon.stub().resolves({}),
       }
+      stubUpdateMessageById({ _id: messageId, sessionId: 'conv-1', orgId: 'org-1', seq: 1 })
 
       handleRegenerationStreamData(
         chunk,
         '',
         mockConversation,
-        0,
+        messageId,
         null,
         'req-1',
         res,
         () => {},
+        false,
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1507,31 +1519,37 @@ describe('Enterprise Search Utils', () => {
     it('should mark conversation as failed with reason', async () => {
       const mockConversation: any = {
         _id: 'conv-1',
+        orgId: 'org-1',
         status: 'Inprogress',
         failReason: undefined,
         lastActivityAt: 0,
-        messages: [],
         conversationErrors: [],
         save: sinon.stub().resolves(true),
       }
+      const { allocateSeqStub, insertManyStub } = stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
 
       await markConversationFailed(mockConversation, 'Test failure reason')
 
       expect(mockConversation.status).to.equal('Failed')
       expect(mockConversation.failReason).to.equal('Test failure reason')
-      expect(mockConversation.messages).to.have.length(1)
-      expect(mockConversation.messages[0].messageType).to.equal('error')
-      expect(mockConversation.messages[0].content).to.equal('Test failure reason')
+      // markConversationFailed no longer mutates a `.messages` array — it
+      // inserts a failure message via appendMessages (allocateSeq + insertMany).
+      expect(allocateSeqStub.calledOnce).to.be.true
+      expect(insertManyStub.calledOnce).to.be.true
+      const insertedMessages = insertManyStub.firstCall.args[0]
+      expect(insertedMessages[0].messageType).to.equal('error')
+      expect(insertedMessages[0].content).to.equal('Test failure reason')
       expect(mockConversation.save.calledOnce).to.be.true
     })
 
     it('should add error to conversationErrors array', async () => {
       const mockConversation: any = {
         _id: 'conv-2',
+        orgId: 'org-1',
         status: 'Inprogress',
-        messages: [],
         save: sinon.stub().resolves(true),
       }
+      stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
 
       await markConversationFailed(mockConversation, 'Fail reason', null, 'stream_error', 'stack trace')
 
@@ -1543,16 +1561,34 @@ describe('Enterprise Search Utils', () => {
     it('should throw if save fails', async () => {
       const mockConversation: any = {
         _id: 'conv-3',
+        orgId: 'org-1',
         status: 'Inprogress',
-        messages: [],
         save: sinon.stub().rejects(new Error('DB error')),
       }
+      stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
 
       try {
         await markConversationFailed(mockConversation, 'Fail reason')
         expect.fail('Should have thrown')
       } catch (error: any) {
         expect(error.message).to.equal('DB error')
+      }
+    })
+
+    it('should throw if the failure message cannot be appended', async () => {
+      const mockConversation: any = {
+        _id: 'conv-4',
+        orgId: 'org-1',
+        status: 'Inprogress',
+        save: sinon.stub().resolves(true),
+      }
+      sinon.stub(ChatSession, 'findOneAndUpdate').rejects(new Error('seq allocation failed'))
+
+      try {
+        await markConversationFailed(mockConversation, 'Fail reason')
+        expect.fail('Should have thrown')
+      } catch (error: any) {
+        expect(error.message).to.equal('seq allocation failed')
       }
     })
   })
@@ -1567,58 +1603,55 @@ describe('Enterprise Search Utils', () => {
       replaceMessageWithError = require('../../../../src/modules/enterprise_search/utils/utils').replaceMessageWithError
     })
 
-    it('should replace message at specified index with error', async () => {
+    it('should replace the message by id with an error, preserving its identity', async () => {
       const originalId = new mongoose.Types.ObjectId()
+      const existingMessage = {
+        _id: originalId,
+        sessionId: 'conv-1',
+        orgId: 'org-1',
+        seq: 2,
+        messageType: 'bot_response',
+        content: 'old answer',
+      }
+      const { findByIdStub, findOneAndReplaceStub } = stubUpdateMessageById(existingMessage)
+
       const mockConversation: any = {
         _id: 'conv-1',
         status: 'Complete',
-        messages: [
-          { _id: new mongoose.Types.ObjectId(), messageType: 'user_query', content: 'hi' },
-          { _id: originalId, messageType: 'bot_response', content: 'old answer' },
-        ],
         conversationErrors: [],
         save: sinon.stub().resolves(true),
       }
 
-      await replaceMessageWithError(mockConversation, 1, 'Error in regeneration')
+      await replaceMessageWithError(mockConversation, originalId, 'Error in regeneration')
 
+      expect(findByIdStub.calledOnce).to.be.true
+      expect(findOneAndReplaceStub.calledOnce).to.be.true
+      const replacement = findOneAndReplaceStub.firstCall.args[1]
+      expect(replacement.messageType).to.equal('error')
+      expect(replacement.content).to.equal('Error in regeneration')
+      // sessionId/orgId/seq preserved from the existing message (full replace, not $set)
+      expect(replacement.sessionId).to.equal(existingMessage.sessionId)
+      expect(replacement.seq).to.equal(existingMessage.seq)
       expect(mockConversation.status).to.equal('Failed')
       expect(mockConversation.failReason).to.equal('Error in regeneration')
-      expect(mockConversation.messages[1].messageType).to.equal('error')
-      expect(mockConversation.messages[1].content).to.equal('Error in regeneration')
-      expect(mockConversation.messages[1]._id).to.equal(originalId) // preserved
     })
 
-    it('should throw for invalid message index (negative)', async () => {
+    it('should log and continue (not throw) when the message id does not exist', async () => {
+      const messageId = new mongoose.Types.ObjectId()
+      sinon.stub(ChatSessionMessage, 'findById').resolves(null)
+      const findOneAndReplaceStub = sinon.stub(ChatSessionMessage, 'findOneAndReplace')
+
       const mockConversation: any = {
         _id: 'conv-1',
-        messages: [{ _id: new mongoose.Types.ObjectId(), messageType: 'user_query' }],
         conversationErrors: [],
         save: sinon.stub().resolves(true),
       }
 
-      try {
-        await replaceMessageWithError(mockConversation, -1, 'Error')
-        expect.fail('Should have thrown')
-      } catch (error: any) {
-        expect(error.message).to.include('Invalid message index')
-      }
-    })
+      await replaceMessageWithError(mockConversation, messageId, 'Error')
 
-    it('should throw for out-of-bounds message index', async () => {
-      const mockConversation: any = {
-        _id: 'conv-1',
-        messages: [{ _id: new mongoose.Types.ObjectId(), messageType: 'user_query' }],
-        conversationErrors: [],
-        save: sinon.stub().resolves(true),
-      }
-
-      try {
-        await replaceMessageWithError(mockConversation, 5, 'Error')
-        expect.fail('Should have thrown')
-      } catch (error: any) {
-        expect(error.message).to.include('Invalid message index')
-      }
+      expect(findOneAndReplaceStub.called).to.be.false
+      expect(mockConversation.status).to.equal('Failed')
+      expect(mockConversation.save.calledOnce).to.be.true
     })
   })
 
@@ -1635,28 +1668,31 @@ describe('Enterprise Search Utils', () => {
     it('should mark agent conversation as failed', async () => {
       const mockConversation: any = {
         _id: 'agent-conv-1',
+        orgId: 'org-1',
         agentKey: 'agent-1',
         status: 'Inprogress',
-        messages: [],
         save: sinon.stub().resolves(true),
       }
+      const { allocateSeqStub, insertManyStub } = stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
 
       await markAgentConversationFailed(mockConversation, 'Agent failed')
 
       expect(mockConversation.status).to.equal('Failed')
       expect(mockConversation.failReason).to.equal('Agent failed')
-      expect(mockConversation.messages).to.have.length(1)
-      expect(mockConversation.messages[0].messageType).to.equal('error')
+      expect(allocateSeqStub.calledOnce).to.be.true
+      expect(insertManyStub.calledOnce).to.be.true
+      expect(insertManyStub.firstCall.args[0][0].messageType).to.equal('error')
     })
 
     it('should add error to conversationErrors', async () => {
       const mockConversation: any = {
         _id: 'agent-conv-2',
+        orgId: 'org-1',
         agentKey: 'agent-1',
         status: 'Inprogress',
-        messages: [],
         save: sinon.stub().resolves(true),
       }
+      stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
 
       await markAgentConversationFailed(mockConversation, 'Agent error', null, 'timeout_error')
 
@@ -1667,11 +1703,12 @@ describe('Enterprise Search Utils', () => {
     it('should throw if save fails', async () => {
       const mockConversation: any = {
         _id: 'agent-conv-3',
+        orgId: 'org-1',
         agentKey: 'agent-1',
         status: 'Inprogress',
-        messages: [],
         save: sinon.stub().rejects(new Error('DB error')),
       }
+      stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
 
       try {
         await markAgentConversationFailed(mockConversation, 'Fail')
@@ -1687,7 +1724,6 @@ describe('Enterprise Search Utils', () => {
   // -----------------------------------------------------------------------
   describe('validateAgentConversationAccess', () => {
     let validateAgentConversationAccess: any
-    const AgentConversation = require('../../../../src/modules/enterprise_search/schema/agent.conversation.schema').AgentConversation
 
     before(() => {
       validateAgentConversationAccess = require('../../../../src/modules/enterprise_search/utils/utils').validateAgentConversationAccess
@@ -1695,7 +1731,7 @@ describe('Enterprise Search Utils', () => {
 
     it('should return conversation when found', async () => {
       const mockConv = { _id: 'conv-1', agentKey: 'agent-1' }
-      sinon.stub(AgentConversation, 'findOne').resolves(mockConv)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConv)
 
       const result = await validateAgentConversationAccess(
         VALID_OID, 'agent-1', VALID_OID, VALID_OID2
@@ -1705,7 +1741,7 @@ describe('Enterprise Search Utils', () => {
     })
 
     it('should return null when conversation not found', async () => {
-      sinon.stub(AgentConversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const result = await validateAgentConversationAccess(
         VALID_OID, 'agent-1', VALID_OID, VALID_OID2
@@ -1715,7 +1751,7 @@ describe('Enterprise Search Utils', () => {
     })
 
     it('should return null on error', async () => {
-      sinon.stub(AgentConversation, 'findOne').rejects(new Error('DB down'))
+      sinon.stub(ChatSession, 'findOne').rejects(new Error('DB down'))
 
       const result = await validateAgentConversationAccess(
         VALID_OID, 'agent-1', VALID_OID, VALID_OID2
@@ -1723,53 +1759,13 @@ describe('Enterprise Search Utils', () => {
 
       expect(result).to.be.null
     })
-  })
 
-  // -----------------------------------------------------------------------
-  // getAgentConversationStats
-  // -----------------------------------------------------------------------
-  describe('getAgentConversationStats', () => {
-    let getAgentConversationStats: any
-    const AgentConversation = require('../../../../src/modules/enterprise_search/schema/agent.conversation.schema').AgentConversation
+    it('should scope the query to agent sessions only (defense-in-depth)', async () => {
+      const findOneStub = sinon.stub(ChatSession, 'findOne').resolves(null)
 
-    before(() => {
-      getAgentConversationStats = require('../../../../src/modules/enterprise_search/utils/utils').getAgentConversationStats
-    })
+      await validateAgentConversationAccess(VALID_OID, 'agent-1', VALID_OID, VALID_OID2)
 
-    it('should return aggregated stats when data exists', async () => {
-      const mockStats = {
-        totalConversations: 10,
-        completedConversations: 7,
-        failedConversations: 2,
-        inProgressConversations: 1,
-        totalMessages: 50,
-        avgMessagesPerConversation: 5,
-        lastActivity: Date.now(),
-      }
-      sinon.stub(AgentConversation, 'aggregate').resolves([mockStats])
-
-      const result = await getAgentConversationStats('agent-1', 'org-1', 'user-1')
-      expect(result.totalConversations).to.equal(10)
-      expect(result.completedConversations).to.equal(7)
-    })
-
-    it('should return default stats when no data', async () => {
-      sinon.stub(AgentConversation, 'aggregate').resolves([])
-
-      const result = await getAgentConversationStats('agent-1', 'org-1', 'user-1')
-      expect(result.totalConversations).to.equal(0)
-      expect(result.lastActivity).to.be.null
-    })
-
-    it('should throw on DB error', async () => {
-      sinon.stub(AgentConversation, 'aggregate').rejects(new Error('Aggregation failed'))
-
-      try {
-        await getAgentConversationStats('agent-1', 'org-1', 'user-1')
-        expect.fail('Should have thrown')
-      } catch (error: any) {
-        expect(error.message).to.equal('Aggregation failed')
-      }
+      expect(findOneStub.firstCall.args[0]).to.deep.include({ sessionType: 'agent', agentKey: 'agent-1' })
     })
   })
 
@@ -1778,14 +1774,13 @@ describe('Enterprise Search Utils', () => {
   // -----------------------------------------------------------------------
   describe('deleteAgentConversation', () => {
     let deleteAgentConversation: any
-    const AgentConversation = require('../../../../src/modules/enterprise_search/schema/agent.conversation.schema').AgentConversation
 
     before(() => {
       deleteAgentConversation = require('../../../../src/modules/enterprise_search/utils/utils').deleteAgentConversation
     })
 
     it('should return null when conversation not found', async () => {
-      sinon.stub(AgentConversation, 'findOne').resolves(null)
+      sinon.stub(ChatSession, 'findOne').resolves(null)
 
       const result = await deleteAgentConversation(VALID_OID, 'agent-1', VALID_OID, VALID_OID2)
       expect(result).to.be.null
@@ -1798,160 +1793,12 @@ describe('Enterprise Search Utils', () => {
         save: sinon.stub(),
       }
       mockConv.save.resolves(mockConv)
-      sinon.stub(AgentConversation, 'findOne').resolves(mockConv)
+      sinon.stub(ChatSession, 'findOne').resolves(mockConv)
 
       const result = await deleteAgentConversation(VALID_OID, 'agent-1', VALID_OID, VALID_OID2)
 
       expect(result).to.not.be.null
       expect(mockConv.isDeleted).to.be.true
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // toggleAgentConversationArchive
-  // -----------------------------------------------------------------------
-  describe('toggleAgentConversationArchive', () => {
-    let toggleAgentConversationArchive: any
-    const AgentConversation = require('../../../../src/modules/enterprise_search/schema/agent.conversation.schema').AgentConversation
-
-    before(() => {
-      toggleAgentConversationArchive = require('../../../../src/modules/enterprise_search/utils/utils').toggleAgentConversationArchive
-    })
-
-    it('should return null when conversation not found', async () => {
-      sinon.stub(AgentConversation, 'findOne').resolves(null)
-
-      const result = await toggleAgentConversationArchive(VALID_OID, 'agent-1', VALID_OID, VALID_OID2, true)
-      expect(result).to.be.null
-    })
-
-    it('should archive conversation when found', async () => {
-      const mockConv: any = {
-        _id: VALID_OID,
-        isArchived: false,
-        save: sinon.stub(),
-      }
-      mockConv.save.resolves(mockConv)
-      sinon.stub(AgentConversation, 'findOne').resolves(mockConv)
-
-      const result = await toggleAgentConversationArchive(VALID_OID, 'agent-1', VALID_OID, VALID_OID2, true)
-
-      expect(result).to.not.be.null
-      expect(mockConv.isArchived).to.be.true
-    })
-
-    it('should unarchive conversation', async () => {
-      const mockConv: any = {
-        _id: VALID_OID,
-        isArchived: true,
-        archivedBy: VALID_OID,
-        save: sinon.stub(),
-      }
-      mockConv.save.resolves(mockConv)
-      sinon.stub(AgentConversation, 'findOne').resolves(mockConv)
-
-      const result = await toggleAgentConversationArchive(VALID_OID, 'agent-1', VALID_OID, VALID_OID2, false)
-
-      expect(result).to.not.be.null
-      expect(mockConv.isArchived).to.be.false
-      expect(mockConv.archivedBy).to.be.undefined
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // searchAgentConversations
-  // -----------------------------------------------------------------------
-  describe('searchAgentConversations', () => {
-    let searchAgentConversations: any
-    const AgentConversation = require('../../../../src/modules/enterprise_search/schema/agent.conversation.schema').AgentConversation
-
-    before(() => {
-      searchAgentConversations = require('../../../../src/modules/enterprise_search/utils/utils').searchAgentConversations
-    })
-
-    it('should return search results with pagination', async () => {
-      const mockConversations = [
-        { _id: VALID_OID, userId: VALID_OID, messages: [], sharedWith: [] },
-      ]
-      const findChain: any = {
-        sort: sinon.stub().returnsThis(),
-        skip: sinon.stub().returnsThis(),
-        limit: sinon.stub().returnsThis(),
-        select: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().resolves(mockConversations),
-      }
-      sinon.stub(AgentConversation, 'find').returns(findChain)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(1)
-
-      const result = await searchAgentConversations('agent-1', 'org-1', VALID_OID, 'test')
-
-      expect(result.conversations).to.have.length(1)
-      expect(result.pagination.total).to.equal(1)
-      expect(result.searchQuery).to.equal('test')
-    })
-
-    it('should handle empty results', async () => {
-      const findChain: any = {
-        sort: sinon.stub().returnsThis(),
-        skip: sinon.stub().returnsThis(),
-        limit: sinon.stub().returnsThis(),
-        select: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().resolves([]),
-      }
-      sinon.stub(AgentConversation, 'find').returns(findChain)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(0)
-
-      const result = await searchAgentConversations('agent-1', 'org-1', VALID_OID, 'nonexistent')
-
-      expect(result.conversations).to.have.length(0)
-      expect(result.pagination.total).to.equal(0)
-    })
-
-    it('should throw on DB error', async () => {
-      const findChain: any = {
-        sort: sinon.stub().returnsThis(),
-        skip: sinon.stub().returnsThis(),
-        limit: sinon.stub().returnsThis(),
-        select: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().rejects(new Error('Search failed')),
-      }
-      sinon.stub(AgentConversation, 'find').returns(findChain)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(0)
-
-      try {
-        await searchAgentConversations('agent-1', 'org-1', VALID_OID, 'test')
-        expect.fail('Should have thrown')
-      } catch (error: any) {
-        expect(error.message).to.equal('Search failed')
-      }
-    })
-
-    it('should use custom pagination options', async () => {
-      const findChain: any = {
-        sort: sinon.stub().returnsThis(),
-        skip: sinon.stub().returnsThis(),
-        limit: sinon.stub().returnsThis(),
-        select: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().resolves([]),
-      }
-      sinon.stub(AgentConversation, 'find').returns(findChain)
-      sinon.stub(AgentConversation, 'countDocuments').resolves(0)
-
-      const result = await searchAgentConversations('agent-1', 'org-1', VALID_OID, 'test', {
-        page: 2,
-        limit: 5,
-        sortBy: 'createdAt',
-        sortOrder: 'asc',
-      })
-
-      expect(result.pagination.page).to.equal(2)
-      expect(result.pagination.limit).to.equal(5)
-      expect(findChain.skip.calledWith(5)).to.be.true // (2-1)*5
-      expect(findChain.limit.calledWith(5)).to.be.true
     })
   })
 
@@ -1970,7 +1817,7 @@ describe('Enterprise Search Utils', () => {
       const error = new Error('Stream broke')
 
       await handleRegenerationError(
-        res, error, null, -1, 'conv-1', null, 'req-1', 'stream_error'
+        res, error, null, null, 'conv-1', null, 'req-1', 'stream_error'
       )
 
       expect(res.write.calledOnce).to.be.true
@@ -1979,22 +1826,50 @@ describe('Enterprise Search Utils', () => {
       expect(writeArg).to.include('Stream broke')
     })
 
-    it('should send SSE error when messageIndex is -1', async () => {
+    it('should send SSE error when there is no messageId', async () => {
       const res = createMockResponse()
       const error = new Error('No message')
 
       const mockConv: any = {
         _id: VALID_OID,
-        messages: [],
         conversationErrors: [],
         save: sinon.stub().resolves(true),
       }
 
       await handleRegenerationError(
-        res, error, mockConv, -1, VALID_OID, null, 'req-1', 'regen_error'
+        res, error, mockConv, null, VALID_OID, null, 'req-1', 'regen_error'
       )
 
       expect(res.write.calledOnce).to.be.true
+    })
+
+    it('should replace the message, reload the session, and send the updated conversation', async () => {
+      const res = createMockResponse()
+      const error = new Error('Regeneration failed')
+      const messageId = new mongoose.Types.ObjectId()
+      const sessionId = new mongoose.Types.ObjectId()
+
+      const mockConv: any = {
+        _id: sessionId,
+        conversationErrors: [],
+        save: sinon.stub().resolves(true),
+      }
+      stubUpdateMessageById({ _id: messageId, sessionId, orgId: 'org-1', seq: 2 })
+      sinon.stub(ChatSession, 'findById').resolves({
+        _id: sessionId,
+        toObject: () => ({ _id: sessionId, title: 'Test' }),
+      })
+      stubGetMessagesChain([
+        { _id: messageId, content: 'Regeneration failed', messageType: 'error' },
+      ])
+
+      await handleRegenerationError(
+        res, error, mockConv, messageId, sessionId.toString(), null, 'req-1', 'regen_error'
+      )
+
+      expect(res.write.calledOnce).to.be.true
+      const writeArg = res.write.firstCall.args[0]
+      expect(writeArg).to.include('Regeneration failed')
     })
   })
 })
@@ -2366,7 +2241,8 @@ describe('Enterprise Search Utils - coverage', () => {
       const req = createMockRequest({ query: { search: 'test query' } })
       const result = buildFilter(req, VALID_OID2, VALID_OID)
       expect(result.$and).to.exist
-      expect(result.$and[0].$or).to.have.lengthOf(2)
+      // Title-only match when no contentMatchIds is supplied.
+      expect(result.$and[0].$or).to.have.lengthOf(1)
     })
 
     it('should throw when search is too long', () => {
@@ -3004,7 +2880,22 @@ describe('Enterprise Search Utils - coverage', () => {
       const req = createMockRequest({ query: { search: 'find me' } })
       const result = buildAgentConversationFilter(req, VALID_OID2, VALID_OID, 'agent-1')
       expect(result.$and).to.exist
+      // Title-only match when no contentMatchIds is supplied.
+      expect(result.$and[0].$or).to.have.lengthOf(1)
+    })
+
+    it('should OR in a contentMatchIds branch when provided', () => {
+      const req = createMockRequest({ query: { search: 'find me' } })
+      const contentMatchIds = [new mongoose.Types.ObjectId()]
+      const result = buildAgentConversationFilter(req, VALID_OID2, VALID_OID, 'agent-1', undefined, contentMatchIds)
       expect(result.$and[0].$or).to.have.lengthOf(2)
+      expect(result.$and[0].$or[1]).to.deep.equal({ _id: { $in: contentMatchIds } })
+    })
+
+    it('should always scope to agent sessions (sessionType: agent)', () => {
+      const req = createMockRequest({ query: {} })
+      const result = buildAgentConversationFilter(req, VALID_OID2, VALID_OID, 'agent-1')
+      expect(result).to.have.property('sessionType', 'agent')
     })
 
     it('should throw for search too long', () => {
@@ -3120,117 +3011,6 @@ describe('Enterprise Search Utils - coverage', () => {
   })
 
   // -----------------------------------------------------------------------
-  // addAgentConversationComputedFields
-  // -----------------------------------------------------------------------
-  describe('addAgentConversationComputedFields', () => {
-    it('should set isOwner true when userId matches', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(VALID_OID), sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.isOwner).to.be.true
-    })
-
-    it('should set isOwner false when userId does not match', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.isOwner).to.be.false
-    })
-
-    it('should set canEdit true for owner', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(VALID_OID), sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.canEdit).to.be.true
-    })
-
-    it('should set canEdit true for user with write access', () => {
-      const conv = {
-        userId: new mongoose.Types.ObjectId(),
-        sharedWith: [{ userId: new mongoose.Types.ObjectId(VALID_OID), accessLevel: 'write' }],
-        messages: [],
-      }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.canEdit).to.be.true
-    })
-
-    it('should set canEdit false for user with read access only', () => {
-      const conv = {
-        userId: new mongoose.Types.ObjectId(),
-        sharedWith: [{ userId: new mongoose.Types.ObjectId(VALID_OID), accessLevel: 'read' }],
-        messages: [],
-      }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.canEdit).to.be.false
-    })
-
-    it('should set canEdit false when user not in sharedWith', () => {
-      const conv = {
-        userId: new mongoose.Types.ObjectId(),
-        sharedWith: [{ userId: new mongoose.Types.ObjectId(), accessLevel: 'write' }],
-        messages: [],
-      }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.canEdit).to.be.false
-    })
-
-    it('should set canView to true always', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.canView).to.be.true
-    })
-
-    it('should calculate messageCount correctly', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [], messages: [1, 2, 3] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.messageCount).to.equal(3)
-    })
-
-    it('should return 0 messageCount for empty messages', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.messageCount).to.equal(0)
-    })
-
-    it('should return 0 messageCount when messages is undefined', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.messageCount).to.equal(0)
-    })
-
-    it('should return lastMessage as last item in messages', () => {
-      const conv = {
-        userId: new mongoose.Types.ObjectId(),
-        sharedWith: [],
-        messages: [{ content: 'first' }, { content: 'last' }],
-      }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.lastMessage.content).to.equal('last')
-    })
-
-    it('should return null lastMessage when messages empty', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.lastMessage).to.be.null
-    })
-
-    it('should return null lastMessage when messages undefined', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.lastMessage).to.be.null
-    })
-
-    it('should handle null userId in conversation', () => {
-      const conv = { userId: null, sharedWith: [], messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.isOwner).to.be.false
-    })
-
-    it('should handle null sharedWith', () => {
-      const conv = { userId: new mongoose.Types.ObjectId(), sharedWith: null, messages: [] }
-      const result = addAgentConversationComputedFields(conv, VALID_OID)
-      expect(result.canEdit).to.not.be.true
-    })
-  })
-
-  // -----------------------------------------------------------------------
   // buildAgentConversationSortOptions
   // -----------------------------------------------------------------------
   describe('buildAgentConversationSortOptions', () => {
@@ -3308,532 +3088,7 @@ describe('Enterprise Search Utils - coverage', () => {
       expect(conv.conversationErrors[0].timestamp).to.be.instanceOf(Date)
     })
   })
-
-  // -----------------------------------------------------------------------
-  // handleRegenerationStreamData
-  // -----------------------------------------------------------------------
-  describe('handleRegenerationStreamData', () => {
-    it('should forward non-complete/non-error events', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('event: token\ndata: {"content":"hello"}\n\n')
-      const onComplete = sinon.stub()
-      const result = handleRegenerationStreamData(
-        chunk, '', null, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.calledOnce).to.be.true
-      expect(onComplete.called).to.be.false
-    })
-
-    it('should capture complete event and call onCompleteData', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('event: complete\ndata: {"answer":"test"}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', null, 0, null, 'req-1', res, onComplete,
-      )
-      expect(onComplete.calledOnce).to.be.true
-      expect(onComplete.firstCall.args[0].answer).to.equal('test')
-    })
-
-    it('should forward event when complete data cannot be parsed', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('event: complete\ndata: {invalid json}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', null, 0, null, 'req-1', res, onComplete,
-      )
-      expect(onComplete.called).to.be.false
-      expect(res.write.called).to.be.true
-    })
-
-    it('should handle error events and call replaceMessageWithError', () => {
-      const res = createMockResponse()
-      const mockConv: any = {
-        _id: 'c1',
-        messages: [{ _id: 'm1' }],
-        conversationErrors: [],
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: Date.now(),
-        save: sinon.stub().resolves({}),
-      }
-      const chunk = Buffer.from('event: error\ndata: {"error":"Something went wrong"}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', mockConv, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-    })
-
-    it('should handle error event with metadata', () => {
-      const res = createMockResponse()
-      const mockConv: any = {
-        _id: 'c1',
-        messages: [{ _id: 'm1' }],
-        conversationErrors: [],
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: Date.now(),
-        save: sinon.stub().resolves({}),
-      }
-      const chunk = Buffer.from('event: error\ndata: {"error":"fail","metadata":{"key":"value"}}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', mockConv, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-    })
-
-    it('should handle unparseable error events', () => {
-      const res = createMockResponse()
-      const mockConv: any = {
-        _id: 'c1',
-        messages: [{ _id: 'm1' }],
-        conversationErrors: [],
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: Date.now(),
-        save: sinon.stub().resolves({}),
-      }
-      const chunk = Buffer.from('event: error\ndata: {invalid json}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', mockConv, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-    })
-
-    it('should handle unparseable error event without conversation', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('event: error\ndata: {invalid}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', null, -1, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-    })
-
-    it('should handle error event without conversation', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('event: error\ndata: {"error":"fail"}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', null, -1, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-    })
-
-    it('should buffer incomplete events', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('event: token\ndata: {"content":"partial')
-      const onComplete = sinon.stub()
-      const result = handleRegenerationStreamData(
-        chunk, '', null, 0, null, 'req-1', res, onComplete,
-      )
-      expect(result).to.include('partial')
-      expect(res.write.called).to.be.false
-    })
-
-    it('should handle empty trimmed events', () => {
-      const res = createMockResponse()
-      const chunk = Buffer.from('\n\n\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', null, 0, null, 'req-1', res, onComplete,
-      )
-      // Empty events should be skipped
-      expect(onComplete.called).to.be.false
-    })
-
-    it('should call flush when filteredChunk is non-empty', () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const chunk = Buffer.from('event: token\ndata: {"content":"hi"}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', null, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.flush.calledOnce).to.be.true
-    })
-
-    it('should concatenate existing buffer with new chunk', () => {
-      const res = createMockResponse()
-      const existingBuffer = 'event: token\ndata: '
-      const chunk = Buffer.from('{"content":"hi"}\n\nevent: another\ndata: ')
-      const onComplete = sinon.stub()
-      const result = handleRegenerationStreamData(
-        chunk, existingBuffer, null, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-      expect(result).to.include('event: another')
-    })
-
-    it('should handle error event with message fallback', () => {
-      const res = createMockResponse()
-      const mockConv: any = {
-        _id: 'c1',
-        messages: [{ _id: 'm1' }],
-        conversationErrors: [],
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: Date.now(),
-        save: sinon.stub().resolves({}),
-      }
-      const chunk = Buffer.from('event: error\ndata: {"message":"fallback error"}\n\n')
-      const onComplete = sinon.stub()
-      handleRegenerationStreamData(
-        chunk, '', mockConv, 0, null, 'req-1', res, onComplete,
-      )
-      expect(res.write.called).to.be.true
-    })
-
-    it('should persist ask_user_question tool_call for agent conversations', () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
-      const toolData = { question: 'Pick a channel', options: ['#general', '#random'] }
-      const chunk = Buffer.from(
-        `event: ask_user_question\ndata: ${JSON.stringify({ status: 'success', toolData })}\n\n`,
-      )
-
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub())
-
-      expect(res.write.calledOnce).to.be.true
-      expect(findByIdAndUpdateStub.calledOnce).to.be.true
-      const updatePayload = findByIdAndUpdateStub.firstCall.args[1]
-      expect(updatePayload.$push.messages.messageType).to.equal('tool_call')
-      expect(updatePayload.$push.messages.tools[0].toolName).to.equal('ask_user_question')
-      expect(updatePayload.$push.messages.tools[0].toolResult).to.deep.equal(toolData)
-    })
-
-    it('should use event payload as toolResult when toolData is absent', () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
-      const eventPayload = { status: 'success', question: 'Which team?' }
-      const chunk = Buffer.from(
-        `event: ask_user_question\ndata: ${JSON.stringify(eventPayload)}\n\n`,
-      )
-
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub())
-
-      const toolResult = findByIdAndUpdateStub.firstCall.args[1].$push.messages.tools[0].toolResult
-      expect(toolResult).to.deep.equal(eventPayload)
-    })
-
-    it('should forward ask_user_question without persisting when status is not success', () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
-      const chunk = Buffer.from('event: ask_user_question\ndata: {"status":"pending"}\n\n')
-
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub())
-
-      expect(res.write.calledOnce).to.be.true
-      expect(findByIdAndUpdateStub.called).to.be.false
-    })
-
-    it('should forward ask_user_question when event data cannot be parsed', () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
-      const chunk = Buffer.from('event: ask_user_question\ndata: {invalid json}\n\n')
-
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub())
-
-      expect(res.write.calledOnce).to.be.true
-      expect(findByIdAndUpdateStub.called).to.be.false
-    })
-
-    it('should not persist ask_user_question for non-agent conversations', () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const mockConv: any = { _id: 'c1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
-      const chunk = Buffer.from(
-        'event: ask_user_question\ndata: {"status":"success","toolData":{"question":"Pick one"}}\n\n',
-      )
-
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub())
-
-      expect(res.write.calledOnce).to.be.true
-      expect(findByIdAndUpdateStub.called).to.be.false
-    })
-
-    it('should still forward ask_user_question when DB persistence fails', async () => {
-      const res = createMockResponse()
-      res.flush = sinon.stub()
-      const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      sinon.stub(AgentConversation, 'findByIdAndUpdate').rejects(new Error('DB write failed'))
-      const chunk = Buffer.from(
-        'event: ask_user_question\ndata: {"status":"success","toolData":{"question":"Pick one"}}\n\n',
-      )
-
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub())
-      await new Promise((resolve) => setTimeout(resolve, 10))
-
-      expect(res.write.calledOnce).to.be.true
-      const forwarded = res.write.firstCall.args[0]
-      expect(forwarded).to.include('ask_user_question')
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // handleRegenerationError
-  // -----------------------------------------------------------------------
-  describe('handleRegenerationError', () => {
-    it('should send SSE error when no conversation exists', async () => {
-      const res = createMockResponse()
-      await handleRegenerationError(
-        res, new Error('Test error'), null, -1, 'c1', null, 'req-1',
-      )
-      expect(res.write.calledOnce).to.be.true
-    })
-
-    it('should send SSE error when messageIndex is -1', async () => {
-      const res = createMockResponse()
-      await handleRegenerationError(
-        res, new Error('Test error'), {} as any, -1, 'c1', null, 'req-1',
-      )
-      expect(res.write.calledOnce).to.be.true
-    })
-
-    it('should handle error without message property', async () => {
-      const res = createMockResponse()
-      await handleRegenerationError(
-        res, {}, null, -1, 'c1', null, 'req-1',
-      )
-      const written = res.write.firstCall.args[0]
-      expect(written).to.include('Unknown error')
-    })
-
-    it('should use custom errorType parameter', async () => {
-      const res = createMockResponse()
-      await handleRegenerationError(
-        res, new Error('fail'), null, -1, 'c1', null, 'req-1', 'custom_error',
-      )
-      expect(res.write.called).to.be.true
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // markConversationFailed
-  // -----------------------------------------------------------------------
-  describe('markConversationFailed', () => {
-    it('should set status to failed and save', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      await markConversationFailed(conv, 'Test fail reason')
-      expect(conv.status).to.equal('Failed')
-      expect(conv.failReason).to.equal('Test fail reason')
-      expect(conv.save.calledOnce).to.be.true
-    })
-
-    it('should handle save returning null', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [],
-        save: sinon.stub().resolves(null),
-      }
-      await markConversationFailed(conv, 'Fail')
-      expect(conv.save.calledOnce).to.be.true
-    })
-
-    it('should use session when provided', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      const mockSession = { id: 'session-1' }
-      await markConversationFailed(conv, 'Fail', mockSession as any)
-      expect(conv.save.calledWith({ session: mockSession })).to.be.true
-    })
-
-    it('should save without session when session is null', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      await markConversationFailed(conv, 'Fail', null)
-      expect(conv.save.calledOnce).to.be.true
-    })
-
-    it('should throw when save fails', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [],
-        save: sinon.stub().rejects(new Error('DB error')),
-      }
-      try {
-        await markConversationFailed(conv, 'Fail')
-        expect.fail('Should have thrown')
-      } catch (err: any) {
-        expect(err.message).to.equal('DB error')
-      }
-    })
-
-    it('should add error to conversationErrors with all fields', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      const meta = new Map([['k', 'v']])
-      await markConversationFailed(conv, 'Fail', null, 'stream_error', 'stack-trace', meta)
-      expect(conv.conversationErrors[0].errorType).to.equal('stream_error')
-      expect(conv.conversationErrors[0].stack).to.equal('stack-trace')
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // replaceMessageWithError
-  // -----------------------------------------------------------------------
-  describe('replaceMessageWithError', () => {
-    it('should replace message at given index', async () => {
-      const msgId = new mongoose.Types.ObjectId()
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [{ _id: msgId, messageType: 'bot_response', content: 'old' }],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      await replaceMessageWithError(conv, 0, 'Error occurred')
-      expect(conv.messages[0].messageType).to.equal('error')
-      expect(conv.messages[0].content).to.equal('Error occurred')
-      expect(conv.messages[0]._id).to.equal(msgId)
-    })
-
-    it('should throw for negative messageIndex', async () => {
-      const conv: any = { _id: 'c1', messages: [] }
-      try {
-        await replaceMessageWithError(conv, -1, 'Error')
-        expect.fail('Should have thrown')
-      } catch (err: any) {
-        expect(err).to.be.instanceOf(InternalServerError)
-      }
-    })
-
-    it('should throw for messageIndex >= messages length', async () => {
-      const conv: any = { _id: 'c1', messages: [] }
-      try {
-        await replaceMessageWithError(conv, 0, 'Error')
-        expect.fail('Should have thrown')
-      } catch (err: any) {
-        expect(err).to.be.instanceOf(InternalServerError)
-      }
-    })
-
-    it('should handle save returning null', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [{ _id: new mongoose.Types.ObjectId(), messageType: 'bot_response' }],
-        save: sinon.stub().resolves(null),
-      }
-      await replaceMessageWithError(conv, 0, 'Error')
-      expect(conv.save.calledOnce).to.be.true
-    })
-
-    it('should use session when provided', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [{ _id: new mongoose.Types.ObjectId(), messageType: 'bot_response' }],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      const mockSession = { id: 's1' }
-      await replaceMessageWithError(conv, 0, 'Error', mockSession as any)
-      expect(conv.save.calledWith({ session: mockSession })).to.be.true
-    })
-
-    it('should throw when save fails', async () => {
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [{ _id: new mongoose.Types.ObjectId(), messageType: 'bot_response' }],
-        save: sinon.stub().rejects(new Error('Save failed')),
-      }
-      try {
-        await replaceMessageWithError(conv, 0, 'Error')
-        expect.fail('Should have thrown')
-      } catch (err: any) {
-        expect(err.message).to.equal('Save failed')
-      }
-    })
-
-    it('should add error to conversationErrors with metadata', async () => {
-      const msgId = new mongoose.Types.ObjectId()
-      const conv: any = {
-        _id: 'c1',
-        status: 'Inprogress',
-        failReason: undefined,
-        lastActivityAt: 0,
-        messages: [{ _id: msgId, messageType: 'bot_response' }],
-        save: sinon.stub().resolves({ _id: 'c1' }),
-      }
-      const meta = new Map([['info', 'test']])
-      await replaceMessageWithError(conv, 0, 'Error', null, 'type1', 'stack', meta)
-      expect(conv.conversationErrors[0].messageId).to.equal(msgId)
-      expect(conv.conversationErrors[0].metadata).to.equal(meta)
-    })
-  })
-
-  // -----------------------------------------------------------------------
-  // attachPopulatedCitations
-  //
-  // Covers both branches of the helper that stitches Citation documents back
-  // into IMessage.citations[]:
-  //   1) DB-connected path → Mongoose `findById().populate()` returns a fully
-  //      hydrated conversation. `citationData` on every message (including
-  //      previously-saved ones) comes from the populated Citation document.
-  //   2) DB-disconnected / buffering path (unit tests, offline) → the
-  //      populate query is short-circuited and `citationData` is filled in
-  //      from the `fallbackCitations` array for the newly-created citations
-  //      only. Previously-saved messages on other conversations are
-  //      unaffected because their `citationData` was already materialized
-  //      before this helper ran (on the GET path) or are not expected in
-  //      this environment.
-  // -----------------------------------------------------------------------
   describe('attachPopulatedCitations', () => {
-    // `readyState` is defined as a non-configurable getter on the Mongoose
-    // Connection prototype, so sinon can't stub it directly. We shadow it by
-    // attaching an own-property to `mongoose.connection` for the duration of
-    // the test (and delete it in an afterEach).
     const withMongooseConnected = (state: number) => {
       Object.defineProperty(mongoose.connection, 'readyState', {
         configurable: true,
@@ -3844,296 +3099,133 @@ describe('Enterprise Search Utils - coverage', () => {
       try {
         delete (mongoose.connection as any).readyState
       } catch {
-        // ignore — property may not be set on this particular run
+        // ignore
       }
     })
 
-    it('should populate citationData for ALL messages when DB is connected (follow-up fix)', async () => {
+    it('should populate citationData for ALL messages when DB is connected', async () => {
       const oldCitationId = new mongoose.Types.ObjectId()
       const newCitationId = new mongoose.Types.ObjectId()
       const conversationId = new mongoose.Types.ObjectId()
-
-      // Simulate what Mongoose returns after `.populate('messages.citations.citationId')`:
-      // every citationId is replaced with the full Citation document.
-      const populatedConversation = {
-        _id: conversationId,
-        messages: [
-          {
-            messageType: 'bot_response',
-            content: 'Old answer',
-            citations: [
-              {
-                citationId: {
-                  _id: oldCitationId,
-                  content: 'Old chunk',
-                  chunkIndex: 0,
-                  citationType: 'document',
-                  metadata: { recordId: 'old-rec' },
-                },
+      const populatedMessages = [
+        {
+          messageType: 'bot_response',
+          content: 'Old answer',
+          citations: [
+            {
+              citationId: {
+                _id: oldCitationId,
+                content: 'Old chunk',
+                chunkIndex: 0,
+                citationType: 'document',
+                metadata: { recordId: 'old-rec' },
               },
-            ],
-          },
-          {
-            messageType: 'bot_response',
-            content: 'New answer',
-            citations: [
-              {
-                citationId: {
-                  _id: newCitationId,
-                  content: 'New chunk',
-                  chunkIndex: 0,
-                  citationType: 'document',
-                  metadata: { recordId: 'new-rec' },
-                },
+            },
+          ],
+        },
+        {
+          messageType: 'bot_response',
+          content: 'New answer',
+          citations: [
+            {
+              citationId: {
+                _id: newCitationId,
+                content: 'New chunk',
+                chunkIndex: 0,
+                citationType: 'document',
+                metadata: { recordId: 'new-rec' },
               },
-            ],
-          },
-        ],
-      }
-
-      const findByIdChain: any = {
-        populate: sinon.stub().returnsThis(),
-        session: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().resolves(populatedConversation),
-      }
-      sinon.stub(Conversation, 'findById').returns(findByIdChain)
-
-      // Force the helper to take the DB-connected branch without requiring
-      // an actual Mongo connection. `readyState` is a getter, so stub the
-      // property descriptor directly.
+            },
+          ],
+        },
+      ]
+      const { chain } = stubGetMessagesChain(populatedMessages)
       withMongooseConnected(1)
 
-      // The "fresh" conversation object the caller would pass in (pre-populate,
-      // citationId is still an ObjectId). This is the fallback that's used
-      // when the DB branch is not taken.
-      const freshConversationObject = {
-        _id: conversationId,
-        messages: [
-          {
-            messageType: 'bot_response',
-            content: 'Old answer',
-            citations: [{ citationId: oldCitationId }],
-          },
-          {
-            messageType: 'bot_response',
-            content: 'New answer',
-            citations: [{ citationId: newCitationId }],
-          },
-        ],
-      } as any
-
-      // Only the newly-created citation is in fallbackCitations — this is
-      // exactly the case that used to wipe `citationData` on the old message
-      // before the fix.
-      const newCitationDoc: any = {
-        _id: newCitationId,
-        content: 'New chunk',
-        chunkIndex: 0,
-        citationType: 'document',
-      }
-
       const result: any = await attachPopulatedCitations(
-        conversationId,
-        freshConversationObject,
-        [newCitationDoc],
-        false,
+        { _id: conversationId, title: 't' },
+        [],
+        [{ _id: newCitationId, content: 'New chunk' } as any],
         null,
       )
 
-      // The DB-connected branch should replace the pre-populate conversation
-      // with the populated one, so BOTH the old and new messages have their
-      // citationData filled in from the Citation documents.
-      expect(findByIdChain.populate.calledOnce).to.be.true
+      expect(chain.populate.calledOnce).to.be.true
       expect(result.messages).to.have.lengthOf(2)
-
-      expect(result.messages[0].citations[0].citationId.toString()).to.equal(
-        oldCitationId.toString(),
-      )
-      expect(result.messages[0].citations[0].citationData).to.exist
-      expect(result.messages[0].citations[0].citationData.content).to.equal(
-        'Old chunk',
-      )
-
-      expect(result.messages[1].citations[0].citationId.toString()).to.equal(
-        newCitationId.toString(),
-      )
-      expect(result.messages[1].citations[0].citationData).to.exist
-      expect(result.messages[1].citations[0].citationData.content).to.equal(
-        'New chunk',
-      )
+      expect(result.messages[0].citations[0].citationData.content).to.equal('Old chunk')
+      expect(result.messages[1].citations[0].citationData.content).to.equal('New chunk')
+      expect(result).to.not.have.property('sessionType')
+      expect(result).to.not.have.property('nextSeq')
     })
 
     it('should fall back to fallbackCitations when DB is not connected', async () => {
       const newCitationId = new mongoose.Types.ObjectId()
       const unknownCitationId = new mongoose.Types.ObjectId()
-      const conversationId = new mongoose.Types.ObjectId()
-
-      // Not connected — helper must NOT hit the DB.
       withMongooseConnected(0)
-      const findByIdStub = sinon.stub(Conversation, 'findById')
+      const findStub = sinon.stub(ChatSessionMessage, 'find')
 
-      const freshConversationObject = {
-        _id: conversationId,
-        messages: [
-          {
-            messageType: 'bot_response',
-            citations: [
-              { citationId: newCitationId },
-              { citationId: unknownCitationId },
-            ],
-          },
-        ],
-      } as any
-
-      const newCitationDoc: any = {
-        _id: newCitationId,
-        content: 'New chunk',
-      }
-
-      const result: any = await attachPopulatedCitations(
-        conversationId,
-        freshConversationObject,
-        [newCitationDoc],
-        false,
-        null,
-      )
-
-      expect(findByIdStub.called).to.be.false
-      // Known (newly-created) citation is populated from fallbackCitations.
-      expect(result.messages[0].citations[0].citationData).to.exist
-      expect(result.messages[0].citations[0].citationData.content).to.equal(
-        'New chunk',
-      )
-      // Unknown citation gets undefined citationData (fallback can't resolve it).
-      expect(result.messages[0].citations[1].citationData).to.be.undefined
-    })
-
-    it('should use AgentConversation model when isAgent is true', async () => {
-      const citationId = new mongoose.Types.ObjectId()
-      const conversationId = new mongoose.Types.ObjectId()
-
-      const findByIdChain: any = {
-        populate: sinon.stub().returnsThis(),
-        session: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().resolves({
-          _id: conversationId,
-          messages: [
-            {
-              messageType: 'bot_response',
-              citations: [
-                {
-                  citationId: {
-                    _id: citationId,
-                    content: 'Agent chunk',
-                  },
-                },
-              ],
-            },
+      const fallbackMessages = [
+        {
+          messageType: 'bot_response',
+          citations: [
+            { citationId: newCitationId },
+            { citationId: unknownCitationId },
           ],
-        }),
-      }
-      const conversationFindById = sinon.stub(Conversation, 'findById')
-      const agentFindById = sinon
-        .stub(AgentConversation, 'findById')
-        .returns(findByIdChain)
-      withMongooseConnected(1)
-
-      const freshConversationObject = {
-        _id: conversationId,
-        messages: [
-          {
-            messageType: 'bot_response',
-            citations: [{ citationId }],
-          },
-        ],
-      } as any
+        },
+      ]
 
       const result: any = await attachPopulatedCitations(
-        conversationId,
-        freshConversationObject,
-        [{ _id: citationId, content: 'Agent chunk' } as any],
-        true,
+        { _id: new mongoose.Types.ObjectId() },
+        fallbackMessages,
+        [{ _id: newCitationId, content: 'New chunk' } as any],
         null,
       )
 
-      expect(agentFindById.calledOnce).to.be.true
-      expect(conversationFindById.called).to.be.false
-      expect(result.messages[0].citations[0].citationData.content).to.equal(
-        'Agent chunk',
-      )
+      expect(findStub.called).to.be.false
+      expect(result.messages[0].citations[0].citationData.content).to.equal('New chunk')
+      expect(result.messages[0].citations[1].citationData).to.be.undefined
     })
 
     it('should fall back gracefully when the populate query throws', async () => {
       const citationId = new mongoose.Types.ObjectId()
       const conversationId = new mongoose.Types.ObjectId()
-
-      const findByIdChain: any = {
+      const chain: any = {
+        sort: sinon.stub().returnsThis(),
+        skip: sinon.stub().returnsThis(),
+        limit: sinon.stub().returnsThis(),
         populate: sinon.stub().returnsThis(),
         session: sinon.stub().returnsThis(),
         lean: sinon.stub().returnsThis(),
         exec: sinon.stub().rejects(new Error('DB buffering timed out')),
       }
-      sinon.stub(Conversation, 'findById').returns(findByIdChain)
+      sinon.stub(ChatSessionMessage, 'find').returns(chain)
       withMongooseConnected(1)
 
-      const freshConversationObject = {
-        _id: conversationId,
-        messages: [
-          {
-            messageType: 'bot_response',
-            citations: [{ citationId }],
-          },
-        ],
-      } as any
-
       const result: any = await attachPopulatedCitations(
-        conversationId,
-        freshConversationObject,
+        { _id: conversationId },
+        [{ messageType: 'bot_response', citations: [{ citationId }] }],
         [{ _id: citationId, content: 'Fallback chunk' } as any],
-        false,
         null,
       )
 
-      expect(result.messages[0].citations[0].citationData).to.exist
-      expect(result.messages[0].citations[0].citationData.content).to.equal(
-        'Fallback chunk',
-      )
+      expect(result.messages[0].citations[0].citationData.content).to.equal('Fallback chunk')
     })
 
-    it('should pass the session to the populate query when provided', async () => {
-      const citationId = new mongoose.Types.ObjectId()
+    it('should pass the mongo session to getMessages when provided', async () => {
       const conversationId = new mongoose.Types.ObjectId()
-
-      const findByIdChain: any = {
-        populate: sinon.stub().returnsThis(),
-        session: sinon.stub().returnsThis(),
-        lean: sinon.stub().returnsThis(),
-        exec: sinon.stub().resolves({
-          _id: conversationId,
-          messages: [],
-        }),
-      }
-      sinon.stub(Conversation, 'findById').returns(findByIdChain)
+      const { chain } = stubGetMessagesChain([])
       withMongooseConnected(1)
-
       const fakeSession: any = { id: 's1' }
 
       await attachPopulatedCitations(
-        conversationId,
-        { _id: conversationId, messages: [] } as any,
+        { _id: conversationId },
         [],
-        false,
+        [],
         fakeSession,
       )
 
-      expect(findByIdChain.session.calledOnceWithExactly(fakeSession)).to.be
-        .true
+      expect(chain.session.calledOnceWithExactly(fakeSession)).to.be.true
     })
-  })
 })
-}
 
 // ---------------------------------------------------------------------------
 // AG-UI protocol negotiation — the SSE helpers stay byte-identical for every
@@ -4241,7 +3333,7 @@ describe('AG-UI Protocol', () => {
       let capturedData: any = null
 
       handleRegenerationStreamData(
-        chunk, '', null, -1, null, 'req-1', res, (d) => { capturedData = d }, AGUI_PROTOCOL,
+        chunk, '', null, null, null, 'req-1', res, (d) => { capturedData = d }, false, AGUI_PROTOCOL,
       )
 
       expect(capturedData).to.deep.equal(result)
@@ -4255,7 +3347,7 @@ describe('AG-UI Protocol', () => {
       let capturedData: any = null
 
       handleRegenerationStreamData(
-        chunk, '', null, -1, null, 'req-1', res, (d) => { capturedData = d }, AGUI_PROTOCOL,
+        chunk, '', null, null, null, 'req-1', res, (d) => { capturedData = d }, false, AGUI_PROTOCOL,
       )
 
       expect(capturedData).to.deep.equal(payload)
@@ -4266,7 +3358,7 @@ describe('AG-UI Protocol', () => {
       const chunk = Buffer.from('event: RUN_FINISHED\ndata: {invalid json}\n\n')
       const onComplete = sinon.stub()
 
-      handleRegenerationStreamData(chunk, '', null, -1, null, 'req-1', res, onComplete, AGUI_PROTOCOL)
+      handleRegenerationStreamData(chunk, '', null, null, null, 'req-1', res, onComplete, false, AGUI_PROTOCOL)
 
       expect(onComplete.called).to.be.false
       expect(res.write.calledOnce).to.be.true
@@ -4285,16 +3377,16 @@ describe('AG-UI Protocol', () => {
         `event: RUN_ERROR\ndata: ${JSON.stringify({ type: 'RUN_ERROR', message: 'boom' })}\n\n`,
       )
 
-      handleRegenerationStreamData(chunk, '', mockConv, 1, null, 'req-1', res, sinon.stub(), AGUI_PROTOCOL)
+      handleRegenerationStreamData(chunk, '', mockConv, 'm2', null, 'req-1', res, sinon.stub(), false, AGUI_PROTOCOL)
 
       expect(res.write.calledOnce).to.be.true
       expect(res.write.firstCall.args[0]).to.include('event: RUN_ERROR')
     })
 
-    it('should persist an ask_user_question tool_call from a CUSTOM event', () => {
+    it('should persist an ask_user_question tool_call from a CUSTOM event', async () => {
       const res = createMockResponse()
-      const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      const mockConv: any = { _id: 'c1', orgId: 'org-1', agentKey: 'agent-1' }
+      const { insertManyStub } = stubAppendMessages([{ _id: new mongoose.Types.ObjectId() }])
       const toolData = { question: 'Pick a channel', options: ['#general', '#random'] }
       const chunk = Buffer.from(
         `event: CUSTOM\ndata: ${JSON.stringify({
@@ -4304,24 +3396,26 @@ describe('AG-UI Protocol', () => {
         })}\n\n`,
       )
 
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub(), AGUI_PROTOCOL)
+      handleRegenerationStreamData(chunk, '', mockConv, null, null, 'req-1', res, sinon.stub(), true, AGUI_PROTOCOL)
+      await Promise.resolve()
+      await Promise.resolve()
 
       expect(res.write.calledOnce).to.be.true
-      expect(findByIdAndUpdateStub.calledOnce).to.be.true
-      const updatePayload = findByIdAndUpdateStub.firstCall.args[1]
-      expect(updatePayload.$push.messages.tools[0].toolName).to.equal('ask_user_question')
-      expect(updatePayload.$push.messages.tools[0].toolResult).to.deep.equal(toolData)
+      expect(insertManyStub.calledOnce).to.be.true
+      const inserted = insertManyStub.firstCall.args[0]
+      expect(inserted[0].tools[0].toolName).to.equal('ask_user_question')
+      expect(inserted[0].tools[0].toolResult).to.deep.equal(toolData)
     })
 
     it('should ignore CUSTOM events that are not ask_user_question', () => {
       const res = createMockResponse()
       const mockConv: any = { _id: 'c1', agentKey: 'agent-1' }
-      const findByIdAndUpdateStub = sinon.stub(AgentConversation, 'findByIdAndUpdate').resolves({})
+      const findByIdAndUpdateStub = sinon.stub(ChatSession, 'findOneAndUpdate').resolves({})
       const chunk = Buffer.from(
         `event: CUSTOM\ndata: ${JSON.stringify({ type: 'CUSTOM', name: 'artifact', value: {} })}\n\n`,
       )
 
-      handleRegenerationStreamData(chunk, '', mockConv, 0, null, 'req-1', res, sinon.stub(), AGUI_PROTOCOL)
+      handleRegenerationStreamData(chunk, '', mockConv, null, null, 'req-1', res, sinon.stub(), true, AGUI_PROTOCOL)
 
       expect(res.write.calledOnce).to.be.true
       expect(findByIdAndUpdateStub.called).to.be.false
@@ -4332,7 +3426,7 @@ describe('AG-UI Protocol', () => {
       const onComplete = sinon.stub()
       const chunk = Buffer.from('event: complete\ndata: {"answer":"legacy"}\n\n')
 
-      handleRegenerationStreamData(chunk, '', null, -1, null, 'req-1', res, onComplete, AGUI_PROTOCOL)
+      handleRegenerationStreamData(chunk, '', null, null, null, 'req-1', res, onComplete, false, AGUI_PROTOCOL)
 
       // Under `agui`, the legacy `complete` name has no special handling and
       // is forwarded through unchanged rather than being parsed as a completion.
@@ -4442,3 +3536,76 @@ describe('AG-UI Protocol', () => {
     })
   })
 })
+})
+}
+
+describe('chatSessions helpers', () => {
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('attachMessages strips sessionType/nextSeq/sessionId/orgId/seq', () => {
+    const sessionId = new mongoose.Types.ObjectId()
+    const orgId = new mongoose.Types.ObjectId()
+    const attached = attachMessages(
+      { _id: sessionId, title: 'Hello', sessionType: 'chat', nextSeq: 4, __v: 3 },
+      [{ _id: new mongoose.Types.ObjectId(), sessionId, orgId, seq: 1, messageType: 'user_query', content: 'hi' }],
+    )
+    expect(attached.title).to.equal('Hello')
+    expect(attached).to.not.have.property('sessionType')
+    expect(attached).to.not.have.property('nextSeq')
+    expect(attached.messages[0]).to.not.have.property('sessionId')
+    expect(attached.messages[0]).to.not.have.property('orgId')
+    expect(attached.messages[0]).to.not.have.property('seq')
+    expect(attached.messages[0].content).to.equal('hi')
+  })
+
+  it('getMessages short-circuits to [] when limit <= 0 without hitting the DB', async () => {
+    const findStub = sinon.stub(ChatSessionMessage, 'find')
+    expect(await getMessages(new mongoose.Types.ObjectId(), { limit: 0 })).to.deep.equal([])
+    expect(await getMessages(new mongoose.Types.ObjectId(), { limit: -1 })).to.deep.equal([])
+    expect(findStub.called).to.be.false
+  })
+
+  it('allocateSeq returns disjoint blocks for concurrent callers', async () => {
+    let counter = 0
+    sinon.stub(ChatSession, 'findOneAndUpdate').callsFake(async (_q: any, update: any) => {
+      counter += update.$inc.nextSeq
+      return { nextSeq: counter } as any
+    })
+    const sessionId = new mongoose.Types.ObjectId()
+    const [a, b] = await Promise.all([allocateSeq(sessionId, 2), allocateSeq(sessionId, 3)])
+    const blocks = [[a - 1, a], [b - 2, b]].sort((x, y) => x[0] - y[0])
+    expect(blocks[0][1]).to.be.lessThan(blocks[1][0])
+    expect(counter).to.equal(5)
+  })
+
+  it('updateMessageById keeps seq stable so regeneration does not jump position', async () => {
+    const messageId = new mongoose.Types.ObjectId()
+    const sessionId = new mongoose.Types.ObjectId()
+    const orgId = new mongoose.Types.ObjectId()
+    const existing = { _id: messageId, sessionId, orgId, seq: 7, content: 'old' }
+    sinon.stub(ChatSessionMessage, 'findById').resolves(existing as any)
+    const replaceStub = sinon.stub(ChatSessionMessage, 'findOneAndReplace').resolves({ ...existing, content: 'new' } as any)
+    await updateMessageById(messageId, { messageType: 'bot_response', content: 'new' } as any)
+    expect(replaceStub.firstCall.args[1].seq).to.equal(7)
+    expect(replaceStub.firstCall.args[1].sessionId).to.equal(sessionId)
+  })
+
+  it('appendMessages is a no-op when given an empty list', async () => {
+    const alloc = sinon.stub(ChatSession, 'findOneAndUpdate')
+    const insert = sinon.stub(ChatSessionMessage, 'insertMany')
+    expect(await appendMessages(new mongoose.Types.ObjectId(), new mongoose.Types.ObjectId(), [])).to.deep.equal([])
+    expect(alloc.called).to.be.false
+    expect(insert.called).to.be.false
+  })
+
+  it('findSessionIdsMatchingContent groups by sessionId and honours the cap', async () => {
+    const sid = new mongoose.Types.ObjectId()
+    const agg = sinon.stub(ChatSessionMessage, 'aggregate').resolves([{ _id: sid }])
+    const ids = await findSessionIdsMatchingContent(VALID_OID2, 'hello', 10)
+    expect(ids).to.deep.equal([sid])
+    expect(agg.firstCall.args[0][2]).to.deep.equal({ $limit: 10 })
+  })
+})
+


### PR DESCRIPTION
…s into chatSessions + chatSessionMessages

Conversations and agent conversations embedded their entire messages[] array in the parent document, which put every thread on a collision course with MongoDB's 16MB document limit and forced a full-document read/rewrite on every turn. Replace both collections with:
  - chatSessions: session/thread metadata only, discriminated by sessionType ('chat' | 'agent'), replacing  and .
  - chatSessionMessages: one row per message, ordered by a allocated from an atomic per-session counter () instead of array position. API responses are byte-identical; no OpenAPI or frontend changes. Tests: rewrote utils.test.ts and es_controller.test.ts for the new models, added chat_sessions.migration.test.ts and migration.service coverage for the new migration step

## Description

Splits chat/agent conversation storage into two collections to get out from under MongoDB's 16MB document limit and stop reading/rewriting entire threads on every turn:
- **`chatSessions`** — session/thread metadata (title, participants, status, model info, agent fields), replacing the separate `conversations` and `agentconversations` collections. A `sessionType: 'chat' | 'agent'` discriminator replaces "which collection is this in."
- **`chatSessionMessages`** — one document per message, ordered by a `seq` field allocated from an atomic per-session `nextSeq` counter instead of array position.
No visible behavior change: API responses are byte-identical, there's no OpenAPI change, and no frontend change. This is a pure storage-layer refactor plus a one-time background data migration.
## Why
Embedding `messages[]` inside the conversation document meant:
- Long-running threads could hit Mongo's 16MB document cap.
- Every single-message append/update required loading and rewriting the whole thread.
- `$slice` pagination and `$size` aggregations against the embedded array got increasingly expensive as threads grew.
## What changed
### Schema (new)
- `chat.session.schema.ts` — `ChatSession` model, collection `chatSessions`. `sessionType` and `nextSeq` are `select: false` (internal bookkeeping, never meant to leak into a response).
- `chat.session.message.schema.ts` — `ChatSessionMessage` model, collection `chatSessionMessages`. Unique index on `{sessionId, seq}`; `sessionId`/`orgId`/`seq` are addressing fields stripped before any response.
- `conversation.schema.ts` / `agent.conversation.schema.ts` — unchanged shape, only gained an `isMigrated: boolean` field for Phase 2 bookkeeping. These are kept around (frozen, no longer written to) purely so the migration and the still-running KB-filters migration have something to read from.
### Runtime (`utils.ts`, `es_controller.ts`)
- New core helpers: `allocateSeq` (atomic `$inc` on `nextSeq`), `appendMessages`, `updateMessageById` (full-replace by `_id`, used by regeneration), `appendMessageFeedback`, `getMessages` (seq-ordered, paginated, optional citation populate), `attachMessages` (reassembles the legacy `{...session, messages: [...]}` response shape and strips internal fields).
- `attachPopulatedCitations` rewritten to re-fetch a session's messages from `chatSessionMessages` (via `getMessages`) instead of re-populating the old embedded array.
- Every read/write path in `es_controller.ts` — `streamChat`, `createConversation`, `addMessage(Stream)`, regeneration (`regenerateAnswersInternal` and friends), feedback, share/unshare, archive/unarchive, delete, and the equivalent agent-conversation endpoints — moved from `Conversation`/`AgentConversation` + array mutation to `ChatSession` + `appendMessages`/`updateMessageById`.
- `EXCLUDE_AGENT` (`{sessionType: 'chat'}`) / `ONLY_AGENT` (`{sessionType: 'agent'}`) applied to every filter and, critically, to every **id-only** mutation (`findByIdAndUpdate` → `findOneAndUpdate({_id, ...EXCLUDE_AGENT|ONLY_AGENT})`) — now that both session types live in one collection, this is what stops a plain-chat route from mutating an agent session (or vice versa) by guessing/reusing an `_id`.
- Content search (`?search=`) can no longer regex-match `messages.content` on the session document (it doesn't exist there anymore); `findSessionIdsMatchingContent` resolves matching session ids from `chatSessionMessages` up front and both `buildFilter`/`buildAgentConversationFilter` OR that into the existing title-regex predicate.
- `listAllArchivesConversation` batch-fetches messages for a whole page of sessions in one query (grouped in memory by `sessionId`) instead of N+1 per-session lookups.
- Removed dead agent-only helpers with no remaining callers: `getAgentConversationStats`, `searchAgentConversations`, `addAgentConversationComputedFields`, `toggleAgentConversationArchive`.
### Migration (`chat_sessions.migration.ts`, new)
One-time, resumable backfill run from `MigrationService` in the background after boot:
- Depends on the chat-KB-filters migration having completed (it rewrites fields on these same legacy documents; running out of order would silently skip documents nobody reads afterward).
- Copies each legacy document's messages into `chatSessionMessages` (native-driver `bulkWrite` with `$setOnInsert` + `_id`-keyed upsert, preserving array order as `seq`), verifies the stored count matches the legacy array length, then upserts the session row into `chatSessions` with `nextSeq` set to the message count (so live traffic on that session continues seq allocation from where the migration left off), then flags the legacy document `isMigrated: true`.
- Resumable at both the per-document level (`isMigrated` flag) and per-collection level (one KV flag object, only set once a whole collection completes with zero errors).
- Hard-stops (and refuses to write the completion flag) if any legacy document is missing `orgId`.
- Samples legacy documents for schema drift against the new `ChatSession` schema and logs a warning (non-fatal) if it finds unexpected top-level fields.
- New env var: `CHAT_SESSIONS_MIGRATION_BATCH_SIZE` (default 10).
### Collections / config
- `mongo.service.ts` — `chatSessions`/`chatSessionMessages` added to `REQUIRED_COLLECTIONS` (DocumentDB compatibility).
- `paths.ts` — new KV path `chatSessionsMigration` for the migration's completion flag.
## Backward compatibility
- API response shapes are unchanged — verified via leakage/snapshot tests that internal fields (`sessionType`, `nextSeq`, `sessionId`, `orgId`, `seq`) never reach a response.
- Slack bot integration is unaffected: it stores `threadId -> conversationId` mappings and only ever needs the `_id`, which is preserved 1:1 through the migration.
- No frontend or OpenAPI changes required.
- **Known gap:** until Phase 2's migration completes for a given org, conversations still sitting only in the legacy `conversations`/`agentconversations` collections are not visible through the new read paths — there is no runtime fallback that reads both old and new collections. This is expected to resolve itself automatically as the background migration runs; flagging in case it needs to be called out to support/rollout.
## Testing
- `utils.test.ts` and `es_controller.test.ts` rewritten for `ChatSession`/`ChatSessionMessage`, including new cases: cross-type isolation (a chat-route mutation can't touch an agent session and vice versa), zero-message sessions, concurrent `allocateSeq`, `updateMessageById` seq stability, and response leakage snapshots.
- New `chat_sessions.migration.test.ts`: happy path, resumability across multiple boots/batches, missing-orgId hard stop, schema-drift audit, malformed/non-object KV flag handling, and flag-persistence failure handling.
- `migration.service.test.ts` updated to cover the new step in the migration pipeline.
- Manually tested end-to-end (per author) for both runtime chat/agent flows and the migration.


### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [x] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #[issue number]
- Closes #[issue number]
- Related to #[issue number]

## How Has This Been Tested?

[Describe the tests you ran to verify your changes. Provide instructions so we can reproduce.]

### Test Configuration

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

Please confirm that the following core functionalities are working as expected:

- [ ] **Search capabilities** are working correctly
- [ ] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [ ] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

## What You Have Tested

Please describe what you have specifically tested:

- [ ] Feature works in development environment
- [ ] Feature works in staging environment
- [ ] Error handling scenarios tested
- [ ] Edge cases considered and tested
- [ ] Performance impact assessed
- [ ] Security implications reviewed

### Test Results

[Provide details of your test results here]

## Screenshots/Videos

**Before:**
[Attach screenshots/videos showing the current behavior]

**After:**
[Attach screenshots/videos showing the new behavior]

**Note:** Screenshots are required before merge for UI changes.

## Code Quality Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

## Security Considerations

- [ ] No sensitive data is exposed
- [ ] Input validation is implemented where necessary
- [ ] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide provided (if applicable)
- [ ] Version bump required

If breaking changes are introduced, please describe them here:

[Describe any breaking changes and how users should adapt]

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

[Describe any performance implications]

## Dependencies

- [ ] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

List any new dependencies:
- [Dependency name and version]

## Deployment Notes

[Any special deployment considerations or steps]

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

[Any additional information that would be helpful for reviewers]

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified chat and agent conversations into shared sessions with separately stored messages.
  * Added support for migrating existing conversations to the new session format with configurable, resumable batch processing.
  * Improved conversation search, message regeneration, feedback, sharing, archiving, citations, and attachments.
  * Added support for large conversations that exceed document size limits.

* **Bug Fixes**
  * Improved migration reliability with validation, retry handling, progress tracking, and consistency checks.

* **Tests**
  * Expanded coverage for migration behavior and conversation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->