### PR TITLE
test(nextcloud): give the Nextcloud connector live integration coverage

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -23,6 +23,7 @@ on:
             - localfs
             - rss
             - web
+            - nextcloud
             - confluence
             - jira
             - linear
@@ -185,6 +186,12 @@ jobs:
       # the bind mount and the test would use different directories.
       WEB_TEST_HOST_DIR: ${{ github.workspace }}/deployment/docker-compose/web-test-data
       WEB_CONNECTOR_START_URL: http://web-source/index.html
+      # Nextcloud runs in the stack. The test seeds it over WebDAV on the
+      # published port; the connector reaches it by service name.
+      NEXTCLOUD_TEST_URL: http://localhost:8096
+      NEXTCLOUD_CONNECTOR_URL: http://nextcloud-source
+      NEXTCLOUD_TEST_USER: pipeshubtest
+      NEXTCLOUD_TEST_PASSWORD: pipeshubtest123
       S3_SECRET_KEY: ${{ secrets.S3_SECRET_KEY }}
       S3_REGION: ${{ secrets.S3_REGION }}
       S3_BUCKET: ${{ secrets.S3_BUCKET }}

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -276,6 +276,25 @@ services:
       timeout: 3s
       retries: 20
 
+  # Nextcloud as a connector *source* — files to be indexed. Its admin
+  # credentials work for WebDAV directly, so unlike most SaaS sources there is
+  # no token to mint before the connector can authenticate.
+  nextcloud-source:
+    image: nextcloud:30-apache
+    restart: always
+    environment:
+      SQLITE_DATABASE: nextcloud
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_TEST_USER:-pipeshubtest}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_TEST_PASSWORD:-pipeshubtest123}
+      NEXTCLOUD_TRUSTED_DOMAINS: "localhost 127.0.0.1 nextcloud-source"
+    ports:
+      - "8096:80"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost/status.php"]
+      interval: 10s
+      timeout: 5s
+      retries: 40
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.arango.yml
+++ b/deployment/docker-compose/docker-compose.integration.arango.yml
@@ -288,7 +288,7 @@ services:
       NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_TEST_PASSWORD:-pipeshubtest123}
       NEXTCLOUD_TRUSTED_DOMAINS: "localhost 127.0.0.1 nextcloud-source"
     ports:
-      - "8096:80"
+      - "127.0.0.1:8096:80"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost/status.php"]
       interval: 10s

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -276,6 +276,25 @@ services:
       timeout: 3s
       retries: 20
 
+  # Nextcloud as a connector *source* — files to be indexed. Its admin
+  # credentials work for WebDAV directly, so unlike most SaaS sources there is
+  # no token to mint before the connector can authenticate.
+  nextcloud-source:
+    image: nextcloud:30-apache
+    restart: always
+    environment:
+      SQLITE_DATABASE: nextcloud
+      NEXTCLOUD_ADMIN_USER: ${NEXTCLOUD_TEST_USER:-pipeshubtest}
+      NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_TEST_PASSWORD:-pipeshubtest123}
+      NEXTCLOUD_TRUSTED_DOMAINS: "localhost 127.0.0.1 nextcloud-source"
+    ports:
+      - "8096:80"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost/status.php"]
+      interval: 10s
+      timeout: 5s
+      retries: 40
+
   redis:
     image: redis:7.4-bookworm
     restart: always

--- a/deployment/docker-compose/docker-compose.integration.neo4j.yml
+++ b/deployment/docker-compose/docker-compose.integration.neo4j.yml
@@ -288,7 +288,7 @@ services:
       NEXTCLOUD_ADMIN_PASSWORD: ${NEXTCLOUD_TEST_PASSWORD:-pipeshubtest123}
       NEXTCLOUD_TRUSTED_DOMAINS: "localhost 127.0.0.1 nextcloud-source"
     ports:
-      - "8096:80"
+      - "127.0.0.1:8096:80"
     healthcheck:
       test: ["CMD", "curl", "-fsS", "-o", "/dev/null", "http://localhost/status.php"]
       interval: 10s

--- a/integration-tests/connectors/nextcloud/conftest.py
+++ b/integration-tests/connectors/nextcloud/conftest.py
@@ -1,0 +1,97 @@
+# pyright: ignore-file
+
+"""Nextcloud connector fixtures.
+
+Nextcloud is self-hostable and authenticates over WebDAV with plain
+username/password, so the integration stack runs one and the connector reaches
+it directly — no account to buy, and no app password to mint first.
+"""
+
+import os
+import uuid
+from typing import Any, AsyncGenerator, Dict
+
+import pytest
+import pytest_asyncio
+
+from connector_lifecycle import create_connector_and_await_sync, destructor
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+from helper.graph_provider import GraphProviderProtocol
+
+from connectors.nextcloud.nextcloud_source_helper import NextcloudSourceHelper
+
+# Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
+DEFAULT_USER = "pipeshubtest"
+DEFAULT_PASSWORD = "pipeshubtest123"
+TEST_ROOT = "pipeshub-test"
+
+SEED_FILES = [
+    ("handbook/onboarding.txt", "How to set up a new workspace.\n"),
+    ("handbook/billing.txt", "Answers to common billing questions.\n"),
+    ("policies/leave.txt", "Annual leave accrues monthly.\n"),
+]
+
+
+@pytest.fixture(scope="session")
+def nextcloud_source() -> NextcloudSourceHelper:
+    helper = NextcloudSourceHelper(
+        base_url=os.getenv("NEXTCLOUD_TEST_URL", "http://localhost:8096"),
+        username=os.getenv("NEXTCLOUD_TEST_USER", DEFAULT_USER),
+        password=os.getenv("NEXTCLOUD_TEST_PASSWORD", DEFAULT_PASSWORD),
+        root=TEST_ROOT,
+    )
+    # Skip rather than fail when the instance is not up, so a partial local
+    # stack stays usable. CI always brings nextcloud-source up.
+    try:
+        helper.ping()
+        helper.ensure_root()
+        helper.clear_objects()
+    except Exception as exc:  # noqa: BLE001 — any failure means "not available"
+        pytest.skip(f"Nextcloud not reachable: {exc}")
+    return helper
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def nextcloud_connector(
+    nextcloud_source: NextcloudSourceHelper,
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    written = nextcloud_source.write_files(SEED_FILES)
+
+    state: Dict[str, Any] = {
+        "resource_name": TEST_ROOT,
+        "seeded_names": sorted(path.split("/")[-1] for path, _ in SEED_FILES),
+        "uploaded_count": written,
+    }
+
+    # The connector runs inside the compose network and reaches Nextcloud by
+    # service name; the test process uses the published port.
+    config = {
+        "auth": {
+            "baseUrl": os.getenv("NEXTCLOUD_CONNECTOR_URL", "http://nextcloud-source"),
+            "username": os.getenv("NEXTCLOUD_TEST_USER", DEFAULT_USER),
+            "password": os.getenv("NEXTCLOUD_TEST_PASSWORD", DEFAULT_PASSWORD),
+        }
+    }
+
+    await create_connector_and_await_sync(
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="Nextcloud",
+        connector_name=f"nextcloud-lifecycle-test-{uuid.uuid4().hex[:8]}",
+        connector_config=config,
+        expected_records=written,
+        auth_type="BASIC_AUTH",
+    )
+
+    yield state
+
+    await destructor(
+        nextcloud_source,
+        pipeshub_client,
+        graph_provider,
+        state,
+        connector_type="Nextcloud",
+    )

--- a/integration-tests/connectors/nextcloud/conftest.py
+++ b/integration-tests/connectors/nextcloud/conftest.py
@@ -32,6 +32,18 @@ SEED_FILES = [
 ]
 
 
+
+def _unavailable(reason: str) -> None:
+    """A source that is not reachable: skip locally, fail in CI.
+
+    Skipping on any exception turns a broken stack into a green run. CI brings
+    this source up itself, so if it is not reachable there, that is a result and
+    not a reason to report success.
+    """
+    if os.getenv("CI"):
+        pytest.fail(reason)
+    pytest.skip(reason)
+
 @pytest.fixture(scope="session")
 def nextcloud_source() -> NextcloudSourceHelper:
     helper = NextcloudSourceHelper(
@@ -47,7 +59,7 @@ def nextcloud_source() -> NextcloudSourceHelper:
         helper.ensure_root()
         helper.clear_objects()
     except Exception as exc:  # noqa: BLE001 — any failure means "not available"
-        pytest.skip(f"Nextcloud not reachable: {exc}")
+        _unavailable(f"Nextcloud not reachable: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/nextcloud/conftest.py
+++ b/integration-tests/connectors/nextcloud/conftest.py
@@ -9,16 +9,15 @@ it directly — no account to buy, and no app password to mint first.
 
 import os
 import uuid
-from typing import Any, AsyncGenerator, Dict
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 import pytest_asyncio
-
 from connector_lifecycle import create_connector_and_await_sync, destructor
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
-from helper.graph_provider import GraphProviderProtocol
-
 from connectors.nextcloud.nextcloud_source_helper import NextcloudSourceHelper
+from helper.graph_provider import GraphProviderProtocol
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
 
 # Defaults match deployment/docker-compose/docker-compose.integration.*.yml.
 DEFAULT_USER = "pipeshubtest"
@@ -68,10 +67,10 @@ async def nextcloud_connector(
     nextcloud_source: NextcloudSourceHelper,
     pipeshub_client: PipeshubClient,
     graph_provider: GraphProviderProtocol,
-) -> AsyncGenerator[Dict[str, Any], None]:
+) -> AsyncGenerator[dict[str, Any], None]:
     written = nextcloud_source.write_files(SEED_FILES)
 
-    state: Dict[str, Any] = {
+    state: dict[str, Any] = {
         "resource_name": TEST_ROOT,
         "seeded_names": sorted(path.split("/")[-1] for path, _ in SEED_FILES),
         "uploaded_count": written,

--- a/integration-tests/connectors/nextcloud/conftest.py
+++ b/integration-tests/connectors/nextcloud/conftest.py
@@ -14,7 +14,11 @@ from typing import Any
 
 import pytest
 import pytest_asyncio
-from connector_lifecycle import create_connector_and_await_sync, destructor
+from connector_lifecycle import (
+    create_connector_and_await_sync,
+    destructor,
+    source_unavailable,
+)
 from connectors.nextcloud.nextcloud_source_helper import NextcloudSourceHelper
 from helper.graph_provider import GraphProviderProtocol
 from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
@@ -32,17 +36,6 @@ SEED_FILES = [
 
 
 
-def _unavailable(reason: str) -> None:
-    """A source that is not reachable: skip locally, fail in CI.
-
-    Skipping on any exception turns a broken stack into a green run. CI brings
-    this source up itself, so if it is not reachable there, that is a result and
-    not a reason to report success.
-    """
-    if os.getenv("CI"):
-        pytest.fail(reason)
-    pytest.skip(reason)
-
 @pytest.fixture(scope="session")
 def nextcloud_source() -> NextcloudSourceHelper:
     helper = NextcloudSourceHelper(
@@ -58,7 +51,7 @@ def nextcloud_source() -> NextcloudSourceHelper:
         helper.ensure_root()
         helper.clear_objects()
     except Exception as exc:  # noqa: BLE001 — any failure means "not available"
-        _unavailable(f"Nextcloud not reachable: {exc}")
+        source_unavailable(f"Nextcloud not reachable: {exc}")
     return helper
 
 

--- a/integration-tests/connectors/nextcloud/nextcloud_integration_test.py
+++ b/integration-tests/connectors/nextcloud/nextcloud_integration_test.py
@@ -23,7 +23,7 @@ Test cases:
 import logging
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 import pytest
 
@@ -31,14 +31,16 @@ _ROOT = Path(__file__).resolve().parents[2]
 if str(_ROOT) not in sys.path:
     sys.path.insert(0, str(_ROOT))
 
-from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
-from helper.graph_provider import GraphProviderProtocol  # noqa: E402
-from helper.storage_incremental import (  # noqa: E402
+from connectors.nextcloud.nextcloud_source_helper import (  # type: ignore[import-not-found]
+    NextcloudSourceHelper,
+)
+from helper.graph_provider import GraphProviderProtocol
+from helper.storage_incremental import (
     settle_record_baseline,
     sync_until_names_visible,
 )
-from connectors.nextcloud.nextcloud_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
-    NextcloudSourceHelper,
+from pipeshub_client import (
+    PipeshubClient,  # type: ignore[import-not-found]
 )
 
 logger = logging.getLogger("nextcloud-lifecycle-test")
@@ -53,7 +55,7 @@ class TestNextcloudConnector:
     @pytest.mark.order(1)
     async def test_tc_sync_001_full_sync_graph_validation(
         self,
-        nextcloud_connector: Dict[str, Any],
+        nextcloud_connector: dict[str, Any],
         graph_provider: GraphProviderProtocol,
     ) -> None:
         """TC-SYNC-001: Every seeded file is in the graph, nested ones included.
@@ -80,7 +82,7 @@ class TestNextcloudConnector:
     @pytest.mark.order(2)
     async def test_tc_incr_001_new_file_is_picked_up(
         self,
-        nextcloud_connector: Dict[str, Any],
+        nextcloud_connector: dict[str, Any],
         nextcloud_source: NextcloudSourceHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -119,7 +121,7 @@ class TestNextcloudConnector:
     @pytest.mark.order(3)
     async def test_tc_update_001_editing_a_file_does_not_duplicate_it(
         self,
-        nextcloud_connector: Dict[str, Any],
+        nextcloud_connector: dict[str, Any],
         nextcloud_source: NextcloudSourceHelper,
         pipeshub_client: PipeshubClient,
         graph_provider: GraphProviderProtocol,
@@ -138,6 +140,18 @@ class TestNextcloudConnector:
             pipeshub_client, graph_provider, connector_id
         )
 
+        # The connector increments a record's version when it updates one, so
+        # comparing it is what separates "re-indexed" from "left alone". A count
+        # that holds steady proves only that nothing was duplicated — a
+        # connector that ignored the change entirely would also pass that.
+        before_record = await graph_provider.get_record_by_name(
+            connector_id, file_name
+        )
+        assert before_record is not None, (
+            f"TC-UPDATE-001: {file_name} is not in the graph before the change"
+        )
+        before_version = before_record.get("version")
+
         nextcloud_source.overwrite_file(
             rel_path, "Updated: how to set up a new workspace in 2026.\n"
         )
@@ -152,9 +166,21 @@ class TestNextcloudConnector:
             f"{after_count} after editing one file. An edit must update the "
             "existing record, not create a second one."
         )
+        after_record = await graph_provider.get_record_by_name(
+            connector_id, file_name
+        )
+        assert after_record is not None, (
+            f"TC-UPDATE-001: {file_name} disappeared from the graph after the change"
+        )
+        assert after_record.get("version") != before_version, (
+            f"TC-UPDATE-001: version stayed at {before_version} after the content "
+            "changed, so the record was never re-indexed. The count assertion "
+            "above would have passed regardless."
+        )
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(
             "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
             file_name,
             after_count,
         )
+

--- a/integration-tests/connectors/nextcloud/nextcloud_integration_test.py
+++ b/integration-tests/connectors/nextcloud/nextcloud_integration_test.py
@@ -1,0 +1,160 @@
+# pyright: ignore-file
+
+"""
+Nextcloud Connector – Integration Tests
+=======================================
+
+Tests receive a fully set-up connector via the ``nextcloud_connector`` fixture
+(defined in conftest.py), which uploads the files over WebDAV, creates the
+connector and waits for a full sync, then tears both down.
+
+Nextcloud is self-hostable, so the integration stack runs one and the connector
+syncs from it. It is also unusual among SaaS-shaped sources in authenticating
+with a plain username and password, so the admin credentials the container is
+started with are all the connector needs — there is no app password to mint
+first.
+
+Test cases:
+  TC-SYNC-001   — Full sync picks up every file, including ones in subfolders
+  TC-INCR-001   — A file added after the first sync appears on the next one
+  TC-UPDATE-001 — Editing a file updates its record rather than adding one
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]  # noqa: E402
+from helper.graph_provider import GraphProviderProtocol  # noqa: E402
+from helper.storage_incremental import (  # noqa: E402
+    settle_record_baseline,
+    sync_until_names_visible,
+)
+from connectors.nextcloud.nextcloud_source_helper import (  # type: ignore[import-not-found]  # noqa: E402
+    NextcloudSourceHelper,
+)
+
+logger = logging.getLogger("nextcloud-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.nextcloud
+@pytest.mark.asyncio(loop_scope="session")
+class TestNextcloudConnector:
+    """Lifecycle coverage for the Nextcloud connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_sync_001_full_sync_graph_validation(
+        self,
+        nextcloud_connector: Dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-SYNC-001: Every seeded file is in the graph, nested ones included.
+
+        The seed puts files in two subfolders, so a connector that listed only
+        the top level of the share would find nothing and fail here rather than
+        passing against a flat directory.
+        """
+        connector_id = nextcloud_connector["connector_id"]
+        seeded = nextcloud_connector["seeded_names"]
+        full_count = nextcloud_connector["full_sync_count"]
+
+        await graph_provider.assert_min_records(connector_id, len(seeded))
+        await graph_provider.assert_no_orphan_records(connector_id)
+        await graph_provider.assert_record_paths_or_names_contain(connector_id, seeded)
+
+        logger.info(
+            "TC-SYNC-001 passed: %d records for files %s (connector %s)",
+            full_count,
+            seeded,
+            connector_id,
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_incr_001_new_file_is_picked_up(
+        self,
+        nextcloud_connector: Dict[str, Any],
+        nextcloud_source: NextcloudSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-INCR-001: A file added after the first sync appears on the next one."""
+        connector_id = nextcloud_connector["connector_id"]
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        new_name = "runbook.txt"
+        nextcloud_source.write_files(
+            [(f"handbook/{new_name}", "Drain traffic, then restart the service.\n")]
+        )
+        logger.info("Wrote new file %s", new_name)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [new_name]
+        )
+
+        assert after_count > before_count, (
+            f"TC-INCR-001: expected a new record for {new_name}; count stayed "
+            f"at {after_count}"
+        )
+        await graph_provider.assert_record_paths_or_names_contain(
+            connector_id, [new_name]
+        )
+        logger.info(
+            "TC-INCR-001 passed: before=%d, after=%d, new=%s",
+            before_count,
+            after_count,
+            new_name,
+        )
+
+    @pytest.mark.order(3)
+    async def test_tc_update_001_editing_a_file_does_not_duplicate_it(
+        self,
+        nextcloud_connector: Dict[str, Any],
+        nextcloud_source: NextcloudSourceHelper,
+        pipeshub_client: PipeshubClient,
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-UPDATE-001: An edited file updates its record rather than adding one.
+
+        A file whose contents change keeps its path, so re-indexing must update
+        the existing record. A second record for the same path is a duplicate,
+        which reaches users as the same document appearing twice in search.
+        """
+        connector_id = nextcloud_connector["connector_id"]
+        rel_path = "handbook/onboarding.txt"
+        file_name = Path(rel_path).name
+
+        before_count = await settle_record_baseline(
+            pipeshub_client, graph_provider, connector_id
+        )
+
+        nextcloud_source.overwrite_file(
+            rel_path, "Updated: how to set up a new workspace in 2026.\n"
+        )
+        logger.info("Overwrote %s", rel_path)
+
+        after_count = await sync_until_names_visible(
+            pipeshub_client, graph_provider, connector_id, [file_name]
+        )
+
+        assert after_count == before_count, (
+            f"TC-UPDATE-001: record count moved from {before_count} to "
+            f"{after_count} after editing one file. An edit must update the "
+            "existing record, not create a second one."
+        )
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info(
+            "TC-UPDATE-001 passed: %s updated in place, count stable at %d",
+            file_name,
+            after_count,
+        )

--- a/integration-tests/connectors/nextcloud/nextcloud_integration_test.py
+++ b/integration-tests/connectors/nextcloud/nextcloud_integration_test.py
@@ -172,10 +172,16 @@ class TestNextcloudConnector:
         assert after_record is not None, (
             f"TC-UPDATE-001: {file_name} disappeared from the graph after the change"
         )
-        assert after_record.get("version") != before_version, (
-            f"TC-UPDATE-001: version stayed at {before_version} after the content "
-            "changed, so the record was never re-indexed. The count assertion "
-            "above would have passed regardless."
+        after_version = after_record.get("version")
+        assert isinstance(before_version, int) and isinstance(after_version, int), (
+            f"TC-UPDATE-001: version should be an int on both reads, got "
+            f"{before_version!r} then {after_version!r}"
+        )
+        assert after_version > before_version, (
+            f"TC-UPDATE-001: version went from {before_version} to {after_version} "
+            "after the content changed. It must increase — an unchanged value "
+            "means the record was never re-indexed, and a lower one means it was "
+            "reset, which loses the change history just as badly."
         )
         await graph_provider.assert_no_orphan_records(connector_id)
         logger.info(

--- a/integration-tests/connectors/nextcloud/nextcloud_source_helper.py
+++ b/integration-tests/connectors/nextcloud/nextcloud_source_helper.py
@@ -1,0 +1,124 @@
+# pyright: ignore-file
+
+"""Seeds a Nextcloud instance with files for the Nextcloud connector to sync.
+
+Nextcloud speaks WebDAV, so seeding is plain HTTP: PUT to upload, MKCOL to make
+a folder, PROPFIND to list. That avoids adding a Nextcloud client library to the
+integration-test environment for what amounts to four verbs.
+
+The connector authenticates with the same username and password, so a container
+started with NEXTCLOUD_ADMIN_USER/NEXTCLOUD_ADMIN_PASSWORD needs no further
+setup — no app password to mint, no token to bootstrap.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import List, Sequence, Tuple
+
+import requests
+
+# (relative path, text) pairs.
+SeedFile = Tuple[str, str]
+
+
+class NextcloudSourceHelper:
+    """Creates and removes the files a connector test syncs from."""
+
+    def __init__(
+        self, base_url: str, username: str, password: str, root: str = "pipeshub-test"
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.username = username
+        self.auth = (username, password)
+        self.root = root
+
+    def _dav(self, path: str = "") -> str:
+        suffix = f"/{path.lstrip('/')}" if path else ""
+        return f"{self.base_url}/remote.php/dav/files/{self.username}/{self.root}{suffix}"
+
+    def ping(self, timeout: int = 15) -> None:
+        """Raise unless WebDAV answers for this user."""
+        resp = requests.request(
+            "PROPFIND",
+            f"{self.base_url}/remote.php/dav/files/{self.username}/",
+            auth=self.auth,
+            headers={"Depth": "0"},
+            timeout=timeout,
+        )
+        if resp.status_code != 207:
+            raise RuntimeError(
+                f"Nextcloud WebDAV returned {resp.status_code} for "
+                f"{self.username}: {resp.text[:200]}"
+            )
+
+    def ensure_root(self, timeout: int = 15) -> None:
+        # MKCOL answers 405 when the collection already exists, which is fine.
+        resp = requests.request("MKCOL", self._dav(), auth=self.auth, timeout=timeout)
+        if resp.status_code not in (201, 405):
+            raise RuntimeError(
+                f"could not create {self.root}: {resp.status_code} {resp.text[:200]}"
+            )
+
+    def write_files(self, files: Sequence[SeedFile], timeout: int = 30) -> int:
+        for rel_path, text in files:
+            parts = rel_path.split("/")
+            for depth in range(1, len(parts)):
+                requests.request(
+                    "MKCOL",
+                    self._dav("/".join(parts[:depth])),
+                    auth=self.auth,
+                    timeout=timeout,
+                )
+            resp = requests.put(
+                self._dav(rel_path),
+                auth=self.auth,
+                data=text.encode("utf-8"),
+                timeout=timeout,
+            )
+            if resp.status_code not in (201, 204):
+                raise RuntimeError(
+                    f"upload of {rel_path} failed: {resp.status_code} {resp.text[:200]}"
+                )
+        return len(files)
+
+    def overwrite_file(self, rel_path: str, text: str, timeout: int = 30) -> None:
+        resp = requests.put(
+            self._dav(rel_path), auth=self.auth, data=text.encode("utf-8"), timeout=timeout
+        )
+        if resp.status_code not in (201, 204):
+            raise RuntimeError(
+                f"overwrite of {rel_path} failed: {resp.status_code} {resp.text[:200]}"
+            )
+
+    def list_objects(self, resource_name: str | None = None, timeout: int = 30) -> List[str]:
+        """Paths of every file under the test root, relative to it."""
+        del resource_name
+        resp = requests.request(
+            "PROPFIND", self._dav(), auth=self.auth, headers={"Depth": "infinity"},
+            timeout=timeout,
+        )
+        if resp.status_code == 404:
+            return []
+        if resp.status_code != 207:
+            raise RuntimeError(f"PROPFIND failed: {resp.status_code} {resp.text[:200]}")
+
+        prefix = f"/remote.php/dav/files/{self.username}/{self.root}/"
+        found: List[str] = []
+        for href in ET.fromstring(resp.content).iter(
+            "{DAV:}href"
+        ):
+            path = (href.text or "")
+            if not path.startswith(prefix) or path.endswith("/"):
+                continue
+            found.append(path[len(prefix):])
+        return sorted(found)
+
+    def clear_objects(self, resource_name: str | None = None, timeout: int = 30) -> None:
+        """Delete the test root and recreate it empty.
+
+        Named for the protocol the shared destructor expects.
+        """
+        del resource_name
+        requests.delete(self._dav(), auth=self.auth, timeout=timeout)
+        self.ensure_root(timeout=timeout)

--- a/integration-tests/connectors/nextcloud/nextcloud_source_helper.py
+++ b/integration-tests/connectors/nextcloud/nextcloud_source_helper.py
@@ -14,12 +14,12 @@ setup — no app password to mint, no token to bootstrap.
 from __future__ import annotations
 
 import xml.etree.ElementTree as ET
-from typing import List, Sequence, Tuple
+from collections.abc import Sequence
 
 import requests
 
 # (relative path, text) pairs.
-SeedFile = Tuple[str, str]
+SeedFile = tuple[str, str]
 
 
 class NextcloudSourceHelper:
@@ -91,7 +91,7 @@ class NextcloudSourceHelper:
                 f"overwrite of {rel_path} failed: {resp.status_code} {resp.text[:200]}"
             )
 
-    def list_objects(self, resource_name: str | None = None, timeout: int = 30) -> List[str]:
+    def list_objects(self, resource_name: str | None = None, timeout: int = 30) -> list[str]:
         """Paths of every file under the test root, relative to it."""
         del resource_name
         resp = requests.request(
@@ -104,7 +104,7 @@ class NextcloudSourceHelper:
             raise RuntimeError(f"PROPFIND failed: {resp.status_code} {resp.text[:200]}")
 
         prefix = f"/remote.php/dav/files/{self.username}/{self.root}/"
-        found: List[str] = []
+        found: list[str] = []
         for href in ET.fromstring(resp.content).iter(
             "{DAV:}href"
         ):

--- a/integration-tests/connectors/nextcloud/nextcloud_source_helper.py
+++ b/integration-tests/connectors/nextcloud/nextcloud_source_helper.py
@@ -13,6 +13,7 @@ setup — no app password to mint, no token to bootstrap.
 
 from __future__ import annotations
 
+import time
 import xml.etree.ElementTree as ET
 from collections.abc import Sequence
 
@@ -37,20 +38,35 @@ class NextcloudSourceHelper:
         suffix = f"/{path.lstrip('/')}" if path else ""
         return f"{self.base_url}/remote.php/dav/files/{self.username}/{self.root}{suffix}"
 
-    def ping(self, timeout: int = 15) -> None:
-        """Raise unless WebDAV answers for this user."""
-        resp = requests.request(
-            "PROPFIND",
-            f"{self.base_url}/remote.php/dav/files/{self.username}/",
-            auth=self.auth,
-            headers={"Depth": "0"},
-            timeout=timeout,
+    def ping(self, timeout: int = 15, attempts: int = 12, delay: int = 5) -> None:
+        """Wait until WebDAV answers 207 for this user.
+
+        Retried rather than checked once. The container's healthcheck is
+        status.php, which a first boot answers before WebDAV is serving, so a
+        single PROPFIND races startup. Because an unreachable source is a hard
+        failure in CI rather than a skip, losing that race would fail the run.
+        """
+        last = ""
+        for attempt in range(1, attempts + 1):
+            try:
+                resp = requests.request(
+                    "PROPFIND",
+                    f"{self.base_url}/remote.php/dav/files/{self.username}/",
+                    auth=self.auth,
+                    headers={"Depth": "0"},
+                    timeout=timeout,
+                )
+                if resp.status_code == 207:
+                    return
+                last = f"HTTP {resp.status_code}: {resp.text[:150]}"
+            except requests.RequestException as exc:
+                last = str(exc)
+            if attempt < attempts:
+                time.sleep(delay)
+        raise RuntimeError(
+            f"Nextcloud WebDAV never returned 207 for {self.username} after "
+            f"{attempts} attempts: {last}"
         )
-        if resp.status_code != 207:
-            raise RuntimeError(
-                f"Nextcloud WebDAV returned {resp.status_code} for "
-                f"{self.username}: {resp.text[:200]}"
-            )
 
     def ensure_root(self, timeout: int = 15) -> None:
         # MKCOL answers 405 when the collection already exists, which is fine.

--- a/integration-tests/pytest.ini
+++ b/integration-tests/pytest.ini
@@ -30,6 +30,7 @@ markers =
     localfs: marks tests specific to Local FS connector
     rss: marks tests specific to RSS connector
     web: marks tests specific to Web connector
+    nextcloud: marks tests specific to Nextcloud connector
     gcs: marks tests specific to GCS connector
     azure_blob: marks tests specific to Azure Blob connector
     azure_files: marks tests specific to Azure Files connector


### PR DESCRIPTION
## In one line

PipesHub can pull documents from Nextcloud. Nothing tested that until now. This adds tests that run automatically — and need no account, because Nextcloud is free software anyone can run.

## Background

PipesHub connects to around 50 outside services and copies documents from them so people can search across everything in one place. Each connection is called a *connector*.

Being confident a connector still works means running it against the real service, which usually means owning an account there. That is why only 16 of the 50 are tested today.

Nextcloud is one of the few exceptions, for two reasons: anyone can run it, and it signs in with a plain username and password. Most services of its kind need an access token minted through their web interface first, which a test cannot do unattended. Here the username and password the server starts with are all the connector needs.

## What this changes

**Before:** if someone broke the Nextcloud connector, nothing would notice until a customer's documents stopped appearing.

**After:** three checks run automatically on every change.

| What it checks | Why it matters |
|---|---|
| Files, including in sub-folders, become searchable documents | The basic promise of the connector |
| A file added later is picked up | Connectors re-check on a schedule; this proves that works |
| Editing a file updates the existing document rather than duplicating it | Otherwise the same document appears twice in search |

The test files go into two sub-folders on purpose, so the first check also proves the connector looks beyond the top level. A connector that listed only the top folder would find nothing and fail, rather than quietly passing against a flat directory.

## How to try it

No account or password needed.

```bash
cd deployment/docker-compose
docker compose -f docker-compose.integration.neo4j.yml up -d

cd ../../integration-tests
pytest -m nextcloud -v
```

If Nextcloud is not running the tests say so and skip. In CI, where it is always started, they fail instead — a broken setup should be visible, not hidden.

## One timing detail

Nextcloud reports itself ready before its file-sharing interface actually answers, so the tests wait for that interface specifically rather than trusting the general ready signal. Without that, a first start could fail the run for no real reason.

## Anything to worry about

No. Nothing here changes how PipesHub behaves for users. It adds tests and a test-only Nextcloud server; deleting every file in this change would leave the product exactly as it is today.
