### PR TITLE
test(web): give the Web connector live integration coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -22,6 +22,7 @@ on:
             - mariadb
             - localfs
             - rss
+            - web
             - confluence
             - jira
             - linear
@@ -175,6 +176,11 @@ jobs:
       # the bind mount and the test would use different directories.
       RSS_TEST_HOST_DIR: ${{ github.workspace }}/deployment/docker-compose/rss-test-data
       RSS_CONNECTOR_FEED_URL: http://rss-source/feed.xml
+      # The Web connector crawls a static site served by nginx in the
+      # stack. The test publishes pages on the host side of the bind mount;
+      # the connector crawls it by service name.
+      WEB_TEST_HOST_DIR: ../deployment/docker-compose/web-test-data
+      WEB_CONNECTOR_START_URL: http://web-source/index.html
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -179,7 +179,11 @@ jobs:
       # The Web connector crawls a static site served by nginx in the
       # stack. The test publishes pages on the host side of the bind mount;
       # the connector crawls it by service name.
-      WEB_TEST_HOST_DIR: ../deployment/docker-compose/web-test-data
+      # Absolute, because this value is read from two different working
+      # directories: compose runs in deployment/docker-compose and pytest in
+      # integration-tests. A relative path resolves differently in each, so
+      # the bind mount and the test would use different directories.
+      WEB_TEST_HOST_DIR: ${{ github.workspace }}/deployment/docker-compose/web-test-data
       WEB_CONNECTOR_START_URL: http://web-source/index.html
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}

--- a/backend/python/app/agents/agent_loop/prompt_builder.py
+++ b/backend/python/app/agents/agent_loop/prompt_builder.py
@@ -197,7 +197,18 @@ used. Web search results use a different marker instead: `url/Citation ID: https
   carrying the real link.
 - Cite the block each fact actually came from; use a distinct ID for each distinct claim.
 - One ID per link, inline right after the key claim it supports. The system numbers them.
+<<<<<<< Updated upstream
   Omit the citation when no Citation ID is available for a fact.
+=======
+  Omit the citation for a fact that has no Citation ID — that fact only. Keep citing every
+  other fact that does have one. Counts and totals are derived from the result set and have
+  no Citation ID of their own: state the count uncited, then cite each item you list under
+  it. An answer must never end up with zero citations because one claim could not be cited.
+  (If nothing in the context supports the question at all, say so and cite nothing — that
+  answer is correctly uncited.)
+- Every list item, table row, or bullet describing a record carries that record's citation,
+  e.g. `| RecordName | One-line summary. [source](refN) |`.
+>>>>>>> Stashed changes
 - Keep prose readable: cite the specific claim it backs, not every clause or sentence in a
   row — a paragraph built from one source needs one citation at its end, not one per sentence.
   Never stack multiple `[source](...)` links back to back; if several blocks support the same

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -269,7 +269,9 @@ services:
     ports:
       - "127.0.0.1:8097:80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/index.html"]
+      # Probes the server, not index.html: the tests publish the site, so a
+      # healthcheck waiting on a page would never pass before they run.
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -258,6 +258,22 @@ services:
       timeout: 3s
       retries: 20
 
+  # Serves the small static site the Web connector crawls. Crawling a real site
+  # would make the suite depend on that site's uptime and content, and would
+  # send traffic to someone else's server on every CI run.
+  web-source:
+    image: nginx:1.27-alpine
+    restart: always
+    volumes:
+      - ${WEB_TEST_HOST_DIR:-./web-test-data}:/usr/share/nginx/html:ro
+    ports:
+      - "8097:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/index.html"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -267,7 +267,7 @@ services:
     volumes:
       - ${WEB_TEST_HOST_DIR:-./web-test-data}:/usr/share/nginx/html:ro
     ports:
-      - "8097:80"
+      - "127.0.0.1:8097:80"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/index.html"]
       interval: 5s

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -269,7 +269,9 @@ services:
     ports:
       - "127.0.0.1:8097:80"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost/index.html"]
+      # Probes the server, not index.html: the tests publish the site, so a
+      # healthcheck waiting on a page would never pass before they run.
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -258,6 +258,22 @@ services:
       timeout: 3s
       retries: 20
 
+  # Serves the small static site the Web connector crawls. Crawling a real site
+  # would make the suite depend on that site's uptime and content, and would
+  # send traffic to someone else's server on every CI run.
+  web-source:
+    image: nginx:1.27-alpine
+    restart: always
+    volumes:
+      - ${WEB_TEST_HOST_DIR:-./web-test-data}:/usr/share/nginx/html:ro
+    ports:
+      - "8097:80"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/index.html"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -267,7 +267,7 @@ services:
     volumes:
       - ${WEB_TEST_HOST_DIR:-./web-test-data}:/usr/share/nginx/html:ro
     ports:
-      - "8097:80"
+      - "127.0.0.1:8097:80"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost/index.html"]
       interval: 5s

--- a/deployment/docker-compose/web-test-data/.gitkeep
+++ b/deployment/docker-compose/web-test-data/.gitkeep
@@ -1,0 +1,4 @@
+Document root for the nginx container the Web connector integration tests crawl.
+
+The directory must exist before compose starts, otherwise Docker creates it as
+root and the test process cannot write pages into it.

--- a/deployment/docker-compose/web-test-data/index.html
+++ b/deployment/docker-compose/web-test-data/index.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<title>Web fixture server</title>
+<p>Document root for the Web connector integration tests. The suite publishes
+the crawlable site here at runtime and overwrites this file; it is committed so
+the container healthcheck has something to serve, because an nginx root holding
+only .gitkeep answers 403 rather than 200.</p>

--- a/integration-tests/connectors/web/conftest.py
+++ b/integration-tests/connectors/web/conftest.py
@@ -1,0 +1,91 @@
+# pyright: ignore-file
+
+"""Web connector fixtures.
+
+The connector crawls a small static site served by an nginx container in the
+integration stack, so it is covered without depending on an external website.
+
+Like Local FS and RSS, its settings live under a ``sync`` key rather than
+``auth``: a start URL and crawl depth are sync settings, not credentials.
+"""
+
+import os
+import uuid
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+import pytest_asyncio
+
+from connector_lifecycle import create_connector_and_await_sync, destructor
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+from helper.graph_provider import GraphProviderProtocol
+
+from connectors.web.web_source_helper import (
+    DEPTH_0_TITLES,
+    DEPTH_1_TITLES,
+    WebSourceHelper,
+)
+
+# Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
+DEFAULT_HOST_DIR = "../deployment/docker-compose/web-test-data"
+DEFAULT_START_URL = "http://web-source/index.html"
+
+# The connector is configured with depth 1, so the landing page and the two
+# pages it links to are expected; guides/deep.html is a hop further and is not.
+EXPECTED_TITLES = DEPTH_0_TITLES + DEPTH_1_TITLES
+
+
+@pytest.fixture(scope="session")
+def web_source() -> WebSourceHelper:
+    helper = WebSourceHelper(os.getenv("WEB_TEST_HOST_DIR", DEFAULT_HOST_DIR))
+    # Skip rather than fail when the directory is not usable, so a partial local
+    # stack stays usable. In CI the mount is always present.
+    try:
+        helper.ensure_root()
+    except OSError as exc:
+        pytest.skip(f"Web site directory not writable at {helper.root}: {exc}")
+    return helper
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def web_connector(
+    web_source: WebSourceHelper,
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    web_source.write_site()
+
+    state: Dict[str, Any] = {
+        "resource_name": str(web_source.root),
+        "expected_titles": EXPECTED_TITLES,
+        "beyond_depth_titles": ["Deep page"],
+        "uploaded_count": len(EXPECTED_TITLES),
+    }
+
+    # Start URL and crawl settings live under "sync", not "auth".
+    config = {
+        "sync": {
+            "url": os.getenv("WEB_CONNECTOR_START_URL", DEFAULT_START_URL),
+            "type": "recursive",
+            "depth": 1,
+            "max_pages": 50,
+            "follow_external": False,
+            "use_headless_browser": False,
+        }
+    }
+
+    await create_connector_and_await_sync(
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="Web",
+        connector_name=f"web-lifecycle-test-{uuid.uuid4().hex[:8]}",
+        connector_config=config,
+        expected_records=len(EXPECTED_TITLES),
+    )
+
+    yield state
+
+    await destructor(
+        web_source, pipeshub_client, graph_provider, state, connector_type="Web"
+    )

--- a/integration-tests/connectors/web/conftest.py
+++ b/integration-tests/connectors/web/conftest.py
@@ -35,6 +35,18 @@ DEFAULT_START_URL = "http://web-source/index.html"
 EXPECTED_TITLES = DEPTH_0_TITLES + DEPTH_1_TITLES
 
 
+
+def _unavailable(reason: str) -> None:
+    """A source that is not reachable: skip locally, fail in CI.
+
+    Skipping on any exception turns a broken stack into a green run. CI brings
+    this source up itself, so if it is not reachable there, that is a result and
+    not a reason to report success.
+    """
+    if os.getenv("CI"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 @pytest.fixture(scope="session")
 def web_source() -> WebSourceHelper:
     helper = WebSourceHelper(os.getenv("WEB_TEST_HOST_DIR", DEFAULT_HOST_DIR))
@@ -43,7 +55,7 @@ def web_source() -> WebSourceHelper:
     try:
         helper.ensure_root()
     except OSError as exc:
-        pytest.skip(f"Web site directory not writable at {helper.root}: {exc}")
+        _unavailable(f"Web site directory not writable at {helper.root}: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/web/conftest.py
+++ b/integration-tests/connectors/web/conftest.py
@@ -16,7 +16,11 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from connector_lifecycle import create_connector_and_await_sync, destructor
+from connector_lifecycle import (
+    create_connector_and_await_sync,
+    destructor,
+    source_unavailable,
+)
 from connectors.web.web_source_helper import (
     DEPTH_0_TITLES,
     DEPTH_1_TITLES,
@@ -35,17 +39,6 @@ EXPECTED_TITLES = DEPTH_0_TITLES + DEPTH_1_TITLES
 
 
 
-def _unavailable(reason: str) -> None:
-    """A source that is not reachable: skip locally, fail in CI.
-
-    Skipping on any exception turns a broken stack into a green run. CI brings
-    this source up itself, so if it is not reachable there, that is a result and
-    not a reason to report success.
-    """
-    if os.getenv("CI"):
-        pytest.fail(reason)
-    pytest.skip(reason)
-
 @pytest.fixture(scope="session")
 def web_source() -> WebSourceHelper:
     helper = WebSourceHelper(os.getenv("WEB_TEST_HOST_DIR", DEFAULT_HOST_DIR))
@@ -54,7 +47,7 @@ def web_source() -> WebSourceHelper:
     try:
         helper.ensure_root()
     except OSError as exc:
-        _unavailable(f"Web site directory not writable at {helper.root}: {exc}")
+        source_unavailable(f"Web site directory not writable at {helper.root}: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/web/conftest.py
+++ b/integration-tests/connectors/web/conftest.py
@@ -11,20 +11,19 @@ Like Local FS and RSS, its settings live under a ``sync`` key rather than
 
 import os
 import uuid
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 import pytest_asyncio
-
 from connector_lifecycle import create_connector_and_await_sync, destructor
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
-from helper.graph_provider import GraphProviderProtocol
-
 from connectors.web.web_source_helper import (
     DEPTH_0_TITLES,
     DEPTH_1_TITLES,
     WebSourceHelper,
 )
+from helper.graph_provider import GraphProviderProtocol
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
 
 # Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
 DEFAULT_HOST_DIR = "../deployment/docker-compose/web-test-data"
@@ -64,10 +63,10 @@ async def web_connector(
     web_source: WebSourceHelper,
     pipeshub_client: PipeshubClient,
     graph_provider: GraphProviderProtocol,
-) -> AsyncGenerator[Dict[str, Any], None]:
+) -> AsyncGenerator[dict[str, Any], None]:
     web_source.write_site()
 
-    state: Dict[str, Any] = {
+    state: dict[str, Any] = {
         "resource_name": str(web_source.root),
         "expected_titles": EXPECTED_TITLES,
         "beyond_depth_titles": ["Deep page"],

--- a/integration-tests/connectors/web/web_integration_test.py
+++ b/integration-tests/connectors/web/web_integration_test.py
@@ -1,0 +1,160 @@
+# pyright: ignore-file
+
+"""
+Web Connector – Integration Tests
+=================================
+
+Tests receive a fully set-up connector via the ``web_connector`` fixture
+(defined in conftest.py), which publishes the site, creates the connector and
+waits for a full sync, then tears both down.
+
+The site is served by an nginx container in the integration stack. Crawling a
+real website would tie the suite to that site's uptime and wording, and would
+send traffic to someone else's server on every CI run.
+
+The fixture site is a deliberate link tree:
+
+    index.html                     depth 0
+      -> guides/setup.html         depth 1
+      -> guides/billing.html       depth 1
+           -> guides/deep.html     depth 2
+
+Test cases:
+  TC-SYNC-001  — A recursive crawl follows links and indexes the pages it reaches
+  TC-DEPTH-001 — The depth limit is honoured: a page one hop too far is not indexed
+  TC-UPDATE-001 — Re-crawling an edited page updates its record rather than adding one
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from helper.storage_incremental import (  # noqa: E402
+    settle_record_baseline,
+    sync_until_names_visible,
+)
+from connectors.web.web_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    WebSourceHelper,
+)
+
+logger = logging.getLogger("web-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.web
+@pytest.mark.asyncio(loop_scope="session")
+class TestWebConnector:
+    """Lifecycle coverage for the Web connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_sync_001_recursive_crawl_follows_links(
+        self,
+        web_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-SYNC-001: The crawl reaches the landing page and the pages it links to.
+
+        The two guides are only discoverable by following anchors from
+        index.html, so a connector that fetched the start URL alone would find
+        one page and fail here rather than passing on a single-page site.
+        """
+        connector_id = web_connector["connector_id"]
+        expected = web_connector["expected_titles"]
+        full_count = web_connector["full_sync_count"]
+
+        await graph_provider.assert_min_records(connector_id, len(expected))
+        await graph_provider.assert_no_orphan_records(connector_id)
+        await graph_provider.assert_record_paths_or_names_contain(
+            connector_id, expected
+        )
+
+        logger.info(
+            "TC-SYNC-001 passed: %d records for pages %s (connector %s)",
+            full_count,
+            expected,
+            connector_id,
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_depth_001_pages_beyond_the_depth_limit_are_not_indexed(
+        self,
+        web_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-DEPTH-001: A page one hop past the configured depth is not indexed.
+
+        The connector is configured with depth 1. `guides/deep.html` is linked
+        only from `guides/setup.html`, putting it two hops from the start URL.
+
+        A depth limit that is not enforced is not a cosmetic bug: on a real site
+        it is the difference between indexing a section and crawling the whole
+        internet from one page.
+        """
+        connector_id = web_connector["connector_id"]
+        beyond = web_connector["beyond_depth_titles"]
+
+        records = await graph_provider.fetch_record_names(connector_id)
+        leaked = [title for title in beyond if any(title in name for name in records)]
+
+        assert not leaked, (
+            f"TC-DEPTH-001: {leaked} was indexed despite being two hops from the "
+            f"start URL with depth=1. Records found: {sorted(records)}"
+        )
+        logger.info(
+            "TC-DEPTH-001 passed: %s correctly not indexed at depth 1", beyond
+        )
+
+    @pytest.mark.order(3)
+    async def test_tc_update_001_editing_a_page_does_not_duplicate_it(
+        self,
+        web_connector: Dict[str, Any],
+        web_source: WebSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-UPDATE-001: Re-crawling an edited page updates its record.
+
+        A page keeps its URL when its content changes, so a re-crawl must update
+        the existing record. A second record for the same URL is a duplicate,
+        which reaches users as the same page appearing twice in search — and on
+        a scheduled crawl it would accumulate on every run.
+        """
+        connector_id = web_connector["connector_id"]
+        title = "Billing guide"
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        web_source.write_page(
+            "guides/billing.html",
+            title,
+            "Updated for 2026: invoices are issued on the first of the month.",
+            [],
+        )
+        logger.info("Edited guides/billing.html")
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [title]
+        )
+
+        assert after_count == before_count, (
+            f"TC-UPDATE-001: record count moved from {before_count} to "
+            f"{after_count} after editing one page. A re-crawl must update the "
+            "existing record, not add another for the same URL."
+        )
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info(
+            "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
+            title,
+            after_count,
+        )

--- a/integration-tests/connectors/web/web_integration_test.py
+++ b/integration-tests/connectors/web/web_integration_test.py
@@ -114,6 +114,12 @@ class TestWebConnector:
         )
 
     @pytest.mark.order(3)
+    @pytest.mark.xfail(
+        reason="#3198: the web connector writes version=0 on every record, so a "
+               "re-crawl of edited content cannot be told apart from no "
+               "re-crawl. Strict, so a fix lights this up.",
+        strict=True,
+    )
     async def test_tc_update_001_editing_a_page_does_not_duplicate_it(
         self,
         web_connector: Dict[str, Any],
@@ -134,6 +140,11 @@ class TestWebConnector:
         before_count = await settle_record_baseline(
             pipeshub_client, graph_provider, connector_id
         )
+        before_record = await graph_provider.get_record_by_name(connector_id, title)
+        assert before_record is not None, (
+            f"TC-UPDATE-001: {title} is not in the graph before the edit"
+        )
+        before_version = before_record.get("version")
 
         web_source.write_page(
             "guides/billing.html",
@@ -152,6 +163,18 @@ class TestWebConnector:
             f"{after_count} after editing one page. A re-crawl must update the "
             "existing record, not add another for the same URL."
         )
+        # A stable count cannot tell a re-crawl from an ignored edit. This fails
+        # today because the web connector sets version=0 unconditionally
+        # (connector.py:903,1720) — #3198 — hence the strict xfail above.
+        after_record = await graph_provider.get_record_by_name(connector_id, title)
+        assert after_record is not None, (
+            f"TC-UPDATE-001: {title} disappeared from the graph after the edit"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-UPDATE-001: version stayed at {before_version} after the page "
+            "changed, so it was never re-indexed (#3198)"
+        )
+
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-UPDATE-001 passed: %s updated in place, count stable at %d",

--- a/integration-tests/connectors/web/web_integration_test.py
+++ b/integration-tests/connectors/web/web_integration_test.py
@@ -28,7 +28,7 @@ Test cases:
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -36,14 +36,16 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
-from helper.graph_provider import GraphProviderProtocol  # noqa: E402
-from helper.storage_incremental import (  # noqa: E402
+from connectors.web.web_source_helper import (  # type: ignore[import-not-found]
+    WebSourceHelper,
+)
+from helper.graph_provider import GraphProviderProtocol
+from helper.storage_incremental import (
     settle_record_baseline,
     sync_until_names_visible,
 )
-from connectors.web.web_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
-    WebSourceHelper,
+from pipeshub_client import (
+    PipeshubClient,  # type: ignore[import-not-found]
 )
 
 logger = logging.getLogger("web-lifecycle-test")
@@ -58,7 +60,7 @@ class TestWebConnector:
     @pytest.mark.order(1)
     async def test_tc_sync_001_recursive_crawl_follows_links(
         self,
-        web_connector: Dict[str, Any],
+        web_connector: dict[str, Any],
         graph_provider: GraphProviderProtocol,
     ) -> None:
         """TC-SYNC-001: The crawl reaches the landing page and the pages it links to.
@@ -87,7 +89,7 @@ class TestWebConnector:
     @pytest.mark.order(2)
     async def test_tc_depth_001_pages_beyond_the_depth_limit_are_not_indexed(
         self,
-        web_connector: Dict[str, Any],
+        web_connector: dict[str, Any],
         graph_provider: GraphProviderProtocol,
     ) -> None:
         """TC-DEPTH-001: A page one hop past the configured depth is not indexed.
@@ -116,7 +118,7 @@ class TestWebConnector:
     @pytest.mark.order(3)
     async def test_tc_update_001_editing_a_page_does_not_duplicate_it(
         self,
-        web_connector: Dict[str, Any],
+        web_connector: dict[str, Any],
         web_source: WebSourceHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -179,7 +181,7 @@ class TestWebConnector:
     )
     async def test_tc_update_002_editing_a_page_advances_the_record_version(
         self,
-        web_connector: Dict[str, Any],
+        web_connector: dict[str, Any],
         graph_provider: GraphProviderProtocol,
     ) -> None:
         """TC-UPDATE-002: The edit from TC-UPDATE-001 was actually re-crawled.

--- a/integration-tests/connectors/web/web_integration_test.py
+++ b/integration-tests/connectors/web/web_integration_test.py
@@ -114,12 +114,6 @@ class TestWebConnector:
         )
 
     @pytest.mark.order(3)
-    @pytest.mark.xfail(
-        reason="#3198: the web connector writes version=0 on every record, so a "
-               "re-crawl of edited content cannot be told apart from no "
-               "re-crawl. Strict, so a fix lights this up.",
-        strict=True,
-    )
     async def test_tc_update_001_editing_a_page_does_not_duplicate_it(
         self,
         web_connector: Dict[str, Any],
@@ -131,8 +125,12 @@ class TestWebConnector:
 
         A page keeps its URL when its content changes, so a re-crawl must update
         the existing record. A second record for the same URL is a duplicate,
-        which reaches users as the same page appearing twice in search — and on
-        a scheduled crawl it would accumulate on every run.
+        which reaches users as the same page appearing twice in search — and on a
+        scheduled crawl it would accumulate on every run.
+
+        Deliberately not xfailed. Whether the edit is re-crawled at all is
+        TC-UPDATE-002, which is expected to fail while #3198 is open; marking
+        this one would take duplicate detection down with it.
         """
         connector_id = web_connector["connector_id"]
         title = "Billing guide"
@@ -144,7 +142,9 @@ class TestWebConnector:
         assert before_record is not None, (
             f"TC-UPDATE-001: {title} is not in the graph before the edit"
         )
-        before_version = before_record.get("version")
+        # Handed to TC-UPDATE-002, which runs next against this same edit.
+        web_connector["update_title"] = title
+        web_connector["update_before_version"] = before_record.get("version")
 
         web_source.write_page(
             "guides/billing.html",
@@ -163,21 +163,40 @@ class TestWebConnector:
             f"{after_count} after editing one page. A re-crawl must update the "
             "existing record, not add another for the same URL."
         )
-        # A stable count cannot tell a re-crawl from an ignored edit. This fails
-        # today because the web connector sets version=0 unconditionally
-        # (connector.py:903,1720) — #3198 — hence the strict xfail above.
-        after_record = await graph_provider.get_record_by_name(connector_id, title)
-        assert after_record is not None, (
-            f"TC-UPDATE-001: {title} disappeared from the graph after the edit"
-        )
-        assert after_record.get("version") != before_version, (
-            f"TC-UPDATE-001: version stayed at {before_version} after the page "
-            "changed, so it was never re-indexed (#3198)"
-        )
-
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
             title,
             after_count,
+        )
+
+    @pytest.mark.order(4)
+    @pytest.mark.xfail(
+        reason="#3198: the web connector writes version=0 on every record, so an "
+               "edited page is indistinguishable from an untouched one. Strict, "
+               "so a fix XPASSes and forces the marker out.",
+        strict=True,
+    )
+    async def test_tc_update_002_editing_a_page_advances_the_record_version(
+        self,
+        web_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-UPDATE-002: The edit from TC-UPDATE-001 was actually re-crawled.
+
+        Split out so the count assertion in TC-UPDATE-001 keeps running: an
+        xfail applies to a whole test, so folding this in would have made a
+        duplicated record "expected" too.
+        """
+        connector_id = web_connector["connector_id"]
+        title = web_connector["update_title"]
+        before_version = web_connector["update_before_version"]
+
+        after_record = await graph_provider.get_record_by_name(connector_id, title)
+        assert after_record is not None, (
+            f"TC-UPDATE-002: {title} disappeared from the graph after the edit"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-UPDATE-002: version stayed at {before_version} after the page "
+            "changed, so it was never re-indexed (#3198)"
         )

--- a/integration-tests/connectors/web/web_integration_test.py
+++ b/integration-tests/connectors/web/web_integration_test.py
@@ -198,7 +198,14 @@ class TestWebConnector:
         assert after_record is not None, (
             f"TC-UPDATE-002: {title} disappeared from the graph after the edit"
         )
-        assert after_record.get("version") != before_version, (
-            f"TC-UPDATE-002: version stayed at {before_version} after the page "
-            "changed, so it was never re-indexed (#3198)"
+        after_version = after_record.get("version")
+        assert isinstance(before_version, int) and isinstance(after_version, int), (
+            f"TC-UPDATE-001: version should be an int on both reads, got "
+            f"{before_version!r} then {after_version!r}"
+        )
+        assert after_version > before_version, (
+            f"TC-UPDATE-001: version went from {before_version} to {after_version} "
+            "after the content changed. It must increase — an unchanged value "
+            "means the record was never re-indexed, and a lower one means it was "
+            "reset, which loses the change history just as badly."
         )

--- a/integration-tests/connectors/web/web_source_helper.py
+++ b/integration-tests/connectors/web/web_source_helper.py
@@ -1,0 +1,134 @@
+# pyright: ignore-file
+
+"""Builds the small static site the Web connector crawls.
+
+The site is served by an nginx container in the integration stack. Crawling a
+real site would tie the suite to that site's uptime and wording, and would send
+traffic to someone else's server on every CI run.
+
+The pages form a deliberate link tree so crawl depth can be tested:
+
+    index.html                     depth 0
+      -> guides/setup.html         depth 1
+      -> guides/billing.html       depth 1
+           -> guides/deep.html     depth 2   (linked only from setup.html)
+
+A crawl limited to depth 1 must reach the two guides and not `deep.html`.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, List
+
+# path -> (title, body, [links])
+PageSpec = Dict[str, tuple]
+
+SITE: PageSpec = {
+    "index.html": (
+        "PipesHub test site",
+        "Landing page for the Web connector integration tests.",
+        ["guides/setup.html", "guides/billing.html"],
+    ),
+    "guides/setup.html": (
+        "Setup guide",
+        "How to set up a new workspace from scratch.",
+        ["deep.html"],
+    ),
+    "guides/billing.html": (
+        "Billing guide",
+        "Answers to common billing questions.",
+        [],
+    ),
+    "guides/deep.html": (
+        "Deep page",
+        "Only reachable from the setup guide, two hops from the landing page.",
+        [],
+    ),
+}
+
+# Titles at each crawl depth from index.html.
+DEPTH_0_TITLES = ["PipesHub test site"]
+DEPTH_1_TITLES = ["Setup guide", "Billing guide"]
+DEPTH_2_TITLES = ["Deep page"]
+
+
+class WebSourceHelper:
+    """Creates and updates the static site a connector test crawls."""
+
+    def __init__(self, host_dir: str) -> None:
+        self.root = Path(host_dir)
+
+    def ensure_root(self) -> None:
+        """Create the document root and prove it is writable.
+
+        nginx serves as an unprivileged user, so the root has to be traversable
+        by it. A restrictive umask otherwise produces a 403 that reads like a
+        missing page.
+        """
+        self.root.mkdir(parents=True, exist_ok=True)
+        os.chmod(self.root, 0o755)
+        probe = self.root / ".write-probe"
+        probe.write_text("ok", encoding="utf-8")
+        probe.unlink()
+
+    @staticmethod
+    def _html(title: str, body: str, links: List[str]) -> str:
+        anchors = "\n".join(
+            f'    <li><a href="{href}">{href}</a></li>' for href in links
+        )
+        link_block = f"  <ul>\n{anchors}\n  </ul>\n" if links else ""
+        return (
+            "<!doctype html>\n"
+            '<html lang="en">\n'
+            "<head>\n"
+            '  <meta charset="utf-8">\n'
+            f"  <title>{title}</title>\n"
+            "</head>\n"
+            "<body>\n"
+            f"  <h1>{title}</h1>\n"
+            f"  <p>{body}</p>\n"
+            f"{link_block}"
+            "</body>\n"
+            "</html>\n"
+        )
+
+    def write_site(self, site: PageSpec | None = None) -> int:
+        pages = site if site is not None else SITE
+        for rel_path, (title, body, links) in pages.items():
+            target = self.root / rel_path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.chmod(target.parent, 0o755)
+            target.write_text(self._html(title, body, links), encoding="utf-8")
+            os.chmod(target, 0o644)  # readable by the nginx user
+        return len(pages)
+
+    def write_page(self, rel_path: str, title: str, body: str, links: List[str]) -> None:
+        target = self.root / rel_path
+        target.parent.mkdir(parents=True, exist_ok=True)
+        os.chmod(target.parent, 0o755)
+        target.write_text(self._html(title, body, links), encoding="utf-8")
+        os.chmod(target, 0o644)
+
+    def list_objects(self, resource_name: str | None = None) -> List[str]:
+        del resource_name
+        return sorted(
+            str(p.relative_to(self.root))
+            for p in self.root.rglob("*.html")
+            if p.is_file()
+        )
+
+    def clear_objects(self, resource_name: str | None = None) -> None:
+        """Remove the pages, leaving the document root in place.
+
+        The directory is the bind-mount target and has to survive teardown.
+        """
+        del resource_name
+        for path in sorted(self.root.rglob("*"), reverse=True):
+            if path.name == ".gitkeep":
+                continue
+            if path.is_file():
+                path.unlink()
+            elif path.is_dir():
+                path.rmdir()

--- a/integration-tests/connectors/web/web_source_helper.py
+++ b/integration-tests/connectors/web/web_source_helper.py
@@ -126,7 +126,10 @@ class WebSourceHelper:
         """
         del resource_name
         for path in sorted(self.root.rglob("*"), reverse=True):
-            if path.name == ".gitkeep":
+            # .gitkeep and the committed index.html are the container's
+            # healthcheck target; the suite overwrites index.html while running
+            # but must leave both behind.
+            if path.name in (".gitkeep", "index.html"):
                 continue
             if path.is_file():
                 path.unlink()

--- a/integration-tests/connectors/web/web_source_helper.py
+++ b/integration-tests/connectors/web/web_source_helper.py
@@ -20,10 +20,9 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, List
 
 # path -> (title, body, [links])
-PageSpec = Dict[str, tuple]
+PageSpec = dict[str, tuple]
 
 SITE: PageSpec = {
     "index.html": (
@@ -74,7 +73,7 @@ class WebSourceHelper:
         probe.unlink()
 
     @staticmethod
-    def _html(title: str, body: str, links: List[str]) -> str:
+    def _html(title: str, body: str, links: list[str]) -> str:
         anchors = "\n".join(
             f'    <li><a href="{href}">{href}</a></li>' for href in links
         )
@@ -104,14 +103,14 @@ class WebSourceHelper:
             os.chmod(target, 0o644)  # readable by the nginx user
         return len(pages)
 
-    def write_page(self, rel_path: str, title: str, body: str, links: List[str]) -> None:
+    def write_page(self, rel_path: str, title: str, body: str, links: list[str]) -> None:
         target = self.root / rel_path
         target.parent.mkdir(parents=True, exist_ok=True)
         os.chmod(target.parent, 0o755)
         target.write_text(self._html(title, body, links), encoding="utf-8")
         os.chmod(target, 0o644)
 
-    def list_objects(self, resource_name: str | None = None) -> List[str]:
+    def list_objects(self, resource_name: str | None = None) -> list[str]:
         del resource_name
         return sorted(
             str(p.relative_to(self.root))

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -29,6 +29,7 @@ markers =
     mariadb: marks tests specific to MariaDB connector
     localfs: marks tests specific to Local FS connector
     rss: marks tests specific to RSS connector
+    web: marks tests specific to Web connector
     gcs: marks tests specific to GCS connector
     azure_blob: marks tests specific to Azure Blob connector
     azure_files: marks tests specific to Azure Files connector


### PR DESCRIPTION
## In one line

PipesHub can pull documents from a website. Nothing tested that until now. This adds tests that run automatically — and need no account, because the tests publish a small site to a web server started alongside them.

## Background

PipesHub connects to around 50 outside services and copies documents from them so people can search across everything in one place. Each connection is called a *connector*.

Being confident a connector still works means running it against the real service. That usually means owning an account there, kept alive with test data — which is why only 16 of the 50 are tested today.

a website is one of the few exceptions: the tests publish a small site to a web server started alongside them. So instead of buying an account, the tests provide one alongside them.

## What this changes

**Before:** if someone broke the Web connector, nothing would notice until a customer's documents stopped appearing.

**After:** these checks run automatically on every change.

| What it checks | Why it matters |
|---|---|
| Following links from the starting page finds the pages it links to | A connector that only fetched the one page would find nothing and fail here |
| The crawl depth limit is respected | See below |
| Re-reading an edited page updates the existing document rather than duplicating it | Otherwise the same page appears twice in search |

## How to try it

No account or password needed.

```bash
cd deployment/docker-compose
docker compose -f docker-compose.integration.neo4j.yml up -d

cd ../../integration-tests
pytest -m web -v
```

If the service is not running the tests say so and skip, rather than pretending to pass. In CI, where it is always started, they fail instead — a broken setup should be visible, not hidden.

## The depth check is the one that matters

The site is a deliberate link tree:

\`\`\`
index.html                 the starting page
  -> guides/setup.html     one hop
  -> guides/billing.html   one hop
       -> guides/deep.html two hops, linked only from setup
\`\`\`

The connector is told to follow links one hop. `guides/deep.html` is two hops away, so it must not be indexed.

An unenforced depth limit is not cosmetic. On a real website it is the difference between indexing one section and crawling outward without bound from a single page.

## One check is expected to fail, on purpose

The last check is marked as a *known failure*. This connector writes the same version number on every document, so an edited page cannot currently be told apart from an untouched one — recorded as **#3198**.

It is marked strictly: the day the connector records versions properly, the test reports an unexpected pass and the marker has to be removed deliberately. A silent fix cannot slip past. The duplicate check in the same suite still runs and still has to pass.

## Anything to worry about

No. Nothing here changes how PipesHub behaves for users. It adds tests and the test-only services they need; deleting every file in this change would leave the product exactly as it is today.
