### PR TITLE
ci: run the golden agent evals on pull requests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -145,6 +145,17 @@ jobs:
           coverage run -m pytest tests/unit -v
           coverage report --fail-under=${{ inputs.python-coverage-threshold || 88.4 }}
 
+      # The only automated check on agent behaviour: six golden properties the
+      # prompt and loop must hold (tool choice, no placeholder write params, a
+      # single final_answer, no write without user intent, resolvable citations,
+      # confidence capped when sources are missing). Kept out of the coverage run
+      # above so a failure reads as a behaviour regression rather than a coverage
+      # change. Structural only — no model call, no network, no API key.
+      - name: Run golden agent evals
+        run: |
+          cd backend/python
+          pytest tests/evals -v
+
       - name: Generate coverage reports
         if: ${{ always() && inputs.generate-coverage-reports == true }}
         run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -152,6 +152,12 @@ jobs:
       # above so a failure reads as a behaviour regression rather than a coverage
       # change. Structural only — no model call, no network, no API key.
       - name: Run golden agent evals
+        # Runs even when the coverage step above failed. A step's implicit
+        # condition is success(), so a coverage regression would otherwise skip
+        # this and hide whether agent behaviour also changed — two separate
+        # questions, and the second is the more expensive one to discover late.
+        # A failure here still fails the job.
+        if: ${{ !cancelled() }}
         run: |
           cd backend/python
           pytest tests/evals -v


### PR DESCRIPTION
## In one line

There are 33 checks on how the AI agent behaves. Nothing has ever run them. This runs them on every change — they take under three seconds and cost nothing.

## Background

PipesHub has an AI agent that answers questions about a company's documents. Beyond "does it crash", there are things it must always do: search internal documents rather than the web when it has been given access to them, never invent a value for a field it is required to fill in, produce exactly one final answer, and never claim high confidence when it could not read one of its sources.

Someone wrote 33 checks for exactly those six properties, in `backend/python/tests/evals/test_golden_assertions.py`. Their own comment describes them as safe to run automatically.

None of them ran. The automated check runs the folder `tests/unit`, and this file lives in `tests/evals` — one directory across, and outside the net.

## What this changes

**Before:** the only automated checks on the agent were that individual functions work. Nothing asked whether the agent still *behaves* correctly.

**After:** all 33 run on every proposed change.

```
33 passed in 2.57s
```

## They cost nothing to run

No AI model is called, no network, no API key. The checks inspect the instructions given to the model, the way tools are marked, and a few pure functions. That is why they are quick and free.

The file next to them, `live_harness.py`, *does* call a real model and does cost money. It is not picked up here — confirmed by asking what gets collected:

```
$ pytest tests/evals --collect-only -q
tests/evals/test_golden_assertions.py: 33
```

## Why this is a separate step

They run as their own step, not folded into the existing coverage check. If they were part of it, a failure would show up as a coverage number moving, which reads like a testing problem. As their own step, a failure says what it is: the agent's behaviour changed.

The step also runs even if the coverage step above it fails. Those are two different questions, and finding out about the second only after fixing the first wastes a round trip.

## How to test it

```bash
cd backend/python
pytest tests/evals -v
```

Expect 33 passing in a few seconds.

To see one genuinely catch something, remove the rule in `app/agents/agent_loop/confidence.py` that caps confidence when a source could not be read. Three checks fail:

```
FAILED TestConfidenceReconciliation::test_very_high_capped_when_source_unavailable
FAILED TestConfidenceReconciliation::test_high_capped_when_source_unavailable
FAILED TestCodeLevelTierInvariance::test_reconcile_caps_very_high_for_all_tiers
```

A user would experience that regression as the assistant confidently answering from documents it never actually read.

## Anything to worry about

No. One step is added. No product code changes, and no test is modified.
