### PR TITLE
fix(scripts): make the connector deletion test able to fail

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -352,6 +352,32 @@ jobs:
             -n "$WORKERS" --dist loadgroup \
             --junitxml=reports/neo4j-results.xml 2>&1
 
+
+      # app/scripts/connector_deletion_integration_test.py exercises
+      # delete_connector_instance() against a live graph: it builds three
+      # connectors with overlapping data, deletes each, and checks the other two
+      # survive intact. No workflow ran it, and the stack here is the only place
+      # it can run.
+      #
+      # After the pytest step on purpose: it creates and deletes its own
+      # connectors, so running it alongside the suite would have the two
+      # competing for the same graph.
+      - name: 'Neo4j: Connector deletion integration test'
+        if: ${{ !cancelled() && (matrix.graph_db == 'neo4j' || matrix.graph_db == 'both') }}
+        working-directory: backend/python
+        env:
+          DATA_STORE: neo4j
+          # The same connection the pytest suites use, so this cannot drift from
+          # how the stack was actually started.
+          NEO4J_URI: ${{ secrets.TEST_NEO4J_URI }}
+          NEO4J_USERNAME: ${{ secrets.TEST_NEO4J_USERNAME }}
+          NEO4J_PASSWORD: ${{ secrets.TEST_NEO4J_PASSWORD }}
+          NEO4J_DATABASE: ${{ secrets.TEST_NEO4J_DATABASE }}
+        run: |
+          python -m venv /tmp/deletion-venv
+          /tmp/deletion-venv/bin/pip install --quiet -e .
+          /tmp/deletion-venv/bin/python -m app.scripts.connector_deletion_integration_test
+
       - name: 'Neo4j: Run Playwright e2e tests'
         if: ${{ !cancelled() && (matrix.graph_db == 'neo4j' || matrix.graph_db == 'both') }}
         working-directory: frontend

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -353,30 +353,6 @@ jobs:
             --junitxml=reports/neo4j-results.xml 2>&1
 
 
-      # app/scripts/connector_deletion_integration_test.py exercises
-      # delete_connector_instance() against a live graph: it builds three
-      # connectors with overlapping data, deletes each, and checks the other two
-      # survive intact. No workflow ran it, and the stack here is the only place
-      # it can run.
-      #
-      # After the pytest step on purpose: it creates and deletes its own
-      # connectors, so running it alongside the suite would have the two
-      # competing for the same graph.
-      - name: 'Neo4j: Connector deletion integration test'
-        if: ${{ !cancelled() && (matrix.graph_db == 'neo4j' || matrix.graph_db == 'both') }}
-        working-directory: backend/python
-        env:
-          DATA_STORE: neo4j
-          # The same connection the pytest suites use, so this cannot drift from
-          # how the stack was actually started.
-          NEO4J_URI: ${{ secrets.TEST_NEO4J_URI }}
-          NEO4J_USERNAME: ${{ secrets.TEST_NEO4J_USERNAME }}
-          NEO4J_PASSWORD: ${{ secrets.TEST_NEO4J_PASSWORD }}
-          NEO4J_DATABASE: ${{ secrets.TEST_NEO4J_DATABASE }}
-        run: |
-          python -m venv /tmp/deletion-venv
-          /tmp/deletion-venv/bin/pip install --quiet -e .
-          /tmp/deletion-venv/bin/python -m app.scripts.connector_deletion_integration_test
 
       - name: 'Neo4j: Run Playwright e2e tests'
         if: ${{ !cancelled() && (matrix.graph_db == 'neo4j' || matrix.graph_db == 'both') }}

--- a/backend/python/app/scripts/connector_deletion_integration_test.py
+++ b/backend/python/app/scripts/connector_deletion_integration_test.py
@@ -1084,7 +1084,8 @@ async def run_deletion_test(
 # MAIN
 # ==============================================================================
 
-async def run_all() -> None:
+async def run_all() -> int:
+    """Run every case. Returns the number that failed."""
     data_store = os.getenv("DATA_STORE", "arangodb").lower()
 
     logger.info("=" * 72)
@@ -1175,6 +1176,11 @@ async def run_all() -> None:
                 logger.info(f"\n  x  {r['name']}")
                 logger.info(f"     Detail: {r['detail']}")
 
+    return failed
+
 
 if __name__ == "__main__":
-    asyncio.run(run_all())
+    # Exit non-zero when anything failed. Without this the script reported its
+    # failures in the log and still exited 0, so any caller — a CI step, a
+    # wrapper, someone checking $? — would read a failed run as a pass.
+    sys.exit(1 if asyncio.run(run_all()) else 0)


### PR DESCRIPTION
## In one line

A test script reported its own failures in the log and then exited successfully, so anything running it would read a failed run as a pass.

## Background

`backend/python/app/scripts/connector_deletion_integration_test.py` checks that deleting one connector does not take neighbouring data with it. It builds three connectors with overlapping data, deletes each in turn, and verifies the other two survive intact.

It is run by hand, against a live graph database.

## The problem

```python
if __name__ == "__main__":
    asyncio.run(run_all())
```

`run_all` returned nothing. The script printed its failures in detail — and then exited with a success code.

So anyone running it and checking the result, whether a person, a wrapper script or an automated job, would be told everything passed.

## What changed

```python
    return failed


if __name__ == "__main__":
    sys.exit(1 if asyncio.run(run_all()) else 0)
```

It reports how many cases failed, and exits non-zero when any did.

## Why this is worth its own change

This is the same shape as two other findings in this series: a harness reporting skipped checks as passed (#3187), and a test suite that hung instead of finishing (#3191). In each case something looked like coverage while being incapable of reporting a problem.

Wiring this script into an automated job without this fix would have been worse than not wiring it up at all — it would have looked like a check while never being able to fail.

## How to test it

The script needs a live graph database, so it cannot run on a bare machine. The change itself is verifiable by reading what the module now declares:

```
run_all return annotation: int
return statements: ['failed']
__main__ block: sys.exit(1 if asyncio.run(run_all()) else 0)
```

With a database available:

```bash
cd backend/python
DATA_STORE=neo4j python -m app.scripts.connector_deletion_integration_test
echo $?
```

Expect `0` when the cases pass, and non-zero when any fail. Before this change it was always `0`.

## Anything to worry about

No product code changes. The script's own logic is untouched — only how it reports its result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Integration test runs now report the number of failed cases.
  - Failed integration tests produce a nonzero exit status, making unsuccessful runs clearly detectable by automated checks.
- **Chores**
  - Minor formatting updates were made to the integration-test workflow without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->