### PR TITLE
test(mariadb): give the MariaDB connector live integration coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,6 +19,7 @@ on:
             - integration
             - s3
             - postgres
+            - mariadb
             - confluence
             - jira
             - linear
@@ -147,6 +148,13 @@ jobs:
       POSTGRES_TEST_USER: pipeshubtest
       POSTGRES_TEST_PASSWORD: pipeshubtest123
       POSTGRES_TEST_DB: pipeshub_connector_test
+      MARIADB_TEST_HOST: localhost
+      MARIADB_TEST_PORT: '3307'
+      MARIADB_CONNECTOR_HOST: mariadb-source
+      MARIADB_CONNECTOR_PORT: '3306'
+      MARIADB_TEST_USER: pipeshubtest
+      MARIADB_TEST_PASSWORD: pipeshubtest123
+      MARIADB_TEST_DB: pipeshub_connector_test
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/backend/python/app/agents/agent_loop/respond.py
+++ b/backend/python/app/agents/agent_loop/respond.py
@@ -378,6 +378,23 @@ class AnswerFinalizer:
         completion_data["answer"] = normalized
         completion_data["citations"] = citations
         completion_data["confidence"] = confidence
+        # Counts, not a verdict. `citationRefsAvailable` is how much citable
+        # material reached the model; `citationsUsed` is how much it attributed.
+        #
+        # Available > 0 with used == 0 is the shape worth counting: the model
+        # had sources and attributed none of them. That is not by itself a
+        # defect — a correct "the documents do not contain this" also lands
+        # there, because retrieval returns nearest neighbours whether or not
+        # anything is relevant. Deliberately reported rather than classified:
+        # nothing at this layer can separate the two, and a wrong label is
+        # worse than two honest numbers. See issue #2975.
+        completion_data["citationRefsAvailable"] = len(ref_to_url or {})
+        completion_data["citationsUsed"] = len(citations)
+        log.info(
+            "CITATION_TELEMETRY refs_available=%d citations_used=%d records_fetched=%d",
+            len(ref_to_url or {}), len(citations),
+            len(getattr(self._context, "full_records_fetched", None) or ()),
+        )
         reasoning_payload = build_reasoning_payload(reasoning_turns)
         if reasoning_payload is not None:
             completion_data["reasoning"] = reasoning_payload

--- a/backend/python/app/agents/agent_loop/respond.py
+++ b/backend/python/app/agents/agent_loop/respond.py
@@ -378,23 +378,6 @@ class AnswerFinalizer:
         completion_data["answer"] = normalized
         completion_data["citations"] = citations
         completion_data["confidence"] = confidence
-        # Counts, not a verdict. `citationRefsAvailable` is how much citable
-        # material reached the model; `citationsUsed` is how much it attributed.
-        #
-        # Available > 0 with used == 0 is the shape worth counting: the model
-        # had sources and attributed none of them. That is not by itself a
-        # defect — a correct "the documents do not contain this" also lands
-        # there, because retrieval returns nearest neighbours whether or not
-        # anything is relevant. Deliberately reported rather than classified:
-        # nothing at this layer can separate the two, and a wrong label is
-        # worse than two honest numbers. See issue #2975.
-        completion_data["citationRefsAvailable"] = len(ref_to_url or {})
-        completion_data["citationsUsed"] = len(citations)
-        log.info(
-            "CITATION_TELEMETRY refs_available=%d citations_used=%d records_fetched=%d",
-            len(ref_to_url or {}), len(citations),
-            len(getattr(self._context, "full_records_fetched", None) or ()),
-        )
         reasoning_payload = build_reasoning_payload(reasoning_turns)
         if reasoning_payload is not None:
             completion_data["reasoning"] = reasoning_payload

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -217,6 +217,24 @@ services:
       timeout: 3s
       retries: 20
 
+  # Like postgres-source, this is a connector *source* — a database to be
+  # indexed — not a store the platform uses.
+  mariadb-source:
+    image: mariadb:11.4.4-noble
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: ${MARIADB_TEST_ROOT_PASSWORD:-pipeshubroot123}
+      MARIADB_USER: ${MARIADB_TEST_USER:-pipeshubtest}
+      MARIADB_PASSWORD: ${MARIADB_TEST_PASSWORD:-pipeshubtest123}
+      MARIADB_DATABASE: ${MARIADB_TEST_DB:-pipeshub_connector_test}
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -228,7 +228,7 @@ services:
       MARIADB_PASSWORD: ${MARIADB_TEST_PASSWORD:-pipeshubtest123}
       MARIADB_DATABASE: ${MARIADB_TEST_DB:-pipeshub_connector_test}
     ports:
-      - "3307:3306"
+      - "127.0.0.1:3307:3306"
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -217,6 +217,24 @@ services:
       timeout: 3s
       retries: 20
 
+  # Like postgres-source, this is a connector *source* — a database to be
+  # indexed — not a store the platform uses.
+  mariadb-source:
+    image: mariadb:11.4.4-noble
+    restart: always
+    environment:
+      MARIADB_ROOT_PASSWORD: ${MARIADB_TEST_ROOT_PASSWORD:-pipeshubroot123}
+      MARIADB_USER: ${MARIADB_TEST_USER:-pipeshubtest}
+      MARIADB_PASSWORD: ${MARIADB_TEST_PASSWORD:-pipeshubtest123}
+      MARIADB_DATABASE: ${MARIADB_TEST_DB:-pipeshub_connector_test}
+    ports:
+      - "3307:3306"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -228,7 +228,7 @@ services:
       MARIADB_PASSWORD: ${MARIADB_TEST_PASSWORD:-pipeshubtest123}
       MARIADB_DATABASE: ${MARIADB_TEST_DB:-pipeshub_connector_test}
     ports:
-      - "3307:3306"
+      - "127.0.0.1:3307:3306"
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s

--- a/integration-tests/connectors/mariadb/conftest.py
+++ b/integration-tests/connectors/mariadb/conftest.py
@@ -37,6 +37,18 @@ SEED_TABLES = {
 }
 
 
+
+def _unavailable(reason: str) -> None:
+    """A source that is not reachable: skip locally, fail in CI.
+
+    Skipping on any exception turns a broken stack into a green run. CI brings
+    this source up itself, so if it is not reachable there, that is a result and
+    not a reason to report success.
+    """
+    if os.getenv("CI"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 @pytest.fixture(scope="session")
 def mariadb_source() -> MariaDBSourceHelper:
     helper = MariaDBSourceHelper(
@@ -51,7 +63,7 @@ def mariadb_source() -> MariaDBSourceHelper:
     try:
         helper.ping()
     except Exception as exc:  # noqa: BLE001 — any failure means "not available"
-        pytest.skip(f"MariaDB source not reachable: {exc}")
+        _unavailable(f"MariaDB source not reachable: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/mariadb/conftest.py
+++ b/integration-tests/connectors/mariadb/conftest.py
@@ -1,0 +1,104 @@
+# pyright: ignore-file
+
+"""MariaDB connector fixtures.
+
+Like MinIO and PostgreSQL, this connector needs no external account: the
+integration compose file runs a MariaDB server for it to sync from.
+"""
+
+import os
+import uuid
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+import pytest_asyncio
+
+from connector_lifecycle import create_connector_and_await_sync, destructor
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+from helper.graph_provider import GraphProviderProtocol
+
+from connectors.mariadb.mariadb_source_helper import MariaDBSourceHelper
+
+# Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
+DEFAULT_USER = "pipeshubtest"
+DEFAULT_PASSWORD = "pipeshubtest123"
+DEFAULT_DB = "pipeshub_connector_test"
+
+# One record per table, so the seed decides how many records to expect.
+SEED_TABLES = {
+    "articles": [
+        ("Onboarding guide", "How to set up a new workspace."),
+        ("Billing FAQ", "Answers to common billing questions."),
+    ],
+    "policies": [
+        ("Leave policy", "Annual leave accrues monthly."),
+        ("Security policy", "Rotate credentials every ninety days."),
+    ],
+}
+
+
+@pytest.fixture(scope="session")
+def mariadb_source() -> MariaDBSourceHelper:
+    helper = MariaDBSourceHelper(
+        host=os.getenv("MARIADB_TEST_HOST", "localhost"),
+        port=int(os.getenv("MARIADB_TEST_PORT", "3307")),
+        user=os.getenv("MARIADB_TEST_USER", DEFAULT_USER),
+        password=os.getenv("MARIADB_TEST_PASSWORD", DEFAULT_PASSWORD),
+        database=os.getenv("MARIADB_TEST_DB", DEFAULT_DB),
+    )
+    # Skip rather than fail when the stack is not up, so a partial local stack
+    # stays usable. CI always brings mariadb-source up.
+    try:
+        helper.ping()
+    except Exception as exc:  # noqa: BLE001 — any failure means "not available"
+        pytest.skip(f"MariaDB source not reachable: {exc}")
+    return helper
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def mariadb_connector(
+    mariadb_source: MariaDBSourceHelper,
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    for table, rows in SEED_TABLES.items():
+        mariadb_source.create_table_with_rows(table, rows)
+
+    state: Dict[str, Any] = {
+        "resource_name": mariadb_source.database,
+        "seeded_tables": sorted(SEED_TABLES),
+        "uploaded_count": len(SEED_TABLES),
+    }
+
+    # The connector runs inside the compose network and reaches the source by
+    # service name; the test process reaches it on the published port.
+    config = {
+        "auth": {
+            "host": os.getenv("MARIADB_CONNECTOR_HOST", "mariadb-source"),
+            "port": int(os.getenv("MARIADB_CONNECTOR_PORT", "3306")),
+            "database": os.getenv("MARIADB_TEST_DB", DEFAULT_DB),
+            "username": os.getenv("MARIADB_TEST_USER", DEFAULT_USER),
+            "password": os.getenv("MARIADB_TEST_PASSWORD", DEFAULT_PASSWORD),
+        }
+    }
+
+    await create_connector_and_await_sync(
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="MariaDB",
+        connector_name=f"mariadb-lifecycle-test-{uuid.uuid4().hex[:8]}",
+        connector_config=config,
+        expected_records=len(SEED_TABLES),
+    )
+
+    yield state
+
+    await destructor(
+        mariadb_source,
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="MariaDB",
+    )
+    mariadb_source.drop_tables()

--- a/integration-tests/connectors/mariadb/conftest.py
+++ b/integration-tests/connectors/mariadb/conftest.py
@@ -8,16 +8,15 @@ integration compose file runs a MariaDB server for it to sync from.
 
 import os
 import uuid
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 import pytest_asyncio
-
 from connector_lifecycle import create_connector_and_await_sync, destructor
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
-from helper.graph_provider import GraphProviderProtocol
-
 from connectors.mariadb.mariadb_source_helper import MariaDBSourceHelper
+from helper.graph_provider import GraphProviderProtocol
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
 
 # Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
 DEFAULT_USER = "pipeshubtest"
@@ -72,11 +71,11 @@ async def mariadb_connector(
     mariadb_source: MariaDBSourceHelper,
     pipeshub_client: PipeshubClient,
     graph_provider: GraphProviderProtocol,
-) -> AsyncGenerator[Dict[str, Any], None]:
+) -> AsyncGenerator[dict[str, Any], None]:
     for table, rows in SEED_TABLES.items():
         mariadb_source.create_table_with_rows(table, rows)
 
-    state: Dict[str, Any] = {
+    state: dict[str, Any] = {
         "resource_name": mariadb_source.database,
         "seeded_tables": sorted(SEED_TABLES),
         "uploaded_count": len(SEED_TABLES),

--- a/integration-tests/connectors/mariadb/conftest.py
+++ b/integration-tests/connectors/mariadb/conftest.py
@@ -13,7 +13,11 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from connector_lifecycle import create_connector_and_await_sync, destructor
+from connector_lifecycle import (
+    create_connector_and_await_sync,
+    destructor,
+    source_unavailable,
+)
 from connectors.mariadb.mariadb_source_helper import MariaDBSourceHelper
 from helper.graph_provider import GraphProviderProtocol
 from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
@@ -37,17 +41,6 @@ SEED_TABLES = {
 
 
 
-def _unavailable(reason: str) -> None:
-    """A source that is not reachable: skip locally, fail in CI.
-
-    Skipping on any exception turns a broken stack into a green run. CI brings
-    this source up itself, so if it is not reachable there, that is a result and
-    not a reason to report success.
-    """
-    if os.getenv("CI"):
-        pytest.fail(reason)
-    pytest.skip(reason)
-
 @pytest.fixture(scope="session")
 def mariadb_source() -> MariaDBSourceHelper:
     helper = MariaDBSourceHelper(
@@ -62,7 +55,7 @@ def mariadb_source() -> MariaDBSourceHelper:
     try:
         helper.ping()
     except Exception as exc:  # noqa: BLE001 — any failure means "not available"
-        _unavailable(f"MariaDB source not reachable: {exc}")
+        source_unavailable(f"MariaDB source not reachable: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/mariadb/mariadb_integration_test.py
+++ b/integration-tests/connectors/mariadb/mariadb_integration_test.py
@@ -21,7 +21,7 @@ Test cases:
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -29,14 +29,16 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
-from helper.graph_provider import GraphProviderProtocol  # noqa: E402
-from helper.storage_incremental import (  # noqa: E402
+from connectors.mariadb.mariadb_source_helper import (  # type: ignore[import-not-found]
+    MariaDBSourceHelper,
+)
+from helper.graph_provider import GraphProviderProtocol
+from helper.storage_incremental import (
     settle_record_baseline,
     sync_until_names_visible,
 )
-from connectors.mariadb.mariadb_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
-    MariaDBSourceHelper,
+from pipeshub_client import (
+    PipeshubClient,  # type: ignore[import-not-found]
 )
 
 logger = logging.getLogger("mariadb-lifecycle-test")
@@ -51,7 +53,7 @@ class TestMariaDBConnector:
     @pytest.mark.order(1)
     async def test_tc_sync_001_full_sync_graph_validation(
         self,
-        mariadb_connector: Dict[str, Any],
+        mariadb_connector: dict[str, Any],
         graph_provider: GraphProviderProtocol,
     ) -> None:
         """TC-SYNC-001: Every seeded table is in the graph after a full sync."""
@@ -73,7 +75,7 @@ class TestMariaDBConnector:
     @pytest.mark.order(2)
     async def test_tc_incr_001_new_table_is_picked_up(
         self,
-        mariadb_connector: Dict[str, Any],
+        mariadb_connector: dict[str, Any],
         mariadb_source: MariaDBSourceHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -117,7 +119,7 @@ class TestMariaDBConnector:
     @pytest.mark.order(3)
     async def test_tc_rows_001_adding_rows_does_not_duplicate_the_table_record(
         self,
-        mariadb_connector: Dict[str, Any],
+        mariadb_connector: dict[str, Any],
         mariadb_source: MariaDBSourceHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -134,6 +136,18 @@ class TestMariaDBConnector:
         before_count = await settle_record_baseline(
             pipeshub_client, graph_provider, connector_id
         )
+
+        # The connector increments a record's version when it updates one, so
+        # comparing it is what separates "re-indexed" from "left alone". A count
+        # that holds steady proves only that nothing was duplicated — a
+        # connector that ignored the change entirely would also pass that.
+        before_record = await graph_provider.get_record_by_name(
+            connector_id, table
+        )
+        assert before_record is not None, (
+            f"TC-ROWS-001: {table} is not in the graph before the change"
+        )
+        before_version = before_record.get("version")
         rows_before = mariadb_source.row_count(table)
 
         mariadb_source.insert_rows(
@@ -150,9 +164,21 @@ class TestMariaDBConnector:
             f"after adding a row to {table}. Rows changing must update the "
             "table's record, not create another one."
         )
+        after_record = await graph_provider.get_record_by_name(
+            connector_id, table
+        )
+        assert after_record is not None, (
+            f"TC-ROWS-001: {table} disappeared from the graph after the change"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-ROWS-001: version stayed at {before_version} after the content "
+            "changed, so the record was never re-indexed. The count assertion "
+            "above would have passed regardless."
+        )
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-ROWS-001 passed: %s updated in place, count stable at %d",
             table,
             after_count,
         )
+

--- a/integration-tests/connectors/mariadb/mariadb_integration_test.py
+++ b/integration-tests/connectors/mariadb/mariadb_integration_test.py
@@ -1,0 +1,158 @@
+# pyright: ignore-file
+
+"""
+MariaDB Connector – Integration Tests
+=====================================
+
+Tests receive a fully set-up connector via the ``mariadb_connector`` fixture
+(defined in conftest.py), which creates the tables, creates the connector and
+waits for a full sync, then tears both down.
+
+MariaDB here is a connector *source* — a database to be indexed — not a store
+the platform uses. Like MinIO and PostgreSQL, it runs in the integration stack,
+so this connector has live coverage without an external database.
+
+Test cases:
+  TC-SYNC-001 — Full sync + graph validation
+  TC-INCR-001 — A table added after the first sync appears on the next one
+  TC-ROWS-001 — Adding rows to an existing table does not duplicate its record
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from helper.storage_incremental import (  # noqa: E402
+    settle_record_baseline,
+    sync_until_names_visible,
+)
+from connectors.mariadb.mariadb_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    MariaDBSourceHelper,
+)
+
+logger = logging.getLogger("mariadb-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.mariadb
+@pytest.mark.asyncio(loop_scope="session")
+class TestMariaDBConnector:
+    """Lifecycle coverage for the MariaDB connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_sync_001_full_sync_graph_validation(
+        self,
+        mariadb_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-SYNC-001: Every seeded table is in the graph after a full sync."""
+        connector_id = mariadb_connector["connector_id"]
+        seeded = mariadb_connector["seeded_tables"]
+        full_count = mariadb_connector["full_sync_count"]
+
+        await graph_provider.assert_min_records(connector_id, len(seeded))
+        await graph_provider.assert_no_orphan_records(connector_id)
+        await graph_provider.assert_record_paths_or_names_contain(connector_id, seeded)
+
+        logger.info(
+            "TC-SYNC-001 passed: %d records for tables %s (connector %s)",
+            full_count,
+            seeded,
+            connector_id,
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_incr_001_new_table_is_picked_up(
+        self,
+        mariadb_connector: Dict[str, Any],
+        mariadb_source: MariaDBSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-INCR-001: A table created after the first sync appears on the next one."""
+        connector_id = mariadb_connector["connector_id"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        new_table = "runbooks"
+        mariadb_source.create_table_with_rows(
+            new_table,
+            [
+                ("Restart procedure", "Drain traffic, then restart the service."),
+                ("Backup restore", "Restore from the most recent nightly snapshot."),
+            ],
+        )
+        logger.info("Created new table %s for incremental sync", new_table)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [new_table]
+        )
+
+        assert after_count > before_count, (
+            f"TC-INCR-001: expected a new record for table {new_table}; count "
+            f"stayed at {after_count}"
+        )
+        await graph_provider.assert_record_paths_or_names_contain(
+            connector_id, [new_table]
+        )
+        mariadb_connector["incr_table"] = new_table
+        logger.info(
+            "TC-INCR-001 passed: before=%d, after=%d, new table=%s",
+            before_count,
+            after_count,
+            new_table,
+        )
+
+    @pytest.mark.order(3)
+    async def test_tc_rows_001_adding_rows_does_not_duplicate_the_table_record(
+        self,
+        mariadb_connector: Dict[str, Any],
+        mariadb_source: MariaDBSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-ROWS-001: Rows added to a synced table update it, not duplicate it.
+
+        The connector syncs one record per table. Re-indexing a table whose rows
+        changed must update that record; a second record for the same table is
+        the duplicate this guards against.
+        """
+        connector_id = mariadb_connector["connector_id"]
+        table = "articles"
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+        rows_before = mariadb_source.row_count(table)
+
+        mariadb_source.insert_rows(
+            table, [("Escalation paths", "Who to page, and when.")]
+        )
+        assert mariadb_source.row_count(table) == rows_before + 1
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [table]
+        )
+
+        assert after_count == before_count, (
+            f"TC-ROWS-001: record count moved from {before_count} to {after_count} "
+            f"after adding a row to {table}. Rows changing must update the "
+            "table's record, not create another one."
+        )
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info(
+            "TC-ROWS-001 passed: %s updated in place, count stable at %d",
+            table,
+            after_count,
+        )

--- a/integration-tests/connectors/mariadb/mariadb_integration_test.py
+++ b/integration-tests/connectors/mariadb/mariadb_integration_test.py
@@ -170,10 +170,16 @@ class TestMariaDBConnector:
         assert after_record is not None, (
             f"TC-ROWS-001: {table} disappeared from the graph after the change"
         )
-        assert after_record.get("version") != before_version, (
-            f"TC-ROWS-001: version stayed at {before_version} after the content "
-            "changed, so the record was never re-indexed. The count assertion "
-            "above would have passed regardless."
+        after_version = after_record.get("version")
+        assert isinstance(before_version, int) and isinstance(after_version, int), (
+            f"TC-ROWS-001: version should be an int on both reads, got "
+            f"{before_version!r} then {after_version!r}"
+        )
+        assert after_version > before_version, (
+            f"TC-ROWS-001: version went from {before_version} to {after_version} "
+            "after the content changed. It must increase — an unchanged value "
+            "means the record was never re-indexed, and a lower one means it was "
+            "reset, which loses the change history just as badly."
         )
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(

--- a/integration-tests/connectors/mariadb/mariadb_source_helper.py
+++ b/integration-tests/connectors/mariadb/mariadb_source_helper.py
@@ -1,0 +1,99 @@
+# pyright: ignore-file
+
+"""Seeds a MariaDB database with tables for the MariaDB connector to sync.
+
+pymysql is used here rather than the `mariadb` package the product depends on.
+The product's driver needs the MariaDB Connector/C system library; this helper
+only has to create tables and insert rows, and a pure-Python driver keeps the
+integration-test environment free of a system dependency. What the connector
+uses to read the data is unaffected — that is the code under test.
+"""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+import pymysql
+
+
+class MariaDBSourceHelper:
+    """Creates and tears down the tables a connector test syncs from."""
+
+    def __init__(
+        self, host: str, port: int, user: str, password: str, database: str
+    ) -> None:
+        self._conn_args = dict(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+            autocommit=True,
+        )
+        self.database = database
+
+    def _connect(self):
+        return pymysql.connect(**self._conn_args)
+
+    def ping(self) -> None:
+        """Raise if the server is not reachable."""
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute("SELECT 1")
+            cur.fetchone()
+
+    def list_tables(self) -> List[str]:
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT table_name FROM information_schema.tables "
+                "WHERE table_schema = %s ORDER BY table_name",
+                (self.database,),
+            )
+            return [r[0] for r in cur.fetchall()]
+
+    def create_table_with_rows(
+        self, table: str, rows: Sequence[tuple[str, str]]
+    ) -> None:
+        """Create a two-column table and fill it.
+
+        Deliberately dull: this suite tests that the connector discovers a table
+        and turns it into a record, not that it handles exotic column types.
+        """
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(
+                f"CREATE TABLE IF NOT EXISTS `{table}` ("
+                "  id INT AUTO_INCREMENT PRIMARY KEY,"
+                "  title VARCHAR(255) NOT NULL,"
+                "  body  TEXT NOT NULL"
+                ") ENGINE=InnoDB"
+            )
+            cur.execute(f"TRUNCATE TABLE `{table}`")
+            cur.executemany(
+                f"INSERT INTO `{table}` (title, body) VALUES (%s, %s)", list(rows)
+            )
+
+    def insert_rows(self, table: str, rows: Sequence[tuple[str, str]]) -> None:
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.executemany(
+                f"INSERT INTO `{table}` (title, body) VALUES (%s, %s)", list(rows)
+            )
+
+    def row_count(self, table: str) -> int:
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(f"SELECT COUNT(*) FROM `{table}`")
+            return cur.fetchone()[0]
+
+    def clear_objects(self, resource_name: str) -> None:
+        """Empty every seeded table.
+
+        Named for the protocol the shared destructor expects: clear the content
+        of the resource the connector synced from. Here that is the tables.
+        """
+        del resource_name  # the database is fixed at construction
+        for table in self.list_tables():
+            with self._connect() as conn, conn.cursor() as cur:
+                cur.execute(f"TRUNCATE TABLE `{table}`")
+
+    def drop_tables(self) -> None:
+        for table in self.list_tables():
+            with self._connect() as conn, conn.cursor() as cur:
+                cur.execute(f"DROP TABLE IF EXISTS `{table}`")

--- a/integration-tests/connectors/mariadb/mariadb_source_helper.py
+++ b/integration-tests/connectors/mariadb/mariadb_source_helper.py
@@ -11,7 +11,7 @@ uses to read the data is unaffected — that is the code under test.
 
 from __future__ import annotations
 
-from typing import List, Sequence
+from collections.abc import Sequence
 
 import pymysql
 
@@ -41,7 +41,7 @@ class MariaDBSourceHelper:
             cur.execute("SELECT 1")
             cur.fetchone()
 
-    def list_tables(self) -> List[str]:
+    def list_tables(self) -> list[str]:
         with self._connect() as conn, conn.cursor() as cur:
             cur.execute(
                 "SELECT table_name FROM information_schema.tables "

--- a/integration-tests/pyproject.toml
+++ b/integration-tests/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "beautifulsoup4==4.12.3",
   "box-sdk-gen==1.12.0",
   "psycopg[binary]>=3.1",
+  "pymysql>=1.1",
   "Brotli==1.2.0",
   "CairoSVG==2.8.2",
   "celery==5.4.0",

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -26,6 +26,7 @@ markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     s3: marks tests specific to S3 connector
     postgres: marks tests specific to PostgreSQL connector
+    mariadb: marks tests specific to MariaDB connector
     gcs: marks tests specific to GCS connector
     azure_blob: marks tests specific to Azure Blob connector
     azure_files: marks tests specific to Azure Files connector


### PR DESCRIPTION
## In one line

PipesHub can pull documents from MariaDB. Nothing tested that until now. This adds tests that run automatically — and need no account, because MariaDB is free software anyone can run.

## Background

PipesHub connects to around 50 outside services and copies documents from them so people can search across everything in one place. Each connection is called a *connector*.

Being confident a connector still works means running it against the real service. That usually means owning an account there, kept alive with test data — which is why only 16 of the 50 are tested today.

MariaDB is one of the few exceptions: MariaDB is free software anyone can run. So instead of buying an account, the tests start one alongside them.

## What this changes

**Before:** if someone broke the MariaDB connector, nothing would notice until a customer's documents stopped appearing.

**After:** these checks run automatically on every change.

| What it checks | Why it matters |
|---|---|
| Tables in the database become searchable documents | The basic promise of the connector |
| A table created later is picked up | Connectors re-check on a schedule; this proves that works |
| Adding rows updates the existing document rather than duplicating it | One document per table — so a re-read that adds instead of updating makes the same table appear twice in search, and again on every schedule |

## How to try it

No account or password needed.

```bash
cd deployment/docker-compose
docker compose -f docker-compose.integration.neo4j.yml up -d

cd ../../integration-tests
pytest -m mariadb -v
```

If the service is not running, the tests say so and skip rather than pretending to pass. In CI, where it is always started, they fail instead — a broken setup should be visible, not hidden.

## A note on the database driver

Seeding the test data uses `pymysql` rather than the driver PipesHub itself uses. The product driver needs a system library installed; this helper only creates tables and inserts rows, so a pure-Python driver keeps the test environment simpler. What the *connector* uses to read the data — the thing under test — is untouched.

The test database is published on port 3307 so it cannot be confused with any other MariaDB.

## Anything to worry about

No. Nothing here changes how PipesHub behaves for users. It adds tests and the test-only services they need; deleting every file in this change would leave the product exactly as it is today.
