### PR TITLE
test(minio): give the MinIO connector live integration coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,6 +18,7 @@ on:
         options:
             - integration
             - s3
+            - minio
             - confluence
             - jira
             - linear
@@ -135,6 +136,15 @@ jobs:
       TEST_NEO4J_PASSWORD: ${{ secrets.TEST_NEO4J_PASSWORD }}
       TEST_NEO4J_DATABASE: ${{ secrets.TEST_NEO4J_DATABASE }}
       S3_ACCESS_KEY: ${{ secrets.S3_ACCESS_KEY }}
+      # MinIO runs in the integration compose stack, so these are fixed
+      # test values rather than secrets. The connector runs inside the
+      # compose network and reaches MinIO by service name; the test process
+      # reaches it on the published port.
+      MINIO_TEST_ENDPOINT: http://localhost:9000
+      MINIO_CONNECTOR_ENDPOINT: http://minio:9000
+      MINIO_ROOT_USER: pipeshubtest
+      MINIO_ROOT_PASSWORD: pipeshubtest123
+      MINIO_TEST_BUCKET: pipeshub-connector-test
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -158,6 +158,11 @@ services:
 
       - ENABLE_PDFPLUMBER_PROCESSOR=${ENABLE_PDFPLUMBER_PROCESSOR:-false}
     depends_on:
+      # Blocks until the bucket exists. Without it pytest can start while
+      # minio-init is still running, and the MinIO suite fails on a bucket
+      # that is merely late rather than missing.
+      minio-init:
+        condition: service_completed_successfully
       qdrant:
         condition: service_healthy
       kafka-1:
@@ -239,8 +244,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-pipeshubtest}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-pipeshubtest123}
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -227,6 +227,38 @@ services:
       timeout: 3s
       retries: 5
 
+  # MinIO gives the MinIO connector a real S3-compatible endpoint to sync from,
+  # so that connector has live coverage without an external account. The bucket
+  # is created by minio-init rather than by the tests, which never create or
+  # delete buckets.
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    restart: always
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-pipeshubtest}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-pipeshubtest123}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-pipeshubtest} ${MINIO_ROOT_PASSWORD:-pipeshubtest123} &&
+      mc mb --ignore-existing local/${MINIO_TEST_BUCKET:-pipeshub-connector-test} &&
+      echo 'minio bucket ready'
+      "
+
   arango:
     image: arangodb:3.12.4
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -227,6 +227,38 @@ services:
       timeout: 3s
       retries: 5
 
+  # MinIO gives the MinIO connector a real S3-compatible endpoint to sync from,
+  # so that connector has live coverage without an external account. The bucket
+  # is created by minio-init rather than by the tests, which never create or
+  # delete buckets.
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    restart: always
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-pipeshubtest}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-pipeshubtest123}
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  minio-init:
+    image: minio/mc:RELEASE.2025-04-16T18-13-26Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 ${MINIO_ROOT_USER:-pipeshubtest} ${MINIO_ROOT_PASSWORD:-pipeshubtest123} &&
+      mc mb --ignore-existing local/${MINIO_TEST_BUCKET:-pipeshub-connector-test} &&
+      echo 'minio bucket ready'
+      "
+
   neo4j:
     image: neo4j:5.26.0
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -160,6 +160,11 @@ services:
       - ENABLE_PDFPLUMBER_PROCESSOR=true
 
     depends_on:
+      # Blocks until the bucket exists. Without it pytest can start while
+      # minio-init is still running, and the MinIO suite fails on a bucket
+      # that is merely late rather than missing.
+      minio-init:
+        condition: service_completed_successfully
       qdrant:
         condition: service_healthy
       redis:
@@ -239,8 +244,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-pipeshubtest}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-pipeshubtest123}
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
     healthcheck:
       test: ["CMD", "mc", "ready", "local"]
       interval: 5s

--- a/integration-tests/connectors/minio/conftest.py
+++ b/integration-tests/connectors/minio/conftest.py
@@ -35,6 +35,18 @@ def _bucket() -> str:
     return os.getenv("MINIO_TEST_BUCKET", DEFAULT_BUCKET)
 
 
+
+def _unavailable(reason: str) -> None:
+    """A source that is not reachable: skip locally, fail in CI.
+
+    Skipping on any exception turns a broken stack into a green run. CI brings
+    this source up itself, so if it is not reachable there, that is a result and
+    not a reason to report success.
+    """
+    if os.getenv("CI"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 @pytest.fixture(scope="session")
 def minio_storage() -> MinioStorageHelper:
     helper = MinioStorageHelper(
@@ -48,7 +60,7 @@ def minio_storage() -> MinioStorageHelper:
     try:
         helper.list_objects(_bucket())
     except Exception as exc:  # noqa: BLE001 — any failure here means "not available"
-        pytest.skip(f"MinIO not reachable at {_endpoint()}: {exc}")
+        _unavailable(f"MinIO not reachable at {_endpoint()}: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/minio/conftest.py
+++ b/integration-tests/connectors/minio/conftest.py
@@ -8,16 +8,15 @@ connector has live coverage on any machine that can start the stack.
 """
 
 import os
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 import pytest_asyncio
-
 from connector_lifecycle import constructor, destructor
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
-from helper.graph_provider import GraphProviderProtocol
-
 from connectors.minio.minio_storage_helper import MinioStorageHelper
+from helper.graph_provider import GraphProviderProtocol
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
 
 # Defaults match deployment/docker-compose/docker-compose.integration.*.yml, so
 # the suite runs against a locally started stack with nothing exported.
@@ -70,7 +69,7 @@ async def minio_connector(
     pipeshub_client: PipeshubClient,
     graph_provider: GraphProviderProtocol,
     sample_data_root,
-) -> AsyncGenerator[Dict[str, Any], None]:
+) -> AsyncGenerator[dict[str, Any], None]:
     # The connector runs inside the compose network, so it reaches MinIO by
     # service name; the test process reaches it on the published port.
     config = {

--- a/integration-tests/connectors/minio/conftest.py
+++ b/integration-tests/connectors/minio/conftest.py
@@ -1,0 +1,88 @@
+# pyright: ignore-file
+
+"""MinIO connector fixtures.
+
+Unlike the other object-store connectors, MinIO needs no external account: the
+integration compose file runs a MinIO server and creates the bucket, so this
+connector has live coverage on any machine that can start the stack.
+"""
+
+import os
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+import pytest_asyncio
+
+from connector_lifecycle import constructor, destructor
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+from helper.graph_provider import GraphProviderProtocol
+
+from connectors.minio.minio_storage_helper import MinioStorageHelper
+
+# Defaults match deployment/docker-compose/docker-compose.integration.*.yml, so
+# the suite runs against a locally started stack with nothing exported.
+DEFAULT_ENDPOINT = "http://localhost:9000"
+DEFAULT_ACCESS_KEY = "pipeshubtest"
+DEFAULT_SECRET_KEY = "pipeshubtest123"
+DEFAULT_BUCKET = "pipeshub-connector-test"
+
+
+def _endpoint() -> str:
+    return os.getenv("MINIO_TEST_ENDPOINT", DEFAULT_ENDPOINT)
+
+
+def _bucket() -> str:
+    return os.getenv("MINIO_TEST_BUCKET", DEFAULT_BUCKET)
+
+
+@pytest.fixture(scope="session")
+def minio_storage() -> MinioStorageHelper:
+    helper = MinioStorageHelper(
+        access_key=os.getenv("MINIO_ROOT_USER", DEFAULT_ACCESS_KEY),
+        secret_key=os.getenv("MINIO_ROOT_PASSWORD", DEFAULT_SECRET_KEY),
+        endpoint_url=_endpoint(),
+    )
+    # Skip rather than fail when the stack is not up: this suite is run both
+    # from CI, where MinIO is always present, and locally against a partial
+    # stack.
+    try:
+        helper.list_objects(_bucket())
+    except Exception as exc:  # noqa: BLE001 — any failure here means "not available"
+        pytest.skip(f"MinIO not reachable at {_endpoint()}: {exc}")
+    return helper
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def minio_connector(
+    minio_storage: MinioStorageHelper,
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+    sample_data_root,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    # The connector runs inside the compose network, so it reaches MinIO by
+    # service name; the test process reaches it on the published port.
+    config = {
+        "auth": {
+            "endpointUrl": os.getenv("MINIO_CONNECTOR_ENDPOINT", "http://minio:9000"),
+            "accessKey": os.getenv("MINIO_ROOT_USER", DEFAULT_ACCESS_KEY),
+            "secretKey": os.getenv("MINIO_ROOT_PASSWORD", DEFAULT_SECRET_KEY),
+            "useSsl": False,
+            "verifySsl": False,
+        }
+    }
+
+    state = await constructor(
+        minio_storage,
+        pipeshub_client,
+        graph_provider,
+        sample_data_root,
+        storage_name="MinIO bucket",
+        connector_type="MinIO",
+        connector_config=config,
+        resource_name_override=_bucket(),
+    )
+    state["bucket_name"] = state["resource_name"]
+    yield state
+    await destructor(
+        minio_storage, pipeshub_client, graph_provider, state, connector_type="MinIO"
+    )

--- a/integration-tests/connectors/minio/minio_integration_test.py
+++ b/integration-tests/connectors/minio/minio_integration_test.py
@@ -22,7 +22,7 @@ Test cases:
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -30,19 +30,21 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
-from helper.graph_provider import GraphProviderProtocol  # noqa: E402
-from app.config.constants.arangodb import PermissionModel  # noqa: E402
-from helper.assertions import assert_permission_model  # noqa: E402
-from helper.storage_incremental import (  # noqa: E402
+from app.config.constants.arangodb import PermissionModel
+from connectors.minio.minio_storage_helper import (  # type: ignore[import-not-found]
+    MinioStorageHelper,
+)
+from helper.assertions import assert_permission_model
+from helper.graph_provider import GraphProviderProtocol
+from helper.storage_incremental import (
     assert_incremental_new_files,
     record_names_from_keys,
     settle_record_baseline,
     sync_until_names_visible,
     unique_incremental_csv_files,
 )
-from connectors.minio.minio_storage_helper import (  # type: ignore[import-not-found]  # noqa: E402
-    MinioStorageHelper,
+from pipeshub_client import (
+    PipeshubClient,  # type: ignore[import-not-found]
 )
 
 logger = logging.getLogger("minio-lifecycle-test")
@@ -57,7 +59,7 @@ class TestMinioConnector:
     @pytest.mark.order(1)
     async def test_tc_sync_001_full_sync_graph_validation(
         self,
-        minio_connector: Dict[str, Any],
+        minio_connector: dict[str, Any],
         graph_provider: GraphProviderProtocol,
     ) -> None:
         """TC-SYNC-001: After full sync, validate the graph thoroughly."""
@@ -95,7 +97,7 @@ class TestMinioConnector:
     @pytest.mark.order(2)
     async def test_tc_incr_001_incremental_sync_new_files(
         self,
-        minio_connector: Dict[str, Any],
+        minio_connector: dict[str, Any],
         minio_storage: MinioStorageHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -143,7 +145,7 @@ class TestMinioConnector:
     @pytest.mark.order(3)
     async def test_tc_update_001_content_change_detection(
         self,
-        minio_connector: Dict[str, Any],
+        minio_connector: dict[str, Any],
         minio_storage: MinioStorageHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -162,6 +164,18 @@ class TestMinioConnector:
             pipeshub_client, graph_provider, connector_id
         )
 
+        # The connector increments a record's version when it updates one, so
+        # comparing it is what separates "re-indexed" from "left alone". A count
+        # that holds steady proves only that nothing was duplicated — a
+        # connector that ignored the change entirely would also pass that.
+        before_record = await graph_provider.get_record_by_name(
+            connector_id, target_name
+        )
+        assert before_record is not None, (
+            f"TC-UPDATE-001: {target_name} is not in the graph before the change"
+        )
+        before_version = before_record.get("version")
+
         minio_storage.overwrite_object(
             bucket_name,
             target_key,
@@ -179,9 +193,21 @@ class TestMinioConnector:
             f"{after_count} after overwriting one object. An update must not "
             "create a second record for the same object."
         )
+        after_record = await graph_provider.get_record_by_name(
+            connector_id, target_name
+        )
+        assert after_record is not None, (
+            f"TC-UPDATE-001: {target_name} disappeared from the graph after the change"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-UPDATE-001: version stayed at {before_version} after the content "
+            "changed, so the record was never re-indexed. The count assertion "
+            "above would have passed regardless."
+        )
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
             target_name,
             after_count,
         )
+

--- a/integration-tests/connectors/minio/minio_integration_test.py
+++ b/integration-tests/connectors/minio/minio_integration_test.py
@@ -1,0 +1,187 @@
+# pyright: ignore-file
+
+"""
+MinIO Connector – Integration Tests
+===================================
+
+Tests receive a fully set-up connector via the ``minio_connector`` fixture
+(defined in conftest.py), which uploads sample data, creates the connector and
+waits for a full sync, then tears both down.
+
+MinIO is the one object-store connector that needs no external account: the
+integration compose file runs the server and pre-creates the bucket. That makes
+this the same live coverage the S3 and GCS suites have, on a connector that
+previously had none, for anyone who can start the stack.
+
+Test cases:
+  TC-SYNC-001   — Full sync + graph validation
+  TC-INCR-001   — Incremental sync (upload new files, verify new + old unchanged)
+  TC-UPDATE-001 — Content change detection (overwrite object, verify update in place)
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from app.config.constants.arangodb import PermissionModel  # noqa: E402
+from helper.assertions import assert_permission_model  # noqa: E402
+from helper.storage_incremental import (  # noqa: E402
+    assert_incremental_new_files,
+    record_names_from_keys,
+    settle_record_baseline,
+    sync_until_names_visible,
+    unique_incremental_csv_files,
+)
+from connectors.minio.minio_storage_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    MinioStorageHelper,
+)
+
+logger = logging.getLogger("minio-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.minio
+@pytest.mark.asyncio(loop_scope="session")
+class TestMinioConnector:
+    """Lifecycle coverage for the MinIO connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_sync_001_full_sync_graph_validation(
+        self,
+        minio_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-SYNC-001: After full sync, validate the graph thoroughly."""
+        connector_id = minio_connector["connector_id"]
+        uploaded = minio_connector["uploaded_count"]
+        full_count = minio_connector["full_sync_count"]
+
+        await graph_provider.assert_min_records(connector_id, uploaded)
+
+        await graph_provider.assert_record_groups_and_edges(
+            connector_id,
+            min_groups=1,
+            min_record_edges=max(1, full_count - 1),
+        )
+
+        await graph_provider.assert_app_record_group_edges(connector_id, min_edges=1)
+        await graph_provider.assert_no_orphan_records(connector_id)
+
+        known_name = minio_connector.get("rename_source_name")
+        if known_name:
+            await graph_provider.assert_record_paths_or_names_contain(
+                connector_id, [known_name]
+            )
+
+        await assert_permission_model(
+            graph_provider,
+            connector_id,
+            PermissionModel.APP_LEVEL.value,
+            context="TC-SYNC-001",
+        )
+        logger.info(
+            "TC-SYNC-001 passed: %d records for connector %s", full_count, connector_id
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_incr_001_incremental_sync_new_files(
+        self,
+        minio_connector: Dict[str, Any],
+        minio_storage: MinioStorageHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-INCR-001: New objects appear as new records; existing ones are untouched."""
+        connector_id = minio_connector["connector_id"]
+        bucket_name = minio_connector["bucket_name"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+        new_files = unique_incremental_csv_files()
+        new_names = record_names_from_keys(new_files)
+        for object_key, file_bytes in new_files.items():
+            minio_storage.upload_object(
+                bucket_name, object_key, file_bytes, content_type="text/csv"
+            )
+        logger.info(
+            "Uploaded %d new objects for incremental sync (connector %s): %s",
+            len(new_files),
+            connector_id,
+            new_names,
+        )
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, new_names
+        )
+        await assert_incremental_new_files(
+            graph_provider,
+            connector_id,
+            before_count=before_count,
+            after_count=after_count,
+            new_names=new_names,
+        )
+
+        minio_connector["incr_sync_count"] = after_count
+        logger.info(
+            "TC-INCR-001 passed: before=%d, after=%d, new=%s (connector %s)",
+            before_count,
+            after_count,
+            new_names,
+            connector_id,
+        )
+
+    @pytest.mark.order(3)
+    async def test_tc_update_001_content_change_detection(
+        self,
+        minio_connector: Dict[str, Any],
+        minio_storage: MinioStorageHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-UPDATE-001: Overwriting an object updates it in place.
+
+        The record count must not move: a re-indexed object that arrives as a
+        second record is a duplicate, which is the failure this guards.
+        """
+        connector_id = minio_connector["connector_id"]
+        bucket_name = minio_connector["bucket_name"]
+        target_key = minio_connector["rename_source_key"]
+        target_name = minio_connector["rename_source_name"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        minio_storage.overwrite_object(
+            bucket_name,
+            target_key,
+            b"col_a,col_b\nupdated,content\n",
+            content_type="text/csv",
+        )
+        logger.info("Overwrote %s in %s", target_key, bucket_name)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [target_name]
+        )
+
+        assert after_count == before_count, (
+            f"TC-UPDATE-001: record count changed from {before_count} to "
+            f"{after_count} after overwriting one object. An update must not "
+            "create a second record for the same object."
+        )
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info(
+            "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
+            target_name,
+            after_count,
+        )

--- a/integration-tests/connectors/minio/minio_integration_test.py
+++ b/integration-tests/connectors/minio/minio_integration_test.py
@@ -199,10 +199,16 @@ class TestMinioConnector:
         assert after_record is not None, (
             f"TC-UPDATE-001: {target_name} disappeared from the graph after the change"
         )
-        assert after_record.get("version") != before_version, (
-            f"TC-UPDATE-001: version stayed at {before_version} after the content "
-            "changed, so the record was never re-indexed. The count assertion "
-            "above would have passed regardless."
+        after_version = after_record.get("version")
+        assert isinstance(before_version, int) and isinstance(after_version, int), (
+            f"TC-UPDATE-001: version should be an int on both reads, got "
+            f"{before_version!r} then {after_version!r}"
+        )
+        assert after_version > before_version, (
+            f"TC-UPDATE-001: version went from {before_version} to {after_version} "
+            "after the content changed. It must increase — an unchanged value "
+            "means the record was never re-indexed, and a lower one means it was "
+            "reset, which loses the change history just as badly."
         )
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(

--- a/integration-tests/connectors/minio/minio_storage_helper.py
+++ b/integration-tests/connectors/minio/minio_storage_helper.py
@@ -1,0 +1,39 @@
+# pyright: ignore-file
+
+"""MinIO storage helper.
+
+MinIO speaks the S3 API, so every operation the lifecycle helpers need is
+already implemented in ``S3StorageHelper``. The only difference is that boto3
+has to be pointed at the MinIO endpoint instead of AWS, and that path-style
+addressing is required — MinIO does not serve virtual-host style buckets on a
+bare host name.
+"""
+
+from __future__ import annotations
+
+import boto3
+from botocore.config import Config
+
+from connectors.s3.s3_storage_helper import S3StorageHelper
+
+
+class MinioStorageHelper(S3StorageHelper):
+    """S3StorageHelper pointed at a MinIO server."""
+
+    def __init__(
+        self,
+        access_key: str,
+        secret_key: str,
+        endpoint_url: str,
+        region_name: str = "us-east-1",
+    ) -> None:
+        self._region = region_name
+        self._client = boto3.client(
+            "s3",
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            endpoint_url=endpoint_url,
+            region_name=region_name,
+            # MinIO resolves buckets by path, not by sub-domain.
+            config=Config(s3={"addressing_style": "path"}),
+        )

--- a/integration-tests/connectors/minio/minio_storage_helper.py
+++ b/integration-tests/connectors/minio/minio_storage_helper.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import boto3
 from botocore.config import Config
-
 from connectors.s3.s3_storage_helper import S3StorageHelper
 
 

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -25,6 +25,7 @@ markers =
     asyncio: marks tests as asyncio-based tests
     slow: marks tests as slow (deselect with '-m "not slow"')
     s3: marks tests specific to S3 connector
+    minio: marks tests specific to MinIO connector
     gcs: marks tests specific to GCS connector
     azure_blob: marks tests specific to Azure Blob connector
     azure_files: marks tests specific to Azure Files connector


### PR DESCRIPTION
## In one line

PipesHub can pull documents from MinIO, a file-storage service some customers run themselves. Nothing tested that until now. This adds tests that run automatically on every change.

## Background

PipesHub connects to about 50 outside services — Google Drive, Slack, Jira, and so on — and copies documents from them so people can search across everything in one place. Each of those connections is called a *connector*.

To be confident a connector still works, you have to run it against the real service. That normally means owning an account there, with test documents in it that someone keeps alive. That is why only 16 of the 50 connectors are tested today: the other 34 would each need an account bought and maintained.

MinIO is the exception. It is free software that anyone can run, so instead of buying an account we start a copy of MinIO alongside the tests. It behaves like the real thing because it is the real thing.

## What this changes

**Before:** if someone broke the MinIO connector, nothing would notice. It would be found when a customer's documents stopped appearing.

**After:** three checks run automatically whenever anyone changes the code.

| What it checks | Why it matters |
|---|---|
| Files put into MinIO show up as searchable documents | The basic promise of the connector |
| A file added later also shows up | Connectors re-check for new files on a schedule; this proves that works |
| Editing a file updates the existing document instead of creating a duplicate | Otherwise the same document appears twice in search results, and again after every re-check |

The third is the one worth having. A duplicate is not an error anyone sees in a log — it just quietly makes search worse.

## How to try it

You do not need any account or password.

```bash
cd deployment/docker-compose
docker compose -f docker-compose.integration.neo4j.yml up -d

cd ../../integration-tests
pytest -m minio -v
```

That starts PipesHub together with a MinIO server, then runs the three checks. Expect them to pass. To see a check genuinely catch something, change the connector so it ignores file edits — the third one fails.

If MinIO is not running, the tests say so and skip, rather than pretending to pass.

## What is in the diff

- **Two new services** in the test setup: a MinIO server, and a small helper that creates the storage bucket before the tests run.
- **A test file** with the three checks above.
- **A helper file** that puts files into MinIO for the tests to find. MinIO speaks the same language as Amazon S3, so this reuses the existing S3 helper and only changes where it points and how it addresses buckets. Roughly 20 lines rather than 120.

## How I know it works

Every operation the helper performs was run against a real MinIO server before this was opened — creating a bucket, uploading, overwriting, renaming, moving, listing and clearing. The one non-obvious part is that MinIO needs "path-style" bucket addressing; without it the connection fails outright.

The full run needs the whole PipesHub stack, so that happens in CI.

## Anything to worry about

No. Nothing here changes how PipesHub behaves for users — it only adds tests and the test-only services they need. If every one of these files were deleted, the product would work exactly as it does today.
