### PR TITLE
test(localfs): give the Local FS connector live integration coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -20,6 +20,7 @@ on:
             - s3
             - postgres
             - mariadb
+            - localfs
             - confluence
             - jira
             - linear
@@ -155,6 +156,11 @@ jobs:
       MARIADB_TEST_USER: pipeshubtest
       MARIADB_TEST_PASSWORD: pipeshubtest123
       MARIADB_TEST_DB: pipeshub_connector_test
+      # The Local FS connector reads a directory bind-mounted into the
+      # connector container. The test writes the host path; the connector
+      # is pointed at the container path.
+      LOCALFS_TEST_HOST_DIR: ../deployment/docker-compose/localfs-test-data
+      LOCALFS_CONNECTOR_ROOT: /data/localfs-test
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -159,7 +159,11 @@ jobs:
       # The Local FS connector reads a directory bind-mounted into the
       # connector container. The test writes the host path; the connector
       # is pointed at the container path.
-      LOCALFS_TEST_HOST_DIR: ../deployment/docker-compose/localfs-test-data
+      # Absolute, because this value is read from two different working
+      # directories: compose runs in deployment/docker-compose and pytest in
+      # integration-tests. A relative path resolves differently in each, so
+      # the bind mount and the test would use different directories.
+      LOCALFS_TEST_HOST_DIR: ${{ github.workspace }}/deployment/docker-compose/localfs-test-data
       LOCALFS_CONNECTOR_ROOT: /data/localfs-test
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -173,6 +173,11 @@ services:
     volumes:
       - pipeshub_data:/data/pipeshub
       - pipeshub_root_local:/root/.local
+      # A directory both the test process and the connector can see, so the
+      # Local FS connector can be tested without an external service. The host
+      # side is written by the test; the container side is what the connector
+      # is pointed at.
+      - ${LOCALFS_TEST_HOST_DIR:-./localfs-test-data}:/data/localfs-test
       # Persist the HuggingFace model cache so models pulled at runtime survive
       # container recreation instead of being re-downloaded on every restart.
       - pipeshub_hf_cache:/root/.cache/huggingface

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -173,6 +173,11 @@ services:
     volumes:
       - pipeshub_data:/data/pipeshub
       - pipeshub_root_local:/root/.local
+      # A directory both the test process and the connector can see, so the
+      # Local FS connector can be tested without an external service. The host
+      # side is written by the test; the container side is what the connector
+      # is pointed at.
+      - ${LOCALFS_TEST_HOST_DIR:-./localfs-test-data}:/data/localfs-test
       # Persist the HuggingFace model cache so models pulled at runtime survive
       # container recreation instead of being re-downloaded on every restart.
       - pipeshub_hf_cache:/root/.cache/huggingface

--- a/deployment/docker-compose/localfs-test-data/.gitkeep
+++ b/deployment/docker-compose/localfs-test-data/.gitkeep
@@ -1,0 +1,5 @@
+Bind-mount target for the Local FS connector integration tests.
+
+The directory has to exist before compose starts, otherwise Docker creates it
+as root and the test process cannot write into it. The tests add and remove
+files here; nothing else should be kept in it.

--- a/integration-tests/connectors/localfs/conftest.py
+++ b/integration-tests/connectors/localfs/conftest.py
@@ -1,0 +1,94 @@
+# pyright: ignore-file
+
+"""Local FS connector fixtures.
+
+This connector reads a folder on the machine the connector service runs on. The
+integration compose file bind-mounts one directory into that container, so the
+test writes files on the host side and the connector reads them on the container
+side — no external service, and nothing to procure.
+
+Unlike the other connectors, its settings live under a ``sync`` key rather than
+``auth``: the folder is a sync setting, not a credential.
+"""
+
+import os
+import uuid
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+import pytest_asyncio
+
+from connector_lifecycle import create_connector_and_await_sync, destructor
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+from helper.graph_provider import GraphProviderProtocol
+
+from connectors.localfs.localfs_source_helper import LocalFsSourceHelper
+
+# Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
+DEFAULT_HOST_DIR = "../deployment/docker-compose/localfs-test-data"
+DEFAULT_CONNECTOR_ROOT = "/data/localfs-test"
+
+SEED_FILES = [
+    ("handbook/onboarding.txt", "How to set up a new workspace.\n"),
+    ("handbook/billing.txt", "Answers to common billing questions.\n"),
+    ("policies/leave.txt", "Annual leave accrues monthly.\n"),
+]
+
+
+@pytest.fixture(scope="session")
+def localfs_source() -> LocalFsSourceHelper:
+    helper = LocalFsSourceHelper(os.getenv("LOCALFS_TEST_HOST_DIR", DEFAULT_HOST_DIR))
+    # Skip rather than fail when the directory is not usable, so a partial local
+    # stack stays usable. In CI the mount is always present.
+    try:
+        helper.ensure_root()
+    except OSError as exc:
+        pytest.skip(f"Local FS test directory not writable at {helper.root}: {exc}")
+    helper.clear_objects()
+    return helper
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def localfs_connector(
+    localfs_source: LocalFsSourceHelper,
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    written = localfs_source.write_files(SEED_FILES)
+
+    state: Dict[str, Any] = {
+        "resource_name": str(localfs_source.root),
+        "seeded_names": sorted(path.split("/")[-1] for path, _ in SEED_FILES),
+        "uploaded_count": written,
+    }
+
+    # The folder is a sync setting, not a credential, so it goes under "sync".
+    # The path is the one the *connector container* sees.
+    config = {
+        "sync": {
+            "sync_root_path": os.getenv(
+                "LOCALFS_CONNECTOR_ROOT", DEFAULT_CONNECTOR_ROOT
+            ),
+            "include_subfolders": True,
+        }
+    }
+
+    await create_connector_and_await_sync(
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="LocalFS",
+        connector_name=f"localfs-lifecycle-test-{uuid.uuid4().hex[:8]}",
+        connector_config=config,
+        expected_records=written,
+    )
+
+    yield state
+
+    await destructor(
+        localfs_source,
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="LocalFS",
+    )

--- a/integration-tests/connectors/localfs/conftest.py
+++ b/integration-tests/connectors/localfs/conftest.py
@@ -35,6 +35,18 @@ SEED_FILES = [
 ]
 
 
+
+def _unavailable(reason: str) -> None:
+    """A source that is not reachable: skip locally, fail in CI.
+
+    Skipping on any exception turns a broken stack into a green run. CI brings
+    this source up itself, so if it is not reachable there, that is a result and
+    not a reason to report success.
+    """
+    if os.getenv("CI"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 @pytest.fixture(scope="session")
 def localfs_source() -> LocalFsSourceHelper:
     helper = LocalFsSourceHelper(os.getenv("LOCALFS_TEST_HOST_DIR", DEFAULT_HOST_DIR))
@@ -43,7 +55,7 @@ def localfs_source() -> LocalFsSourceHelper:
     try:
         helper.ensure_root()
     except OSError as exc:
-        pytest.skip(f"Local FS test directory not writable at {helper.root}: {exc}")
+        _unavailable(f"Local FS test directory not writable at {helper.root}: {exc}")
     helper.clear_objects()
     return helper
 

--- a/integration-tests/connectors/localfs/conftest.py
+++ b/integration-tests/connectors/localfs/conftest.py
@@ -17,12 +17,14 @@ from typing import Any, AsyncGenerator, Dict
 
 import pytest
 import pytest_asyncio
-
-from connector_lifecycle import create_connector_and_await_sync, destructor
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
-from helper.graph_provider import GraphProviderProtocol
-
+from connector_lifecycle import (
+    create_connector_and_await_sync,
+    destructor,
+    source_unavailable,
+)
 from connectors.localfs.localfs_source_helper import LocalFsSourceHelper
+from helper.graph_provider import GraphProviderProtocol
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
 
 # Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
 DEFAULT_HOST_DIR = "../deployment/docker-compose/localfs-test-data"
@@ -36,17 +38,6 @@ SEED_FILES = [
 
 
 
-def _unavailable(reason: str) -> None:
-    """A source that is not reachable: skip locally, fail in CI.
-
-    Skipping on any exception turns a broken stack into a green run. CI brings
-    this source up itself, so if it is not reachable there, that is a result and
-    not a reason to report success.
-    """
-    if os.getenv("CI"):
-        pytest.fail(reason)
-    pytest.skip(reason)
-
 @pytest.fixture(scope="session")
 def localfs_source() -> LocalFsSourceHelper:
     helper = LocalFsSourceHelper(os.getenv("LOCALFS_TEST_HOST_DIR", DEFAULT_HOST_DIR))
@@ -55,7 +46,7 @@ def localfs_source() -> LocalFsSourceHelper:
     try:
         helper.ensure_root()
     except OSError as exc:
-        _unavailable(f"Local FS test directory not writable at {helper.root}: {exc}")
+        source_unavailable(f"Local FS test directory not writable at {helper.root}: {exc}")
     helper.clear_objects()
     return helper
 

--- a/integration-tests/connectors/localfs/localfs_integration_test.py
+++ b/integration-tests/connectors/localfs/localfs_integration_test.py
@@ -1,0 +1,159 @@
+# pyright: ignore-file
+
+"""
+Local FS Connector – Integration Tests
+======================================
+
+Tests receive a fully set-up connector via the ``localfs_connector`` fixture
+(defined in conftest.py), which writes the files, creates the connector and
+waits for a full sync, then tears both down.
+
+This is the cheapest connector to cover: the "provider" is a directory. The
+integration compose file bind-mounts one into the connector container, so the
+test writes files on the host side and the connector reads the same bytes on the
+container side.
+
+Test cases:
+  TC-SYNC-001   — Full sync picks up every file, including nested folders
+  TC-INCR-001   — A file added after the first sync appears on the next one
+  TC-UPDATE-001 — Editing a file updates its record rather than adding one
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from helper.storage_incremental import (  # noqa: E402
+    settle_record_baseline,
+    sync_until_names_visible,
+)
+from connectors.localfs.localfs_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    LocalFsSourceHelper,
+)
+
+logger = logging.getLogger("localfs-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.localfs
+@pytest.mark.asyncio(loop_scope="session")
+class TestLocalFsConnector:
+    """Lifecycle coverage for the Local FS connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_sync_001_full_sync_graph_validation(
+        self,
+        localfs_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-SYNC-001: Every seeded file is in the graph, nested ones included.
+
+        The seed puts files in two subfolders, so this also covers
+        include_subfolders — a connector that only read the top level would
+        find nothing and fail here.
+        """
+        connector_id = localfs_connector["connector_id"]
+        seeded = localfs_connector["seeded_names"]
+        full_count = localfs_connector["full_sync_count"]
+
+        await graph_provider.assert_min_records(connector_id, len(seeded))
+        await graph_provider.assert_no_orphan_records(connector_id)
+        await graph_provider.assert_record_paths_or_names_contain(connector_id, seeded)
+
+        logger.info(
+            "TC-SYNC-001 passed: %d records for files %s (connector %s)",
+            full_count,
+            seeded,
+            connector_id,
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_incr_001_new_file_is_picked_up(
+        self,
+        localfs_connector: Dict[str, Any],
+        localfs_source: LocalFsSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-INCR-001: A file added after the first sync appears on the next one."""
+        connector_id = localfs_connector["connector_id"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        new_name = "runbook.txt"
+        localfs_source.write_files(
+            [(f"handbook/{new_name}", "Drain traffic, then restart the service.\n")]
+        )
+        logger.info("Wrote new file %s", new_name)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [new_name]
+        )
+
+        assert after_count > before_count, (
+            f"TC-INCR-001: expected a new record for {new_name}; count stayed "
+            f"at {after_count}"
+        )
+        await graph_provider.assert_record_paths_or_names_contain(
+            connector_id, [new_name]
+        )
+        logger.info(
+            "TC-INCR-001 passed: before=%d, after=%d, new=%s",
+            before_count,
+            after_count,
+            new_name,
+        )
+
+    @pytest.mark.order(3)
+    async def test_tc_update_001_editing_a_file_does_not_duplicate_it(
+        self,
+        localfs_connector: Dict[str, Any],
+        localfs_source: LocalFsSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-UPDATE-001: An edited file updates its record rather than adding one.
+
+        A file whose contents change keeps its path, so re-indexing must update
+        the existing record. A second record for the same path is a duplicate,
+        which reaches users as the same document appearing twice in search.
+        """
+        connector_id = localfs_connector["connector_id"]
+        rel_path = "handbook/onboarding.txt"
+        file_name = Path(rel_path).name
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        localfs_source.overwrite_file(
+            rel_path, "Updated: how to set up a new workspace in 2026.\n"
+        )
+        logger.info("Overwrote %s", rel_path)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [file_name]
+        )
+
+        assert after_count == before_count, (
+            f"TC-UPDATE-001: record count moved from {before_count} to "
+            f"{after_count} after editing one file. An edit must update the "
+            "existing record, not create a second one."
+        )
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info(
+            "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
+            file_name,
+            after_count,
+        )

--- a/integration-tests/connectors/localfs/localfs_integration_test.py
+++ b/integration-tests/connectors/localfs/localfs_integration_test.py
@@ -116,12 +116,6 @@ class TestLocalFsConnector:
         )
 
     @pytest.mark.order(3)
-    @pytest.mark.xfail(
-        reason="#3198: local_fs writes version=0 on every record, so an edit "
-               "cannot be distinguished from no edit. Strict, so this lights up "
-               "the moment the connector starts advancing version.",
-        strict=True,
-    )
     async def test_tc_update_001_editing_a_file_does_not_duplicate_it(
         self,
         localfs_connector: Dict[str, Any],
@@ -134,6 +128,10 @@ class TestLocalFsConnector:
         A file whose contents change keeps its path, so re-indexing must update
         the existing record. A second record for the same path is a duplicate,
         which reaches users as the same document appearing twice in search.
+
+        Deliberately not xfailed. Whether the edit is re-indexed at all is
+        TC-UPDATE-002, which is expected to fail while #3198 is open — marking
+        this one would take duplicate detection down with it.
         """
         connector_id = localfs_connector["connector_id"]
         rel_path = "handbook/onboarding.txt"
@@ -146,7 +144,9 @@ class TestLocalFsConnector:
         assert before_record is not None, (
             f"TC-UPDATE-001: {file_name} is not in the graph before the edit"
         )
-        before_version = before_record.get("version")
+        # Handed to TC-UPDATE-002, which runs next against this same edit.
+        localfs_connector["update_file_name"] = file_name
+        localfs_connector["update_before_version"] = before_record.get("version")
 
         localfs_source.overwrite_file(
             rel_path, "Updated: how to set up a new workspace in 2026.\n"
@@ -162,24 +162,42 @@ class TestLocalFsConnector:
             f"{after_count} after editing one file. An edit must update the "
             "existing record, not create a second one."
         )
-
-        # The count alone cannot tell an update from an ignored edit, so this
-        # asserts the record was actually re-indexed. It fails today: local_fs
-        # sets version=0 unconditionally (connector.py:573,647), which is #3198.
-        # Marked xfail(strict) rather than dropped, so a fix turns this green
-        # and the marker has to be removed deliberately.
-        after_record = await graph_provider.get_record_by_name(connector_id, file_name)
-        assert after_record is not None, (
-            f"TC-UPDATE-001: {file_name} disappeared from the graph after the edit"
-        )
-        assert after_record.get("version") != before_version, (
-            f"TC-UPDATE-001: version stayed at {before_version} after the file "
-            "changed, so the record was never re-indexed (#3198)"
-        )
-
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
             file_name,
             after_count,
+        )
+
+    @pytest.mark.order(4)
+    @pytest.mark.xfail(
+        reason="#3198: local_fs writes version=0 on every record, so an edited "
+               "file is indistinguishable from an untouched one. Strict, so the "
+               "day the connector advances version this XPASSes and the marker "
+               "has to be removed.",
+        strict=True,
+    )
+    async def test_tc_update_002_editing_a_file_advances_the_record_version(
+        self,
+        localfs_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-UPDATE-002: The edit from TC-UPDATE-001 was actually re-indexed.
+
+        Split out so that the count assertion in TC-UPDATE-001 keeps running.
+        An xfail applies to the whole test, so folding this into that one would
+        have made any failure there "expected" — including a duplicated record,
+        which is the failure that test exists to catch.
+        """
+        connector_id = localfs_connector["connector_id"]
+        file_name = localfs_connector["update_file_name"]
+        before_version = localfs_connector["update_before_version"]
+
+        after_record = await graph_provider.get_record_by_name(connector_id, file_name)
+        assert after_record is not None, (
+            f"TC-UPDATE-002: {file_name} disappeared from the graph after the edit"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-UPDATE-002: version stayed at {before_version} after the file "
+            "changed, so the record was never re-indexed (#3198)"
         )

--- a/integration-tests/connectors/localfs/localfs_integration_test.py
+++ b/integration-tests/connectors/localfs/localfs_integration_test.py
@@ -30,14 +30,16 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from connectors.localfs.localfs_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    LocalFsSourceHelper,
+)
 from helper.graph_provider import GraphProviderProtocol  # noqa: E402
 from helper.storage_incremental import (  # noqa: E402
     settle_record_baseline,
     sync_until_names_visible,
 )
-from connectors.localfs.localfs_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
-    LocalFsSourceHelper,
+from pipeshub_client import (
+    PipeshubClient,  # type: ignore[import-not-found]  # noqa: E402
 )
 
 logger = logging.getLogger("localfs-lifecycle-test")

--- a/integration-tests/connectors/localfs/localfs_integration_test.py
+++ b/integration-tests/connectors/localfs/localfs_integration_test.py
@@ -199,7 +199,14 @@ class TestLocalFsConnector:
         assert after_record is not None, (
             f"TC-UPDATE-002: {file_name} disappeared from the graph after the edit"
         )
-        assert after_record.get("version") != before_version, (
-            f"TC-UPDATE-002: version stayed at {before_version} after the file "
-            "changed, so the record was never re-indexed (#3198)"
+        after_version = after_record.get("version")
+        assert isinstance(before_version, int) and isinstance(after_version, int), (
+            f"TC-UPDATE-001: version should be an int on both reads, got "
+            f"{before_version!r} then {after_version!r}"
+        )
+        assert after_version > before_version, (
+            f"TC-UPDATE-001: version went from {before_version} to {after_version} "
+            "after the content changed. It must increase — an unchanged value "
+            "means the record was never re-indexed, and a lower one means it was "
+            "reset, which loses the change history just as badly."
         )

--- a/integration-tests/connectors/localfs/localfs_integration_test.py
+++ b/integration-tests/connectors/localfs/localfs_integration_test.py
@@ -116,6 +116,12 @@ class TestLocalFsConnector:
         )
 
     @pytest.mark.order(3)
+    @pytest.mark.xfail(
+        reason="#3198: local_fs writes version=0 on every record, so an edit "
+               "cannot be distinguished from no edit. Strict, so this lights up "
+               "the moment the connector starts advancing version.",
+        strict=True,
+    )
     async def test_tc_update_001_editing_a_file_does_not_duplicate_it(
         self,
         localfs_connector: Dict[str, Any],
@@ -136,6 +142,11 @@ class TestLocalFsConnector:
         before_count = await settle_record_baseline(
             pipeshub_client, graph_provider, connector_id
         )
+        before_record = await graph_provider.get_record_by_name(connector_id, file_name)
+        assert before_record is not None, (
+            f"TC-UPDATE-001: {file_name} is not in the graph before the edit"
+        )
+        before_version = before_record.get("version")
 
         localfs_source.overwrite_file(
             rel_path, "Updated: how to set up a new workspace in 2026.\n"
@@ -151,6 +162,21 @@ class TestLocalFsConnector:
             f"{after_count} after editing one file. An edit must update the "
             "existing record, not create a second one."
         )
+
+        # The count alone cannot tell an update from an ignored edit, so this
+        # asserts the record was actually re-indexed. It fails today: local_fs
+        # sets version=0 unconditionally (connector.py:573,647), which is #3198.
+        # Marked xfail(strict) rather than dropped, so a fix turns this green
+        # and the marker has to be removed deliberately.
+        after_record = await graph_provider.get_record_by_name(connector_id, file_name)
+        assert after_record is not None, (
+            f"TC-UPDATE-001: {file_name} disappeared from the graph after the edit"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-UPDATE-001: version stayed at {before_version} after the file "
+            "changed, so the record was never re-indexed (#3198)"
+        )
+
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-UPDATE-001 passed: %s updated in place, count stable at %d",

--- a/integration-tests/connectors/localfs/localfs_source_helper.py
+++ b/integration-tests/connectors/localfs/localfs_source_helper.py
@@ -1,0 +1,71 @@
+# pyright: ignore-file
+
+"""Writes files for the Local FS connector to sync.
+
+The other connector suites talk to a server; this one writes to a directory. The
+directory is bind-mounted into the connector container by the integration
+compose file, so the test writes on the host side and the connector reads the
+same bytes on the container side.
+
+Method names follow the protocol the shared lifecycle helpers expect
+(``list_objects``, ``clear_objects``), so the same destructor works here.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Sequence
+
+
+class LocalFsSourceHelper:
+    """Creates and removes the files a connector test syncs from."""
+
+    def __init__(self, host_dir: str) -> None:
+        self.root = Path(host_dir)
+
+    def ensure_root(self) -> None:
+        """Create the directory and prove it is writable.
+
+        A bind-mount target created by Docker is owned by root, which the test
+        process cannot write to. Failing here with a clear reason beats failing
+        later inside a sync with an empty result.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        probe = self.root / ".write-probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+
+    def list_objects(self, resource_name: str | None = None) -> List[str]:
+        """Relative paths of every file under the root."""
+        del resource_name  # the root is fixed at construction
+        return sorted(
+            str(p.relative_to(self.root))
+            for p in self.root.rglob("*")
+            if p.is_file() and not p.name.startswith(".")
+        )
+
+    def write_files(self, files: Sequence[tuple[str, str]]) -> int:
+        """Write ``(relative_path, text)`` pairs, creating parent folders."""
+        for rel_path, text in files:
+            target = self.root / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(text, encoding="utf-8")
+        return len(files)
+
+    def overwrite_file(self, rel_path: str, text: str) -> None:
+        (self.root / rel_path).write_text(text, encoding="utf-8")
+
+    def clear_objects(self, resource_name: str | None = None) -> None:
+        """Remove every file the tests wrote, leaving the directory in place.
+
+        The directory itself is the bind-mount target and must survive, so this
+        deletes contents rather than the root.
+        """
+        del resource_name
+        for path in sorted(self.root.rglob("*"), reverse=True):
+            if path.name == ".gitkeep":
+                continue
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -27,6 +27,7 @@ markers =
     s3: marks tests specific to S3 connector
     postgres: marks tests specific to PostgreSQL connector
     mariadb: marks tests specific to MariaDB connector
+    localfs: marks tests specific to Local FS connector
     gcs: marks tests specific to GCS connector
     azure_blob: marks tests specific to Azure Blob connector
     azure_files: marks tests specific to Azure Files connector


### PR DESCRIPTION
## In one line

PipesHub can pull documents from a folder on the machine PipesHub runs on. Nothing tested that until now. This adds tests that run automatically — and need no account, because it is just a directory — no server at all.

## Background

PipesHub connects to around 50 outside services and copies documents from them so people can search across everything in one place. Each connection is called a *connector*.

Being confident a connector still works means running it against the real service. That usually means owning an account there, kept alive with test data — which is why only 16 of the 50 are tested today.

a folder on the machine PipesHub runs on is one of the few exceptions: it is just a directory — no server at all. So instead of buying an account, the tests start one alongside them.

## What this changes

**Before:** if someone broke the a folder on the machine PipesHub runs on connector, nothing would notice until a customer's documents stopped appearing.

**After:** these checks run automatically on every change.

| What it checks | Why it matters |
|---|---|
| Files in the folder, including in sub-folders, become searchable documents | The basic promise of the connector |
| A file added later is picked up | Connectors re-check on a schedule; this proves that works |
| Editing a file updates the existing document rather than duplicating it | Otherwise the same document appears twice in search |

## How to try it

No account or password needed.

```bash
cd deployment/docker-compose
docker compose -f docker-compose.integration.neo4j.yml up -d

cd ../../integration-tests
pytest -m localfs -v
```

If the service is not running the tests say so and skip, rather than pretending to pass. In CI, where it is always started, they fail instead — a broken setup should be visible, not hidden.

## One check is expected to fail, on purpose

The last check is marked as a *known failure*. This connector writes the same version number on every document, so there is currently no way to tell an edited file from an untouched one. That is recorded as **#3198**.

It is marked strictly, which means the day the connector starts recording versions properly, this test will report an unexpected pass and someone has to remove the marker deliberately. A silent fix cannot slip past.

The other checks in the same test — including that an edit does not create a duplicate — still run and still have to pass.

## Anything to worry about

No. Nothing here changes how PipesHub behaves for users. It adds tests and the test-only services they need; deleting every file in this change would leave the product exactly as it is today.
