### PR TITLE
test(rss): give the RSS connector live integration coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,6 +21,7 @@ on:
             - postgres
             - mariadb
             - localfs
+            - rss
             - confluence
             - jira
             - linear
@@ -165,6 +166,11 @@ jobs:
       # the bind mount and the test would use different directories.
       LOCALFS_TEST_HOST_DIR: ${{ github.workspace }}/deployment/docker-compose/localfs-test-data
       LOCALFS_CONNECTOR_ROOT: /data/localfs-test
+      # The RSS feed is served by an nginx container in the stack. The test
+      # writes the feed on the host side of the bind mount; the connector
+      # fetches it by service name.
+      RSS_TEST_HOST_DIR: ../deployment/docker-compose/rss-test-data
+      RSS_CONNECTOR_FEED_URL: http://rss-source/feed.xml
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -169,7 +169,11 @@ jobs:
       # The RSS feed is served by an nginx container in the stack. The test
       # writes the feed on the host side of the bind mount; the connector
       # fetches it by service name.
-      RSS_TEST_HOST_DIR: ../deployment/docker-compose/rss-test-data
+      # Absolute, because this value is read from two different working
+      # directories: compose runs in deployment/docker-compose and pytest in
+      # integration-tests. A relative path resolves differently in each, so
+      # the bind mount and the test would use different directories.
+      RSS_TEST_HOST_DIR: ${{ github.workspace }}/deployment/docker-compose/rss-test-data
       RSS_CONNECTOR_FEED_URL: http://rss-source/feed.xml
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}

--- a/backend/python/app/agents/agent_loop/prompt_builder.py
+++ b/backend/python/app/agents/agent_loop/prompt_builder.py
@@ -197,7 +197,18 @@ used. Web search results use a different marker instead: `url/Citation ID: https
   carrying the real link.
 - Cite the block each fact actually came from; use a distinct ID for each distinct claim.
 - One ID per link, inline right after the key claim it supports. The system numbers them.
+<<<<<<< Updated upstream
   Omit the citation when no Citation ID is available for a fact.
+=======
+  Omit the citation for a fact that has no Citation ID — that fact only. Keep citing every
+  other fact that does have one. Counts and totals are derived from the result set and have
+  no Citation ID of their own: state the count uncited, then cite each item you list under
+  it. An answer must never end up with zero citations because one claim could not be cited.
+  (If nothing in the context supports the question at all, say so and cite nothing — that
+  answer is correctly uncited.)
+- Every list item, table row, or bullet describing a record carries that record's citation,
+  e.g. `| RecordName | One-line summary. [source](refN) |`.
+>>>>>>> Stashed changes
 - Keep prose readable: cite the specific claim it backs, not every clause or sentence in a
   row — a paragraph built from one source needs one citation at its end, not one per sentence.
   Never stack multiple `[source](...)` links back to back; if several blocks support the same

--- a/backend/python/app/agents/agent_loop/prompt_builder.py
+++ b/backend/python/app/agents/agent_loop/prompt_builder.py
@@ -197,18 +197,7 @@ used. Web search results use a different marker instead: `url/Citation ID: https
   carrying the real link.
 - Cite the block each fact actually came from; use a distinct ID for each distinct claim.
 - One ID per link, inline right after the key claim it supports. The system numbers them.
-<<<<<<< Updated upstream
   Omit the citation when no Citation ID is available for a fact.
-=======
-  Omit the citation for a fact that has no Citation ID — that fact only. Keep citing every
-  other fact that does have one. Counts and totals are derived from the result set and have
-  no Citation ID of their own: state the count uncited, then cite each item you list under
-  it. An answer must never end up with zero citations because one claim could not be cited.
-  (If nothing in the context supports the question at all, say so and cite nothing — that
-  answer is correctly uncited.)
-- Every list item, table row, or bullet describing a record carries that record's citation,
-  e.g. `| RecordName | One-line summary. [source](refN) |`.
->>>>>>> Stashed changes
 - Keep prose readable: cite the specific claim it backs, not every clause or sentence in a
   row — a paragraph built from one source needs one citation at its end, not one per sentence.
   Never stack multiple `[source](...)` links back to back; if several blocks support the same

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -249,7 +249,7 @@ services:
     volumes:
       - ${RSS_TEST_HOST_DIR:-./rss-test-data}:/usr/share/nginx/html:ro
     ports:
-      - "8099:80"
+      - "127.0.0.1:8099:80"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/feed.xml"]
       interval: 5s

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -240,6 +240,22 @@ services:
       timeout: 3s
       retries: 20
 
+  # Serves the RSS feed the RSS connector syncs from, so that connector can be
+  # tested without depending on a feed on the public internet — which would make
+  # the suite fail whenever that site changed or went down.
+  rss-source:
+    image: nginx:1.27-alpine
+    restart: always
+    volumes:
+      - ${RSS_TEST_HOST_DIR:-./rss-test-data}:/usr/share/nginx/html:ro
+    ports:
+      - "8099:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/feed.xml"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -251,7 +251,9 @@ services:
     ports:
       - "127.0.0.1:8099:80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/feed.xml"]
+      # Probes the server, not feed.xml: the tests write the feed, so a
+      # healthcheck waiting on it would never pass before they run.
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -249,7 +249,7 @@ services:
     volumes:
       - ${RSS_TEST_HOST_DIR:-./rss-test-data}:/usr/share/nginx/html:ro
     ports:
-      - "8099:80"
+      - "127.0.0.1:8099:80"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/feed.xml"]
       interval: 5s

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -240,6 +240,22 @@ services:
       timeout: 3s
       retries: 20
 
+  # Serves the RSS feed the RSS connector syncs from, so that connector can be
+  # tested without depending on a feed on the public internet — which would make
+  # the suite fail whenever that site changed or went down.
+  rss-source:
+    image: nginx:1.27-alpine
+    restart: always
+    volumes:
+      - ${RSS_TEST_HOST_DIR:-./rss-test-data}:/usr/share/nginx/html:ro
+    ports:
+      - "8099:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/feed.xml"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -251,7 +251,9 @@ services:
     ports:
       - "127.0.0.1:8099:80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/feed.xml"]
+      # Probes the server, not feed.xml: the tests write the feed, so a
+      # healthcheck waiting on it would never pass before they run.
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/deployment/docker-compose/rss-test-data/.gitkeep
+++ b/deployment/docker-compose/rss-test-data/.gitkeep
@@ -1,0 +1,5 @@
+Document root for the nginx container that serves the RSS connector tests.
+
+The directory must exist before compose starts, otherwise Docker creates it as
+root and the test process cannot write the feed into it. The tests write
+feed.xml here; nothing else belongs in it.

--- a/deployment/docker-compose/rss-test-data/index.html
+++ b/deployment/docker-compose/rss-test-data/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<title>RSS fixture server</title>
+<p>Document root for the RSS connector integration tests. The suite writes
+feed.xml here at runtime; this page exists so the container healthcheck has
+something to serve — an nginx root containing only .gitkeep answers 403, not
+200, and a healthcheck waiting on the feed itself could never pass before the
+tests that write it.</p>

--- a/integration-tests/connectors/rss/conftest.py
+++ b/integration-tests/connectors/rss/conftest.py
@@ -27,6 +27,18 @@ DEFAULT_HOST_DIR = "../deployment/docker-compose/rss-test-data"
 DEFAULT_FEED_URL = "http://rss-source/feed.xml"
 
 
+
+def _unavailable(reason: str) -> None:
+    """A source that is not reachable: skip locally, fail in CI.
+
+    Skipping on any exception turns a broken stack into a green run. CI brings
+    this source up itself, so if it is not reachable there, that is a result and
+    not a reason to report success.
+    """
+    if os.getenv("CI"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 @pytest.fixture(scope="session")
 def rss_source() -> RssSourceHelper:
     helper = RssSourceHelper(os.getenv("RSS_TEST_HOST_DIR", DEFAULT_HOST_DIR))
@@ -35,7 +47,7 @@ def rss_source() -> RssSourceHelper:
     try:
         helper.ensure_root()
     except OSError as exc:
-        pytest.skip(f"RSS feed directory not writable at {helper.root}: {exc}")
+        _unavailable(f"RSS feed directory not writable at {helper.root}: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/rss/conftest.py
+++ b/integration-tests/connectors/rss/conftest.py
@@ -1,0 +1,80 @@
+# pyright: ignore-file
+
+"""RSS connector fixtures.
+
+The feed is served by an nginx container in the integration stack, so this
+connector is covered without depending on a feed on the public internet.
+
+Like Local FS, its settings live under a ``sync`` key rather than ``auth``: a
+feed URL is a sync setting, not a credential.
+"""
+
+import os
+import uuid
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+import pytest_asyncio
+
+from connector_lifecycle import create_connector_and_await_sync, destructor
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+from helper.graph_provider import GraphProviderProtocol
+
+from connectors.rss.rss_source_helper import BASE_ARTICLES, RssSourceHelper
+
+# Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
+DEFAULT_HOST_DIR = "../deployment/docker-compose/rss-test-data"
+DEFAULT_FEED_URL = "http://rss-source/feed.xml"
+
+
+@pytest.fixture(scope="session")
+def rss_source() -> RssSourceHelper:
+    helper = RssSourceHelper(os.getenv("RSS_TEST_HOST_DIR", DEFAULT_HOST_DIR))
+    # Skip rather than fail when the directory is not usable, so a partial local
+    # stack stays usable. In CI the mount is always present.
+    try:
+        helper.ensure_root()
+    except OSError as exc:
+        pytest.skip(f"RSS feed directory not writable at {helper.root}: {exc}")
+    return helper
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def rss_connector(
+    rss_source: RssSourceHelper,
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    written = rss_source.write_feed(BASE_ARTICLES)
+
+    state: Dict[str, Any] = {
+        "resource_name": str(rss_source.feed_path),
+        "seeded_titles": [title for title, _ in BASE_ARTICLES],
+        "uploaded_count": written,
+    }
+
+    # A feed URL is a sync setting, not a credential, so it goes under "sync".
+    # The URL is the one the *connector container* resolves.
+    config = {
+        "sync": {
+            "feed_urls": os.getenv("RSS_CONNECTOR_FEED_URL", DEFAULT_FEED_URL),
+            "max_articles_per_feed": 50,
+            "fetch_full_content": False,
+        }
+    }
+
+    await create_connector_and_await_sync(
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="RSS",
+        connector_name=f"rss-lifecycle-test-{uuid.uuid4().hex[:8]}",
+        connector_config=config,
+        expected_records=written,
+    )
+
+    yield state
+
+    await destructor(
+        rss_source, pipeshub_client, graph_provider, state, connector_type="RSS"
+    )

--- a/integration-tests/connectors/rss/conftest.py
+++ b/integration-tests/connectors/rss/conftest.py
@@ -15,29 +15,20 @@ from typing import Any, AsyncGenerator, Dict
 
 import pytest
 import pytest_asyncio
-
-from connector_lifecycle import create_connector_and_await_sync, destructor
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
-from helper.graph_provider import GraphProviderProtocol
-
+from connector_lifecycle import (
+    create_connector_and_await_sync,
+    destructor,
+    source_unavailable,
+)
 from connectors.rss.rss_source_helper import BASE_ARTICLES, RssSourceHelper
+from helper.graph_provider import GraphProviderProtocol
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
 
 # Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
 DEFAULT_HOST_DIR = "../deployment/docker-compose/rss-test-data"
 DEFAULT_FEED_URL = "http://rss-source/feed.xml"
 
 
-
-def _unavailable(reason: str) -> None:
-    """A source that is not reachable: skip locally, fail in CI.
-
-    Skipping on any exception turns a broken stack into a green run. CI brings
-    this source up itself, so if it is not reachable there, that is a result and
-    not a reason to report success.
-    """
-    if os.getenv("CI"):
-        pytest.fail(reason)
-    pytest.skip(reason)
 
 @pytest.fixture(scope="session")
 def rss_source() -> RssSourceHelper:
@@ -47,7 +38,7 @@ def rss_source() -> RssSourceHelper:
     try:
         helper.ensure_root()
     except OSError as exc:
-        _unavailable(f"RSS feed directory not writable at {helper.root}: {exc}")
+        source_unavailable(f"RSS feed directory not writable at {helper.root}: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/rss/rss_integration_test.py
+++ b/integration-tests/connectors/rss/rss_integration_test.py
@@ -1,0 +1,163 @@
+# pyright: ignore-file
+
+"""
+RSS Connector – Integration Tests
+=================================
+
+Tests receive a fully set-up connector via the ``rss_connector`` fixture
+(defined in conftest.py), which writes the feed, creates the connector and waits
+for a full sync, then tears both down.
+
+The feed is served by an nginx container in the integration stack. Pointing
+these tests at a real feed would make them fail whenever that site changed or
+went down, which is noise rather than signal about the connector.
+
+Test cases:
+  TC-SYNC-001  — Full sync turns every article into a record
+  TC-INCR-001  — An article published after the first sync appears on the next one
+  TC-DEDUP-001 — Re-syncing an unchanged feed does not duplicate its articles
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from helper.storage_incremental import (  # noqa: E402
+    settle_record_baseline,
+    sync_until_names_visible,
+)
+from connectors.rss.rss_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    BASE_ARTICLES,
+    RssSourceHelper,
+)
+
+logger = logging.getLogger("rss-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.rss
+@pytest.mark.asyncio(loop_scope="session")
+class TestRssConnector:
+    """Lifecycle coverage for the RSS connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_sync_001_full_sync_graph_validation(
+        self,
+        rss_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-SYNC-001: Every article in the feed becomes a record."""
+        connector_id = rss_connector["connector_id"]
+        seeded = rss_connector["seeded_titles"]
+        full_count = rss_connector["full_sync_count"]
+
+        await graph_provider.assert_min_records(connector_id, len(seeded))
+        await graph_provider.assert_no_orphan_records(connector_id)
+        await graph_provider.assert_record_paths_or_names_contain(connector_id, seeded)
+
+        logger.info(
+            "TC-SYNC-001 passed: %d records for articles %s (connector %s)",
+            full_count,
+            seeded,
+            connector_id,
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_incr_001_new_article_is_picked_up(
+        self,
+        rss_connector: Dict[str, Any],
+        rss_source: RssSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-INCR-001: An article added to the feed appears on the next sync."""
+        connector_id = rss_connector["connector_id"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        new_title = "Incident review 2026-09"
+        rss_source.write_feed(
+            [(new_title, "What happened, and what changed afterwards."), *BASE_ARTICLES]
+        )
+        logger.info("Published new article %r to the feed", new_title)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [new_title]
+        )
+
+        assert after_count > before_count, (
+            f"TC-INCR-001: expected a new record for {new_title!r}; count stayed "
+            f"at {after_count}"
+        )
+        await graph_provider.assert_record_paths_or_names_contain(
+            connector_id, [new_title]
+        )
+        rss_connector["after_incr_count"] = after_count
+        logger.info(
+            "TC-INCR-001 passed: before=%d, after=%d, new=%r",
+            before_count,
+            after_count,
+            new_title,
+        )
+
+    @pytest.mark.order(3)
+    async def test_tc_dedup_001_resyncing_an_unchanged_feed_adds_nothing(
+        self,
+        rss_connector: Dict[str, Any],
+        rss_source: RssSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-DEDUP-001: Re-syncing an unchanged feed must not duplicate articles.
+
+        A feed is re-fetched in full on every sync, so an article the connector
+        has already seen arrives again each time. If it is not recognised by its
+        guid, every sync adds another copy — the record count grows on a
+        schedule with no user action, and the same article fills up search
+        results. This is the failure mode most specific to feed connectors.
+        """
+        connector_id = rss_connector["connector_id"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+        titles_before = rss_source.article_titles()
+
+        # Republish byte-for-byte the same articles. The helper derives each
+        # guid from the title, so the feed is genuinely unchanged.
+        rss_source.write_feed(
+            [
+                ("Incident review 2026-09", "What happened, and what changed afterwards."),
+                *BASE_ARTICLES,
+            ]
+        )
+        assert rss_source.article_titles() == titles_before, (
+            "TC-DEDUP-001 requires the feed to be unchanged; the fixture rewrote "
+            "different articles"
+        )
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, titles_before[:1]
+        )
+
+        assert after_count == before_count, (
+            f"TC-DEDUP-001: record count grew from {before_count} to {after_count} "
+            "after re-syncing an unchanged feed. Articles must be recognised by "
+            "guid, not re-added on every fetch."
+        )
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info(
+            "TC-DEDUP-001 passed: unchanged feed re-synced, count stable at %d",
+            after_count,
+        )

--- a/integration-tests/connectors/rss/rss_integration_test.py
+++ b/integration-tests/connectors/rss/rss_integration_test.py
@@ -29,15 +29,17 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from connectors.rss.rss_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    BASE_ARTICLES,
+    RssSourceHelper,
+)
 from helper.graph_provider import GraphProviderProtocol  # noqa: E402
 from helper.storage_incremental import (  # noqa: E402
     settle_record_baseline,
     sync_until_names_visible,
 )
-from connectors.rss.rss_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
-    BASE_ARTICLES,
-    RssSourceHelper,
+from pipeshub_client import (
+    PipeshubClient,  # type: ignore[import-not-found]  # noqa: E402
 )
 
 logger = logging.getLogger("rss-lifecycle-test")

--- a/integration-tests/connectors/rss/rss_source_helper.py
+++ b/integration-tests/connectors/rss/rss_source_helper.py
@@ -1,0 +1,119 @@
+# pyright: ignore-file
+
+"""Writes the RSS feed the RSS connector syncs from.
+
+The feed is served by an nginx container in the integration stack rather than
+fetched from a real site. A public feed would make this suite fail whenever that
+site changed its content or went down, which is noise rather than signal about
+the connector.
+
+The feed is written on the host side of a bind mount; nginx serves the same
+bytes to the connector.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import List, Sequence, Tuple
+
+# (title, description) — the guid is derived from the title, so re-writing a
+# feed with the same titles produces the same guids, which is what the
+# deduplication case depends on.
+Article = Tuple[str, str]
+
+BASE_ARTICLES: List[Article] = [
+    ("Release notes 2026.09", "What changed in the September release."),
+    ("Scaling the indexer", "How the indexing pipeline handles large corpora."),
+    ("Connector roadmap", "Which sources are planned next."),
+]
+
+
+class RssSourceHelper:
+    """Creates and updates the feed a connector test syncs from."""
+
+    def __init__(self, host_dir: str, feed_name: str = "feed.xml") -> None:
+        self.root = Path(host_dir)
+        self.feed_name = feed_name
+
+    @property
+    def feed_path(self) -> Path:
+        return self.root / self.feed_name
+
+    def ensure_root(self) -> None:
+        """Create the document root and prove it is writable.
+
+        A bind-mount target created by Docker is owned by root. Failing here
+        with a clear reason beats failing later inside a sync that fetched a
+        404.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        # nginx serves as its own unprivileged user, so the document root has to
+        # be traversable by it. A restrictive umask on the runner otherwise
+        # produces a 403 that looks like a missing feed.
+        os.chmod(self.root, 0o755)
+        probe = self.root / ".write-probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+
+    @staticmethod
+    def _item(title: str, description: str, published: datetime) -> str:
+        # The guid is stable for a given title so that re-publishing an
+        # unchanged feed does not look like new articles.
+        guid = title.lower().replace(" ", "-").replace(".", "")
+        return (
+            "    <item>\n"
+            f"      <title>{title}</title>\n"
+            f"      <description>{description}</description>\n"
+            f"      <link>https://example.invalid/{guid}</link>\n"
+            f'      <guid isPermaLink="false">{guid}</guid>\n'
+            f"      <pubDate>{published.strftime('%a, %d %b %Y %H:%M:%S +0000')}</pubDate>\n"
+            "    </item>\n"
+        )
+
+    def write_feed(self, articles: Sequence[Article]) -> int:
+        """Write the whole feed, replacing whatever was there."""
+        now = datetime.now(timezone.utc)
+        items = "".join(
+            self._item(title, description, now - timedelta(hours=index))
+            for index, (title, description) in enumerate(articles)
+        )
+        xml = (
+            '<?xml version="1.0" encoding="UTF-8"?>\n'
+            '<rss version="2.0">\n'
+            "  <channel>\n"
+            "    <title>PipesHub connector test feed</title>\n"
+            "    <link>https://example.invalid/</link>\n"
+            "    <description>Fixture feed for the RSS connector integration tests.</description>\n"
+            f"{items}"
+            "  </channel>\n"
+            "</rss>\n"
+        )
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.feed_path.write_text(xml, encoding="utf-8")
+        os.chmod(self.feed_path, 0o644)  # readable by the nginx user
+        return len(articles)
+
+    def article_titles(self) -> List[str]:
+        """Titles currently in the feed, read back from the file."""
+        if not self.feed_path.exists():
+            return []
+        text = self.feed_path.read_text(encoding="utf-8")
+        titles: List[str] = []
+        for chunk in text.split("<item>")[1:]:
+            start = chunk.find("<title>") + len("<title>")
+            end = chunk.find("</title>")
+            if start > len("<title>") - 1 and end > start:
+                titles.append(chunk[start:end])
+        return titles
+
+    def clear_objects(self, resource_name: str | None = None) -> None:
+        """Remove the feed, leaving the document root in place.
+
+        Named for the protocol the shared destructor expects. The directory is
+        the bind-mount target and has to survive teardown.
+        """
+        del resource_name
+        if self.feed_path.exists():
+            self.feed_path.unlink()

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -28,6 +28,7 @@ markers =
     postgres: marks tests specific to PostgreSQL connector
     mariadb: marks tests specific to MariaDB connector
     localfs: marks tests specific to Local FS connector
+    rss: marks tests specific to RSS connector
     gcs: marks tests specific to GCS connector
     azure_blob: marks tests specific to Azure Blob connector
     azure_files: marks tests specific to Azure Files connector


### PR DESCRIPTION
## In one line

PipesHub can pull documents from an RSS feed. Nothing tested that until now. This adds tests that run automatically — and need no account, because the tests publish their own feed from a small web server started alongside them.

## Background

PipesHub connects to around 50 outside services and copies documents from them so people can search across everything in one place. Each connection is called a *connector*.

Being confident a connector still works means running it against the real service. That usually means owning an account there, kept alive with test data — which is why only 16 of the 50 are tested today.

an RSS feed is one of the few exceptions: the tests publish their own feed from a small web server started alongside them. So instead of buying an account, the tests provide one alongside them.

## What this changes

**Before:** if someone broke the RSS connector, nothing would notice until a customer's documents stopped appearing.

**After:** these checks run automatically on every change.

| What it checks | Why it matters |
|---|---|
| Articles in the feed become searchable documents | The basic promise of the connector |
| An article published later is picked up | Feeds are re-read on a schedule; this proves that works |
| Re-reading an unchanged feed does not duplicate its articles | The one specific to feeds — see below |

## How to try it

No account or password needed.

```bash
cd deployment/docker-compose
docker compose -f docker-compose.integration.neo4j.yml up -d

cd ../../integration-tests
pytest -m rss -v
```

If the service is not running the tests say so and skip, rather than pretending to pass. In CI, where it is always started, they fail instead — a broken setup should be visible, not hidden.

## The duplicate check is why this suite exists

A feed is fetched in full every time it is read. Articles the connector has already seen arrive again on every single check.

If they are not recognised as ones it already has, each scheduled read adds another copy. The number of documents grows with nobody doing anything, and the same article fills up search results. Nothing else in the suite would catch that.

The test publishes the same articles again — genuinely identical, with the same identifiers — and confirms the document count did not move.

The feed is served locally rather than from a real site on the internet, so the tests cannot fail because someone else changed their content or their server went down.

## Anything to worry about

No. Nothing here changes how PipesHub behaves for users. It adds tests and the test-only services they need; deleting every file in this change would leave the product exactly as it is today.
