### PR TITLE
feat: device-code login for agents, optional app self-registration, eval install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -362,7 +362,11 @@ trap cleanup SIGTERM SIGINT SIGQUIT
 
 log "=== Process Monitor Starting ==="
 start_nodejs
-start_slackbot
+if [ "${PIPESHUB_SKIP_SLACKBOT:-false}" = "true" ]; then
+    log "PIPESHUB_SKIP_SLACKBOT=true — skipping Slack Bot"
+else
+    start_slackbot
+fi
 start_embedding
 start_connector
 start_query

--- a/backend/nodejs/apps/src/libs/errors/oauth.errors.ts
+++ b/backend/nodejs/apps/src/libs/errors/oauth.errors.ts
@@ -76,3 +76,16 @@ export class ServerError extends OAuthError {
     super('SERVER_ERROR', message, 500, metadata);
   }
 }
+
+/**
+ * RFC 8628 device-grant errors. Always HTTP 400; the JSON `error` member is
+ * `oauthError` (`authorization_pending`, `slow_down`, `expired_token`, …).
+ */
+export class DeviceGrantError extends OAuthError {
+  readonly oauthError: string
+
+  constructor(oauthError: string, message: string, metadata?: ErrorMetadata) {
+    super(oauthError.toUpperCase().replace(/-/g, '_'), message, 400, metadata)
+    this.oauthError = oauthError
+  }
+}

--- a/backend/nodejs/apps/src/modules/oauth_provider/config/scopes.config.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/config/scopes.config.ts
@@ -299,6 +299,19 @@ export const DefaultMcpScopes = [
   'connector:read',
 ];
 
+/**
+ * Scopes the CLI/agent preset mints. Dynamic Client Registration defaults to
+ * this set (intersected with instance MCP_SCOPES). Never grant
+ * `client_credentials` through DCR — that grant has no user identity.
+ */
+export const AgentMcpScopes = [
+  'conversation:chat',
+  'semantic:write',
+  'kb:read',
+  'user:read',
+  'connector:read',
+] as const;
+
 export const ScopeCategories = [
   'Identity',
   'Access',

--- a/backend/nodejs/apps/src/modules/oauth_provider/config/scopes.config.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/config/scopes.config.ts
@@ -300,9 +300,11 @@ export const DefaultMcpScopes = [
 ];
 
 /**
- * Scopes the CLI/agent preset mints. Dynamic Client Registration defaults to
- * this set (intersected with instance MCP_SCOPES). Never grant
- * `client_credentials` through DCR — that grant has no user identity.
+ * Scopes the CLI/agent preset mints. The first-party device app
+ * (`pipeshub-agent`) and Dynamic Client Registration default to this set
+ * (intersected with instance MCP_SCOPES). Never grant
+ * `client_credentials` through DCR or the first-party device app — that
+ * grant has no user identity.
  */
 export const AgentMcpScopes = [
   'conversation:chat',

--- a/backend/nodejs/apps/src/modules/oauth_provider/constants/constants.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/constants/constants.ts
@@ -24,3 +24,12 @@ export const PAT_TOKEN_PREFIX = 'phpat_'
  * the regular OAuth-clients UI.
  */
 export const PAT_APP_CLIENT_ID_PREFIX = 'pat-system:'
+
+/**
+ * clientId of the instance-wide first-party device app ("PipesHub agent").
+ * Public client, device_code + refresh_token only. Advertised as
+ * `pipeshub_device_client_id` on OIDC discovery so agents can start the
+ * TV-code flow without DCR or an admin-created OAuth app. Hidden from
+ * Developer Settings the same way as {@link PAT_APP_CLIENT_ID_PREFIX}.
+ */
+export const FIRST_PARTY_DEVICE_CLIENT_ID = 'pipeshub-agent'

--- a/backend/nodejs/apps/src/modules/oauth_provider/container/oauth.provider.container.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/container/oauth.provider.container.ts
@@ -12,6 +12,8 @@ import { OAuthTokenService } from '../services/oauth_token.service'
 import { AuthorizationCodeService } from '../services/authorization_code.service'
 import { ScopeValidatorService } from '../services/scope.validator.service'
 import { PatService } from '../services/pat.service'
+import { OAuthDcrService } from '../services/oauth.dcr.service'
+import { OAuthDeviceService } from '../services/oauth.device.service'
 import { OAuthAppController } from '../controller/oauth.app.controller'
 import { OAuthProviderController } from '../controller/oauth.provider.controller'
 import { OIDCProviderController } from '../controller/oid.provider.controller'
@@ -152,6 +154,26 @@ export class OAuthProviderContainer {
       )
       container.bind<PatService>('PatService').toConstantValue(patService)
 
+      const oauthDcrService = new OAuthDcrService(
+        logger,
+        oauthAppService,
+        scopeValidatorService,
+        appConfig,
+      )
+      container
+        .bind<OAuthDcrService>('OAuthDcrService')
+        .toConstantValue(oauthDcrService)
+
+      const oauthDeviceService = new OAuthDeviceService(
+        logger,
+        oauthAppService,
+        oauthTokenService,
+        scopeValidatorService,
+      )
+      container
+        .bind<OAuthDeviceService>('OAuthDeviceService')
+        .toConstantValue(oauthDeviceService)
+
       // Initialize Controllers
       container
         .bind<OAuthAppController>('OAuthAppController')
@@ -177,6 +199,8 @@ export class OAuthProviderContainer {
             oauthTokenService,
             authorizationCodeService,
             scopeValidatorService,
+            oauthDcrService,
+            oauthDeviceService,
           )
         })
 

--- a/backend/nodejs/apps/src/modules/oauth_provider/container/oauth.provider.container.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/container/oauth.provider.container.ts
@@ -14,6 +14,7 @@ import { ScopeValidatorService } from '../services/scope.validator.service'
 import { PatService } from '../services/pat.service'
 import { OAuthDcrService } from '../services/oauth.dcr.service'
 import { OAuthDeviceService } from '../services/oauth.device.service'
+import { FirstPartyDeviceAppService } from '../services/oauth.first_party_device.service'
 import { OAuthAppController } from '../controller/oauth.app.controller'
 import { OAuthProviderController } from '../controller/oauth.provider.controller'
 import { OIDCProviderController } from '../controller/oid.provider.controller'
@@ -164,11 +165,22 @@ export class OAuthProviderContainer {
         .bind<OAuthDcrService>('OAuthDcrService')
         .toConstantValue(oauthDcrService)
 
+      const firstPartyDeviceAppService = new FirstPartyDeviceAppService(
+        logger,
+        encryptionService,
+        scopeValidatorService,
+        appConfig,
+      )
+      container
+        .bind<FirstPartyDeviceAppService>('FirstPartyDeviceAppService')
+        .toConstantValue(firstPartyDeviceAppService)
+
       const oauthDeviceService = new OAuthDeviceService(
         logger,
         oauthAppService,
         oauthTokenService,
         scopeValidatorService,
+        firstPartyDeviceAppService,
       )
       container
         .bind<OAuthDeviceService>('OAuthDeviceService')
@@ -211,6 +223,7 @@ export class OAuthProviderContainer {
             oauthTokenService,
             scopeValidatorService,
             appConfig,
+            firstPartyDeviceAppService,
           )
         })
 

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
@@ -12,7 +12,9 @@ import {
   InvalidScopeError,
   AccessDeniedError,
   InvalidRedirectUriError,
+  DeviceGrantError,
 } from '../../../libs/errors/oauth.errors'
+import { BadRequestError, ForbiddenError, NotFoundError } from '../../../libs/errors/http.errors'
 import {
   AuthorizeRequest,
   TokenRequest,
@@ -20,7 +22,10 @@ import {
   ConsentData,
   OAuthErrorResponse,
 } from '../types/oauth.types'
-import { Users, Org } from '../../../config'
+import { Users } from '../../user_management/schema/users.schema'
+import { Org } from '../../user_management/schema/org.schema'
+import { OAuthDcrService } from '../services/oauth.dcr.service'
+import { OAuthDeviceService } from '../services/oauth.device.service'
 
 interface AuthenticatedRequest extends Request {
   user?: {
@@ -42,6 +47,8 @@ export class OAuthProviderController {
     private authorizationCodeService: AuthorizationCodeService,
     @inject('ScopeValidatorService')
     private scopeValidatorService: ScopeValidatorService,
+    @inject('OAuthDcrService') private oauthDcrService: OAuthDcrService,
+    @inject('OAuthDeviceService') private oauthDeviceService: OAuthDeviceService,
   ) {}
 
   /**
@@ -295,6 +302,14 @@ export class OAuthProviderController {
           )
           break
 
+        case 'urn:ietf:params:oauth:grant-type:device_code':
+          tokenResponse = await this.oauthDeviceService.poll(
+            clientId,
+            clientSecret,
+            tokenRequest.device_code || '',
+          )
+          break
+
         default:
           throw new UnsupportedGrantTypeError(
             `Unsupported grant_type: ${tokenRequest.grant_type}`,
@@ -372,6 +387,132 @@ export class OAuthProviderController {
       }
       // RFC 7662: For other errors, return inactive token to prevent information disclosure
       res.json({ active: false })
+    }
+  }
+
+  /**
+   * RFC 7591 Dynamic Client Registration — POST /oauth2/register
+   */
+  async register(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const created = await this.oauthDcrService.register(req.body)
+      res.status(201).json(created)
+    } catch (error) {
+      if (error instanceof ForbiddenError) {
+        res.status(403).json({
+          error: 'access_denied',
+          error_description: error.message,
+        })
+        return
+      }
+      if (
+        error instanceof BadRequestError ||
+        error instanceof InvalidScopeError ||
+        error instanceof InvalidRedirectUriError
+      ) {
+        res.status(400).json({
+          error: 'invalid_client_metadata',
+          error_description: error.message,
+        })
+        return
+      }
+      next(error)
+    }
+  }
+
+  /**
+   * RFC 8628 Device Authorization — POST /oauth2/device_authorization
+   */
+  async deviceAuthorization(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const { client_id, scope } = req.body
+      const frontendUrl = (req as Request & { oauthFrontendUrl?: string })
+        .oauthFrontendUrl
+      if (!frontendUrl) {
+        throw new Error('frontendUrl is not configured')
+      }
+      const result = await this.oauthDeviceService.createAuthorization(
+        client_id,
+        scope,
+        frontendUrl,
+      )
+      res.status(200).json(result)
+    } catch (error) {
+      const oauthError = this.buildErrorResponse(error as Error)
+      res.status(this.getErrorStatusCode(error as Error)).json(oauthError)
+    }
+  }
+
+  /**
+   * Authenticated lookup of a device user_code for the consent page.
+   */
+  async deviceVerify(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const user = req.user!
+      const consentData = await this.oauthDeviceService.getConsentData(
+        req.body.user_code,
+      )
+      consentData.user = {
+        email: user.email,
+        name: user.fullName,
+      }
+      res.json({ requiresConsent: true, consentData })
+    } catch (error) {
+      if (error instanceof NotFoundError || error instanceof BadRequestError) {
+        res.status(400).json({
+          error: 'invalid_request',
+          error_description: error.message,
+        })
+        return
+      }
+      if (error instanceof DeviceGrantError) {
+        res.status(400).json(this.buildErrorResponse(error))
+        return
+      }
+      next(error)
+    }
+  }
+
+  async deviceConsent(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction,
+  ): Promise<void> {
+    try {
+      const user = req.user!
+      const consent = req.body.consent === 'denied' ? 'denied' : 'granted'
+      await this.oauthDeviceService.approve(
+        req.body.user_code,
+        user.userId,
+        user.orgId,
+        consent,
+      )
+      res.json({ ok: true, consent })
+    } catch (error) {
+      if (error instanceof NotFoundError || error instanceof BadRequestError) {
+        res.status(400).json({
+          error: 'invalid_request',
+          error_description: error.message,
+        })
+        return
+      }
+      if (error instanceof DeviceGrantError) {
+        res.status(400).json(this.buildErrorResponse(error))
+        return
+      }
+      next(error)
     }
   }
 
@@ -615,6 +756,8 @@ export class OAuthProviderController {
 
     if (error instanceof InvalidGrantError) {
       errorCode = 'invalid_grant'
+    } else if (error instanceof DeviceGrantError) {
+      errorCode = error.oauthError
     } else if (error instanceof InvalidClientError) {
       errorCode = 'invalid_client'
     } else if (error instanceof UnsupportedGrantTypeError) {

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
@@ -431,7 +431,7 @@ export class OAuthProviderController {
   async deviceAuthorization(
     req: Request,
     res: Response,
-    next: NextFunction,
+    _next: NextFunction,
   ): Promise<void> {
     try {
       const { client_id, scope } = req.body

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
@@ -127,6 +127,7 @@ export class OAuthProviderController {
           logoUrl: app.logoUrl,
           homepageUrl: app.homepageUrl,
           privacyPolicyUrl: app.privacyPolicyUrl,
+          isDynamic: app.isDynamic === true,
         },
         scopes: scopeDefinitions.map((s) => ({
           name: s.name,

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
@@ -493,7 +493,10 @@ export class OAuthProviderController {
   ): Promise<void> {
     try {
       const user = req.user!
-      const consent = req.body.consent === 'denied' ? 'denied' : 'granted'
+      if (req.body.consent !== 'granted' && req.body.consent !== 'denied') {
+        throw new BadRequestError('consent must be granted or denied')
+      }
+      const consent = req.body.consent
       await this.oauthDeviceService.approve(
         req.body.user_code,
         user.userId,

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
@@ -11,7 +11,7 @@ import {
   JWK,
 } from '../types/oauth.types';
 import { AppConfig } from '../../tokens_manager/config/config';
-import { Users } from '../../../config';
+import { Users } from '../../user_management/schema/users.schema';
 import {
   OAuthRequest,
   buildWwwAuthenticateHeader,
@@ -112,6 +112,8 @@ export class OIDCProviderController {
       revocation_endpoint: `${baseUrl}/revoke`,
       introspection_endpoint: `${baseUrl}/introspect`,
       jwks_uri: `${backendUrl}/.well-known/jwks.json`,
+      registration_endpoint: `${baseUrl}/register`,
+      device_authorization_endpoint: `${baseUrl}/device_authorization`,
       scopes_supported: this.scopeValidatorService
         .getAllScopes()
         .map((s) => s.name),
@@ -120,8 +122,10 @@ export class OIDCProviderController {
         'authorization_code',
         'client_credentials',
         'refresh_token',
+        'urn:ietf:params:oauth:grant-type:device_code',
       ],
       token_endpoint_auth_methods_supported: [
+        'none',
         'client_secret_basic',
         'client_secret_post',
       ],

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
@@ -103,6 +103,8 @@ export class OIDCProviderController {
   ): Promise<void> {
     const backendUrl = this.appConfig.oauthIssuer;
     const baseUrl = `${backendUrl}/api/v1/oauth2`;
+    const dcrEnabled = process.env.PIPESHUB_ENABLE_DCR === 'true';
+    const deviceEnabled = process.env.PIPESHUB_ENABLE_DEVICE_GRANT !== 'false';
 
     const config: OpenIDConfiguration = {
       issuer: this.appConfig.oauthIssuer,
@@ -112,10 +114,10 @@ export class OIDCProviderController {
       revocation_endpoint: `${baseUrl}/revoke`,
       introspection_endpoint: `${baseUrl}/introspect`,
       jwks_uri: `${backendUrl}/.well-known/jwks.json`,
-      ...(process.env.PIPESHUB_ENABLE_DCR === 'true'
-        ? { registration_endpoint: `${baseUrl}/register` }
+      ...(dcrEnabled ? { registration_endpoint: `${baseUrl}/register` } : {}),
+      ...(deviceEnabled
+        ? { device_authorization_endpoint: `${baseUrl}/device_authorization` }
         : {}),
-      device_authorization_endpoint: `${baseUrl}/device_authorization`,
       scopes_supported: this.scopeValidatorService
         .getAllScopes()
         .map((s) => s.name),
@@ -124,7 +126,9 @@ export class OIDCProviderController {
         'authorization_code',
         'client_credentials',
         'refresh_token',
-        'urn:ietf:params:oauth:grant-type:device_code',
+        ...(deviceEnabled
+          ? ['urn:ietf:params:oauth:grant-type:device_code']
+          : []),
       ],
       token_endpoint_auth_methods_supported: [
         'none',

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
@@ -112,7 +112,9 @@ export class OIDCProviderController {
       revocation_endpoint: `${baseUrl}/revoke`,
       introspection_endpoint: `${baseUrl}/introspect`,
       jwks_uri: `${backendUrl}/.well-known/jwks.json`,
-      registration_endpoint: `${baseUrl}/register`,
+      ...(process.env.PIPESHUB_ENABLE_DCR === 'true'
+        ? { registration_endpoint: `${baseUrl}/register` }
+        : {}),
       device_authorization_endpoint: `${baseUrl}/device_authorization`,
       scopes_supported: this.scopeValidatorService
         .getAllScopes()

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oid.provider.controller.ts
@@ -16,6 +16,7 @@ import {
   OAuthRequest,
   buildWwwAuthenticateHeader,
 } from '../middlewares/oauth.auth.middleware';
+import { FirstPartyDeviceAppService } from '../services/oauth.first_party_device.service';
 
 /**
  * OpenID Connect Provider Controller
@@ -35,6 +36,8 @@ export class OIDCProviderController {
     @inject('ScopeValidatorService')
     private scopeValidatorService: ScopeValidatorService,
     @inject('AppConfig') private appConfig: AppConfig,
+    @inject('FirstPartyDeviceAppService')
+    private firstPartyDeviceAppService: FirstPartyDeviceAppService,
   ) {}
 
   /**
@@ -105,6 +108,9 @@ export class OIDCProviderController {
     const baseUrl = `${backendUrl}/api/v1/oauth2`;
     const dcrEnabled = process.env.PIPESHUB_ENABLE_DCR === 'true';
     const deviceEnabled = process.env.PIPESHUB_ENABLE_DEVICE_GRANT !== 'false';
+    const deviceClientId = deviceEnabled
+      ? await this.firstPartyDeviceAppService.getOrCreate()
+      : null;
 
     const config: OpenIDConfiguration = {
       issuer: this.appConfig.oauthIssuer,
@@ -117,6 +123,9 @@ export class OIDCProviderController {
       ...(dcrEnabled ? { registration_endpoint: `${baseUrl}/register` } : {}),
       ...(deviceEnabled
         ? { device_authorization_endpoint: `${baseUrl}/device_authorization` }
+        : {}),
+      ...(deviceClientId
+        ? { pipeshub_device_client_id: deviceClientId }
         : {}),
       scopes_supported: this.scopeValidatorService
         .getAllScopes()
@@ -170,6 +179,10 @@ export class OIDCProviderController {
     _next: NextFunction,
   ): Promise<void> {
     const backendUrl = this.appConfig.oauthIssuer;
+    const deviceEnabled = process.env.PIPESHUB_ENABLE_DEVICE_GRANT !== 'false';
+    const deviceClientId = deviceEnabled
+      ? await this.firstPartyDeviceAppService.getOrCreate()
+      : null;
 
     const metadata: OAuthProtectedResourceMetadata = {
       resource: `${backendUrl}/mcp`,
@@ -177,6 +190,9 @@ export class OIDCProviderController {
       scopes_supported: this.appConfig.mcpScopes,
       bearer_methods_supported: ['header'],
       resource_documentation: `${backendUrl}/api/v1/docs`,
+      ...(deviceClientId
+        ? { pipeshub_device_client_id: deviceClientId }
+        : {}),
     };
 
     res.json(metadata);

--- a/backend/nodejs/apps/src/modules/oauth_provider/routes/oauth.provider.routes.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/routes/oauth.provider.routes.ts
@@ -16,6 +16,9 @@ import {
   tokenSchema,
   revokeSchema,
   introspectSchema,
+  dcrRequestSchema,
+  deviceAuthorizationSchema,
+  deviceUserCodeSchema,
 } from '../validators/oauth.validators'
 
 export function createOAuthProviderRouter(container: Container): Router {
@@ -122,6 +125,63 @@ export function createOAuthProviderRouter(container: Container): Router {
     oauthAuthMiddleware.requireScopes('openid'),
     (req: Request, res: Response, next: NextFunction) =>
       oidcController.userInfo(req, res, next),
+  )
+
+  /**
+   * POST /register
+   * RFC 7591 Dynamic Client Registration. Never issues client_credentials.
+   */
+  router.post(
+    '/register',
+    oauthTokenRateLimiter,
+    ValidationMiddleware.validate(dcrRequestSchema),
+    (req: Request, res: Response, next: NextFunction) =>
+      controller.register(req, res, next),
+  )
+
+  /**
+   * POST /device_authorization
+   * RFC 8628 Device Authorization Grant.
+   */
+  router.post(
+    '/device_authorization',
+    oauthTokenRateLimiter,
+    ValidationMiddleware.validate(deviceAuthorizationSchema),
+    (req: Request, res: Response, next: NextFunction) => {
+      ;(req as Request & { oauthFrontendUrl?: string }).oauthFrontendUrl =
+        frontendUrl
+      controller.deviceAuthorization(req, res, next)
+    },
+  )
+
+  /**
+   * POST /device/verify — authenticated user_code lookup for the consent page.
+   */
+  router.post(
+    '/device/verify',
+    authMiddleware.authenticate.bind(authMiddleware),
+    ValidationMiddleware.validate(deviceUserCodeSchema),
+    (req: Request, res: Response, next: NextFunction) =>
+      controller.deviceVerify(
+        req as Parameters<typeof controller.deviceVerify>[0],
+        res,
+        next,
+      ),
+  )
+
+  /**
+   * POST /device/consent — user approves or denies a device grant.
+   */
+  router.post(
+    '/device/consent',
+    authMiddleware.authenticate.bind(authMiddleware),
+    ValidationMiddleware.validate(deviceUserCodeSchema),
+    (req: Request, res: Response, next: NextFunction) =>
+      controller.deviceConsent(
+        req as Parameters<typeof controller.deviceConsent>[0],
+        res,
+        next,
+      ),
   )
 
   return router

--- a/backend/nodejs/apps/src/modules/oauth_provider/routes/oauth.provider.routes.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/routes/oauth.provider.routes.ts
@@ -19,6 +19,7 @@ import {
   dcrRequestSchema,
   deviceAuthorizationSchema,
   deviceUserCodeSchema,
+  deviceConsentSchema,
 } from '../validators/oauth.validators'
 
 export function createOAuthProviderRouter(container: Container): Router {
@@ -177,7 +178,7 @@ export function createOAuthProviderRouter(container: Container): Router {
     '/device/consent',
     oauthTokenRateLimiter,
     authMiddleware.authenticate.bind(authMiddleware),
-    ValidationMiddleware.validate(deviceUserCodeSchema),
+    ValidationMiddleware.validate(deviceConsentSchema),
     (req: Request, res: Response, next: NextFunction) =>
       controller.deviceConsent(
         req as Parameters<typeof controller.deviceConsent>[0],

--- a/backend/nodejs/apps/src/modules/oauth_provider/routes/oauth.provider.routes.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/routes/oauth.provider.routes.ts
@@ -159,6 +159,7 @@ export function createOAuthProviderRouter(container: Container): Router {
    */
   router.post(
     '/device/verify',
+    oauthTokenRateLimiter,
     authMiddleware.authenticate.bind(authMiddleware),
     ValidationMiddleware.validate(deviceUserCodeSchema),
     (req: Request, res: Response, next: NextFunction) =>
@@ -174,6 +175,7 @@ export function createOAuthProviderRouter(container: Container): Router {
    */
   router.post(
     '/device/consent',
+    oauthTokenRateLimiter,
     authMiddleware.authenticate.bind(authMiddleware),
     ValidationMiddleware.validate(deviceUserCodeSchema),
     (req: Request, res: Response, next: NextFunction) =>

--- a/backend/nodejs/apps/src/modules/oauth_provider/schema/oauth.app.schema.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/schema/oauth.app.schema.ts
@@ -11,6 +11,7 @@ export enum OAuthGrantType {
   AUTHORIZATION_CODE = 'authorization_code',
   CLIENT_CREDENTIALS = 'client_credentials',
   REFRESH_TOKEN = 'refresh_token',
+  DEVICE_CODE = 'urn:ietf:params:oauth:grant-type:device_code',
 }
 
 export interface IOAuthApp extends Document {
@@ -30,6 +31,8 @@ export interface IOAuthApp extends Document {
   privacyPolicyUrl?: string
   termsOfServiceUrl?: string
   isConfidential: boolean
+  /** RFC 7591 Dynamic Client Registration. Hidden from the developer-apps UI. */
+  isDynamic?: boolean
   accessTokenLifetime: number
   refreshTokenLifetime: number
   isDeleted: boolean
@@ -106,6 +109,7 @@ const OAuthAppSchema = new Schema<IOAuthApp>(
     privacyPolicyUrl: { type: String },
     termsOfServiceUrl: { type: String },
     isConfidential: { type: Boolean, default: true },
+    isDynamic: { type: Boolean, default: false, index: true },
     accessTokenLifetime: { type: Number, default: 3600 },
     refreshTokenLifetime: { type: Number, default: 2592000 },
     isDeleted: { type: Boolean, default: false },

--- a/backend/nodejs/apps/src/modules/oauth_provider/schema/oauth.device_code.schema.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/schema/oauth.device_code.schema.ts
@@ -1,0 +1,67 @@
+import mongoose, { Document, Schema, Model, Types } from 'mongoose'
+
+export enum OAuthDeviceCodeStatus {
+  PENDING = 'pending',
+  APPROVED = 'approved',
+  DENIED = 'denied',
+}
+
+export interface IOAuthDeviceCode extends Document {
+  deviceCodeHash: string
+  userCode: string
+  clientId: string
+  scopes: string[]
+  status: OAuthDeviceCodeStatus
+  userId?: Types.ObjectId
+  orgId?: Types.ObjectId
+  interval: number
+  lastPolledAt?: Date
+  expiresAt: Date
+  createdAt: Date
+  updatedAt: Date
+}
+
+const OAuthDeviceCodeSchema = new Schema<IOAuthDeviceCode>(
+  {
+    deviceCodeHash: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    userCode: {
+      type: String,
+      required: true,
+      unique: true,
+      index: true,
+    },
+    clientId: {
+      type: String,
+      required: true,
+      index: true,
+    },
+    scopes: { type: [String], required: true },
+    status: {
+      type: String,
+      enum: Object.values(OAuthDeviceCodeStatus),
+      default: OAuthDeviceCodeStatus.PENDING,
+    },
+    userId: { type: Schema.Types.ObjectId, ref: 'users' },
+    orgId: { type: Schema.Types.ObjectId, ref: 'org' },
+    interval: { type: Number, default: 5 },
+    lastPolledAt: { type: Date },
+    expiresAt: {
+      type: Date,
+      required: true,
+      index: { expireAfterSeconds: 0 },
+    },
+  },
+  { timestamps: true },
+)
+
+export const OAuthDeviceCode: Model<IOAuthDeviceCode> =
+  mongoose.model<IOAuthDeviceCode>(
+    'oauthDeviceCode',
+    OAuthDeviceCodeSchema,
+    'oauthDeviceCodes',
+  )

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.app.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.app.service.ts
@@ -55,6 +55,7 @@ export class OAuthAppService {
       isDeleted: false,
       createdBy: new Types.ObjectId(userId),
       clientId: { $not: new RegExp(`^${PAT_APP_CLIENT_ID_PREFIX}`) },
+      isDynamic: { $ne: true },
     }
   }
 
@@ -111,6 +112,66 @@ export class OAuthAppService {
       clientId,
       orgId,
       name: data.name,
+    })
+
+    return {
+      ...this.toAppResponse(app),
+      clientSecret,
+    }
+  }
+
+  /**
+   * RFC 7591 Dynamic Client Registration.
+   * Never accepts `client_credentials` — that grant has no user identity.
+   */
+  async createDynamicClient(params: {
+    orgId: string
+    createdBy: string
+    name: string
+    redirectUris: string[]
+    allowedGrantTypes: OAuthGrantType[]
+    allowedScopes: string[]
+    isConfidential: boolean
+    homepageUrl?: string
+    privacyPolicyUrl?: string
+    termsOfServiceUrl?: string
+    logoUrl?: string
+  }): Promise<OAuthAppWithSecret> {
+    if (params.allowedGrantTypes.includes(OAuthGrantType.CLIENT_CREDENTIALS)) {
+      throw new BadRequestError(
+        'client_credentials is not allowed for dynamically registered clients',
+      )
+    }
+    this.validateGrantTypes(params.allowedGrantTypes)
+    this.validateDcrRedirectUris(params.redirectUris)
+
+    const clientId = randomUUID()
+    const clientSecret = this.generateClientSecret()
+    const clientSecretEncrypted = this.encryptionService.encrypt(clientSecret)
+
+    const app = await OAuthApp.create({
+      clientId,
+      clientSecretEncrypted,
+      name: params.name,
+      orgId: new Types.ObjectId(params.orgId),
+      createdBy: new Types.ObjectId(params.createdBy),
+      redirectUris: params.redirectUris,
+      allowedGrantTypes: params.allowedGrantTypes,
+      allowedScopes: params.allowedScopes,
+      homepageUrl: params.homepageUrl,
+      privacyPolicyUrl: params.privacyPolicyUrl,
+      termsOfServiceUrl: params.termsOfServiceUrl,
+      logoUrl: params.logoUrl,
+      isConfidential: params.isConfidential,
+      isDynamic: true,
+      accessTokenLifetime: 3600,
+      refreshTokenLifetime: 2592000,
+    })
+
+    this.logger.info('Dynamically registered OAuth client', {
+      clientId,
+      orgId: params.orgId,
+      isConfidential: params.isConfidential,
     })
 
     return {
@@ -486,6 +547,40 @@ export class OAuthAppService {
       } catch (error) {
         if (error instanceof InvalidRedirectUriError) throw error
         throw new InvalidRedirectUriError(`Invalid redirect URI: ${uri}`)
+      }
+    }
+  }
+
+  /**
+   * DCR redirect URIs: HTTPS, loopback HTTP, or private-use schemes (RFC 8252).
+   * `javascript:` / `data:` / `file:` / `vbscript:` are rejected.
+   */
+  validateDcrRedirectUris(uris: string[]): void {
+    const blocked = new Set(['javascript:', 'data:', 'file:', 'vbscript:'])
+    for (const uri of uris) {
+      let parsed: URL
+      try {
+        parsed = new URL(uri)
+      } catch {
+        throw new InvalidRedirectUriError(`Invalid redirect URI: ${uri}`)
+      }
+      if (parsed.hash) {
+        throw new InvalidRedirectUriError(
+          `Redirect URI must not contain a fragment: ${uri}`,
+        )
+      }
+      if (blocked.has(parsed.protocol)) {
+        throw new InvalidRedirectUriError(
+          `Redirect URI scheme is not allowed: ${uri}`,
+        )
+      }
+      if (parsed.protocol === 'http:') {
+        const host = parsed.hostname.toLowerCase()
+        if (host !== 'localhost' && host !== '127.0.0.1' && host !== '[::1]' && host !== '::1') {
+          throw new InvalidRedirectUriError(
+            `http redirect URIs are only allowed on loopback: ${uri}`,
+          )
+        }
       }
     }
   }

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.app.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.app.service.ts
@@ -26,6 +26,7 @@ import {
 } from '../types/oauth.types'
 import {
   ALLOWED_CUSTOM_REDIRECT_URIS,
+  FIRST_PARTY_DEVICE_CLIENT_ID,
   PAT_APP_CLIENT_ID_PREFIX,
 } from '../constants/constants'
 
@@ -45,16 +46,20 @@ export class OAuthAppService {
    * Matches compound index `{ orgId, createdBy, isDeleted, createdAt }` on `OAuthApp` for list queries.
    *
    * Excludes the per-org synthetic PAT app (`pat-system:<orgId>`, see
-   * {@link PatService}) — it's an internal pseudo-client, not something
-   * its creator should be able to view, edit, suspend, delete, or pull a
-   * working secret for through this CRUD surface.
+   * {@link PatService}) and the instance-wide first-party device app
+   * (`pipeshub-agent`) — internal clients, not something their creator
+   * should be able to view, edit, suspend, delete, or pull a working
+   * secret for through this CRUD surface.
    */
   private buildAppFilter(orgId: string, userId: string): Record<string, unknown> {
     return {
       orgId: new Types.ObjectId(orgId),
       isDeleted: false,
       createdBy: new Types.ObjectId(userId),
-      clientId: { $not: new RegExp(`^${PAT_APP_CLIENT_ID_PREFIX}`) },
+      clientId: {
+        $nin: [FIRST_PARTY_DEVICE_CLIENT_ID],
+        $not: new RegExp(`^${PAT_APP_CLIENT_ID_PREFIX}`),
+      },
       isDynamic: { $ne: true },
     }
   }

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
@@ -1,0 +1,171 @@
+import { injectable, inject } from 'inversify'
+import { Logger } from '../../../libs/services/logger.service'
+import { BadRequestError, ForbiddenError } from '../../../libs/errors/http.errors'
+import { InvalidScopeError } from '../../../libs/errors/oauth.errors'
+import { Org } from '../../user_management/schema/org.schema'
+import { Users } from '../../user_management/schema/users.schema'
+import { OAuthGrantType } from '../schema/oauth.app.schema'
+import { OAuthAppService } from './oauth.app.service'
+import { ScopeValidatorService } from './scope.validator.service'
+import { AgentMcpScopes } from '../config/scopes.config'
+import { AppConfig } from '../../tokens_manager/config/config'
+
+export interface DcrRequestBody {
+  redirect_uris?: string[]
+  token_endpoint_auth_method?: 'none' | 'client_secret_basic' | 'client_secret_post'
+  grant_types?: string[]
+  response_types?: string[]
+  client_name?: string
+  client_uri?: string
+  logo_uri?: string
+  scope?: string
+  tos_uri?: string
+  policy_uri?: string
+}
+
+export interface DcrResponse {
+  client_id: string
+  client_secret?: string
+  client_id_issued_at: number
+  client_secret_expires_at: number
+  redirect_uris: string[]
+  grant_types: string[]
+  token_endpoint_auth_method: string
+  client_name: string
+  scope: string
+}
+
+@injectable()
+export class OAuthDcrService {
+  constructor(
+    @inject('Logger') private logger: Logger,
+    @inject('OAuthAppService') private oauthAppService: OAuthAppService,
+    @inject('ScopeValidatorService')
+    private scopeValidatorService: ScopeValidatorService,
+    @inject('AppConfig') private appConfig: AppConfig,
+  ) {}
+
+  async register(body: DcrRequestBody): Promise<DcrResponse> {
+    if (process.env.PIPESHUB_ENABLE_DCR === 'false') {
+      throw new ForbiddenError('dynamic client registration is disabled')
+    }
+
+    const grantTypes = this.parseGrantTypes(body.grant_types)
+    if (grantTypes.includes(OAuthGrantType.CLIENT_CREDENTIALS)) {
+      throw new BadRequestError(
+        'client_credentials is not allowed for dynamically registered clients',
+      )
+    }
+
+    const redirectUris = body.redirect_uris ?? []
+    const needsRedirect = grantTypes.includes(OAuthGrantType.AUTHORIZATION_CODE)
+    if (needsRedirect && redirectUris.length < 1) {
+      throw new BadRequestError(
+        'redirect_uris is required when authorization_code is requested',
+      )
+    }
+
+    const isConfidential =
+      (body.token_endpoint_auth_method ?? 'none') !== 'none'
+    const tokenEndpointAuthMethod = body.token_endpoint_auth_method ?? 'none'
+
+    const { orgId, createdBy } = await this.resolveRegistrationOrg()
+    const allowedScopes = this.resolveScopes(body.scope)
+
+    const created = await this.oauthAppService.createDynamicClient({
+      orgId,
+      createdBy,
+      name: body.client_name || 'Dynamically registered client',
+      redirectUris,
+      allowedGrantTypes: grantTypes,
+      allowedScopes,
+      isConfidential,
+      homepageUrl: body.client_uri,
+      privacyPolicyUrl: body.policy_uri,
+      termsOfServiceUrl: body.tos_uri,
+      logoUrl: body.logo_uri,
+    })
+
+    const issuedAt = Math.floor(Date.now() / 1000)
+    const response: DcrResponse = {
+      client_id: created.clientId,
+      client_id_issued_at: issuedAt,
+      client_secret_expires_at: 0,
+      redirect_uris: created.redirectUris,
+      grant_types: created.allowedGrantTypes,
+      token_endpoint_auth_method: tokenEndpointAuthMethod,
+      client_name: created.name,
+      scope: created.allowedScopes.join(' '),
+    }
+    if (isConfidential) {
+      response.client_secret = created.clientSecret
+    }
+    return response
+  }
+
+  private parseGrantTypes(raw?: string[]): OAuthGrantType[] {
+    if (!raw || raw.length === 0) {
+      return [OAuthGrantType.AUTHORIZATION_CODE, OAuthGrantType.REFRESH_TOKEN]
+    }
+    const allowed = new Set<string>(Object.values(OAuthGrantType))
+    const parsed: OAuthGrantType[] = []
+    for (const g of raw) {
+      if (!allowed.has(g)) {
+        throw new BadRequestError(`unsupported grant_type: ${g}`)
+      }
+      parsed.push(g as OAuthGrantType)
+    }
+    return parsed
+  }
+
+  private resolveScopes(scope?: string): string[] {
+    const mcp = new Set(this.appConfig.mcpScopes || [])
+    const memberAllowed = new Set(
+      this.scopeValidatorService.getAllowedScopeNamesForRole(false),
+    )
+    const requested = scope
+      ? this.scopeValidatorService.parseScopes(scope)
+      : [...AgentMcpScopes]
+
+    const granted: string[] = []
+    for (const s of requested) {
+      if (!memberAllowed.has(s)) {
+        throw new InvalidScopeError(`scope is not allowed: ${s}`)
+      }
+      if (mcp.size > 0 && !mcp.has(s)) {
+        throw new InvalidScopeError(`scope is not in MCP_SCOPES: ${s}`)
+      }
+      granted.push(s)
+    }
+    if (granted.length === 0) {
+      throw new InvalidScopeError('at least one scope is required')
+    }
+    return granted
+  }
+
+  private async resolveRegistrationOrg(): Promise<{
+    orgId: string
+    createdBy: string
+  }> {
+    const orgs = await Org.find({ isDeleted: { $ne: true } })
+      .sort({ createdAt: 1 })
+      .select('_id')
+      .lean()
+    if (orgs.length === 0) {
+      throw new BadRequestError('Instance is not initialized')
+    }
+    const orgId = orgs[0]._id.toString()
+    const user = await Users.findOne({
+      orgId: orgs[0]._id,
+      isDeleted: { $ne: true },
+    })
+      .sort({ createdAt: 1 })
+      .select('_id')
+      .lean()
+    if (!user) {
+      throw new BadRequestError('Instance has no users')
+    }
+    this.logger.info('DCR bound to instance org', { orgId })
+    return { orgId, createdBy: user._id.toString() }
+  }
+}

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
@@ -58,7 +58,10 @@ export class OAuthDcrService {
       )
     }
 
-    const responseTypes = this.parseResponseTypes(body.response_types)
+    const responseTypes = this.parseResponseTypes(
+      body.response_types,
+      grantTypes,
+    )
 
     const redirectUris = body.redirect_uris ?? []
     const needsRedirect = grantTypes.includes(OAuthGrantType.AUTHORIZATION_CODE)
@@ -122,12 +125,23 @@ export class OAuthDcrService {
     return parsed
   }
 
-  private parseResponseTypes(raw?: string[]): string[] {
-    const requested = raw && raw.length > 0 ? raw : ['code']
-    for (const t of requested) {
+  private parseResponseTypes(
+    raw: string[] | undefined,
+    grantTypes: OAuthGrantType[],
+  ): string[] {
+    const hasAuthCode = grantTypes.includes(OAuthGrantType.AUTHORIZATION_CODE)
+    if (!raw || raw.length === 0) {
+      return hasAuthCode ? ['code'] : []
+    }
+    for (const t of raw) {
       if (t !== 'code') {
         throw new BadRequestError(`unsupported response_type: ${t}`)
       }
+    }
+    if (!hasAuthCode) {
+      throw new BadRequestError(
+        'response_type code requires the authorization_code grant',
+      )
     }
     return ['code']
   }

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
@@ -46,7 +46,7 @@ export class OAuthDcrService {
   ) {}
 
   async register(body: DcrRequestBody): Promise<DcrResponse> {
-    if (process.env.PIPESHUB_ENABLE_DCR === 'false') {
+    if (process.env.PIPESHUB_ENABLE_DCR !== 'true') {
       throw new ForbiddenError('dynamic client registration is disabled')
     }
 

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
@@ -179,18 +179,19 @@ export class OAuthDcrService {
       .sort({ createdAt: 1 })
       .select('_id')
       .lean()
-    if (orgs.length === 0) {
+    const org = orgs[0]
+    if (!org) {
       throw new BadRequestError('Instance is not initialized')
     }
-    const orgId = orgs[0]._id.toString()
+    const orgId = org._id.toString()
     const user = await Users.findOne({
-      orgId: orgs[0]._id,
+      orgId: org._id,
       isDeleted: { $ne: true },
     })
       .sort({ createdAt: 1 })
       .select('_id')
       .lean()
-    if (!user) {
+    if (!user?._id) {
       throw new BadRequestError('Instance has no users')
     }
     this.logger.info('DCR bound to instance org', { orgId })

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.dcr.service.ts
@@ -30,6 +30,7 @@ export interface DcrResponse {
   client_secret_expires_at: number
   redirect_uris: string[]
   grant_types: string[]
+  response_types: string[]
   token_endpoint_auth_method: string
   client_name: string
   scope: string
@@ -56,6 +57,8 @@ export class OAuthDcrService {
         'client_credentials is not allowed for dynamically registered clients',
       )
     }
+
+    const responseTypes = this.parseResponseTypes(body.response_types)
 
     const redirectUris = body.redirect_uris ?? []
     const needsRedirect = grantTypes.includes(OAuthGrantType.AUTHORIZATION_CODE)
@@ -93,6 +96,7 @@ export class OAuthDcrService {
       client_secret_expires_at: 0,
       redirect_uris: created.redirectUris,
       grant_types: created.allowedGrantTypes,
+      response_types: responseTypes,
       token_endpoint_auth_method: tokenEndpointAuthMethod,
       client_name: created.name,
       scope: created.allowedScopes.join(' '),
@@ -116,6 +120,16 @@ export class OAuthDcrService {
       parsed.push(g as OAuthGrantType)
     }
     return parsed
+  }
+
+  private parseResponseTypes(raw?: string[]): string[] {
+    const requested = raw && raw.length > 0 ? raw : ['code']
+    for (const t of requested) {
+      if (t !== 'code') {
+        throw new BadRequestError(`unsupported response_type: ${t}`)
+      }
+    }
+    return ['code']
   }
 
   private resolveScopes(scope?: string): string[] {

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
@@ -1,0 +1,288 @@
+import { injectable, inject } from 'inversify'
+import crypto from 'crypto'
+import { Types } from 'mongoose'
+import { Logger } from '../../../libs/services/logger.service'
+import {
+  DeviceGrantError,
+  InvalidClientError,
+  InvalidGrantError,
+  UnsupportedGrantTypeError,
+} from '../../../libs/errors/oauth.errors'
+import { NotFoundError, BadRequestError } from '../../../libs/errors/http.errors'
+import {
+  OAuthDeviceCode,
+  OAuthDeviceCodeStatus,
+} from '../schema/oauth.device_code.schema'
+import { OAuthGrantType } from '../schema/oauth.app.schema'
+import { OAuthAppService } from './oauth.app.service'
+import { OAuthTokenService } from './oauth_token.service'
+import { ScopeValidatorService } from './scope.validator.service'
+import { Users } from '../../user_management/schema/users.schema'
+import { Org } from '../../user_management/schema/org.schema'
+import { TokenResponse, ConsentData } from '../types/oauth.types'
+
+const DEVICE_CODE_BYTES = 32
+const USER_CODE_LENGTH = 8
+const DEVICE_TTL_SECONDS = 600
+const POLL_INTERVAL_SECONDS = 5
+const USER_CODE_ALPHABET = 'ABCDEFGHJKMNPQRSTVWXYZ23456789'
+
+export interface DeviceAuthorizationResponse {
+  device_code: string
+  user_code: string
+  verification_uri: string
+  verification_uri_complete: string
+  expires_in: number
+  interval: number
+}
+
+@injectable()
+export class OAuthDeviceService {
+  constructor(
+    @inject('Logger') private logger: Logger,
+    @inject('OAuthAppService') private oauthAppService: OAuthAppService,
+    @inject('OAuthTokenService') private oauthTokenService: OAuthTokenService,
+    @inject('ScopeValidatorService')
+    private scopeValidatorService: ScopeValidatorService,
+  ) {}
+
+  async createAuthorization(
+    clientId: string,
+    scope: string | undefined,
+    frontendUrl: string,
+  ): Promise<DeviceAuthorizationResponse> {
+    if (process.env.PIPESHUB_ENABLE_DEVICE_GRANT === 'false') {
+      throw new UnsupportedGrantTypeError('device grant is disabled')
+    }
+
+    const app = await this.oauthAppService.getAppByClientId(clientId)
+    if (!this.oauthAppService.isGrantTypeAllowed(app, OAuthGrantType.DEVICE_CODE)) {
+      throw new UnsupportedGrantTypeError(
+        'device_code grant not allowed for this app',
+      )
+    }
+
+    const requested = scope
+      ? this.scopeValidatorService.parseScopes(scope)
+      : app.allowedScopes
+    this.scopeValidatorService.validateScopesForApp(requested, app.allowedScopes)
+
+    const deviceCode = crypto.randomBytes(DEVICE_CODE_BYTES).toString('hex')
+    const userCode = this.generateUserCode()
+    const expiresAt = new Date(Date.now() + DEVICE_TTL_SECONDS * 1000)
+
+    await OAuthDeviceCode.create({
+      deviceCodeHash: this.hashDeviceCode(deviceCode),
+      userCode,
+      clientId,
+      scopes: requested,
+      status: OAuthDeviceCodeStatus.PENDING,
+      interval: POLL_INTERVAL_SECONDS,
+      expiresAt,
+    })
+
+    const verificationUri = new URL('/oauth/device', frontendUrl).toString()
+    const displayCode = `${userCode.slice(0, 4)}-${userCode.slice(4)}`
+
+    this.logger.info('Device authorization created', { clientId, userCode })
+
+    return {
+      device_code: deviceCode,
+      user_code: displayCode,
+      verification_uri: verificationUri,
+      verification_uri_complete: `${verificationUri}?user_code=${displayCode}`,
+      expires_in: DEVICE_TTL_SECONDS,
+      interval: POLL_INTERVAL_SECONDS,
+    }
+  }
+
+  async getConsentData(userCodeRaw: string): Promise<ConsentData> {
+    const record = await this.findPendingByUserCode(userCodeRaw)
+    const app = await this.oauthAppService.getAppByClientId(record.clientId)
+    const scopeDefinitions = this.scopeValidatorService.getScopeDefinitions(
+      record.scopes,
+    )
+    return {
+      app: {
+        name: app.name,
+        description: app.description,
+        logoUrl: app.logoUrl,
+        homepageUrl: app.homepageUrl,
+        privacyPolicyUrl: app.privacyPolicyUrl,
+      },
+      scopes: scopeDefinitions,
+      user: { email: '', name: undefined },
+      redirectUri: '',
+      state: '',
+    }
+  }
+
+  async approve(
+    userCodeRaw: string,
+    userId: string,
+    orgId: string,
+    consent: 'granted' | 'denied',
+  ): Promise<void> {
+    const record = await this.findPendingByUserCode(userCodeRaw)
+    if (consent !== 'granted') {
+      record.status = OAuthDeviceCodeStatus.DENIED
+      await record.save()
+      this.logger.info('Device authorization denied', {
+        clientId: record.clientId,
+        userId,
+      })
+      return
+    }
+    record.status = OAuthDeviceCodeStatus.APPROVED
+    record.userId = new Types.ObjectId(userId)
+    record.orgId = new Types.ObjectId(orgId)
+    await record.save()
+    this.logger.info('Device authorization approved', {
+      clientId: record.clientId,
+      userId,
+      orgId,
+    })
+  }
+
+  async poll(
+    clientId: string,
+    clientSecret: string | undefined,
+    deviceCode: string,
+  ): Promise<TokenResponse> {
+    if (!deviceCode) {
+      throw new InvalidGrantError('device_code is required')
+    }
+
+    const app = await this.oauthAppService.getAppByClientId(clientId)
+    if (!this.oauthAppService.isGrantTypeAllowed(app, OAuthGrantType.DEVICE_CODE)) {
+      throw new UnsupportedGrantTypeError(
+        'device_code grant not allowed for this app',
+      )
+    }
+    if (app.isConfidential) {
+      if (!clientSecret) {
+        throw new InvalidClientError('client_secret required for confidential clients')
+      }
+      await this.oauthAppService.verifyClientCredentials(clientId, clientSecret)
+    }
+
+    const record = await OAuthDeviceCode.findOne({
+      deviceCodeHash: this.hashDeviceCode(deviceCode),
+      clientId,
+    })
+    if (!record || record.expiresAt.getTime() <= Date.now()) {
+      throw new DeviceGrantError('expired_token', 'device_code has expired')
+    }
+
+    if (record.status === OAuthDeviceCodeStatus.DENIED) {
+      throw new DeviceGrantError('access_denied', 'the user denied the request')
+    }
+
+    if (record.status === OAuthDeviceCodeStatus.PENDING) {
+      const now = Date.now()
+      if (
+        record.lastPolledAt &&
+        now - record.lastPolledAt.getTime() < record.interval * 1000
+      ) {
+        record.lastPolledAt = new Date(now)
+        await record.save()
+        throw new DeviceGrantError(
+          'slow_down',
+          'polling too frequently',
+        )
+      }
+      record.lastPolledAt = new Date(now)
+      await record.save()
+      throw new DeviceGrantError(
+        'authorization_pending',
+        'authorization is still pending',
+      )
+    }
+
+    if (!record.userId || !record.orgId) {
+      throw new InvalidGrantError('device authorization is incomplete')
+    }
+
+    const userId = record.userId.toString()
+    const orgId = record.orgId.toString()
+
+    let fullName: string | undefined
+    let accountType: string | undefined
+    const user = await Users.findOne({
+      _id: record.userId,
+      orgId: record.orgId,
+      isDeleted: false,
+    })
+      .select('fullName')
+      .lean()
+      .exec()
+    if (user) {
+      fullName = user.fullName
+    }
+    const org = await Org.findOne({
+      _id: record.orgId,
+      isDeleted: false,
+    })
+      .select('accountType')
+      .lean()
+      .exec()
+    if (org) {
+      accountType = (org as { accountType?: string }).accountType
+    }
+
+    const tokens = await this.oauthTokenService.generateTokens(
+      app,
+      userId,
+      orgId,
+      record.scopes,
+      true,
+      fullName,
+      accountType,
+    )
+
+    await OAuthDeviceCode.deleteOne({ _id: record._id })
+
+    return {
+      access_token: tokens.accessToken,
+      token_type: tokens.tokenType,
+      expires_in: tokens.expiresIn,
+      refresh_token: tokens.refreshToken,
+      scope: tokens.scope,
+    }
+  }
+
+  private async findPendingByUserCode(userCodeRaw: string) {
+    const userCode = this.normalizeUserCode(userCodeRaw)
+    if (!userCode) {
+      throw new BadRequestError('user_code is required')
+    }
+    const record = await OAuthDeviceCode.findOne({ userCode })
+    if (!record) {
+      throw new NotFoundError('Unknown user_code')
+    }
+    if (record.expiresAt.getTime() <= Date.now()) {
+      throw new DeviceGrantError('expired_token', 'user_code has expired')
+    }
+    if (record.status !== OAuthDeviceCodeStatus.PENDING) {
+      throw new BadRequestError('user_code has already been used')
+    }
+    return record
+  }
+
+  private generateUserCode(): string {
+    const bytes = crypto.randomBytes(USER_CODE_LENGTH)
+    let code = ''
+    for (let i = 0; i < USER_CODE_LENGTH; i++) {
+      code += USER_CODE_ALPHABET[bytes[i] % USER_CODE_ALPHABET.length]
+    }
+    return code
+  }
+
+  normalizeUserCode(raw: string): string {
+    return raw.replace(/[^A-Za-z0-9]/g, '').toUpperCase()
+  }
+
+  private hashDeviceCode(deviceCode: string): string {
+    return crypto.createHash('sha256').update(deviceCode).digest('hex')
+  }
+}

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
@@ -84,7 +84,7 @@ export class OAuthDeviceService {
     const verificationUri = new URL('/oauth/device', frontendUrl).toString()
     const displayCode = `${userCode.slice(0, 4)}-${userCode.slice(4)}`
 
-    this.logger.info('Device authorization created', { clientId, userCode })
+    this.logger.info('Device authorization created', { clientId })
 
     return {
       device_code: deviceCode,
@@ -109,6 +109,7 @@ export class OAuthDeviceService {
         logoUrl: app.logoUrl,
         homepageUrl: app.homepageUrl,
         privacyPolicyUrl: app.privacyPolicyUrl,
+        isDynamic: app.isDynamic === true,
       },
       scopes: scopeDefinitions,
       user: { email: '', name: undefined },
@@ -184,8 +185,6 @@ export class OAuthDeviceService {
         record.lastPolledAt &&
         now - record.lastPolledAt.getTime() < record.interval * 1000
       ) {
-        record.lastPolledAt = new Date(now)
-        await record.save()
         throw new DeviceGrantError(
           'slow_down',
           'polling too frequently',

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
@@ -198,18 +198,27 @@ export class OAuthDeviceService {
       )
     }
 
-    if (!record.userId || !record.orgId) {
-      throw new InvalidGrantError('device authorization is incomplete')
+    if (record.status !== OAuthDeviceCodeStatus.APPROVED) {
+      throw new InvalidGrantError('device_code is not approved')
     }
 
-    const userId = record.userId.toString()
-    const orgId = record.orgId.toString()
+    // Claim before minting so two concurrent polls cannot both issue tokens.
+    const claimed = await OAuthDeviceCode.findOneAndDelete({
+      _id: record._id,
+      status: OAuthDeviceCodeStatus.APPROVED,
+    })
+    if (!claimed || !claimed.userId || !claimed.orgId) {
+      throw new InvalidGrantError('device_code has already been used')
+    }
+
+    const userId = claimed.userId.toString()
+    const orgId = claimed.orgId.toString()
 
     let fullName: string | undefined
     let accountType: string | undefined
     const user = await Users.findOne({
-      _id: record.userId,
-      orgId: record.orgId,
+      _id: claimed.userId,
+      orgId: claimed.orgId,
       isDeleted: false,
     })
       .select('fullName')
@@ -219,7 +228,7 @@ export class OAuthDeviceService {
       fullName = user.fullName
     }
     const org = await Org.findOne({
-      _id: record.orgId,
+      _id: claimed.orgId,
       isDeleted: false,
     })
       .select('accountType')
@@ -233,13 +242,11 @@ export class OAuthDeviceService {
       app,
       userId,
       orgId,
-      record.scopes,
+      claimed.scopes,
       true,
       fullName,
       accountType,
     )
-
-    await OAuthDeviceCode.deleteOne({ _id: record._id })
 
     return {
       access_token: tokens.accessToken,
@@ -269,10 +276,16 @@ export class OAuthDeviceService {
   }
 
   private generateUserCode(): string {
-    const bytes = crypto.randomBytes(USER_CODE_LENGTH)
+    const alphabet = USER_CODE_ALPHABET
+    const alphabetLen = alphabet.length
+    const rejectAbove = Math.floor(256 / alphabetLen) * alphabetLen
     let code = ''
-    for (let i = 0; i < USER_CODE_LENGTH; i++) {
-      code += USER_CODE_ALPHABET[bytes[i] % USER_CODE_ALPHABET.length]
+    while (code.length < USER_CODE_LENGTH) {
+      const byte = crypto.randomBytes(1)[0]
+      if (byte >= rejectAbove) {
+        continue
+      }
+      code += alphabet[byte % alphabetLen]
     }
     return code
   }

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
@@ -168,8 +168,8 @@ export class OAuthDeviceService {
     }
 
     const record = await OAuthDeviceCode.findOne({
-      deviceCodeHash: this.hashDeviceCode(deviceCode),
-      clientId,
+      deviceCodeHash: { $eq: this.hashDeviceCode(deviceCode) },
+      clientId: { $eq: app.clientId },
     })
     if (!record || record.expiresAt.getTime() <= Date.now()) {
       throw new DeviceGrantError('expired_token', 'device_code has expired')
@@ -283,10 +283,14 @@ export class OAuthDeviceService {
     let code = ''
     while (code.length < USER_CODE_LENGTH) {
       const byte = crypto.randomBytes(1)[0]
-      if (byte >= rejectAbove) {
+      if (byte === undefined || byte >= rejectAbove) {
         continue
       }
-      code += alphabet[byte % alphabetLen]
+      const char = alphabet[byte % alphabetLen]
+      if (char === undefined) {
+        continue
+      }
+      code += char
     }
     return code
   }

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
@@ -206,6 +206,7 @@ export class OAuthDeviceService {
     const claimed = await OAuthDeviceCode.findOneAndDelete({
       _id: record._id,
       status: OAuthDeviceCodeStatus.APPROVED,
+      expiresAt: { $gt: new Date() },
     })
     if (!claimed || !claimed.userId || !claimed.orgId) {
       throw new InvalidGrantError('device_code has already been used')

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.device.service.ts
@@ -20,6 +20,8 @@ import { ScopeValidatorService } from './scope.validator.service'
 import { Users } from '../../user_management/schema/users.schema'
 import { Org } from '../../user_management/schema/org.schema'
 import { TokenResponse, ConsentData } from '../types/oauth.types'
+import { FirstPartyDeviceAppService } from './oauth.first_party_device.service'
+import { FIRST_PARTY_DEVICE_CLIENT_ID } from '../constants/constants'
 
 const DEVICE_CODE_BYTES = 32
 const USER_CODE_LENGTH = 8
@@ -44,6 +46,8 @@ export class OAuthDeviceService {
     @inject('OAuthTokenService') private oauthTokenService: OAuthTokenService,
     @inject('ScopeValidatorService')
     private scopeValidatorService: ScopeValidatorService,
+    @inject('FirstPartyDeviceAppService')
+    private firstPartyDeviceAppService: FirstPartyDeviceAppService,
   ) {}
 
   async createAuthorization(
@@ -53,6 +57,13 @@ export class OAuthDeviceService {
   ): Promise<DeviceAuthorizationResponse> {
     if (process.env.PIPESHUB_ENABLE_DEVICE_GRANT === 'false') {
       throw new UnsupportedGrantTypeError('device grant is disabled')
+    }
+
+    if (clientId === FIRST_PARTY_DEVICE_CLIENT_ID) {
+      const ensured = await this.firstPartyDeviceAppService.getOrCreate()
+      if (!ensured) {
+        throw new InvalidClientError('Invalid client_id')
+      }
     }
 
     const app = await this.oauthAppService.getAppByClientId(clientId)

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.first_party_device.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.first_party_device.service.ts
@@ -1,0 +1,151 @@
+import { injectable, inject } from 'inversify'
+import crypto from 'crypto'
+import { Types } from 'mongoose'
+import { Logger } from '../../../libs/services/logger.service'
+import { EncryptionService } from '../../../libs/encryptor/encryptor'
+import { Org } from '../../user_management/schema/org.schema'
+import { Users } from '../../user_management/schema/users.schema'
+import {
+  OAuthApp,
+  IOAuthApp,
+  OAuthAppStatus,
+  OAuthGrantType,
+} from '../schema/oauth.app.schema'
+import { AgentMcpScopes } from '../config/scopes.config'
+import { ScopeValidatorService } from './scope.validator.service'
+import { AppConfig } from '../../tokens_manager/config/config'
+import { FIRST_PARTY_DEVICE_CLIENT_ID } from '../constants/constants'
+
+const CLIENT_SECRET_BYTES = 32
+
+/**
+ * Ensures the official "PipesHub agent" OAuth app exists so coding agents
+ * can start RFC 8628 device login without DCR and without an admin creating
+ * an OAuth app. One public client_id per instance; many agents share it.
+ * Tokens still carry the person who clicked Allow.
+ *
+ * Never grants `client_credentials`. Created lazily (first discovery or
+ * first device_authorization with this client_id) so upgrades of existing
+ * orgs get the app without re-running first-run.
+ */
+@injectable()
+export class FirstPartyDeviceAppService {
+  constructor(
+    @inject('Logger') private logger: Logger,
+    @inject('EncryptionService') private encryptionService: EncryptionService,
+    @inject('ScopeValidatorService')
+    private scopeValidatorService: ScopeValidatorService,
+    @inject('AppConfig') private appConfig: AppConfig,
+  ) {}
+
+  /**
+   * @returns the well-known client_id, or null when the instance has no org
+   * yet or the agent preset cannot be granted under current MCP_SCOPES.
+   */
+  async getOrCreate(): Promise<string | null> {
+    const existing = await OAuthApp.findOne({
+      clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+    })
+    if (existing) {
+      return existing.clientId
+    }
+
+    const owner = await this.resolveOwner()
+    if (!owner) {
+      return null
+    }
+
+    const allowedScopes = this.resolveScopes()
+    if (allowedScopes.length === 0) {
+      this.logger.warn(
+        'First-party device app not created: agent preset is empty under MCP_SCOPES',
+      )
+      return null
+    }
+
+    try {
+      const app = await this.createApp(owner.orgId, owner.createdBy, allowedScopes)
+      this.logger.info('First-party device app created', {
+        clientId: app.clientId,
+        orgId: owner.orgId,
+      })
+      return app.clientId
+    } catch (error) {
+      const winner = await OAuthApp.findOne({
+        clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+      })
+      if (winner) {
+        return winner.clientId
+      }
+      throw error
+    }
+  }
+
+  private async createApp(
+    orgId: string,
+    createdBy: string,
+    allowedScopes: string[],
+  ): Promise<IOAuthApp> {
+    const clientSecret = crypto.randomBytes(CLIENT_SECRET_BYTES).toString('hex')
+    return OAuthApp.create({
+      clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+      // Public client: device poll uses token_endpoint_auth_method none.
+      // Schema still requires a stored secret; it is never used to authenticate.
+      clientSecretEncrypted: this.encryptionService.encrypt(clientSecret),
+      name: 'PipesHub agent',
+      description:
+        'Official coding-agent device login for this instance. Public client; ' +
+        'device_code and refresh_token only. Not a third-party app and not ' +
+        'created through dynamic client registration.',
+      orgId: new Types.ObjectId(orgId),
+      createdBy: new Types.ObjectId(createdBy),
+      redirectUris: [],
+      allowedGrantTypes: [OAuthGrantType.DEVICE_CODE, OAuthGrantType.REFRESH_TOKEN],
+      allowedScopes,
+      isConfidential: false,
+      isDynamic: false,
+      status: OAuthAppStatus.ACTIVE,
+    })
+  }
+
+  private resolveScopes(): string[] {
+    const mcp = new Set(this.appConfig.mcpScopes || [])
+    const memberAllowed = new Set(
+      this.scopeValidatorService.getAllowedScopeNamesForRole(false),
+    )
+    return AgentMcpScopes.filter((scope) => {
+      if (!memberAllowed.has(scope)) {
+        return false
+      }
+      if (mcp.size > 0 && !mcp.has(scope)) {
+        return false
+      }
+      return true
+    })
+  }
+
+  private async resolveOwner(): Promise<{
+    orgId: string
+    createdBy: string
+  } | null> {
+    const orgs = await Org.find({ isDeleted: { $ne: true } })
+      .sort({ createdAt: 1 })
+      .select('_id')
+      .lean()
+    const org = orgs[0]
+    if (!org) {
+      return null
+    }
+    const user = await Users.findOne({
+      orgId: org._id,
+      isDeleted: { $ne: true },
+    })
+      .sort({ createdAt: 1 })
+      .select('_id')
+      .lean()
+    if (!user?._id) {
+      return null
+    }
+    return { orgId: org._id.toString(), createdBy: user._id.toString() }
+  }
+}

--- a/backend/nodejs/apps/src/modules/oauth_provider/types/oauth.types.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/types/oauth.types.ts
@@ -60,7 +60,11 @@ export interface AuthorizeRequest {
 
 // Token Request Parameters
 export interface TokenRequest {
-  grant_type: 'authorization_code' | 'client_credentials' | 'refresh_token'
+  grant_type:
+    | 'authorization_code'
+    | 'client_credentials'
+    | 'refresh_token'
+    | 'urn:ietf:params:oauth:grant-type:device_code'
   code?: string
   redirect_uri?: string
   client_id: string
@@ -68,6 +72,7 @@ export interface TokenRequest {
   refresh_token?: string
   scope?: string
   code_verifier?: string
+  device_code?: string
 }
 
 // Revoke Request
@@ -224,6 +229,8 @@ export interface OpenIDConfiguration {
   revocation_endpoint: string
   introspection_endpoint: string
   jwks_uri: string
+  registration_endpoint?: string
+  device_authorization_endpoint?: string
   scopes_supported: string[]
   response_types_supported: string[]
   grant_types_supported: string[]

--- a/backend/nodejs/apps/src/modules/oauth_provider/types/oauth.types.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/types/oauth.types.ts
@@ -219,6 +219,8 @@ export interface OAuthProtectedResourceMetadata {
   scopes_supported: string[]
   bearer_methods_supported: string[]
   resource_documentation?: string
+  /** PipesHub first-party device client. Present when device grant is on and the instance has an org. */
+  pipeshub_device_client_id?: string
 }
 
 // OIDC Discovery Response
@@ -232,6 +234,8 @@ export interface OpenIDConfiguration {
   jwks_uri: string
   registration_endpoint?: string
   device_authorization_endpoint?: string
+  /** PipesHub first-party device client. Present when device grant is on and the instance has an org. */
+  pipeshub_device_client_id?: string
   scopes_supported: string[]
   response_types_supported: string[]
   grant_types_supported: string[]

--- a/backend/nodejs/apps/src/modules/oauth_provider/types/oauth.types.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/types/oauth.types.ts
@@ -182,6 +182,7 @@ export interface ConsentData {
     logoUrl?: string
     homepageUrl?: string
     privacyPolicyUrl?: string
+    isDynamic?: boolean
   }
   scopes: Array<{
     name: string

--- a/backend/nodejs/apps/src/modules/oauth_provider/validators/oauth.validators.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/validators/oauth.validators.ts
@@ -48,6 +48,7 @@ export const tokenSchema = z.object({
       OAuthGrantType.AUTHORIZATION_CODE,
       OAuthGrantType.CLIENT_CREDENTIALS,
       OAuthGrantType.REFRESH_TOKEN,
+      OAuthGrantType.DEVICE_CODE,
     ]),
     code: z.string().optional(),
     redirect_uri: z.string().url().optional(),
@@ -58,6 +59,41 @@ export const tokenSchema = z.object({
     scope: z.string().optional(),
     // RFC 7636: code_verifier must match the pattern [A-Za-z0-9-._~]{43,128}
     code_verifier: z.string().regex(codeVerifierPattern, 'Invalid code_verifier format').optional(),
+    device_code: z.string().min(1).optional(),
+  }),
+})
+
+export const dcrRequestSchema = z.object({
+  body: z.object({
+    redirect_uris: z.array(z.string().min(1)).max(10).optional(),
+    token_endpoint_auth_method: z
+      .enum(['none', 'client_secret_basic', 'client_secret_post'])
+      .optional(),
+    grant_types: z.array(z.string()).optional(),
+    response_types: z.array(z.string()).optional(),
+    client_name: z.string().min(1).max(100).optional(),
+    client_uri: z.string().url().optional(),
+    logo_uri: z.string().url().optional(),
+    scope: z.string().optional(),
+    contacts: z.array(z.string()).optional(),
+    tos_uri: z.string().url().optional(),
+    policy_uri: z.string().url().optional(),
+    software_id: z.string().optional(),
+    software_version: z.string().optional(),
+  }),
+})
+
+export const deviceAuthorizationSchema = z.object({
+  body: z.object({
+    client_id: z.string().min(1),
+    scope: z.string().optional(),
+  }),
+})
+
+export const deviceUserCodeSchema = z.object({
+  body: z.object({
+    user_code: z.string().min(1).max(32),
+    consent: z.enum(['granted', 'denied']).optional(),
   }),
 })
 

--- a/backend/nodejs/apps/src/modules/oauth_provider/validators/oauth.validators.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/validators/oauth.validators.ts
@@ -97,6 +97,13 @@ export const deviceUserCodeSchema = z.object({
   }),
 })
 
+export const deviceConsentSchema = z.object({
+  body: z.object({
+    user_code: z.string().min(1).max(32),
+    consent: z.enum(['granted', 'denied']),
+  }),
+})
+
 export const revokeSchema = z.object({
   body: z.object({
     token: z.string().min(1),

--- a/backend/nodejs/apps/tests/libs/errors/oauth.errors.test.ts
+++ b/backend/nodejs/apps/tests/libs/errors/oauth.errors.test.ts
@@ -13,6 +13,7 @@ import {
   AccessDeniedError,
   UnauthorizedClientError,
   ServerError,
+  DeviceGrantError,
 } from '../../../src/libs/errors/oauth.errors';
 
 describe('OAuth Errors', () => {
@@ -632,5 +633,23 @@ describe('OAuth Errors', () => {
       expect(json).to.have.property('code', 'OAUTH_SERVER_ERROR');
       expect(json).to.have.property('statusCode', 500);
     });
+  });
+
+  describe('DeviceGrantError', () => {
+    it('should keep the RFC oauthError on the instance', () => {
+      const error = new DeviceGrantError(
+        'authorization_pending',
+        'authorization is still pending',
+      )
+      expect(error.oauthError).to.equal('authorization_pending')
+      expect(error.statusCode).to.equal(400)
+      expect(error.code).to.equal('OAUTH_AUTHORIZATION_PENDING')
+    })
+
+    it('should map hyphenated RFC errors to uppercase codes', () => {
+      const error = new DeviceGrantError('slow_down', 'polling too frequently')
+      expect(error.oauthError).to.equal('slow_down')
+      expect(error.code).to.equal('OAUTH_SLOW_DOWN')
+    })
   });
 });

--- a/backend/nodejs/apps/tests/modules/oauth_provider/container/oauth.provider.container.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/container/oauth.provider.container.test.ts
@@ -149,6 +149,8 @@ describe('OAuthProviderContainer', () => {
         expect(container.isBound('OAuthAuthMiddleware')).to.be.true
         expect(container.isBound('OAuthAppController')).to.be.true
         expect(container.isBound('OAuthProviderController')).to.be.true
+        expect(container.isBound('OAuthDcrService')).to.be.true
+        expect(container.isBound('OAuthDeviceService')).to.be.true
         expect(container.isBound('OIDCProviderController')).to.be.true
 
         // Verify getInstance returns the same container
@@ -287,6 +289,8 @@ describe('OAuthProviderContainer - coverage', () => {
       expect(container.isBound('OAuthAuthMiddleware')).to.be.true
       expect(container.isBound('OAuthAppController')).to.be.true
       expect(container.isBound('OAuthProviderController')).to.be.true
+      expect(container.isBound('OAuthDcrService')).to.be.true
+      expect(container.isBound('OAuthDeviceService')).to.be.true
       expect(container.isBound('OIDCProviderController')).to.be.true
 
       const instance = OAuthProviderContainer.getInstance()

--- a/backend/nodejs/apps/tests/modules/oauth_provider/container/oauth.provider.container.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/container/oauth.provider.container.test.ts
@@ -150,6 +150,7 @@ describe('OAuthProviderContainer', () => {
         expect(container.isBound('OAuthAppController')).to.be.true
         expect(container.isBound('OAuthProviderController')).to.be.true
         expect(container.isBound('OAuthDcrService')).to.be.true
+        expect(container.isBound('FirstPartyDeviceAppService')).to.be.true
         expect(container.isBound('OAuthDeviceService')).to.be.true
         expect(container.isBound('OIDCProviderController')).to.be.true
 
@@ -290,6 +291,7 @@ describe('OAuthProviderContainer - coverage', () => {
       expect(container.isBound('OAuthAppController')).to.be.true
       expect(container.isBound('OAuthProviderController')).to.be.true
       expect(container.isBound('OAuthDcrService')).to.be.true
+      expect(container.isBound('FirstPartyDeviceAppService')).to.be.true
       expect(container.isBound('OAuthDeviceService')).to.be.true
       expect(container.isBound('OIDCProviderController')).to.be.true
 

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
@@ -51,6 +51,8 @@ describe('OAuthProviderController', () => {
       mockOAuthTokenService,
       mockAuthCodeService,
       mockScopeValidatorService,
+      { register: sinon.stub() } as any,
+      { poll: sinon.stub(), createAuthorization: sinon.stub() } as any,
     )
     mockRes = {
       json: sinon.stub(),

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
@@ -19,6 +19,7 @@ describe('OAuthProviderController', () => {
   let mockOAuthTokenService: any
   let mockAuthCodeService: any
   let mockScopeValidatorService: any
+  let mockOAuthDeviceService: any
   let mockRes: any
   let mockNext: any
 
@@ -45,6 +46,12 @@ describe('OAuthProviderController', () => {
       validateScopesForApp: sinon.stub(),
       getScopeDefinitions: sinon.stub().returns([{ name: 'org:read', description: 'Read org', category: 'Organization' }]),
     }
+    mockOAuthDeviceService = {
+      poll: sinon.stub(),
+      createAuthorization: sinon.stub(),
+      getConsentData: sinon.stub(),
+      approve: sinon.stub(),
+    }
     controller = new OAuthProviderController(
       mockLogger,
       mockOAuthAppService,
@@ -52,7 +59,7 @@ describe('OAuthProviderController', () => {
       mockAuthCodeService,
       mockScopeValidatorService,
       { register: sinon.stub() } as any,
-      { poll: sinon.stub(), createAuthorization: sinon.stub() } as any,
+      mockOAuthDeviceService,
     )
     mockRes = {
       json: sinon.stub(),
@@ -756,6 +763,124 @@ describe('OAuthProviderController', () => {
 
       await controller.introspect(req, mockRes, mockNext)
       expect(mockRes.status.calledWith(401)).to.be.true
+    })
+  })
+
+  describe('deviceAuthorization', () => {
+    it('should return 200 with the device payload', async () => {
+      const payload = {
+        device_code: 'dc',
+        user_code: 'ABCD-EFGH',
+        verification_uri: 'http://localhost:3000/oauth/device',
+        verification_uri_complete:
+          'http://localhost:3000/oauth/device?user_code=ABCD-EFGH',
+        expires_in: 600,
+        interval: 5,
+      }
+      mockOAuthDeviceService.createAuthorization.resolves(payload)
+      const req = {
+        body: { client_id: 'pipeshub-agent', scope: 'user:read' },
+        oauthFrontendUrl: 'http://localhost:3000',
+      } as any
+
+      await controller.deviceAuthorization(req, mockRes, mockNext)
+      expect(mockRes.status.calledWith(200)).to.be.true
+      expect(mockRes.json.firstCall.args[0]).to.deep.equal(payload)
+      expect(
+        mockOAuthDeviceService.createAuthorization.calledWith(
+          'pipeshub-agent',
+          'user:read',
+          'http://localhost:3000',
+        ),
+      ).to.be.true
+    })
+
+    it('should return 400 when frontendUrl is not configured', async () => {
+      const req = { body: { client_id: 'cid' } } as any
+      await controller.deviceAuthorization(req, mockRes, mockNext)
+      expect(mockRes.status.calledWith(400)).to.be.true
+      expect(mockRes.json.firstCall.args[0].error).to.equal('server_error')
+      expect(mockOAuthDeviceService.createAuthorization.called).to.be.false
+    })
+  })
+
+  describe('deviceConsent', () => {
+    it('should reject consent values other than granted or denied', async () => {
+      const req = {
+        body: { user_code: 'ABCD-EFGH', consent: 'maybe' },
+        user: { userId: 'u1', orgId: 'o1' },
+      } as any
+      await controller.deviceConsent(req, mockRes, mockNext)
+      expect(mockRes.status.calledWith(400)).to.be.true
+      expect(mockOAuthDeviceService.approve.called).to.be.false
+    })
+
+    it('should approve with the authenticated user identity', async () => {
+      mockOAuthDeviceService.approve.resolves()
+      const req = {
+        body: { user_code: 'ABCD-EFGH', consent: 'granted' },
+        user: { userId: 'u1', orgId: 'o1', email: 'u@e.com' },
+      } as any
+      await controller.deviceConsent(req, mockRes, mockNext)
+      expect(
+        mockOAuthDeviceService.approve.calledWith(
+          'ABCD-EFGH',
+          'u1',
+          'o1',
+          'granted',
+        ),
+      ).to.be.true
+      expect(mockRes.json.firstCall.args[0]).to.deep.equal({
+        ok: true,
+        consent: 'granted',
+      })
+    })
+  })
+
+  describe('deviceVerify', () => {
+    it('should attach the signed-in user onto consent data', async () => {
+      mockOAuthDeviceService.getConsentData.resolves({
+        app: { name: 'CLI', isDynamic: false },
+        scopes: [{ name: 'user:read' }],
+        user: { email: '', name: undefined },
+        redirectUri: '',
+        state: '',
+      })
+      const req = {
+        body: { user_code: 'ABCD-EFGH' },
+        user: { userId: 'u1', orgId: 'o1', email: 'u@e.com', fullName: 'Test' },
+      } as any
+      await controller.deviceVerify(req, mockRes, mockNext)
+      const body = mockRes.json.firstCall.args[0]
+      expect(body.requiresConsent).to.equal(true)
+      expect(body.consentData.user).to.deep.equal({
+        email: 'u@e.com',
+        name: 'Test',
+      })
+    })
+  })
+
+  describe('token - device_code grant', () => {
+    it('should poll the device service', async () => {
+      mockOAuthDeviceService.poll.resolves({
+        access_token: 'at',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: 'rt',
+        scope: 'user:read',
+      })
+      const req = {
+        body: {
+          grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+          client_id: 'cid',
+          device_code: 'dc',
+        },
+        headers: {},
+      } as any
+      await controller.token(req, mockRes, mockNext)
+      expect(mockOAuthDeviceService.poll.calledWith('cid', undefined, 'dc')).to
+        .be.true
+      expect(mockRes.json.firstCall.args[0].access_token).to.equal('at')
     })
   })
 })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
@@ -49,6 +49,14 @@ describe('OIDCProviderController', () => {
       expect(config.userinfo_endpoint).to.include('/userinfo')
       expect(config.response_types_supported).to.deep.equal(['code'])
       expect(config.grant_types_supported).to.include('authorization_code')
+      expect(config.grant_types_supported).to.include(
+        'urn:ietf:params:oauth:grant-type:device_code',
+      )
+      expect(config.registration_endpoint).to.include('/register')
+      expect(config.device_authorization_endpoint).to.include(
+        '/device_authorization',
+      )
+      expect(config.token_endpoint_auth_methods_supported).to.include('none')
       expect(config.code_challenge_methods_supported).to.deep.equal(['S256', 'plain'])
     })
   })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
@@ -37,7 +37,10 @@ describe('OIDCProviderController', () => {
     mockNext = sinon.stub()
   })
 
-  afterEach(() => { sinon.restore() })
+  afterEach(() => {
+    sinon.restore()
+    delete process.env.PIPESHUB_ENABLE_DCR
+  })
 
   describe('openidConfiguration', () => {
     it('should return valid OIDC configuration', async () => {
@@ -52,12 +55,19 @@ describe('OIDCProviderController', () => {
       expect(config.grant_types_supported).to.include(
         'urn:ietf:params:oauth:grant-type:device_code',
       )
-      expect(config.registration_endpoint).to.include('/register')
+      expect(config.registration_endpoint).to.equal(undefined)
       expect(config.device_authorization_endpoint).to.include(
         '/device_authorization',
       )
       expect(config.token_endpoint_auth_methods_supported).to.include('none')
       expect(config.code_challenge_methods_supported).to.deep.equal(['S256', 'plain'])
+    })
+
+    it('should advertise registration_endpoint only when DCR is enabled', async () => {
+      process.env.PIPESHUB_ENABLE_DCR = 'true'
+      await controller.openidConfiguration({} as any, mockRes, mockNext)
+      const config = mockRes.json.firstCall.args[0]
+      expect(config.registration_endpoint).to.include('/register')
     })
   })
 

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
@@ -100,6 +100,16 @@ describe('OIDCProviderController', () => {
       expect(config.pipeshub_device_client_id).to.equal(undefined)
       expect(mockFirstPartyDeviceAppService.getOrCreate.called).to.be.false
     })
+
+    it('should not advertise registration_endpoint for truthy values other than true', async () => {
+      for (const value of ['TRUE', '1', 'yes', 'on']) {
+        process.env.PIPESHUB_ENABLE_DCR = value
+        mockRes.json.resetHistory()
+        await controller.openidConfiguration({} as any, mockRes, mockNext)
+        const config = mockRes.json.firstCall.args[0]
+        expect(config.registration_endpoint, value).to.equal(undefined)
+      }
+    })
   })
 
   describe('oauthProtectedResource', () => {
@@ -110,6 +120,14 @@ describe('OIDCProviderController', () => {
       expect(meta.authorization_servers).to.deep.equal(['http://localhost:3000'])
       expect(meta.bearer_methods_supported).to.deep.equal(['header'])
       expect(meta.pipeshub_device_client_id).to.equal('pipeshub-agent')
+    })
+
+    it('should omit pipeshub_device_client_id when the device grant is disabled', async () => {
+      process.env.PIPESHUB_ENABLE_DEVICE_GRANT = 'false'
+      await controller.oauthProtectedResource({} as any, mockRes, mockNext)
+      const meta = mockRes.json.firstCall.args[0]
+      expect(meta.pipeshub_device_client_id).to.equal(undefined)
+      expect(mockFirstPartyDeviceAppService.getOrCreate.called).to.be.false
     })
   })
 

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
@@ -13,6 +13,8 @@ describe('OIDCProviderController', () => {
   let mockNext: any
 
   beforeEach(() => {
+    delete process.env.PIPESHUB_ENABLE_DCR
+    delete process.env.PIPESHUB_ENABLE_DEVICE_GRANT
     mockOAuthTokenService = {
       getAlgorithm: sinon.stub().returns('HS256'),
       getPublicKey: sinon.stub().returns(undefined),
@@ -40,6 +42,7 @@ describe('OIDCProviderController', () => {
   afterEach(() => {
     sinon.restore()
     delete process.env.PIPESHUB_ENABLE_DCR
+    delete process.env.PIPESHUB_ENABLE_DEVICE_GRANT
   })
 
   describe('openidConfiguration', () => {
@@ -68,6 +71,16 @@ describe('OIDCProviderController', () => {
       await controller.openidConfiguration({} as any, mockRes, mockNext)
       const config = mockRes.json.firstCall.args[0]
       expect(config.registration_endpoint).to.include('/register')
+    })
+
+    it('should omit device grant metadata when the device grant is disabled', async () => {
+      process.env.PIPESHUB_ENABLE_DEVICE_GRANT = 'false'
+      await controller.openidConfiguration({} as any, mockRes, mockNext)
+      const config = mockRes.json.firstCall.args[0]
+      expect(config.device_authorization_endpoint).to.equal(undefined)
+      expect(config.grant_types_supported).to.not.include(
+        'urn:ietf:params:oauth:grant-type:device_code',
+      )
     })
   })
 

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oid.provider.controller.test.ts
@@ -9,6 +9,7 @@ describe('OIDCProviderController', () => {
   let mockOAuthTokenService: any
   let mockScopeValidatorService: any
   let mockAppConfig: any
+  let mockFirstPartyDeviceAppService: any
   let mockRes: any
   let mockNext: any
 
@@ -30,10 +31,14 @@ describe('OIDCProviderController', () => {
       oauthIssuer: 'http://localhost:3000',
       mcpScopes: ['org:read'],
     }
+    mockFirstPartyDeviceAppService = {
+      getOrCreate: sinon.stub().resolves('pipeshub-agent'),
+    }
     controller = new OIDCProviderController(
       mockOAuthTokenService,
       mockScopeValidatorService,
       mockAppConfig,
+      mockFirstPartyDeviceAppService,
     )
     mockRes = { json: sinon.stub(), status: sinon.stub().returnsThis(), setHeader: sinon.stub() }
     mockNext = sinon.stub()
@@ -64,6 +69,17 @@ describe('OIDCProviderController', () => {
       )
       expect(config.token_endpoint_auth_methods_supported).to.include('none')
       expect(config.code_challenge_methods_supported).to.deep.equal(['S256', 'plain'])
+      expect(config.pipeshub_device_client_id).to.equal('pipeshub-agent')
+    })
+
+    it('should omit pipeshub_device_client_id when the instance has no org yet', async () => {
+      mockFirstPartyDeviceAppService.getOrCreate.resolves(null)
+      await controller.openidConfiguration({} as any, mockRes, mockNext)
+      const config = mockRes.json.firstCall.args[0]
+      expect(config.pipeshub_device_client_id).to.equal(undefined)
+      expect(config.device_authorization_endpoint).to.include(
+        '/device_authorization',
+      )
     })
 
     it('should advertise registration_endpoint only when DCR is enabled', async () => {
@@ -81,6 +97,8 @@ describe('OIDCProviderController', () => {
       expect(config.grant_types_supported).to.not.include(
         'urn:ietf:params:oauth:grant-type:device_code',
       )
+      expect(config.pipeshub_device_client_id).to.equal(undefined)
+      expect(mockFirstPartyDeviceAppService.getOrCreate.called).to.be.false
     })
   })
 
@@ -91,6 +109,7 @@ describe('OIDCProviderController', () => {
       expect(meta.resource).to.include('/mcp')
       expect(meta.authorization_servers).to.deep.equal(['http://localhost:3000'])
       expect(meta.bearer_methods_supported).to.deep.equal(['header'])
+      expect(meta.pipeshub_device_client_id).to.equal('pipeshub-agent')
     })
   })
 

--- a/backend/nodejs/apps/tests/modules/oauth_provider/routes/oauth.provider.routes.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/routes/oauth.provider.routes.test.ts
@@ -28,6 +28,19 @@ describe('OAuth Provider Routes', () => {
       const router = createOAuthProviderRouter(mockContainer as any)
       expect(router).to.exist
       expect(router.stack).to.be.an('array')
+      const routes = (router as any).stack
+        .filter((layer: any) => layer.route)
+        .map((layer: any) => {
+          const method = Object.keys(layer.route.methods).find(
+            (m: string) => layer.route.methods[m],
+          )
+          return `${method}:${layer.route.path}`
+        })
+      expect(routes).to.include('post:/device_authorization')
+      expect(routes).to.include('post:/device/verify')
+      expect(routes).to.include('post:/device/consent')
+      expect(routes).to.include('post:/register')
+      expect(routes).to.include('post:/token')
     })
   })
 })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.app.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.app.service.test.ts
@@ -1301,6 +1301,55 @@ describe('OAuthAppService - branch coverage', () => {
     })
   })
 
+  describe('createDynamicClient', () => {
+    it('should reject client_credentials', async () => {
+      try {
+        await service.createDynamicClient({
+          orgId: VALID_ORG_ID,
+          createdBy: VALID_USER_ID,
+          name: 'Cursor',
+          redirectUris: ['https://example.com/cb'],
+          allowedGrantTypes: [OAuthGrantType.CLIENT_CREDENTIALS],
+          allowedScopes: ['user:read'],
+          isConfidential: false,
+        })
+        expect.fail('should have thrown')
+      } catch (err: any) {
+        expect(err).to.be.instanceOf(BadRequestError)
+      }
+    })
+
+    it('should allow a private-use redirect URI', async () => {
+      const mockApp = {
+        _id: new Types.ObjectId(),
+        slug: 'dcr',
+        clientId: 'cid',
+        name: 'Cursor',
+        redirectUris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+        allowedGrantTypes: [OAuthGrantType.AUTHORIZATION_CODE, OAuthGrantType.REFRESH_TOKEN],
+        allowedScopes: ['user:read'],
+        status: OAuthAppStatus.ACTIVE,
+        isConfidential: false,
+        accessTokenLifetime: 3600,
+        refreshTokenLifetime: 2592000,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      const createStub = sinon.stub(OAuthApp, 'create').resolves(mockApp as any)
+      await service.createDynamicClient({
+          orgId: VALID_ORG_ID,
+          createdBy: VALID_USER_ID,
+        name: 'Cursor',
+        redirectUris: ['cursor://anysphere.cursor-mcp/oauth/callback'],
+        allowedGrantTypes: [OAuthGrantType.AUTHORIZATION_CODE, OAuthGrantType.REFRESH_TOKEN],
+        allowedScopes: ['user:read'],
+        isConfidential: false,
+      })
+      expect(createStub.calledOnce).to.be.true
+      expect(createStub.firstCall.args[0].isDynamic).to.be.true
+    })
+  })
+
   // =========================================================================
   // deleteApp
   // =========================================================================

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.app.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.app.service.test.ts
@@ -14,7 +14,7 @@ import {
   InvalidRedirectUriError,
 } from '../../../../src/libs/errors/oauth.errors'
 import { NotFoundError, BadRequestError } from '../../../../src/libs/errors/http.errors'
-import { PAT_APP_CLIENT_ID_PREFIX } from '../../../../src/modules/oauth_provider/constants/constants'
+import { PAT_APP_CLIENT_ID_PREFIX, FIRST_PARTY_DEVICE_CLIENT_ID } from '../../../../src/modules/oauth_provider/constants/constants'
 import { createMockLogger } from '../../../helpers/mock-logger'
 
 describe('OAuthAppService', () => {
@@ -311,10 +311,11 @@ describe('OAuthAppService', () => {
         // expected NotFoundError
       }
       const filter = findStub.firstCall.args[0] as Record<string, unknown>
-      const clientIdFilter = filter.clientId as { $not: RegExp }
+      const clientIdFilter = filter.clientId as { $not: RegExp; $nin: string[] }
       expect(clientIdFilter.$not.source).to.equal(`^${PAT_APP_CLIENT_ID_PREFIX}`)
       expect(clientIdFilter.$not.test(`${PAT_APP_CLIENT_ID_PREFIX}${fakeOrgId}`)).to.be.true
       expect(clientIdFilter.$not.test('some-other-client-id')).to.be.false
+      expect(clientIdFilter.$nin).to.deep.equal([FIRST_PARTY_DEVICE_CLIENT_ID])
     })
 
     it('should throw NotFoundError when app is not visible to caller (e.g. different creator in same org)', async () => {

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
@@ -1,0 +1,111 @@
+import 'reflect-metadata'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { Types } from 'mongoose'
+import { OAuthDcrService } from '../../../../src/modules/oauth_provider/services/oauth.dcr.service'
+import { OAuthGrantType } from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
+import { Org } from '../../../../src/modules/user_management/schema/org.schema'
+import { Users } from '../../../../src/modules/user_management/schema/users.schema'
+import { BadRequestError, ForbiddenError } from '../../../../src/libs/errors/http.errors'
+import { createMockLogger } from '../../../helpers/mock-logger'
+
+describe('OAuthDcrService', () => {
+  let service: OAuthDcrService
+  let mockOAuthAppService: any
+  let mockScopeValidatorService: any
+  const orgId = new Types.ObjectId()
+  const userId = new Types.ObjectId()
+
+  beforeEach(() => {
+    delete process.env.PIPESHUB_ENABLE_DCR
+    mockOAuthAppService = {
+      createDynamicClient: sinon.stub().resolves({
+        clientId: 'cid',
+        clientSecret: 'secret',
+        name: 'Cursor',
+        redirectUris: ['http://127.0.0.1/cb'],
+        allowedGrantTypes: [
+          OAuthGrantType.AUTHORIZATION_CODE,
+          OAuthGrantType.REFRESH_TOKEN,
+        ],
+        allowedScopes: ['user:read'],
+      }),
+    }
+    mockScopeValidatorService = {
+      parseScopes: sinon.stub().callsFake((s: string) => s.split(' ').filter(Boolean)),
+      getAllowedScopeNamesForRole: sinon.stub().returns([
+        'conversation:chat',
+        'semantic:write',
+        'kb:read',
+        'user:read',
+        'connector:read',
+      ]),
+    }
+    service = new OAuthDcrService(
+      createMockLogger(),
+      mockOAuthAppService,
+      mockScopeValidatorService,
+      {
+        mcpScopes: [
+          'conversation:chat',
+          'semantic:write',
+          'kb:read',
+          'user:read',
+          'connector:read',
+        ],
+      } as any,
+    )
+    const orgQuery: any = {
+      sort: sinon.stub().returnsThis(),
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().resolves([{ _id: orgId }]),
+    }
+    sinon.stub(Org, 'find').returns(orgQuery)
+    const userQuery: any = {
+      sort: sinon.stub().returnsThis(),
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().resolves({ _id: userId }),
+    }
+    sinon.stub(Users, 'findOne').returns(userQuery)
+  })
+
+  afterEach(() => {
+    sinon.restore()
+    delete process.env.PIPESHUB_ENABLE_DCR
+  })
+
+  it('should register a public client without returning a secret', async () => {
+    const result = await service.register({
+      client_name: 'Cursor',
+      redirect_uris: ['http://127.0.0.1/cb'],
+      token_endpoint_auth_method: 'none',
+      scope: 'user:read',
+    })
+    expect(result.client_id).to.equal('cid')
+    expect(result.client_secret).to.equal(undefined)
+    expect(result.token_endpoint_auth_method).to.equal('none')
+    expect(mockOAuthAppService.createDynamicClient.firstCall.args[0].isConfidential).to.be.false
+  })
+
+  it('should reject client_credentials', async () => {
+    try {
+      await service.register({
+        grant_types: ['client_credentials'],
+        client_name: 'bad',
+      })
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(BadRequestError)
+    }
+  })
+
+  it('should refuse when DCR is disabled', async () => {
+    process.env.PIPESHUB_ENABLE_DCR = 'false'
+    try {
+      await service.register({ client_name: 'Cursor' })
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(ForbiddenError)
+    }
+  })
+})

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
@@ -74,7 +74,17 @@ describe('OAuthDcrService', () => {
     delete process.env.PIPESHUB_ENABLE_DCR
   })
 
+  it('should refuse when DCR is unset', async () => {
+    try {
+      await service.register({ client_name: 'Cursor' })
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(ForbiddenError)
+    }
+  })
+
   it('should register a public client without returning a secret', async () => {
+    process.env.PIPESHUB_ENABLE_DCR = 'true'
     const result = await service.register({
       client_name: 'Cursor',
       redirect_uris: ['http://127.0.0.1/cb'],
@@ -88,6 +98,7 @@ describe('OAuthDcrService', () => {
   })
 
   it('should reject client_credentials', async () => {
+    process.env.PIPESHUB_ENABLE_DCR = 'true'
     try {
       await service.register({
         grant_types: ['client_credentials'],

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
@@ -167,4 +167,17 @@ describe('OAuthDcrService', () => {
       expect(err).to.be.instanceOf(ForbiddenError)
     }
   })
+
+  it('should refuse when DCR is a truthy string other than true', async () => {
+    for (const value of ['TRUE', '1', 'yes']) {
+      process.env.PIPESHUB_ENABLE_DCR = value
+      try {
+        await service.register({ client_name: 'Cursor' })
+        expect.fail(`should have thrown for ${value}`)
+      } catch (err) {
+        expect(err).to.be.instanceOf(ForbiddenError)
+      }
+    }
+    expect(mockOAuthAppService.createDynamicClient.called).to.be.false
+  })
 })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
@@ -98,6 +98,40 @@ describe('OAuthDcrService', () => {
     expect(mockOAuthAppService.createDynamicClient.firstCall.args[0].isConfidential).to.be.false
   })
 
+  it('should omit response_types code when authorization_code is not granted', async () => {
+    process.env.PIPESHUB_ENABLE_DCR = 'true'
+    mockOAuthAppService.createDynamicClient.resolves({
+      clientId: 'cid',
+      clientSecret: 'secret',
+      name: 'CLI',
+      redirectUris: [],
+      allowedGrantTypes: [OAuthGrantType.REFRESH_TOKEN],
+      allowedScopes: ['user:read'],
+    })
+    const result = await service.register({
+      client_name: 'CLI',
+      grant_types: ['refresh_token'],
+      token_endpoint_auth_method: 'none',
+      scope: 'user:read',
+    })
+    expect(result.response_types).to.deep.equal([])
+    expect(result.grant_types).to.deep.equal([OAuthGrantType.REFRESH_TOKEN])
+  })
+
+  it('should reject response_type code without authorization_code', async () => {
+    process.env.PIPESHUB_ENABLE_DCR = 'true'
+    try {
+      await service.register({
+        client_name: 'CLI',
+        grant_types: ['refresh_token'],
+        response_types: ['code'],
+      })
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(BadRequestError)
+    }
+  })
+
   it('should reject unsupported response_types', async () => {
     process.env.PIPESHUB_ENABLE_DCR = 'true'
     try {

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.dcr.service.test.ts
@@ -94,7 +94,21 @@ describe('OAuthDcrService', () => {
     expect(result.client_id).to.equal('cid')
     expect(result.client_secret).to.equal(undefined)
     expect(result.token_endpoint_auth_method).to.equal('none')
+    expect(result.response_types).to.deep.equal(['code'])
     expect(mockOAuthAppService.createDynamicClient.firstCall.args[0].isConfidential).to.be.false
+  })
+
+  it('should reject unsupported response_types', async () => {
+    process.env.PIPESHUB_ENABLE_DCR = 'true'
+    try {
+      await service.register({
+        client_name: 'Cursor',
+        response_types: ['token'],
+      })
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(BadRequestError)
+    }
   })
 
   it('should reject client_credentials', async () => {

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
@@ -1,0 +1,128 @@
+import 'reflect-metadata'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { Types } from 'mongoose'
+import { OAuthDeviceService } from '../../../../src/modules/oauth_provider/services/oauth.device.service'
+import {
+  OAuthDeviceCode,
+  OAuthDeviceCodeStatus,
+} from '../../../../src/modules/oauth_provider/schema/oauth.device_code.schema'
+import { OAuthGrantType } from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
+import { DeviceGrantError } from '../../../../src/libs/errors/oauth.errors'
+import { Users } from '../../../../src/modules/user_management/schema/users.schema'
+import { Org } from '../../../../src/modules/user_management/schema/org.schema'
+import { createMockLogger } from '../../../helpers/mock-logger'
+
+describe('OAuthDeviceService', () => {
+  let service: OAuthDeviceService
+  let mockOAuthAppService: any
+  let mockOAuthTokenService: any
+  let mockScopeValidatorService: any
+
+  const app = {
+    clientId: 'cid',
+    isConfidential: false,
+    allowedScopes: ['user:read'],
+    allowedGrantTypes: [OAuthGrantType.DEVICE_CODE],
+    name: 'CLI',
+  }
+
+  beforeEach(() => {
+    delete process.env.PIPESHUB_ENABLE_DEVICE_GRANT
+    mockOAuthAppService = {
+      getAppByClientId: sinon.stub().resolves(app),
+      isGrantTypeAllowed: sinon.stub().returns(true),
+      verifyClientCredentials: sinon.stub(),
+    }
+    mockOAuthTokenService = {
+      generateTokens: sinon.stub().resolves({
+        accessToken: 'at',
+        tokenType: 'Bearer',
+        expiresIn: 3600,
+        scope: 'user:read',
+        refreshToken: 'rt',
+      }),
+    }
+    mockScopeValidatorService = {
+      parseScopes: sinon.stub().returns(['user:read']),
+      validateScopesForApp: sinon.stub(),
+      getScopeDefinitions: sinon.stub().returns([{ name: 'user:read' }]),
+    }
+    service = new OAuthDeviceService(
+      createMockLogger(),
+      mockOAuthAppService,
+      mockOAuthTokenService,
+      mockScopeValidatorService,
+    )
+  })
+
+  afterEach(() => {
+    sinon.restore()
+    delete process.env.PIPESHUB_ENABLE_DEVICE_GRANT
+  })
+
+  it('should create a device authorization', async () => {
+    sinon.stub(OAuthDeviceCode, 'create').resolves({} as any)
+    const result = await service.createAuthorization(
+      'cid',
+      'user:read',
+      'http://localhost:3000',
+    )
+    expect(result.device_code).to.have.length.greaterThan(16)
+    expect(result.user_code).to.match(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/)
+    expect(result.verification_uri).to.equal('http://localhost:3000/oauth/device')
+    expect(result.interval).to.equal(5)
+  })
+
+  it('should return authorization_pending while the user has not approved', async () => {
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      interval: 5,
+      lastPolledAt: undefined,
+      save: sinon.stub().resolves(),
+    } as any)
+
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(DeviceGrantError)
+      expect((err as DeviceGrantError).oauthError).to.equal(
+        'authorization_pending',
+      )
+    }
+  })
+
+  it('should mint a user-identity token after approval', async () => {
+    const userId = new Types.ObjectId()
+    const orgId = new Types.ObjectId()
+    const recordId = new Types.ObjectId()
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      _id: recordId,
+      status: OAuthDeviceCodeStatus.APPROVED,
+      expiresAt: new Date(Date.now() + 60_000),
+      userId,
+      orgId,
+      scopes: ['user:read'],
+      clientId: 'cid',
+    } as any)
+    const chainable = {
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().returnsThis(),
+      exec: sinon.stub().resolves(null),
+    }
+    sinon.stub(Users, 'findOne').returns(chainable as any)
+    sinon.stub(Org, 'findOne').returns(chainable as any)
+    sinon.stub(OAuthDeviceCode, 'deleteOne').resolves({} as any)
+
+    const tokens = await service.poll('cid', undefined, 'device-code')
+    expect(tokens.access_token).to.equal('at')
+    expect(mockOAuthTokenService.generateTokens.firstCall.args[1]).to.equal(
+      userId.toString(),
+    )
+    expect(mockOAuthTokenService.generateTokens.firstCall.args[1]).to.not.equal(
+      null,
+    )
+  })
+})

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
@@ -8,7 +8,7 @@ import {
   OAuthDeviceCodeStatus,
 } from '../../../../src/modules/oauth_provider/schema/oauth.device_code.schema'
 import { OAuthGrantType } from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
-import { DeviceGrantError } from '../../../../src/libs/errors/oauth.errors'
+import { DeviceGrantError, InvalidGrantError } from '../../../../src/libs/errors/oauth.errors'
 import { Users } from '../../../../src/modules/user_management/schema/users.schema'
 import { Org } from '../../../../src/modules/user_management/schema/org.schema'
 import { createMockLogger } from '../../../helpers/mock-logger'
@@ -136,7 +136,14 @@ describe('OAuthDeviceService', () => {
     }
     sinon.stub(Users, 'findOne').returns(chainable as any)
     sinon.stub(Org, 'findOne').returns(chainable as any)
-    sinon.stub(OAuthDeviceCode, 'deleteOne').resolves({} as any)
+    sinon.stub(OAuthDeviceCode, 'findOneAndDelete').resolves({
+      _id: recordId,
+      status: OAuthDeviceCodeStatus.APPROVED,
+      userId,
+      orgId,
+      scopes: ['user:read'],
+      clientId: 'cid',
+    } as any)
 
     const tokens = await service.poll('cid', undefined, 'device-code')
     expect(tokens.access_token).to.equal('at')
@@ -146,5 +153,29 @@ describe('OAuthDeviceService', () => {
     expect(mockOAuthTokenService.generateTokens.firstCall.args[1]).to.not.equal(
       null,
     )
+  })
+
+  it('should not mint tokens when a concurrent poll already claimed the code', async () => {
+    const userId = new Types.ObjectId()
+    const orgId = new Types.ObjectId()
+    const recordId = new Types.ObjectId()
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      _id: recordId,
+      status: OAuthDeviceCodeStatus.APPROVED,
+      expiresAt: new Date(Date.now() + 60_000),
+      userId,
+      orgId,
+      scopes: ['user:read'],
+      clientId: 'cid',
+    } as any)
+    sinon.stub(OAuthDeviceCode, 'findOneAndDelete').resolves(null)
+
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(InvalidGrantError)
+    }
+    expect(mockOAuthTokenService.generateTokens.called).to.be.false
   })
 })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 import { expect } from 'chai'
 import sinon from 'sinon'
+import crypto from 'crypto'
 import { Types } from 'mongoose'
 import { OAuthDeviceService } from '../../../../src/modules/oauth_provider/services/oauth.device.service'
 import {
@@ -8,13 +9,24 @@ import {
   OAuthDeviceCodeStatus,
 } from '../../../../src/modules/oauth_provider/schema/oauth.device_code.schema'
 import { OAuthGrantType } from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
-import { DeviceGrantError, InvalidGrantError, InvalidClientError } from '../../../../src/libs/errors/oauth.errors'
+import {
+  DeviceGrantError,
+  InvalidGrantError,
+  InvalidClientError,
+  UnsupportedGrantTypeError,
+} from '../../../../src/libs/errors/oauth.errors'
+import { BadRequestError, NotFoundError } from '../../../../src/libs/errors/http.errors'
 import { Users } from '../../../../src/modules/user_management/schema/users.schema'
 import { Org } from '../../../../src/modules/user_management/schema/org.schema'
-import { createMockLogger } from '../../../helpers/mock-logger'
+import { createMockLogger, MockLogger } from '../../../helpers/mock-logger'
+
+function sha256Hex(value: string): string {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
 
 describe('OAuthDeviceService', () => {
   let service: OAuthDeviceService
+  let mockLogger: MockLogger
   let mockOAuthAppService: any
   let mockOAuthTokenService: any
   let mockScopeValidatorService: any
@@ -52,8 +64,9 @@ describe('OAuthDeviceService', () => {
     mockFirstPartyDeviceAppService = {
       getOrCreate: sinon.stub().resolves('pipeshub-agent'),
     }
+    mockLogger = createMockLogger()
     service = new OAuthDeviceService(
-      createMockLogger(),
+      mockLogger as any,
       mockOAuthAppService,
       mockOAuthTokenService,
       mockScopeValidatorService,
@@ -141,7 +154,7 @@ describe('OAuthDeviceService', () => {
     }
     sinon.stub(Users, 'findOne').returns(chainable as any)
     sinon.stub(Org, 'findOne').returns(chainable as any)
-    const claim = sinon.stub(OAuthDeviceCode, 'findOneAndDelete').callsFake((query: any) => {
+    sinon.stub(OAuthDeviceCode, 'findOneAndDelete').callsFake((query: any) => {
       expect(query.status).to.equal(OAuthDeviceCodeStatus.APPROVED)
       expect(query.expiresAt.$gt).to.be.instanceOf(Date)
       return Promise.resolve({
@@ -158,6 +171,9 @@ describe('OAuthDeviceService', () => {
     expect(tokens.access_token).to.equal('at')
     expect(mockOAuthTokenService.generateTokens.firstCall.args[1]).to.equal(
       userId.toString(),
+    )
+    expect(mockOAuthTokenService.generateTokens.firstCall.args[2]).to.equal(
+      orgId.toString(),
     )
     expect(mockOAuthTokenService.generateTokens.firstCall.args[1]).to.not.equal(
       null,
@@ -247,5 +263,249 @@ describe('OAuthDeviceService', () => {
       expect(err).to.be.instanceOf(InvalidClientError)
     }
     expect(mockOAuthAppService.getAppByClientId.called).to.be.false
+  })
+
+  it('should refuse create when PIPESHUB_ENABLE_DEVICE_GRANT is false', async () => {
+    process.env.PIPESHUB_ENABLE_DEVICE_GRANT = 'false'
+    try {
+      await service.createAuthorization(
+        'cid',
+        'user:read',
+        'http://localhost:3000',
+      )
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(UnsupportedGrantTypeError)
+    }
+    expect(mockOAuthAppService.getAppByClientId.called).to.be.false
+  })
+
+  it('should store a SHA-256 of device_code and a hyphen-free userCode', async () => {
+    const create = sinon.stub(OAuthDeviceCode, 'create').resolves({} as any)
+    const result = await service.createAuthorization(
+      'cid',
+      'user:read',
+      'http://localhost:3000',
+    )
+    const stored = create.firstCall.args[0] as {
+      deviceCodeHash: string
+      userCode: string
+    }
+    expect(stored.deviceCodeHash).to.equal(sha256Hex(result.device_code))
+    expect(stored.deviceCodeHash).to.not.equal(result.device_code)
+    expect(stored.userCode).to.not.include('-')
+    expect(result.user_code).to.match(/^[A-Z0-9]{4}-[A-Z0-9]{4}$/)
+    expect(stored.userCode).to.equal(result.user_code.replace('-', ''))
+  })
+
+  it('should not log device_code or user_code', async () => {
+    sinon.stub(OAuthDeviceCode, 'create').resolves({} as any)
+    const result = await service.createAuthorization(
+      'cid',
+      'user:read',
+      'http://localhost:3000',
+    )
+    const logged = JSON.stringify(mockLogger.info.args)
+    expect(logged).to.not.include(result.device_code)
+    expect(logged).to.not.include(result.user_code)
+  })
+
+  it('should look up polls by hashed device_code, not plaintext', async () => {
+    const plaintext = 'plaintext-device-code'
+    const findOne = sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      interval: 5,
+      lastPolledAt: undefined,
+      save: sinon.stub().resolves(),
+    } as any)
+    try {
+      await service.poll('cid', undefined, plaintext)
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(DeviceGrantError)
+    }
+    expect(findOne.firstCall.args[0].deviceCodeHash).to.deep.equal({
+      $eq: sha256Hex(plaintext),
+    })
+    expect(findOne.firstCall.args[0].deviceCodeHash.$eq).to.not.equal(plaintext)
+  })
+
+  it('should reject a missing device_code before lookup', async () => {
+    try {
+      await service.poll('cid', undefined, '')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(InvalidGrantError)
+    }
+    expect(mockOAuthAppService.getAppByClientId.called).to.be.false
+  })
+
+  it('should return expired_token when the device_code is unknown or expired', async () => {
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves(null)
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(DeviceGrantError)
+      expect((err as DeviceGrantError).oauthError).to.equal('expired_token')
+    }
+  })
+
+  it('should return access_denied when the user denied the request', async () => {
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.DENIED,
+      expiresAt: new Date(Date.now() + 60_000),
+    } as any)
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(DeviceGrantError)
+      expect((err as DeviceGrantError).oauthError).to.equal('access_denied')
+    }
+    expect(mockOAuthTokenService.generateTokens.called).to.be.false
+  })
+
+  it('should require client_secret for confidential clients', async () => {
+    mockOAuthAppService.getAppByClientId.resolves({
+      ...app,
+      isConfidential: true,
+    })
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(InvalidClientError)
+    }
+    expect(mockOAuthAppService.verifyClientCredentials.called).to.be.false
+  })
+
+  it('should poll a public client without a secret', async () => {
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      interval: 5,
+      lastPolledAt: undefined,
+      save: sinon.stub().resolves(),
+    } as any)
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect((err as DeviceGrantError).oauthError).to.equal(
+        'authorization_pending',
+      )
+    }
+    expect(mockOAuthAppService.verifyClientCredentials.called).to.be.false
+  })
+
+  it('should set userId and orgId on grant, and not on deny', async () => {
+    const userId = new Types.ObjectId().toString()
+    const orgId = new Types.ObjectId().toString()
+    const granted: any = {
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      clientId: 'cid',
+      save: sinon.stub().resolves(),
+    }
+    const denied: any = {
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      clientId: 'cid',
+      save: sinon.stub().resolves(),
+    }
+    const findOne = sinon.stub(OAuthDeviceCode, 'findOne')
+    findOne.onFirstCall().resolves(granted)
+    findOne.onSecondCall().resolves(denied)
+
+    await service.approve('ABCD-EFGH', userId, orgId, 'granted')
+    expect(granted.status).to.equal(OAuthDeviceCodeStatus.APPROVED)
+    expect(granted.userId.toString()).to.equal(userId)
+    expect(granted.orgId.toString()).to.equal(orgId)
+
+    await service.approve('ABCD-EFGH', userId, orgId, 'denied')
+    expect(denied.status).to.equal(OAuthDeviceCodeStatus.DENIED)
+    expect(denied.userId).to.equal(undefined)
+    expect(mockOAuthTokenService.generateTokens.called).to.be.false
+  })
+
+  it('should surface isDynamic on consent data', async () => {
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      clientId: 'cid',
+      scopes: ['user:read'],
+    } as any)
+    mockOAuthAppService.getAppByClientId.resolves({
+      ...app,
+      isDynamic: true,
+      description: 'dyn',
+    })
+    const data = await service.getConsentData('ABCD-EFGH')
+    expect(data.app.isDynamic).to.equal(true)
+  })
+
+  it('should omit isDynamic when the app is first-party', async () => {
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      clientId: 'cid',
+      scopes: ['user:read'],
+    } as any)
+    mockOAuthAppService.getAppByClientId.resolves({ ...app, isDynamic: false })
+    const data = await service.getConsentData('ABCD-EFGH')
+    expect(data.app.isDynamic).to.equal(false)
+  })
+
+  it('should normalize hyphenated user_code before lookup', async () => {
+    const findOne = sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      clientId: 'cid',
+      scopes: ['user:read'],
+    } as any)
+    mockOAuthAppService.getAppByClientId.resolves(app)
+    await service.getConsentData('ab-cd-efgh')
+    expect(findOne.firstCall.args[0]).to.deep.equal({ userCode: 'ABCDEFGH' })
+  })
+
+  it('should reject unknown, expired, and already-used user_code', async () => {
+    const findOne = sinon.stub(OAuthDeviceCode, 'findOne')
+    findOne.onFirstCall().resolves(null)
+    try {
+      await service.getConsentData('ABCD-EFGH')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(NotFoundError)
+    }
+
+    findOne.onSecondCall().resolves({
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() - 1000),
+    } as any)
+    try {
+      await service.getConsentData('ABCD-EFGH')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(DeviceGrantError)
+      expect((err as DeviceGrantError).oauthError).to.equal('expired_token')
+    }
+
+    findOne.onThirdCall().resolves({
+      status: OAuthDeviceCodeStatus.APPROVED,
+      expiresAt: new Date(Date.now() + 60_000),
+    } as any)
+    try {
+      await service.getConsentData('ABCD-EFGH')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(BadRequestError)
+    }
+  })
+
+  it('should strip hyphens in normalizeUserCode', () => {
+    expect(service.normalizeUserCode('ab-cd-efgh')).to.equal('ABCDEFGH')
+    expect(service.normalizeUserCode('ABCD EFGH')).to.equal('ABCDEFGH')
   })
 })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
@@ -74,6 +74,28 @@ describe('OAuthDeviceService', () => {
     expect(result.interval).to.equal(5)
   })
 
+  it('should not reset lastPolledAt when rejecting a fast poll', async () => {
+    const original = new Date(Date.now() - 1000)
+    const record: any = {
+      status: OAuthDeviceCodeStatus.PENDING,
+      expiresAt: new Date(Date.now() + 60_000),
+      interval: 5,
+      lastPolledAt: original,
+      save: sinon.stub().resolves(),
+    }
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves(record)
+
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(DeviceGrantError)
+      expect((err as DeviceGrantError).oauthError).to.equal('slow_down')
+    }
+    expect(record.lastPolledAt).to.equal(original)
+    expect(record.save.called).to.be.false
+  })
+
   it('should return authorization_pending while the user has not approved', async () => {
     sinon.stub(OAuthDeviceCode, 'findOne').resolves({
       status: OAuthDeviceCodeStatus.PENDING,

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
@@ -8,7 +8,7 @@ import {
   OAuthDeviceCodeStatus,
 } from '../../../../src/modules/oauth_provider/schema/oauth.device_code.schema'
 import { OAuthGrantType } from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
-import { DeviceGrantError, InvalidGrantError } from '../../../../src/libs/errors/oauth.errors'
+import { DeviceGrantError, InvalidGrantError, InvalidClientError } from '../../../../src/libs/errors/oauth.errors'
 import { Users } from '../../../../src/modules/user_management/schema/users.schema'
 import { Org } from '../../../../src/modules/user_management/schema/org.schema'
 import { createMockLogger } from '../../../helpers/mock-logger'
@@ -18,6 +18,7 @@ describe('OAuthDeviceService', () => {
   let mockOAuthAppService: any
   let mockOAuthTokenService: any
   let mockScopeValidatorService: any
+  let mockFirstPartyDeviceAppService: any
 
   const app = {
     clientId: 'cid',
@@ -48,11 +49,15 @@ describe('OAuthDeviceService', () => {
       validateScopesForApp: sinon.stub(),
       getScopeDefinitions: sinon.stub().returns([{ name: 'user:read' }]),
     }
+    mockFirstPartyDeviceAppService = {
+      getOrCreate: sinon.stub().resolves('pipeshub-agent'),
+    }
     service = new OAuthDeviceService(
       createMockLogger(),
       mockOAuthAppService,
       mockOAuthTokenService,
       mockScopeValidatorService,
+      mockFirstPartyDeviceAppService,
     )
   })
 
@@ -205,5 +210,42 @@ describe('OAuthDeviceService', () => {
       expect(err).to.be.instanceOf(InvalidGrantError)
     }
     expect(mockOAuthTokenService.generateTokens.called).to.be.false
+  })
+
+  it('should ensure the first-party device app before starting login', async () => {
+    sinon.stub(OAuthDeviceCode, 'create').resolves({} as any)
+    await service.createAuthorization(
+      'pipeshub-agent',
+      'user:read',
+      'http://localhost:3000',
+    )
+    expect(mockFirstPartyDeviceAppService.getOrCreate.calledOnce).to.be.true
+    expect(mockOAuthAppService.getAppByClientId.calledWith('pipeshub-agent')).to.be
+      .true
+  })
+
+  it('should not ensure the first-party app for other client_ids', async () => {
+    sinon.stub(OAuthDeviceCode, 'create').resolves({} as any)
+    await service.createAuthorization(
+      'cid',
+      'user:read',
+      'http://localhost:3000',
+    )
+    expect(mockFirstPartyDeviceAppService.getOrCreate.called).to.be.false
+  })
+
+  it('should reject first-party login when the instance has no org', async () => {
+    mockFirstPartyDeviceAppService.getOrCreate.resolves(null)
+    try {
+      await service.createAuthorization(
+        'pipeshub-agent',
+        'user:read',
+        'http://localhost:3000',
+      )
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(InvalidClientError)
+    }
+    expect(mockOAuthAppService.getAppByClientId.called).to.be.false
   })
 })

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.device.service.test.ts
@@ -136,14 +136,18 @@ describe('OAuthDeviceService', () => {
     }
     sinon.stub(Users, 'findOne').returns(chainable as any)
     sinon.stub(Org, 'findOne').returns(chainable as any)
-    sinon.stub(OAuthDeviceCode, 'findOneAndDelete').resolves({
-      _id: recordId,
-      status: OAuthDeviceCodeStatus.APPROVED,
-      userId,
-      orgId,
-      scopes: ['user:read'],
-      clientId: 'cid',
-    } as any)
+    const claim = sinon.stub(OAuthDeviceCode, 'findOneAndDelete').callsFake((query: any) => {
+      expect(query.status).to.equal(OAuthDeviceCodeStatus.APPROVED)
+      expect(query.expiresAt.$gt).to.be.instanceOf(Date)
+      return Promise.resolve({
+        _id: recordId,
+        status: OAuthDeviceCodeStatus.APPROVED,
+        userId,
+        orgId,
+        scopes: ['user:read'],
+        clientId: 'cid',
+      }) as any
+    })
 
     const tokens = await service.poll('cid', undefined, 'device-code')
     expect(tokens.access_token).to.equal('at')
@@ -156,6 +160,30 @@ describe('OAuthDeviceService', () => {
   })
 
   it('should not mint tokens when a concurrent poll already claimed the code', async () => {
+    const userId = new Types.ObjectId()
+    const orgId = new Types.ObjectId()
+    const recordId = new Types.ObjectId()
+    sinon.stub(OAuthDeviceCode, 'findOne').resolves({
+      _id: recordId,
+      status: OAuthDeviceCodeStatus.APPROVED,
+      expiresAt: new Date(Date.now() + 60_000),
+      userId,
+      orgId,
+      scopes: ['user:read'],
+      clientId: 'cid',
+    } as any)
+    sinon.stub(OAuthDeviceCode, 'findOneAndDelete').resolves(null)
+
+    try {
+      await service.poll('cid', undefined, 'device-code')
+      expect.fail('should have thrown')
+    } catch (err) {
+      expect(err).to.be.instanceOf(InvalidGrantError)
+    }
+    expect(mockOAuthTokenService.generateTokens.called).to.be.false
+  })
+
+  it('should not mint tokens when the code expires between lookup and claim', async () => {
     const userId = new Types.ObjectId()
     const orgId = new Types.ObjectId()
     const recordId = new Types.ObjectId()

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.first_party_device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.first_party_device.service.test.ts
@@ -99,6 +99,19 @@ describe('FirstPartyDeviceAppService', () => {
     expect(create.called).to.be.false
   })
 
+  it('should return null when the org has no users yet', async () => {
+    ;(Users.findOne as sinon.SinonStub).returns({
+      sort: sinon.stub().returnsThis(),
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().resolves(null),
+    })
+    sinon.stub(OAuthApp, 'findOne').resolves(null)
+    const create = sinon.stub(OAuthApp, 'create')
+
+    expect(await service.getOrCreate()).to.equal(null)
+    expect(create.called).to.be.false
+  })
+
   it('should return the winner when two creates race on clientId', async () => {
     const findOne = sinon.stub(OAuthApp, 'findOne')
     findOne.onFirstCall().resolves(null)

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.first_party_device.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.first_party_device.service.test.ts
@@ -1,0 +1,151 @@
+import 'reflect-metadata'
+import { expect } from 'chai'
+import sinon from 'sinon'
+import { Types } from 'mongoose'
+import { FirstPartyDeviceAppService } from '../../../../src/modules/oauth_provider/services/oauth.first_party_device.service'
+import {
+  OAuthApp,
+  OAuthGrantType,
+} from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
+import { Org } from '../../../../src/modules/user_management/schema/org.schema'
+import { Users } from '../../../../src/modules/user_management/schema/users.schema'
+import { FIRST_PARTY_DEVICE_CLIENT_ID } from '../../../../src/modules/oauth_provider/constants/constants'
+import { AgentMcpScopes } from '../../../../src/modules/oauth_provider/config/scopes.config'
+import { createMockLogger } from '../../../helpers/mock-logger'
+
+describe('FirstPartyDeviceAppService', () => {
+  let service: FirstPartyDeviceAppService
+  let mockEncryptionService: any
+  const orgId = new Types.ObjectId()
+  const userId = new Types.ObjectId()
+
+  beforeEach(() => {
+    mockEncryptionService = {
+      encrypt: sinon.stub().returns('encrypted-secret'),
+    }
+    service = new FirstPartyDeviceAppService(
+      createMockLogger(),
+      mockEncryptionService,
+      {
+        getAllowedScopeNamesForRole: sinon.stub().returns([...AgentMcpScopes]),
+      } as any,
+      {
+        mcpScopes: [...AgentMcpScopes],
+      } as any,
+    )
+    const orgQuery: any = {
+      sort: sinon.stub().returnsThis(),
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().resolves([{ _id: orgId }]),
+    }
+    sinon.stub(Org, 'find').returns(orgQuery)
+    const userQuery: any = {
+      sort: sinon.stub().returnsThis(),
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().resolves({ _id: userId }),
+    }
+    sinon.stub(Users, 'findOne').returns(userQuery)
+  })
+
+  afterEach(() => {
+    sinon.restore()
+  })
+
+  it('should return the existing client_id without creating another app', async () => {
+    sinon.stub(OAuthApp, 'findOne').resolves({
+      clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+    } as any)
+    const create = sinon.stub(OAuthApp, 'create')
+
+    const clientId = await service.getOrCreate()
+    expect(clientId).to.equal(FIRST_PARTY_DEVICE_CLIENT_ID)
+    expect(create.called).to.be.false
+  })
+
+  it('should create a public device-only app with the agent preset', async () => {
+    sinon.stub(OAuthApp, 'findOne').resolves(null)
+    const create = sinon.stub(OAuthApp, 'create').resolves({
+      clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+    } as any)
+
+    const clientId = await service.getOrCreate()
+    expect(clientId).to.equal(FIRST_PARTY_DEVICE_CLIENT_ID)
+    const data = create.firstCall.args[0] as Record<string, unknown>
+    expect(data.clientId).to.equal(FIRST_PARTY_DEVICE_CLIENT_ID)
+    expect(data.name).to.equal('PipesHub agent')
+    expect(data.isConfidential).to.equal(false)
+    expect(data.isDynamic).to.equal(false)
+    expect(data.allowedGrantTypes).to.deep.equal([
+      OAuthGrantType.DEVICE_CODE,
+      OAuthGrantType.REFRESH_TOKEN,
+    ])
+    expect(data.allowedGrantTypes).to.not.include(
+      OAuthGrantType.CLIENT_CREDENTIALS,
+    )
+    expect(data.allowedScopes).to.deep.equal([...AgentMcpScopes])
+    expect(mockEncryptionService.encrypt.calledOnce).to.be.true
+  })
+
+  it('should return null when the instance has no org', async () => {
+    ;(Org.find as sinon.SinonStub).returns({
+      sort: sinon.stub().returnsThis(),
+      select: sinon.stub().returnsThis(),
+      lean: sinon.stub().resolves([]),
+    })
+    sinon.stub(OAuthApp, 'findOne').resolves(null)
+    const create = sinon.stub(OAuthApp, 'create')
+
+    expect(await service.getOrCreate()).to.equal(null)
+    expect(create.called).to.be.false
+  })
+
+  it('should return the winner when two creates race on clientId', async () => {
+    const findOne = sinon.stub(OAuthApp, 'findOne')
+    findOne.onFirstCall().resolves(null)
+    findOne.onSecondCall().resolves({
+      clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+    } as any)
+    sinon.stub(OAuthApp, 'create').rejects(new Error('E11000 duplicate key'))
+
+    expect(await service.getOrCreate()).to.equal(FIRST_PARTY_DEVICE_CLIENT_ID)
+  })
+
+  it('should omit scopes that are not in MCP_SCOPES', async () => {
+    service = new FirstPartyDeviceAppService(
+      createMockLogger(),
+      mockEncryptionService,
+      {
+        getAllowedScopeNamesForRole: sinon.stub().returns([...AgentMcpScopes]),
+      } as any,
+      {
+        mcpScopes: ['user:read', 'kb:read'],
+      } as any,
+    )
+    sinon.stub(OAuthApp, 'findOne').resolves(null)
+    const create = sinon.stub(OAuthApp, 'create').resolves({
+      clientId: FIRST_PARTY_DEVICE_CLIENT_ID,
+    } as any)
+
+    await service.getOrCreate()
+    const data = create.firstCall.args[0] as Record<string, unknown>
+    expect(data.allowedScopes).to.deep.equal(['kb:read', 'user:read'])
+  })
+
+  it('should return null when the agent preset intersects MCP_SCOPES as empty', async () => {
+    service = new FirstPartyDeviceAppService(
+      createMockLogger(),
+      mockEncryptionService,
+      {
+        getAllowedScopeNamesForRole: sinon.stub().returns([...AgentMcpScopes]),
+      } as any,
+      {
+        mcpScopes: ['config:read'],
+      } as any,
+    )
+    sinon.stub(OAuthApp, 'findOne').resolves(null)
+    const create = sinon.stub(OAuthApp, 'create')
+
+    expect(await service.getOrCreate()).to.equal(null)
+    expect(create.called).to.be.false
+  })
+})

--- a/backend/nodejs/apps/tests/modules/oauth_provider/validators/oauth.validators.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/validators/oauth.validators.test.ts
@@ -1,22 +1,57 @@
 import 'reflect-metadata'
 import { expect } from 'chai'
-import sinon from 'sinon'
+import { ZodError } from 'zod'
+import {
+  deviceAuthorizationSchema,
+  deviceConsentSchema,
+  deviceUserCodeSchema,
+  tokenSchema,
+} from '../../../../src/modules/oauth_provider/validators/oauth.validators'
+import { OAuthGrantType } from '../../../../src/modules/oauth_provider/schema/oauth.app.schema'
 
-// Import the validators module to check it exports schemas
 describe('oauth_provider/validators/oauth.validators', () => {
-  afterEach(() => {
-    sinon.restore()
+  it('should accept a device authorization body', () => {
+    const parsed = deviceAuthorizationSchema.parse({
+      body: { client_id: 'pipeshub-agent', scope: 'user:read' },
+    })
+    expect(parsed.body.client_id).to.equal('pipeshub-agent')
   })
 
-  it('should be importable without errors', async () => {
-    // The oauth.validators module should be importable
-    try {
-      const validators = await import('../../../../src/modules/oauth_provider/validators/oauth.validators')
-      expect(validators).to.be.an('object')
-    } catch (error: any) {
-      // Some validators may depend on external modules that arent available in test
-      // This is acceptable - the test verifies the module structure
-      expect(error).to.exist
-    }
+  it('should reject an empty user_code', () => {
+    expect(() =>
+      deviceUserCodeSchema.parse({ body: { user_code: '' } }),
+    ).to.throw(ZodError)
+  })
+
+  it('should reject consent values other than granted or denied', () => {
+    expect(() =>
+      deviceConsentSchema.parse({
+        body: { user_code: 'ABCD-EFGH', consent: 'maybe' },
+      }),
+    ).to.throw(ZodError)
+  })
+
+  it('should accept granted and denied consent', () => {
+    expect(
+      deviceConsentSchema.parse({
+        body: { user_code: 'ABCD-EFGH', consent: 'granted' },
+      }).body.consent,
+    ).to.equal('granted')
+    expect(
+      deviceConsentSchema.parse({
+        body: { user_code: 'ABCD-EFGH', consent: 'denied' },
+      }).body.consent,
+    ).to.equal('denied')
+  })
+
+  it('should accept the device_code grant on the token schema', () => {
+    const parsed = tokenSchema.parse({
+      body: {
+        grant_type: OAuthGrantType.DEVICE_CODE,
+        client_id: 'cid',
+        device_code: 'abc',
+      },
+    })
+    expect(parsed.body.device_code).to.equal('abc')
   })
 })

--- a/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
+++ b/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
@@ -8,12 +8,13 @@ For the standard interactive install, see the [Deployment Guide in the main READ
 ## Contents
 
 - [Standalone one-command install](#standalone-one-command-install)
-- [Deployment types (slim vs. full)](#deployment-types-slim-vs-full)
+- [Deployment types (slim vs. full vs. eval)](#deployment-types-slim-vs-full-vs-eval)
 - [Environment overrides for CI / scripted installs](#environment-overrides-for-ci--scripted-installs)
 - [Upgrading an existing Compose install](#upgrading-an-existing-compose-install)
 - [A second instance on the same host](#a-second-instance-on-the-same-host)
 - [Manual deployment with Compose profiles](#manual-deployment-with-compose-profiles)
 - [Secrets and configuration](#secrets-and-configuration)
+- [OAuth dynamic registration and device grant](#oauth-dynamic-registration-and-device-grant)
 - [Runtime tuning (workers and query-service flags)](#runtime-tuning-workers-and-query-service-flags)
 - [Container outbound connectivity](#container-outbound-connectivity)
 - [Developer / local build](#developer--local-build)
@@ -54,24 +55,36 @@ requires a full clone — see [Developer / local build](#developer--local-build)
 
 ---
 
-## Deployment types (slim vs. full)
+## Deployment types (slim vs. full vs. eval)
 
-| | **Slim** | **Full** |
-|---|---|---|
-| Image | `pipeshubai/pipeshub-ai:slim` | `pipeshubai/pipeshub-ai:latest` |
-| Embedding model | Downloaded on first use | Bundled in image (~1.3 GB extra) |
-| Graph DB (default) | Neo4j | Neo4j |
-| Broker (default) | Redis Streams | Kafka + Zookeeper |
-| KV store (default) | Redis | Redis |
-| Recommended for | Laptops, evaluations | Production, air-gapped servers |
+| | **Slim** | **Full** | **Eval** |
+|---|---|---|---|
+| Image | `pipeshubai/pipeshub-ai:slim` | `pipeshubai/pipeshub-ai:latest` | `pipeshubai/pipeshub-ai:slim` |
+| Embedding model | Downloaded on first use | Bundled in image (~1.3 GB extra) | Downloaded on first use |
+| Graph DB (default) | Neo4j | Neo4j | Neo4j (required) |
+| Broker (default) | Redis Streams | Kafka + Zookeeper | Redis Streams |
+| KV store (default) | Redis | Redis | Redis |
+| Coding sandbox | Pulled (`sandbox` profile) | Pulled | **Omitted** — `run_code` unavailable |
+| Slack bot process | Starts | Starts | Skipped (`PIPESHUB_SKIP_SLACKBOT=true`) |
+| RAM class | 16 GB host / 8 GB Docker VM | 16 GB+ | 8 GB-class laptop |
+| Recommended for | Laptops, servers | Production, air-gapped | MCP search/ask demos |
 
-Both deployment types default to **Neo4j** for the graph DB and **Redis** for the
+Eval is **not** a fourth image tag. It is slim plus a smaller Compose topology.
+Neo4j stays: records and ACLs live in the graph store, and search is not proven
+without it. Do not drop Neo4j to save RAM.
+
+```bash
+PIPESHUB_DEPLOY_TYPE=eval ./install.sh --yes
+```
+
+Both slim and full default to **Neo4j** for the graph DB and **Redis** for the
 KV store; the difference is the bundled embedding model and the message broker
 (Redis Streams for slim, Kafka for full). ArangoDB and etcd are opt-in — choose
 them at the prompts or via `PIPESHUB_GRAPH_DB` / `PIPESHUB_KV_STORE`.
 
 **Slim** uses no extra broker or KV-store containers (Redis handles both).  
 **Full** pre-bakes the [BAAI/bge-large-en-v1.5](https://huggingface.co/BAAI/bge-large-en-v1.5) embedding model so the first query does not stall waiting for a download.
+**Eval** is slim without the sandbox image pull and without the Slack bot process.
 
 ---
 
@@ -81,7 +94,7 @@ All variables are optional. When set, they suppress the corresponding interactiv
 
 | Variable | Values | Default |
 |----------|--------|---------|
-| `PIPESHUB_DEPLOY_TYPE` | `full` \| `slim` | interactive |
+| `PIPESHUB_DEPLOY_TYPE` | `full` \| `slim` \| `eval` | interactive |
 | `PIPESHUB_GRAPH_DB` | `arango` \| `neo4j` | per deploy type |
 | `PIPESHUB_BROKER` | `kafka` \| `redis` | per deploy type |
 | `PIPESHUB_KV_STORE` | `etcd` \| `redis` | per deploy type |
@@ -291,6 +304,28 @@ manager instead of `.env` — for example Docker/Swarm secrets, HashiCorp Vault,
 or your cloud provider's KMS / Secrets Manager — and inject the values into the
 containers at runtime. The Compose services read standard environment variables,
 so any tool that can populate the container environment will work.
+
+---
+
+## OAuth dynamic registration and device grant
+
+PipesHub's authorization server advertises RFC 7591 dynamic client registration
+and RFC 8628 device authorization. Coding agents use these to obtain a **user**
+access token (never `client_credentials` through DCR).
+
+| Variable | Default | Effect |
+|----------|---------|--------|
+| `PIPESHUB_ENABLE_DCR` | on (any value other than `false`) | `POST /api/v1/oauth2/register` |
+| `PIPESHUB_ENABLE_DEVICE_GRANT` | on | `POST /api/v1/oauth2/device_authorization` and the device `grant_type` |
+
+Discovery: `GET {origin}/.well-known/openid-configuration` lists
+`registration_endpoint` and `device_authorization_endpoint`. Public clients
+register with `token_endpoint_auth_method: none`. Request
+`urn:ietf:params:oauth:grant-type:device_code` in `grant_types` if the agent
+will poll the device grant. The user completes consent at `/oauth/device`.
+
+DCR refuses `client_credentials`. Tokens issued after device consent carry the
+logged-in user's `userId` and `orgId`.
 
 ---
 

--- a/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
+++ b/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
@@ -315,14 +315,18 @@ access token (never `client_credentials` through DCR).
 
 | Variable | Default | Effect |
 |----------|---------|--------|
-| `PIPESHUB_ENABLE_DCR` | on (any value other than `false`) | `POST /api/v1/oauth2/register` |
+| `PIPESHUB_ENABLE_DCR` | off (only `true` enables it) | `POST /api/v1/oauth2/register` |
 | `PIPESHUB_ENABLE_DEVICE_GRANT` | on | `POST /api/v1/oauth2/device_authorization` and the device `grant_type` |
 
 Discovery: `GET {origin}/.well-known/openid-configuration` lists
-`registration_endpoint` and `device_authorization_endpoint`. Public clients
-register with `token_endpoint_auth_method: none`. Request
+`device_authorization_endpoint`, and `registration_endpoint` only when DCR is
+on. Public clients register with `token_endpoint_auth_method: none`. Request
 `urn:ietf:params:oauth:grant-type:device_code` in `grant_types` if the agent
 will poll the device grant. The user completes consent at `/oauth/device`.
+Unauthenticated DCR is off by default so a stock instance cannot be used for
+consent phishing. Operators who want agents to self-register set
+`PIPESHUB_ENABLE_DCR=true`. The consent screen warns when the app registered
+itself (`isDynamic`) rather than being created by an administrator.
 
 DCR refuses `client_credentials`. Tokens issued after device consent carry the
 logged-in user's `userId` and `orgId`.

--- a/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
+++ b/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
@@ -321,14 +321,20 @@ access token (never `client_credentials` through DCR).
 
 Discovery: `GET {origin}/.well-known/openid-configuration` lists
 `device_authorization_endpoint` and the device grant type only while the
-device grant is on, and `registration_endpoint` only when DCR is on. Public
-clients register with `token_endpoint_auth_method: none`. Request
-`urn:ietf:params:oauth:grant-type:device_code` in `grant_types` if the agent
-will poll the device grant. The user completes consent at `/oauth/device`.
-Unauthenticated DCR is off by default so a stock instance cannot be used for
-consent phishing. Operators who want agents to self-register set
-`PIPESHUB_ENABLE_DCR=true`. The consent screen warns when the app registered
-itself (`isDynamic`) rather than being created by an administrator.
+device grant is on, and `registration_endpoint` only when DCR is on. When
+the instance has an organization, discovery also includes
+`pipeshub_device_client_id` (`pipeshub-agent`): the official public device
+client, created automatically, device_code + refresh_token only, never
+`client_credentials`. Agents use that `client_id` to start the TV-code
+flow. It is hidden from Developer Settings. Public clients that
+self-register still use `token_endpoint_auth_method: none`. Request
+`urn:ietf:params:oauth:grant-type:device_code` in `grant_types` if a
+*self-registered* agent will poll the device grant. The user completes
+consent at `/oauth/device`. Unauthenticated DCR is off by default so a
+stock instance cannot be used for consent phishing. Operators who want
+agents to self-register set `PIPESHUB_ENABLE_DCR=true`. The consent screen
+warns when the app registered itself (`isDynamic`) rather than being the
+official agent app or created by an administrator.
 
 DCR refuses `client_credentials`. Tokens issued after device consent carry the
 logged-in user's `userId` and `orgId`.

--- a/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
+++ b/deployment/docker-compose/ADVANCED_DEPLOYMENT.md
@@ -245,6 +245,7 @@ docker compose -p pipeshub-ai exec -T pipeshub-ai bash
 | `graph-neo4j` | Neo4j | `DATA_STORE=neo4j` |
 | `kv-etcd` | etcd | `KV_STORE_TYPE=etcd` |
 | `broker-kafka` | Kafka + Zookeeper | `MESSAGE_BROKER=kafka` |
+| `sandbox` | coding-sandbox image pull | slim/full; **eval omits this** |
 
 Always-on services (no profile needed): `redis`, `mongodb`, `qdrant`.
 
@@ -319,8 +320,9 @@ access token (never `client_credentials` through DCR).
 | `PIPESHUB_ENABLE_DEVICE_GRANT` | on | `POST /api/v1/oauth2/device_authorization` and the device `grant_type` |
 
 Discovery: `GET {origin}/.well-known/openid-configuration` lists
-`device_authorization_endpoint`, and `registration_endpoint` only when DCR is
-on. Public clients register with `token_endpoint_auth_method: none`. Request
+`device_authorization_endpoint` and the device grant type only while the
+device grant is on, and `registration_endpoint` only when DCR is on. Public
+clients register with `token_endpoint_auth_method: none`. Request
 `urn:ietf:params:oauth:grant-type:device_code` in `grant_types` if the agent
 will poll the device grant. The user completes consent at `/oauth/device`.
 Unauthenticated DCR is off by default so a stock instance cannot be used for

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -18,11 +18,13 @@
 #   graph-arango  — ArangoDB          (with DATA_STORE=arangodb)
 #   kv-etcd       — etcd              (with KV_STORE_TYPE=etcd)
 #   broker-kafka  — Zookeeper + Kafka (with MESSAGE_BROKER=kafka)
+#   sandbox       — coding-sandbox image pull (SANDBOX_MODE=docker)
 #
 # Full stack: DATA_STORE=neo4j, KV_STORE_TYPE=etcd, MESSAGE_BROKER=kafka and
-# COMPOSE_PROFILES=graph-neo4j,kv-etcd,broker-kafka
+# COMPOSE_PROFILES=graph-neo4j,kv-etcd,broker-kafka,sandbox
 #
-# Always-on: pipeshub-ai, redis, mongodb, qdrant, sandbox-image
+# Always-on: pipeshub-ai, redis, mongodb, qdrant.
+# Eval omits the sandbox profile (run_code is unavailable).
 #
 # Requires Docker Compose v2.20+ for `required: false` on depends_on.
 
@@ -211,6 +213,9 @@ services:
       - MCP_SCOPES=${MCP_SCOPES:-openid,profile,email,offline_access,semantic:write,conversation:write,conversation:chat,kb:read,team:read,user:read,config:read,agent:read,agent:execute,connector:read}
       - ACCESS_TOKEN_EXPIRY=${ACCESS_TOKEN_EXPIRY:-24h}
       - REFRESH_TOKEN_EXPIRY=${REFRESH_TOKEN_EXPIRY:-720h}
+      # RFC 7591 / RFC 8628. Unset or any value other than "false" leaves them on.
+      - PIPESHUB_ENABLE_DCR=${PIPESHUB_ENABLE_DCR:-}
+      - PIPESHUB_ENABLE_DEVICE_GRANT=${PIPESHUB_ENABLE_DEVICE_GRANT:-}
 
       # ML threading
       - OMP_NUM_THREADS=${OMP_NUM_THREADS:-2}
@@ -287,6 +292,8 @@ services:
       # Code sandbox
       - SANDBOX_MODE=${SANDBOX_MODE:-docker}
       - SANDBOX_DOCKER_IMAGE=${SANDBOX_DOCKER_IMAGE:-pipeshubai/pipeshub-sandbox:${IMAGE_TAG:-latest}}
+      # Eval deploy type skips the Slack bot process inside the app container.
+      - PIPESHUB_SKIP_SLACKBOT=${PIPESHUB_SKIP_SLACKBOT:-false}
 
       # Standalone parsing / extraction services (opt-in)
       - PARSING_SERVICE_URL=http://localhost:8092
@@ -322,6 +329,7 @@ services:
         required: false
       sandbox-image:
         condition: service_completed_successfully
+        required: false
 
     volumes:
       - pipeshub_data:/data/pipeshub
@@ -446,7 +454,10 @@ services:
 
   # Pull-only helper: ensures the sandbox image exists before pipeshub-ai starts.
   # With --build it builds the sandbox image locally from deployment/sandbox/Dockerfile.
+  # Profile-gated so eval can skip the pull; slim/full include `sandbox` in
+  # COMPOSE_PROFILES. depends_on above is required:false for the same reason.
   sandbox-image:
+    profiles: ["sandbox"]
     image: ${SANDBOX_DOCKER_IMAGE:-pipeshubai/pipeshub-sandbox:${IMAGE_TAG:-latest}}
     build:
       context: ../../deployment/sandbox

--- a/deployment/docker-compose/docker-compose.yml
+++ b/deployment/docker-compose/docker-compose.yml
@@ -213,7 +213,7 @@ services:
       - MCP_SCOPES=${MCP_SCOPES:-openid,profile,email,offline_access,semantic:write,conversation:write,conversation:chat,kb:read,team:read,user:read,config:read,agent:read,agent:execute,connector:read}
       - ACCESS_TOKEN_EXPIRY=${ACCESS_TOKEN_EXPIRY:-24h}
       - REFRESH_TOKEN_EXPIRY=${REFRESH_TOKEN_EXPIRY:-720h}
-      # RFC 7591 / RFC 8628. Unset or any value other than "false" leaves them on.
+      # RFC 7591 DCR is off unless "true". RFC 8628 device grant is on unless "false".
       - PIPESHUB_ENABLE_DCR=${PIPESHUB_ENABLE_DCR:-}
       - PIPESHUB_ENABLE_DEVICE_GRANT=${PIPESHUB_ENABLE_DEVICE_GRANT:-}
 

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -104,13 +104,15 @@ MESSAGE_BROKER=redis
 #   graph-arango   ArangoDB           (pairs with DATA_STORE=arangodb)
 #   kv-etcd        etcd               (pairs with KV_STORE_TYPE=etcd)
 #   broker-kafka   Kafka + Zookeeper  (pairs with MESSAGE_BROKER=kafka)
+#   sandbox        coding-sandbox image pull (omit for eval; run_code unavailable)
 # redis, mongodb and qdrant always start and need no profile.
 #
 # The values below are the slim stack, matching IMAGE_TAG=slim above: Neo4j for
 # the graph, Redis Streams for the broker, Redis for the key-value store. For the
 # full stack set MESSAGE_BROKER=kafka, KV_STORE_TYPE=etcd and
-# COMPOSE_PROFILES=graph-neo4j,broker-kafka,kv-etcd together.
-COMPOSE_PROFILES=graph-neo4j
+# COMPOSE_PROFILES=graph-neo4j,broker-kafka,kv-etcd,sandbox together.
+# Eval is slim without sandbox: COMPOSE_PROFILES=graph-neo4j
+COMPOSE_PROFILES=graph-neo4j,sandbox
 # Optional: isolate this copy from another PipesHub stack on the same Docker host.
 # The installer writes this; --stop / --uninstall read it. Default is pipeshub-ai.
 # COMPOSE_PROJECT_NAME=pipeshub-ai
@@ -123,6 +125,10 @@ REDIS_STREAMS_MAXLEN=500000
 
 # MCP OAuth scopes (comma-separated)
 MCP_SCOPES=openid,profile,email,offline_access,semantic:write,conversation:write,conversation:chat,kb:read,team:read,user:read,config:read,agent:read,agent:execute,connector:read
+# Dynamic client registration (RFC 7591). Set to false to disable POST /api/v1/oauth2/register.
+# PIPESHUB_ENABLE_DCR=false
+# Device authorization grant (RFC 8628). Set to false to disable device_code.
+# PIPESHUB_ENABLE_DEVICE_GRANT=false
 
 
 # Worker counts

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -125,8 +125,8 @@ REDIS_STREAMS_MAXLEN=500000
 
 # MCP OAuth scopes (comma-separated)
 MCP_SCOPES=openid,profile,email,offline_access,semantic:write,conversation:write,conversation:chat,kb:read,team:read,user:read,config:read,agent:read,agent:execute,connector:read
-# Dynamic client registration (RFC 7591). Set to false to disable POST /api/v1/oauth2/register.
-# PIPESHUB_ENABLE_DCR=false
+# Dynamic client registration (RFC 7591). Off unless set to true.
+# PIPESHUB_ENABLE_DCR=true
 # Device authorization grant (RFC 8628). Set to false to disable device_code.
 # PIPESHUB_ENABLE_DEVICE_GRANT=false
 

--- a/deployment/docker-compose/env.template
+++ b/deployment/docker-compose/env.template
@@ -129,6 +129,8 @@ MCP_SCOPES=openid,profile,email,offline_access,semantic:write,conversation:write
 # PIPESHUB_ENABLE_DCR=true
 # Device authorization grant (RFC 8628). Set to false to disable device_code.
 # PIPESHUB_ENABLE_DEVICE_GRANT=false
+# Official agent device client_id is minted on first discovery after first-run
+# and advertised as pipeshub_device_client_id. DCR is not required for that.
 
 
 # Worker counts

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -20,7 +20,7 @@
 #   ./install.sh --help
 #
 # Environment overrides for CI / scripted installs (all optional):
-#   PIPESHUB_DEPLOY_TYPE     full | slim
+#   PIPESHUB_DEPLOY_TYPE     full | slim | eval
 #   PIPESHUB_GRAPH_DB        arango | neo4j
 #   PIPESHUB_BROKER          kafka | redis
 #   PIPESHUB_KV_STORE        etcd | redis
@@ -118,7 +118,7 @@ Options:
   -h, --help           Show this help
 
 Environment overrides (bypass prompts in CI):
-  PIPESHUB_DEPLOY_TYPE   full | slim
+  PIPESHUB_DEPLOY_TYPE   full | slim | eval
   PIPESHUB_GRAPH_DB      arango | neo4j
   PIPESHUB_BROKER        kafka | redis
   PIPESHUB_KV_STORE      etcd | redis
@@ -240,6 +240,9 @@ derive_compose_profiles() {
   esac
   [[ "${KV_STORE_TYPE:-}"  == "etcd"  ]] && p+=("kv-etcd")
   [[ "${MESSAGE_BROKER:-}" == "kafka" ]] && p+=("broker-kafka")
+  # Coding sandbox image. Eval skips it: Neo4j stays (search ACLs live there);
+  # run_code is the cut. Slim/full keep the profile so SANDBOX_MODE=docker works.
+  [[ "${DEPLOY_TYPE:-}" != "eval" ]] && p+=("sandbox")
   # Guard the empty-array case: on bash 3.2 under `set -u`, "${p[*]}" on an empty
   # array is an unbound-variable error.
   if (( ${#p[@]} == 0 )); then echo ""; return; fi
@@ -621,7 +624,7 @@ if $FLAG_STOP; then
   # profile stays attached to the network and blocks its removal
   # ("Resource is still in use"). --remove-orphans clears containers left by a
   # previously-active profile too.
-  export COMPOSE_PROFILES="graph-arango,graph-neo4j,kv-etcd,broker-kafka"
+  export COMPOSE_PROFILES="graph-arango,graph-neo4j,kv-etcd,broker-kafka,sandbox"
   docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" down --remove-orphans
   success "PipesHub stopped (project ${PROJECT_NAME}). Data volumes are preserved."
   info "To start again: ./install.sh"
@@ -644,7 +647,7 @@ if $FLAG_UNINSTALL; then
   # profile was active for this deployment.  Without this, volumes from a
   # previously-used profile (e.g. arango_data after switching to neo4j) would
   # be silently left behind.
-  export COMPOSE_PROFILES="graph-arango,graph-neo4j,kv-etcd,broker-kafka"
+  export COMPOSE_PROFILES="graph-arango,graph-neo4j,kv-etcd,broker-kafka,sandbox"
   docker compose -f "$COMPOSE_FILE" -p "$PROJECT_NAME" down -v --remove-orphans
   success "PipesHub stopped and all data volumes removed (project ${PROJECT_NAME})."
   exit 0
@@ -751,7 +754,11 @@ if ! $FLAG_UPGRADE; then
   # of MemTotal because firmware, the kernel, and (on iGPU systems) shared video
   # memory are reserved before user space sees it — commonly ~15.3–15.7 GiB. Use
   # a 16 GB-class floor (15000 MB) so genuine 16 GB machines are not warned.
-  if $IS_WSL; then
+  # Eval is an 8 GB-class laptop demo (Neo4j stays; coding sandbox is omitted).
+  if [[ "${PIPESHUB_DEPLOY_TYPE:-}" == "eval" ]]; then
+    _RAM_MIN_MB=7500
+    _RAM_MIN_LABEL="8 GB"
+  elif $IS_WSL; then
     _RAM_MIN_MB=10240
     _RAM_MIN_LABEL="10 GB"
   else
@@ -761,7 +768,7 @@ if ! $FLAG_UPGRADE; then
 
   if (( TOTAL_RAM_MB > 0 && TOTAL_RAM_MB < _RAM_MIN_MB )); then
     warn "Low RAM: ${TOTAL_RAM_MB} MB detected. PipesHub recommends a ${_RAM_MIN_LABEL}-class machine."
-    warn "The 'slim' deployment may still work on lower-memory machines, but performance may suffer."
+    warn "Slim and full want ~16 GB. Eval (PIPESHUB_DEPLOY_TYPE=eval) is the 8 GB-class laptop demo."
     if ! $FLAG_YES; then
       printf "\n  ${BOLD}Proceed with installation anyway?${RESET} [y/N]: "
       read -r _proceed
@@ -880,21 +887,26 @@ if ! ${SKIP_WIZARD:-false}; then
 
   printf "\n  ${BOLD}Choose a deployment type:${RESET}\n\n"
   printf "  ${GREEN}[1] Slim${RESET}  — Smaller image (model downloads on first use), fewer containers.\n"
-  printf "         Broker: Redis Streams  |  KV store: Redis  |  Graph: Neo4j\n"
-  printf "         Recommended for: laptops, low-resource servers, quick evaluations.\n\n"
+  printf "         Broker: Redis Streams  |  KV store: Redis  |  Graph: Neo4j  |  Sandbox: yes\n"
+  printf "         Recommended for: laptops, low-resource servers.\n\n"
   printf "  [2] Full  — Larger image with the embedding model bundled; uses Kafka.\n"
-  printf "         Broker: Kafka  |  KV store: Redis  |  Graph: Neo4j\n"
+  printf "         Broker: Kafka  |  KV store: Redis  |  Graph: Neo4j  |  Sandbox: yes\n"
   printf "         Recommended for: production servers, air-gapped deployments.\n\n"
+  printf "  [3] Eval  — Slim image without the coding-sandbox pull or Slack bot.\n"
+  printf "         Broker: Redis Streams  |  KV store: Redis  |  Graph: Neo4j  |  Sandbox: no\n"
+  printf "         Neo4j stays (search ACLs live there). run_code is unavailable.\n"
+  printf "         Recommended for: 8 GB-class laptops, MCP search/ask demos.\n\n"
 
   if [[ -n "${PIPESHUB_DEPLOY_TYPE:-}" ]]; then
     DEPLOY_TYPE="$PIPESHUB_DEPLOY_TYPE"
     info "Using PIPESHUB_DEPLOY_TYPE=$DEPLOY_TYPE"
   else
-    prompt_choice DEPLOY_TYPE "Deployment type?" "slim" "slim" "full"
+    prompt_choice DEPLOY_TYPE "Deployment type?" "slim" "slim" "full" "eval"
   fi
 
   case "$DEPLOY_TYPE" in
     full) DEFAULT_IMAGE_TAG="latest"; DEFAULT_GRAPH="neo4j";  DEFAULT_BROKER="kafka"; DEFAULT_KV="redis" ;;
+    eval) DEFAULT_IMAGE_TAG="slim";   DEFAULT_GRAPH="neo4j";  DEFAULT_BROKER="redis"; DEFAULT_KV="redis" ;;
     *)    DEPLOY_TYPE="slim"
           DEFAULT_IMAGE_TAG="slim";   DEFAULT_GRAPH="neo4j";  DEFAULT_BROKER="redis"; DEFAULT_KV="redis" ;;
   esac
@@ -1029,6 +1041,7 @@ if ! ${SKIP_WIZARD:-false}; then
   esac
   [[ "$KV_STORE"  == "etcd"  ]] && PROFILES+=("kv-etcd")
   [[ "$BROKER"    == "kafka" ]] && PROFILES+=("broker-kafka")
+  [[ "$DEPLOY_TYPE" != "eval" ]] && PROFILES+=("sandbox")
   COMPOSE_PROFILES="$(IFS=','; echo "${PROFILES[*]}")"
 
   case "$GRAPH_DB" in
@@ -1170,12 +1183,14 @@ IMAGE_TAG=${IMAGE_TAG}
 IMAGE_SOURCE=${IMAGE_SOURCE}
 # Override sandbox image tag for local builds; leave blank to use compose default
 SANDBOX_DOCKER_IMAGE=${SANDBOX_DOCKER_IMAGE}
+# Eval skips the in-container Slack bot. Slim/full leave this false.
+PIPESHUB_SKIP_SLACKBOT=$([ "${DEPLOY_TYPE}" = "eval" ] && echo true || echo false)
 
 # ── Compose project (isolates volumes/network from other copies on this host) ─
 COMPOSE_PROJECT_NAME=${PROJECT_NAME}
 
 # ── Compose profiles (controls which optional containers start) ──────────────
-# Values: graph-arango | graph-neo4j | kv-etcd | broker-kafka  (comma-separated)
+# Values: graph-arango | graph-neo4j | kv-etcd | broker-kafka | sandbox  (comma-separated)
 COMPOSE_PROFILES=${COMPOSE_PROFILES}
 
 # ── Core ─────────────────────────────────────────────────────────────────────
@@ -1672,18 +1687,25 @@ if $_USE_BUILD; then
   fi
 else
   if [[ "$_DO_PULL" == true ]]; then
-    info "Refreshing the PipesHub images ($_APP_IMAGE, $_SANDBOX_IMAGE)... (pass --no-pull to keep cached images)"
+    info "Refreshing the PipesHub images ($_APP_IMAGE$([ "${DEPLOY_TYPE:-}" = "eval" ] || echo ", $_SANDBOX_IMAGE"))... (pass --no-pull to keep cached images)"
     # App and sandbox images share the moving IMAGE_TAG (often :latest). Infra
     # images use pinned tags and are fetched by `up -d` when absent.
     # A pull failure is non-fatal when an image is already cached, so a flaky
     # network or a temporary registry outage does not block a working install.
+    # Eval does not start the sandbox profile, so skip that pull.
+    _PULL_SERVICES=(pipeshub-ai)
+    [[ "${DEPLOY_TYPE:-}" != "eval" ]] && _PULL_SERVICES+=(sandbox-image)
     if ! docker compose "${_PROGRESS[@]}" \
         -f "$COMPOSE_FILE" \
         -p "$PROJECT_NAME" \
         --env-file "$ENV_FILE" \
-        pull pipeshub-ai sandbox-image 2>&1; then
-      if docker image inspect "$_APP_IMAGE" >/dev/null 2>&1 &&
-          docker image inspect "$_SANDBOX_IMAGE" >/dev/null 2>&1; then
+        pull "${_PULL_SERVICES[@]}" 2>&1; then
+      _cached=true
+      docker image inspect "$_APP_IMAGE" >/dev/null 2>&1 || _cached=false
+      if [[ "${DEPLOY_TYPE:-}" != "eval" ]]; then
+        docker image inspect "$_SANDBOX_IMAGE" >/dev/null 2>&1 || _cached=false
+      fi
+      if $_cached; then
         warn "Could not refresh images; continuing with cached copies if present."
       else
         warn "Could not pull a required image and it is not cached locally — the next step may fail."

--- a/deployment/docker-compose/install.sh
+++ b/deployment/docker-compose/install.sh
@@ -921,6 +921,11 @@ if ! ${SKIP_WIZARD:-false}; then
     DEFAULT_KV="etcd"; info "Defaulting KV store to etcd to reuse existing data volume."
   fi
 
+  if [[ "$DEPLOY_TYPE" == "eval" && "$DEFAULT_GRAPH" != "neo4j" ]]; then
+    warn "Eval requires Neo4j (search ACLs live in the graph). Using neo4j instead of $DEFAULT_GRAPH."
+    DEFAULT_GRAPH="neo4j"
+  fi
+
   # ── 7. IMAGE SOURCE & VERSION ───────────────────────────────────────────────
   header "Image source & version"
 

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -241,7 +241,7 @@ check "health wait detects crash loops" "$inner" "crash_looping_containers"
 check "crash loop reported as the failure cause" "$inner" "keeps restarting"
 check "crash loop guidance is cause-neutral (137 vs 139)" "$inner" "exit 137"
 check "crash loop guidance covers segfault/corruption" "$inner" "exit 139"
-check "crash loop guidance still offers slim profile" "$inner" "drops Kafka/Zookeeper"
+check "eval is a deploy type" "$inner" 'prompt_choice DEPLOY_TYPE "Deployment type?" "slim" "slim" "full" "eval"'
 # Must not revert to asserting OOM as the definitive cause.
 if [[ "$inner" == *"almost always host memory pressure"* ]]; then
   fail "crash-loop message must not assert OOM as the certain cause"
@@ -252,6 +252,8 @@ fi
 echo "== Compose: app healthcheck reconciled with installer =="
 compose="$(cat "$COMPOSE_DIR/docker-compose.yml")"
 check "app healthcheck gates on core services" "$compose" "required=('query','connector','indexing','docling')"
+check "sandbox image is profile-gated" "$compose" 'profiles: ["sandbox"]'
+check "eval skip slackbot env is wired" "$compose" "PIPESHUB_SKIP_SLACKBOT"
 echo "== Compose: Hub slim empty ints are unset before start =="
 # Compose ${KEY:-} injects "". Hub slim int(os.getenv(KEY, default)) crashes
 # on that. The app entrypoint must unset blanks so the key is absent.
@@ -382,7 +384,7 @@ eval "$(extract_fn crash_looping_containers "$INNER_INSTALLER")"
 # --stop must tear down ALL profile-gated containers (not just the active
 # profile) so leftover graph/broker containers do not block network removal.
 stop_block="$(awk '/if \$FLAG_STOP; then/{g=1} g{print} g&&/^fi/{exit}' "$INNER_INSTALLER")"
-check "stop enables all profiles" "$stop_block" 'COMPOSE_PROFILES="graph-arango,graph-neo4j,kv-etcd,broker-kafka"'
+check "stop enables all profiles" "$stop_block" 'COMPOSE_PROFILES="graph-arango,graph-neo4j,kv-etcd,broker-kafka,sandbox"'
 check "stop removes orphans" "$stop_block" "down --remove-orphans"
 check "stop uses COMPOSE_PROJECT_NAME from .env" "$stop_block" 'PROJECT_NAME="$(resolve_project_name)"'
 check "stop validates project name from .env" "$stop_block" 'require_valid_project_name "$PROJECT_NAME"'
@@ -424,15 +426,17 @@ eval "$(extract_fn derive_compose_profiles "$INNER_INSTALLER")"
 eval "$(extract_fn persist_env_var "$INNER_INSTALLER")"
 
 dp() { DATA_STORE="$1" KV_STORE_TYPE="$2" MESSAGE_BROKER="$3" derive_compose_profiles; }
-check "arango + kafka + redis kv" "$(dp arangodb redis kafka)" "graph-arango,broker-kafka"
-check "neo4j + redis + redis (slim)" "$(dp neo4j redis redis)" "graph-neo4j"
-check "neo4j + etcd + kafka (full custom)" "$(dp neo4j etcd kafka)" "graph-neo4j,kv-etcd,broker-kafka"
-[[ -z "$(dp '' '' '')" ]] && pass "all-unset derives empty" || fail "all-unset derives empty"
+check "arango + kafka + redis kv" "$(dp arangodb redis kafka)" "graph-arango,broker-kafka,sandbox"
+check "neo4j + redis + redis (slim)" "$(dp neo4j redis redis)" "graph-neo4j,sandbox"
+check "eval omits sandbox" "$(DEPLOY_TYPE=eval dp neo4j redis redis)" "graph-neo4j"
+check "neo4j + etcd + kafka (full custom)" "$(dp neo4j etcd kafka)" "graph-neo4j,kv-etcd,broker-kafka,sandbox"
+[[ -z "$(DEPLOY_TYPE=eval dp '' '' '')" ]] && pass "eval all-unset derives empty" || fail "eval all-unset derives empty"
+check "all-unset still includes sandbox" "$(dp '' '' '')" "sandbox"
 # The exact stale value from the user's terminal must be corrected, not trusted.
-check "repairs stale 'kafka' to real profiles" "$(dp arangodb redis kafka)" "graph-arango,broker-kafka"
+check "repairs stale 'kafka' to real profiles" "$(dp arangodb redis kafka)" "graph-arango,broker-kafka,sandbox"
 # Missing DATA_STORE drops the graph profile (only broker-kafka) — this is why
 # the installer hard-validates DATA_STORE before launch.
-check "missing DATA_STORE yields no graph profile" "$(dp '' redis kafka)" "broker-kafka"
+check "missing DATA_STORE yields no graph profile" "$(dp '' redis kafka)" "broker-kafka,sandbox"
 if [[ "$(dp '' redis kafka)" == *"graph-"* ]]; then fail "must not invent a graph profile"; else pass "no graph profile when DATA_STORE empty"; fi
 
 echo "== In-tree installer: persist_env_var replaces in place =="
@@ -466,7 +470,8 @@ check "PIPESHUB_NO_PULL=yes skips the refresh" "$(should_pull_image false false 
 # tag argument, so assert the launch path builds _APP_IMAGE from IMAGE_TAG.
 check "refresh target honours the pinned tag" "$inner" '_APP_IMAGE="pipeshubai/pipeshub-ai:${IMAGE_TAG:-latest}"'
 # Launch-path guards.
-check "refreshes app and sandbox images" "$inner" "pull pipeshub-ai sandbox-image"
+check "refreshes app image via compose pull" "$inner" 'pull "${_PULL_SERVICES[@]}"'
+check "eval skips sandbox image pull" "$inner" 'DEPLOY_TYPE:-}" != "eval"'
 check "--no-pull flag is parsed" "$inner" "FLAG_NO_PULL=true"
 check "refresh decision uses the testable helper" "$inner" 'should_pull_image "$_USE_BUILD" "$FLAG_NO_PULL" "${PIPESHUB_NO_PULL:-}"'
 # A pull failure must NOT abort when an image is already cached (flaky network).

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -242,6 +242,7 @@ check "crash loop reported as the failure cause" "$inner" "keeps restarting"
 check "crash loop guidance is cause-neutral (137 vs 139)" "$inner" "exit 137"
 check "crash loop guidance covers segfault/corruption" "$inner" "exit 139"
 check "eval is a deploy type" "$inner" 'prompt_choice DEPLOY_TYPE "Deployment type?" "slim" "slim" "full" "eval"'
+check "eval forces Neo4j even if an Arango volume exists" "$inner" 'Eval requires Neo4j'
 # Must not revert to asserting OOM as the definitive cause.
 if [[ "$inner" == *"almost always host memory pressure"* ]]; then
   fail "crash-loop message must not assert OOM as the certain cause"

--- a/deployment/docker-compose/tests/installer_test.sh
+++ b/deployment/docker-compose/tests/installer_test.sh
@@ -365,6 +365,25 @@ else
   pass "env.template does not pin pending indexing tasks 28"
 fi
 
+echo "== OAuth device / DCR launch defaults =="
+envtmpl="$(cat "$COMPOSE_DIR/env.template")"
+compose="$(cat "$COMPOSE_DIR/docker-compose.yml")"
+check "env.template documents PIPESHUB_ENABLE_DCR" "$envtmpl" "PIPESHUB_ENABLE_DCR"
+check "env.template documents PIPESHUB_ENABLE_DEVICE_GRANT" "$envtmpl" "PIPESHUB_ENABLE_DEVICE_GRANT"
+check "env.template names pipeshub_device_client_id" "$envtmpl" "pipeshub_device_client_id"
+if grep -qE '^PIPESHUB_ENABLE_DCR=true' "$COMPOSE_DIR/env.template"; then
+  fail "env.template must not enable DCR by default"
+else
+  pass "env.template does not enable DCR by default"
+fi
+if grep -qE '^PIPESHUB_ENABLE_DEVICE_GRANT=false' "$COMPOSE_DIR/env.template"; then
+  fail "env.template must not disable device grant by default"
+else
+  pass "env.template does not disable device grant by default"
+fi
+check "compose wires PIPESHUB_ENABLE_DCR" "$compose" 'PIPESHUB_ENABLE_DCR=${PIPESHUB_ENABLE_DCR:-}'
+check "compose wires PIPESHUB_ENABLE_DEVICE_GRANT" "$compose" 'PIPESHUB_ENABLE_DEVICE_GRANT=${PIPESHUB_ENABLE_DEVICE_GRANT:-}'
+
 echo "== In-tree installer: crash-loop detection (real function) =="
 eval "$(extract_fn crash_looping_containers "$INNER_INSTALLER")"
 (

--- a/frontend/app/(public)/oauth/authorize/oauth-authorize-view.tsx
+++ b/frontend/app/(public)/oauth/authorize/oauth-authorize-view.tsx
@@ -29,6 +29,7 @@ interface AppInfo {
   logoUrl?: string;
   homepageUrl?: string;
   privacyPolicyUrl?: string;
+  isDynamic?: boolean;
 }
 
 interface ConsentData {
@@ -542,6 +543,12 @@ export function OAuthAuthorizeView() {
               {appName}
             </Text>
           </Flex>
+
+          {consentData.app.isDynamic ? (
+            <Text as="p" size="2" color="amber">
+              {t('oauthConsent.unreviewedApp')}
+            </Text>
+          ) : null}
 
           <Separator size="4" />
 

--- a/frontend/app/(public)/oauth/device/__tests__/oauth-device-view.test.tsx
+++ b/frontend/app/(public)/oauth/device/__tests__/oauth-device-view.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+
+import en from '@/lib/i18n/locales/en-US.json';
+
+const PHISHING_WARNING = en.oauthDevice.phishingWarning;
+const UNREVIEWED_APP = en.oauthConsent.unreviewedApp;
+
+const replace = vi.fn();
+let searchParamsGet: (key: string) => string | null = () => null;
+let searchParamsToString = () => '';
+let authState = { isHydrated: true, isAuthenticated: true };
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace, push: vi.fn() }),
+  useSearchParams: () => ({
+    get: (key: string) => searchParamsGet(key),
+    toString: () => searchParamsToString(),
+  }),
+}));
+
+vi.mock('@/config', () => ({
+  useAuthStore: (fn: (s: typeof authState) => unknown) => fn(authState),
+}));
+
+const post = vi.fn();
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    post: (...args: unknown[]) => post(...args),
+  },
+}));
+
+vi.mock('@/lib/api/api-error', () => ({
+  extractApiErrorMessage: () => '',
+  processError: () => ({ message: 'error' }),
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => {
+      const parts = key.split('.');
+      let cur: unknown = en;
+      for (const part of parts) {
+        if (typeof cur !== 'object' || cur === null || !(part in cur)) {
+          return key;
+        }
+        cur = (cur as Record<string, unknown>)[part];
+      }
+      return typeof cur === 'string' ? cur : key;
+    },
+  }),
+}));
+
+vi.mock('@/app/components/ui/lottie-loader', () => ({
+  LottieLoader: () => null,
+}));
+
+vi.mock('@/app/components/ui/loading-button', () => ({
+  LoadingButton: ({
+    children,
+    onClick,
+    loading,
+    ...rest
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    loading?: boolean;
+  }) =>
+    React.createElement(
+      'button',
+      { type: 'button', onClick, disabled: loading, ...rest },
+      children,
+    ),
+}));
+
+import { OAuthDeviceView } from '../oauth-device-view';
+
+const h = React.createElement;
+
+function renderView() {
+  return render(h(Theme, null, h(OAuthDeviceView, null)));
+}
+
+const firstPartyConsent = {
+  requiresConsent: true,
+  consentData: {
+    app: { name: 'PipesHub agent', isDynamic: false },
+    scopes: [{ name: 'user:read', description: 'Read users', category: 'User' }],
+    user: { email: 'u@e.com', name: 'Test' },
+  },
+};
+
+beforeEach(() => {
+  replace.mockClear();
+  post.mockReset();
+  searchParamsGet = () => null;
+  searchParamsToString = () => '';
+  authState = { isHydrated: true, isAuthenticated: true };
+});
+afterEach(() => cleanup());
+
+describe('OAuthDeviceView', () => {
+  it('keeps the phishing warning copy that tells people to close a sent code', () => {
+    expect(PHISHING_WARNING).toMatch(/started this yourself/i);
+    expect(PHISHING_WARNING).toMatch(/someone sent you this code/i);
+    expect(PHISHING_WARNING).toMatch(/close this page/i);
+  });
+
+  it('redirects unauthenticated users to login with returnTo', async () => {
+    authState = { isHydrated: true, isAuthenticated: false };
+    searchParamsToString = () => 'user_code=ABCD-EFGH';
+    renderView();
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith(
+        '/login?returnTo=' + encodeURIComponent('/oauth/device?user_code=ABCD-EFGH'),
+      );
+    });
+  });
+
+  it('shows the phishing warning on the code-entry screen', () => {
+    renderView();
+    expect(screen.getByText(PHISHING_WARNING)).toBeTruthy();
+    expect(screen.queryByText(UNREVIEWED_APP)).toBeNull();
+  });
+
+  it('shows the phishing warning on Allow and hides unreviewedApp for first-party apps', async () => {
+    searchParamsGet = (key: string) => (key === 'user_code' ? 'ABCD-EFGH' : null);
+    post.mockResolvedValue({ data: firstPartyConsent });
+    renderView();
+    await waitFor(() => {
+      expect(screen.getByText('PipesHub agent')).toBeTruthy();
+    });
+    expect(screen.getByText(PHISHING_WARNING)).toBeTruthy();
+    expect(screen.queryByText(UNREVIEWED_APP)).toBeNull();
+    expect(screen.getByText(en.oauthConsent.allow)).toBeTruthy();
+  });
+
+  it('shows unreviewedApp only for dynamically registered apps', async () => {
+    searchParamsGet = (key: string) => (key === 'user_code' ? 'ABCD-EFGH' : null);
+    post.mockResolvedValue({
+      data: {
+        requiresConsent: true,
+        consentData: {
+          app: { name: 'Cursor', isDynamic: true },
+          scopes: [{ name: 'user:read', description: '', category: 'User' }],
+          user: { email: 'u@e.com' },
+        },
+      },
+    });
+    renderView();
+    await waitFor(() => {
+      expect(screen.getByText(UNREVIEWED_APP)).toBeTruthy();
+    });
+    expect(screen.getByText(PHISHING_WARNING)).toBeTruthy();
+  });
+
+  it('looks up a typed code and posts Allow to the consent API', async () => {
+    post.mockResolvedValueOnce({ data: firstPartyConsent }).mockResolvedValueOnce({
+      data: { ok: true, consent: 'granted' },
+    });
+    renderView();
+    fireEvent.change(screen.getByLabelText(en.oauthDevice.codeLabel), {
+      target: { value: 'ABCD-EFGH' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: en.oauthDevice.continue }));
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith(
+        '/api/v1/oauth2/device/verify',
+        { user_code: 'ABCD-EFGH' },
+        { suppressErrorToast: true },
+      );
+    });
+    fireEvent.click(screen.getByRole('button', { name: en.oauthConsent.allow }));
+    await waitFor(() => {
+      expect(post).toHaveBeenCalledWith(
+        '/api/v1/oauth2/device/consent',
+        { user_code: 'ABCD-EFGH', consent: 'granted' },
+        { suppressErrorToast: true },
+      );
+    });
+    expect(screen.getByText(en.oauthDevice.doneTitle)).toBeTruthy();
+  });
+});

--- a/frontend/app/(public)/oauth/device/oauth-device-view.tsx
+++ b/frontend/app/(public)/oauth/device/oauth-device-view.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import axios from 'axios';
+import { Box, Button, Flex, Text, TextField } from '@radix-ui/themes';
+import { useTranslation } from 'react-i18next';
+
+import { apiClient } from '@/lib/api';
+import { extractApiErrorMessage, processError } from '@/lib/api/api-error';
+import { useAuthStore } from '@/config';
+import { LoadingScreen } from '@/app/components/ui/auth-guard';
+import { LottieLoader } from '@/app/components/ui/lottie-loader';
+import { LoadingButton } from '@/app/components/ui/loading-button';
+
+const OAUTH_DEVICE_PATH = '/oauth/device';
+const VERIFY_API = '/api/v1/oauth2/device/verify';
+const CONSENT_API = '/api/v1/oauth2/device/consent';
+
+interface ScopeInfo {
+  name: string;
+  description: string;
+  category: string;
+}
+
+interface ConsentData {
+  app: { name: string; description?: string };
+  scopes: ScopeInfo[];
+  user: { email: string; name?: string };
+}
+
+function errorMessageFromUnknown(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    const data = err.response?.data;
+    if (
+      typeof data === 'object' &&
+      data !== null &&
+      'error_description' in data &&
+      typeof (data as { error_description?: string }).error_description ===
+        'string'
+    ) {
+      return (data as { error_description: string }).error_description;
+    }
+    const fromBody = extractApiErrorMessage(data);
+    if (fromBody) return fromBody;
+    return processError(err).message;
+  }
+  if (err instanceof Error) return err.message;
+  return 'An error occurred';
+}
+
+export function OAuthDeviceView() {
+  const { t } = useTranslation();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isHydrated = useAuthStore((s) => s.isHydrated);
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  const initialCode = searchParams.get('user_code') ?? '';
+  const [userCode, setUserCode] = useState(initialCode);
+  const [loading, setLoading] = useState(Boolean(initialCode));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState('');
+  const [consentData, setConsentData] = useState<ConsentData | null>(null);
+  const [done, setDone] = useState<'granted' | 'denied' | null>(null);
+
+  const returnToPath = useMemo(() => {
+    const q = searchParams.toString();
+    return q ? `${OAUTH_DEVICE_PATH}?${q}` : OAUTH_DEVICE_PATH;
+  }, [searchParams]);
+
+  useEffect(() => {
+    if (!isHydrated) return;
+    if (!isAuthenticated) {
+      router.replace(`/login?returnTo=${encodeURIComponent(returnToPath)}`);
+    }
+  }, [isHydrated, isAuthenticated, router, returnToPath]);
+
+  const lookup = async (code: string) => {
+    setLoading(true);
+    setError('');
+    try {
+      const { data } = await apiClient.post<{
+        requiresConsent?: boolean;
+        consentData?: ConsentData;
+      }>(
+        VERIFY_API,
+        { user_code: code },
+        { suppressErrorToast: true },
+      );
+      if (data.requiresConsent && data.consentData) {
+        setConsentData(data.consentData);
+      } else {
+        setError(t('oauthConsent.noData'));
+      }
+    } catch (err) {
+      setError(errorMessageFromUnknown(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (!isHydrated || !isAuthenticated || !initialCode) {
+      if (!initialCode) setLoading(false);
+      return;
+    }
+    void lookup(initialCode);
+    // lookup on first authenticated landing with a code in the URL
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isHydrated, isAuthenticated, initialCode]);
+
+  const handleConsent = async (consent: 'granted' | 'denied') => {
+    setSubmitting(true);
+    setError('');
+    try {
+      await apiClient.post(
+        CONSENT_API,
+        { user_code: userCode, consent },
+        { suppressErrorToast: true },
+      );
+      setDone(consent);
+    } catch (err) {
+      setError(errorMessageFromUnknown(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!isHydrated || !isAuthenticated) {
+    return <LoadingScreen />;
+  }
+
+  if (done) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        direction="column"
+        gap="3"
+        style={{ minHeight: '100vh', padding: 'var(--space-5)' }}
+      >
+        <Text size="5" weight="bold">
+          {done === 'granted'
+            ? t('oauthDevice.doneTitle')
+            : t('oauthDevice.deniedTitle')}
+        </Text>
+        <Text size="2" color="gray">
+          {done === 'granted'
+            ? t('oauthDevice.doneLine')
+            : t('oauthDevice.deniedLine')}
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (loading) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        direction="column"
+        gap="3"
+        style={{ minHeight: '100vh', padding: 'var(--space-5)' }}
+      >
+        <LottieLoader variant="loader" size={64} />
+        <Text size="2" color="gray">
+          {t('oauthDevice.loading')}
+        </Text>
+      </Flex>
+    );
+  }
+
+  if (!consentData) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        style={{ minHeight: '100vh', padding: 'var(--space-5)' }}
+      >
+        <Box style={{ width: '100%', maxWidth: 420 }}>
+          <Text size="5" weight="bold">
+            {t('oauthDevice.title')}
+          </Text>
+          <Text as="p" size="2" color="gray" mt="2">
+            {t('oauthDevice.codeLabel')}
+          </Text>
+          <TextField.Root
+            mt="3"
+            size="3"
+            placeholder={t('oauthDevice.codePlaceholder')}
+            value={userCode}
+            onChange={(e) => setUserCode(e.target.value)}
+          />
+          {error ? (
+            <Text as="p" size="2" color="red" mt="2">
+              {error}
+            </Text>
+          ) : null}
+          <Button
+            mt="4"
+            onClick={() => lookup(userCode)}
+            disabled={!userCode.trim()}
+          >
+            {t('oauthDevice.continue')}
+          </Button>
+        </Box>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      style={{ minHeight: '100vh', padding: 'var(--space-5)' }}
+    >
+      <Box style={{ width: '100%', maxWidth: 480 }}>
+        <Text size="5" weight="bold">
+          {consentData.app.name}
+        </Text>
+        <Text as="p" size="2" color="gray" mt="2">
+          {t('oauthConsent.requestHeading')}
+        </Text>
+        <Box mt="3">
+          {consentData.scopes.map((scope) => (
+            <Text as="p" size="2" key={scope.name}>
+              {scope.name}
+              {scope.description ? ` — ${scope.description}` : ''}
+            </Text>
+          ))}
+        </Box>
+        {error ? (
+          <Text as="p" size="2" color="red" mt="2">
+            {error}
+          </Text>
+        ) : null}
+        <Flex gap="3" mt="4">
+          <Button
+            variant="soft"
+            color="gray"
+            disabled={submitting}
+            onClick={() => handleConsent('denied')}
+          >
+            {t('oauthConsent.deny')}
+          </Button>
+          <LoadingButton
+            loading={submitting}
+            onClick={() => handleConsent('granted')}
+          >
+            {t('oauthConsent.allow')}
+          </LoadingButton>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+}

--- a/frontend/app/(public)/oauth/device/oauth-device-view.tsx
+++ b/frontend/app/(public)/oauth/device/oauth-device-view.tsx
@@ -191,6 +191,7 @@ export function OAuthDeviceView() {
             placeholder={t('oauthDevice.codePlaceholder')}
             value={userCode}
             onChange={(e) => setUserCode(e.target.value)}
+            aria-label={t('oauthDevice.codeLabel')}
           />
           {error ? (
             <Text as="p" size="2" color="red" mt="2">

--- a/frontend/app/(public)/oauth/device/oauth-device-view.tsx
+++ b/frontend/app/(public)/oauth/device/oauth-device-view.tsx
@@ -185,6 +185,9 @@ export function OAuthDeviceView() {
           <Text as="p" size="2" color="gray" mt="2">
             {t('oauthDevice.codeLabel')}
           </Text>
+          <Text as="p" size="2" color="amber" mt="2">
+            {t('oauthDevice.phishingWarning')}
+          </Text>
           <TextField.Root
             mt="3"
             size="3"
@@ -225,6 +228,9 @@ export function OAuthDeviceView() {
             {t('oauthConsent.unreviewedApp')}
           </Text>
         ) : null}
+        <Text as="p" size="2" color="amber" mt="2">
+          {t('oauthDevice.phishingWarning')}
+        </Text>
         <Text as="p" size="2" color="gray" mt="2">
           {t('oauthConsent.requestHeading')}
         </Text>

--- a/frontend/app/(public)/oauth/device/oauth-device-view.tsx
+++ b/frontend/app/(public)/oauth/device/oauth-device-view.tsx
@@ -24,7 +24,7 @@ interface ScopeInfo {
 }
 
 interface ConsentData {
-  app: { name: string; description?: string };
+  app: { name: string; description?: string; isDynamic?: boolean };
   scopes: ScopeInfo[];
   user: { email: string; name?: string };
 }
@@ -219,6 +219,11 @@ export function OAuthDeviceView() {
         <Text size="5" weight="bold">
           {consentData.app.name}
         </Text>
+        {consentData.app.isDynamic ? (
+          <Text as="p" size="2" color="amber" mt="2">
+            {t('oauthConsent.unreviewedApp')}
+          </Text>
+        ) : null}
         <Text as="p" size="2" color="gray" mt="2">
           {t('oauthConsent.requestHeading')}
         </Text>

--- a/frontend/app/(public)/oauth/device/page.tsx
+++ b/frontend/app/(public)/oauth/device/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react';
+
+import { LoadingScreen } from '@/app/components/ui/auth-guard';
+
+import { OAuthDeviceView } from './oauth-device-view';
+
+export default function OAuthDevicePage() {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <OAuthDeviceView />
+    </Suspense>
+  );
+}

--- a/frontend/lib/i18n/locales/en-US.json
+++ b/frontend/lib/i18n/locales/en-US.json
@@ -3350,6 +3350,17 @@
       "server_error": "An unexpected error occurred on the server. Please try again later."
     }
   },
+  "oauthDevice": {
+    "title": "Connect a device",
+    "codeLabel": "Enter the code shown in your terminal",
+    "codePlaceholder": "ABCD-EFGH",
+    "continue": "Continue",
+    "loading": "Looking up this device…",
+    "doneTitle": "Device connected",
+    "doneLine": "You can return to the terminal. This window can be closed.",
+    "deniedTitle": "Request denied",
+    "deniedLine": "The device was not granted access."
+  },
   "auth": {
     "titleSection": {
       "defaultTitle": "Welcome to Pipeshub",

--- a/frontend/lib/i18n/locales/en-US.json
+++ b/frontend/lib/i18n/locales/en-US.json
@@ -3318,6 +3318,7 @@
     "errorTitle": "Authorization error",
     "signedInAs": "Signed in as {{display}}",
     "requestHeading": "This application is requesting access to:",
+    "unreviewedApp": "This application registered itself. No administrator reviewed it.",
     "legalNotice": "By clicking “Allow”, you authorize {{appName}} to access your data as described above.",
     "privacyPolicy": "Privacy Policy",
     "deny": "Deny",

--- a/frontend/lib/i18n/locales/en-US.json
+++ b/frontend/lib/i18n/locales/en-US.json
@@ -3354,6 +3354,7 @@
   "oauthDevice": {
     "title": "Connect a device",
     "codeLabel": "Enter the code shown in your terminal",
+    "phishingWarning": "Only continue if you started this yourself on a device you control. If someone sent you this code, close this page.",
     "codePlaceholder": "ABCD-EFGH",
     "continue": "Continue",
     "loading": "Looking up this device…",

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -45,6 +45,7 @@ export default defineConfig({
       'app/(main)/workspace/ai-models/__tests__/resolve-model-config-save-error.test.ts',
       'app/(main)/onboarding/utils/__tests__/s3-credentials.test.ts',
       'app/(main)/workspace/connectors/components/__tests__/vector-store-actions.test.tsx',
+      'app/(public)/oauth/device/__tests__/oauth-device-view.test.tsx',
       'lib/store/__tests__/auth-store.test.ts',
     ],
     passWithNoTests: false,


### PR DESCRIPTION
## Background

A coding agent (Cursor, Claude Code, etc.) can talk to PipesHub over `/mcp`, but only if it has a **token that belongs to a real person**.

PipesHub decides what you can see by looking at **who the token says you are**. Inside the token are two labels: **this person** and **this company**. Search and chat then show Slack, Drive, and Knowledge Base that *that person in that company* can already access — not “whatever the app can see.”

Until now there was no supported way for an agent to get that kind of token on its own:

- A **personal access token** works, but a human has to mint it in the UI. The create API returns the secret in JSON, so an agent that curls it dumps the PAT into the chat. (The script that writes the PAT to a file is a separate PR: #3182.)
- **`client_credentials`** is the usual “app login” grant. We must not use it here. That grant has **no person on it**, so PipesHub has nobody to check permissions against. The agent would not be acting as the signed-in user.

So the missing piece is: the agent starts a login, a human who is already signed into PipesHub says “yes”, and the agent walks away with **that human’s** token.

This PR adds that. It also adds a smaller Docker install for “try search/ask on a laptop” demos.

The EE twin (same OAuth, plus a hosted trial) is https://github.com/pipeshub-ai/pipeshubai-ee/pull/194.

## What this PR does

### 1. Device login (the important one)

This is the TV-style “enter the code on your other device” flow (RFC 8628).

1. The agent asks PipesHub for a device code and gets back an 8-character user code (`ABCD-EFGH`) and a link.
2. The person opens `/oauth/device` while logged into PipesHub, pastes the code, and clicks Allow or Deny.
3. The agent polls until they decide. On Allow, it receives an access token that still says **this is the person who clicked Allow, in their company** — not “this is some app.”

The code at rest is hashed. It can only be used once. If two polls race, only one gets a token. The 8-character code is not written to logs.

Stock instances mint a first-party public client (`pipeshub-agent`) on first discovery after first-run, advertised as `pipeshub_device_client_id`. Agents use that `client_id` to start the TV flow. DCR is not required. The app is hidden from Developer Settings. Grants are device_code + refresh_token only — never `client_credentials`.

Device login is **on by default**. Because `pipeshub-agent` is public, anyone who can reach the instance can start a device login and send a victim the code. `/oauth/device` now warns on both the code-entry and Allow screens: only continue if you started this yourself; if someone sent you the code, close the page. Self-registered apps still also get the “no administrator reviewed this app” line.

### 2. App self-registration (off by default)

OAuth apps are normally created by an admin in Developer Settings. Dynamic client registration (RFC 7591) lets an agent **register itself** via `POST /api/v1/oauth2/register` so it has a `client_id` to start device login.

That is convenient and also dangerous: anyone who can hit `/register` can create an app named “PipesHub Drive Sync”, send a victim the user code, and if the victim approves, the attacker holds the victim’s token.

So this is **off unless the operator sets `PIPESHUB_ENABLE_DCR=true`**. Unset or any other value leaves it off. Discovery does not even advertise the register URL unless it is on. Stock agents should use `pipeshub-agent` instead.

When it *is* on:

- The registered app cannot use `client_credentials` (no user-less tokens through this door).
- The consent screen says the app registered itself and no administrator reviewed it.
- `response_types` only includes `code` if the app actually asked for the authorization-code grant.

### 3. Eval install

`PIPESHUB_DEPLOY_TYPE=eval` is **not a new image**. It is the slim image with two things dropped so an 8 GB laptop can demo search/ask:

- no coding-sandbox image pull (`run_code` is unavailable)
- no Slack bot process

Neo4j stays. Search ACLs live in the graph; dropping Neo4j to save RAM would make the demo lie. If an old Arango volume is on the machine, eval still forces Neo4j.

## Defaults

| Flag | Stock instance | How to change |
|------|----------------|---------------|
| Device login | **On** | `PIPESHUB_ENABLE_DEVICE_GRANT=false` |
| First-party agent client | **On** (lazy, after first-run) | n/a |
| App self-registration | **Off** | `PIPESHUB_ENABLE_DCR=true` |
| Eval topology | Off (you opt in at install) | `PIPESHUB_DEPLOY_TYPE=eval` |

A stock `docker compose` / installer run does **not** get self-registration.

## How to review

If you only read four files:

1. `oauth.device.service.ts` — create code, consent, poll, single-use claim, no `user_code` in logs
2. `oauth.first_party_device.service.ts` — `pipeshub-agent`, public, device+refresh only
3. `oauth.dcr.service.ts` — refused unless `PIPESHUB_ENABLE_DCR=true`; no `client_credentials`
4. `install.sh` + the `sandbox` Compose profile — eval omits the sandbox pull and keeps Neo4j

The consent UI is `/oauth/device`.

## Test plan

- [x] Installer tests, including eval (omits sandbox, forces Neo4j)
- [x] mocha: DCR gate, device poll/claim, discovery only advertises what is enabled, first-party client
- [x] Live device consent on a **fresh empty** instance — not one that already has an org or a corpus you care about

## Not this PR

| Need | Where |
|------|--------|
| Mint a PAT to a file without printing it | #3182 |
| Hosted self-serve trial | EE #194 |
| Docs / skill for “I have no instance yet” | documentation#171, mcp-server#75 |
| Cursor Directory listing | mcp-server#76, documentation#172 |
| Making self-registration require an admin-issued credential | Follow-up if someone turns DCR on in production (`initial_access_token`) |
| List/revoke connected agent (device) grants in the dashboard | Follow-up. PAT list/revoke does not cover `pipeshub-agent`. RFC 7009 `/revoke` exists only if you hold the token. |
| Uploading demo KB files, isolating `/mcp` per tenant | Out of scope |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth dynamic client registration and device authorization flows.
  * Added a device-code consent screen with login handling, scope details, and approval or denial states.
  * Added an evaluation deployment option for lightweight demos, omitting the coding sandbox and Slack bot.
  * Added configuration controls for enabling OAuth registration, device grants, and Slack bot startup.
* **Documentation**
  * Documented evaluation deployments and OAuth registration/device authorization setup.
* **Bug Fixes**
  * Improved validation for device consent decisions and expired device codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->