### PR TITLE
test(connectors): add the GitHub Teams and GitLab suites the environment was built for

### DIFF
--- a/integration-tests/connectors/github_teams/conftest.py
+++ b/integration-tests/connectors/github_teams/conftest.py
@@ -1,0 +1,145 @@
+# pyright: ignore-file
+
+"""GitHub Teams connector fixtures.
+
+The credentials this needs were provisioned in #3157, which also registered the
+``github_teams`` pytest marker and documented how the account must be set up.
+No suite followed, so nothing has been reading them.
+
+Read-only. The organisation and its repositories are shared fixtures that this
+suite does not own, so it creates nothing and deletes nothing there; only the
+connector and its graph data are cleaned up.
+"""
+
+import os
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from connector_lifecycle import destructor
+from helper.graph_provider import GraphProviderProtocol
+from helper.graph_provider_utils import wait_until_graph_condition
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+
+# Set by #3157. env.local.template documents the required scopes and, more
+# importantly, that the token owner needs PUSH access on every repository: the
+# connector reads /collaborators to resolve permissions, and without push it
+# silently falls back to the repository's visibility instead.
+ENV_TOKEN = "GH_TEAMS_TEST_TOKEN"
+ENV_ORG = "GH_TEAMS_TEST_ORG"
+ENV_PRIMARY_REPO = "GH_TEAMS_TEST_PRIMARY_REPO"
+ENV_PUBLIC_REPO = "GH_TEAMS_TEST_PUBLIC_REPO"
+
+REQUIRED = (ENV_TOKEN, ENV_ORG, ENV_PRIMARY_REPO)
+
+
+@pytest.fixture(scope="session")
+def github_teams_settings() -> dict[str, str]:
+    missing = [name for name in REQUIRED if not os.getenv(name)]
+    if missing:
+        pytest.skip(f"GitHub Teams credentials not set: {', '.join(missing)}")
+    settings = {name: os.environ[name] for name in REQUIRED}
+    settings[ENV_PUBLIC_REPO] = os.getenv(ENV_PUBLIC_REPO, "")
+    return settings
+
+
+def expected_repos(settings: dict[str, str]) -> list[str]:
+    """Repositories the sync is expected to reach, from configuration."""
+    names = [settings[ENV_PRIMARY_REPO]]
+    if settings.get(ENV_PUBLIC_REPO):
+        names.append(settings[ENV_PUBLIC_REPO])
+    return [n for n in names if n]
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def github_teams_connector(
+    github_teams_settings: dict[str, str],
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[dict[str, Any], None]:
+    org = github_teams_settings[ENV_ORG]
+
+    # authType selects the branch in app/sources/client/github/github.py:192.
+    # `credentials` is required even here: the client raises on an empty one at
+    # line 189, before it reaches the API_TOKEN branch that never reads it.
+    config: dict[str, Any] = {
+        "auth": {
+            "authType": "API_TOKEN",
+            "token": github_teams_settings[ENV_TOKEN],
+        },
+        "credentials": {"access_token": github_teams_settings[ENV_TOKEN]},
+        "filters": {
+            "sync": {
+                "values": {
+                    "org_ids": {"operator": "in", "type": "list", "value": [org]}
+                }
+            }
+        },
+    }
+
+    connector_name = f"github-teams-lifecycle-test-{uuid.uuid4().hex[:8]}"
+    instance = pipeshub_client.create_connector(
+        connector_type="GithubTeams",
+        instance_name=connector_name,
+        scope="team",
+        config=config,
+        auth_type="API_TOKEN",
+    )
+    assert instance.connector_id, "Connector must have a valid ID"
+
+    state: dict[str, Any] = {
+        "connector_id": instance.connector_id,
+        "connector_name": connector_name,
+        "resource_name": org,
+        "org": org,
+        "expected_repos": expected_repos(github_teams_settings),
+    }
+
+    # Anything between here and the yield can raise, and pytest runs no teardown
+    # for a fixture that fails before yielding — which would leave the connector
+    # enabled with its graph data behind.
+    try:
+        pipeshub_client.toggle_sync(instance.connector_id, enable=True)
+
+        async def _any_records() -> bool:
+            return await graph_provider.count_records(instance.connector_id) > 0
+
+        # How much is in the organisation is not knowable from here, and GitHub
+        # is slower than a container on the same network, so this waits for the
+        # sync to produce anything rather than for a count it cannot predict.
+        await wait_until_graph_condition(
+            instance.connector_id,
+            check=_any_records,
+            timeout=900,
+            poll_interval=15,
+            description="GitHub Teams full sync",
+        )
+        state["full_sync_count"] = await graph_provider.count_records(
+            instance.connector_id
+        )
+    except BaseException:
+        await destructor(
+            _NoOpStorage(), pipeshub_client, graph_provider, state,
+            connector_type="GithubTeams",
+        )
+        raise
+
+    yield state
+
+    await destructor(
+        _NoOpStorage(), pipeshub_client, graph_provider, state,
+        connector_type="GithubTeams",
+    )
+
+
+class _NoOpStorage:
+    """Satisfies the destructor's storage protocol without touching GitHub.
+
+    Suites that own their source clear it on teardown. This one syncs from an
+    organisation it does not own, so clearing is deliberately nothing.
+    """
+
+    def clear_objects(self, resource_name: str) -> None:
+        del resource_name

--- a/integration-tests/connectors/github_teams/github_teams_integration_test.py
+++ b/integration-tests/connectors/github_teams/github_teams_integration_test.py
@@ -1,0 +1,159 @@
+# pyright: ignore-file
+
+"""
+GitHub Teams Connector – Integration Tests
+==========================================
+
+Tests receive a fully set-up connector via the ``github_teams_connector``
+fixture (defined in conftest.py), which authenticates with the configured
+personal access token, runs a full sync against the configured organisation, and
+removes the connector afterwards.
+
+Scope
+-----
+Read-only and content-agnostic. The organisation and its repositories are shared
+fixtures this suite does not own: nothing is created there, nothing is deleted,
+and no assertion names a particular issue or file. A test that hard-coded the
+organisation's contents would fail whenever somebody pushed to it, which is
+noise rather than a connector regression.
+
+What that leaves is the failure mode that matters most here. This connector
+breaks when GitHub changes something — a token expires, a scope is withdrawn, an
+API is retired, a permissions endpoint changes shape. None of that involves a
+change to this repository, and nothing else would notice.
+
+Test cases:
+  TC-AUTH-001  — Token authentication succeeds and the sync produces records
+  TC-GRAPH-001 — The synced graph is coherent: groups, edges, no orphans
+  TC-PERM-001  — Permissions are synced, not only content
+  TC-REPOS-001 — The configured repositories are among what was synced
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from helper.graph_provider import GraphProviderProtocol
+
+logger = logging.getLogger("github-teams-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.github_teams
+@pytest.mark.asyncio(loop_scope="session")
+class TestGitHubTeamsConnector:
+    """Read-only coverage for the GitHub Teams connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_auth_001_token_auth_and_sync(
+        self,
+        github_teams_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-AUTH-001: The connector authenticates and syncs something.
+
+        Reaching this point proves more than it looks: the token was accepted,
+        its scopes still cover what the connector reads, and the GitHub APIs it
+        calls still answer in the shape it expects.
+        """
+        connector_id = github_teams_connector["connector_id"]
+        full_count = github_teams_connector["full_sync_count"]
+
+        assert full_count > 0, (
+            "TC-AUTH-001: the sync produced no records. Either the token was "
+            "rejected, its scopes were reduced, or the organisation is empty."
+        )
+        await graph_provider.assert_min_records(connector_id, 1)
+        logger.info(
+            "TC-AUTH-001 passed: %d records synced from %s",
+            full_count,
+            github_teams_connector["org"],
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_graph_001_synced_graph_is_coherent(
+        self,
+        github_teams_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-GRAPH-001: Records are attached to groups, with nothing orphaned.
+
+        A record with no group or app edge is invisible to search even though it
+        indexed, which a user experiences as the document never having synced.
+        """
+        connector_id = github_teams_connector["connector_id"]
+
+        await graph_provider.assert_record_groups_and_edges(
+            connector_id, min_groups=1, min_record_edges=1
+        )
+        await graph_provider.assert_app_record_group_edges(connector_id, min_edges=1)
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info("TC-GRAPH-001 passed: graph is coherent for %s", connector_id)
+
+    @pytest.mark.order(3)
+    async def test_tc_perm_001_permissions_are_synced(
+        self,
+        github_teams_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-PERM-001: Permission edges exist.
+
+        Private repositories are access-controlled and this connector maps that
+        into the graph. If permission sync stopped, content would still index and
+        search would still return results while access decisions were made
+        against nothing.
+
+        Worth reading with the setup note in env.local.template: the token owner
+        needs push access on the repositories, because the connector resolves
+        permissions through /collaborators and falls back to the repository's
+        visibility without it. A sudden drop to zero edges here can mean the
+        token lost push access rather than that the code broke.
+        """
+        connector_id = github_teams_connector["connector_id"]
+
+        edges = await graph_provider.count_permission_edges(connector_id)
+        assert edges > 0, (
+            "TC-PERM-001: no permission edges were created. Content synced but "
+            "its access control did not, so permissions are being evaluated "
+            "against nothing."
+        )
+        logger.info("TC-PERM-001 passed: %d permission edges", edges)
+
+    @pytest.mark.order(4)
+    async def test_tc_repos_001_configured_repositories_were_synced(
+        self,
+        github_teams_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-REPOS-001: The configured repositories appear in the sync.
+
+        Names are matched case-insensitively against record names and paths,
+        because a repository surfaces in the graph through the records it
+        contains rather than as a record of its own.
+        """
+        expected = github_teams_connector["expected_repos"]
+        if not expected:
+            pytest.skip("no repositories configured")
+
+        connector_id = github_teams_connector["connector_id"]
+        names = await graph_provider.fetch_record_names(connector_id)
+        paths = await graph_provider.fetch_record_paths(connector_id)
+        haystack = " ".join(
+            names + [str(p) for pair in paths for p in pair if p]
+        ).lower()
+
+        missing = [repo for repo in expected if repo.lower() not in haystack]
+        assert not missing, (
+            f"TC-REPOS-001: configured repositories {missing} produced no "
+            f"records. {len(names)} records synced from elsewhere, so the token "
+            "worked but these repositories were not reached — check that it has "
+            "access to them."
+        )
+        logger.info("TC-REPOS-001 passed: repositories %s are present", expected)

--- a/integration-tests/connectors/gitlab/conftest.py
+++ b/integration-tests/connectors/gitlab/conftest.py
@@ -1,0 +1,153 @@
+# pyright: ignore-file
+
+"""GitLab connector fixtures.
+
+The credentials this needs were provisioned in #3157, which also registered the
+``gitlab`` pytest marker and documented how the account must be set up. No suite
+followed, so nothing has been reading them.
+
+Read-only. The group and its projects are shared fixtures this suite does not
+own, so it creates nothing and deletes nothing there; only the connector and its
+graph data are cleaned up.
+"""
+
+import os
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from connector_lifecycle import destructor
+from helper.graph_provider import GraphProviderProtocol
+from helper.graph_provider_utils import wait_until_graph_condition
+from pipeshub_client import PipeshubClient  # type: ignore[import-not-found]
+
+# Set by #3157. env.local.template documents the required scopes (read_api,
+# read_user, read_repository) and that the token owner must be Owner or
+# Maintainer on the group, because reading project members needs it.
+ENV_TOKEN = "GITLAB_TEST_TOKEN"
+ENV_INSTANCE_URL = "GITLAB_TEST_INSTANCE_URL"
+ENV_GROUP = "GITLAB_TEST_GROUP"
+ENV_SUBGROUP = "GITLAB_TEST_SUBGROUP"
+ENV_PRIMARY_PROJECT = "GITLAB_TEST_PRIMARY_PROJECT"
+
+REQUIRED = (ENV_TOKEN, ENV_GROUP, ENV_PRIMARY_PROJECT)
+
+# env.local.template: blank or https://gitlab.com for cloud, the host for
+# self-managed EE.
+DEFAULT_INSTANCE_URL = "https://gitlab.com"
+
+
+@pytest.fixture(scope="session")
+def gitlab_settings() -> dict[str, str]:
+    missing = [name for name in REQUIRED if not os.getenv(name)]
+    if missing:
+        pytest.skip(f"GitLab credentials not set: {', '.join(missing)}")
+    settings = {name: os.environ[name] for name in REQUIRED}
+    settings[ENV_INSTANCE_URL] = (
+        os.getenv(ENV_INSTANCE_URL, "").strip() or DEFAULT_INSTANCE_URL
+    )
+    settings[ENV_SUBGROUP] = os.getenv(ENV_SUBGROUP, "")
+    return settings
+
+
+def expected_projects(settings: dict[str, str]) -> list[str]:
+    """Projects the sync is expected to reach, from configuration."""
+    return [p for p in (settings[ENV_PRIMARY_PROJECT],) if p]
+
+
+@pytest_asyncio.fixture(scope="module", loop_scope="session")
+async def gitlab_connector(
+    gitlab_settings: dict[str, str],
+    pipeshub_client: PipeshubClient,
+    graph_provider: GraphProviderProtocol,
+) -> AsyncGenerator[dict[str, Any], None]:
+    group = gitlab_settings[ENV_GROUP]
+    token = gitlab_settings[ENV_TOKEN]
+
+    # authType has to be set explicitly here: the GitLab client defaults to
+    # OAUTH (app/sources/client/gitlab/gitlab.py:284), unlike the GitHub client
+    # which defaults to API_TOKEN. `credentials` is required even on this path —
+    # the client raises on an empty one at line 280, before reaching the branch
+    # that never reads it.
+    config: dict[str, Any] = {
+        "auth": {
+            "authType": "API_TOKEN",
+            "token": token,
+            "instanceUrl": gitlab_settings[ENV_INSTANCE_URL],
+        },
+        "credentials": {"access_token": token},
+        "filters": {
+            "sync": {
+                "values": {
+                    "group_ids": {"operator": "in", "type": "list", "value": [group]}
+                }
+            }
+        },
+    }
+
+    connector_name = f"gitlab-lifecycle-test-{uuid.uuid4().hex[:8]}"
+    instance = pipeshub_client.create_connector(
+        connector_type="GitLab",
+        instance_name=connector_name,
+        scope="team",
+        config=config,
+        auth_type="API_TOKEN",
+    )
+    assert instance.connector_id, "Connector must have a valid ID"
+
+    state: dict[str, Any] = {
+        "connector_id": instance.connector_id,
+        "connector_name": connector_name,
+        "resource_name": group,
+        "group": group,
+        "subgroup": gitlab_settings[ENV_SUBGROUP],
+        "instance_url": gitlab_settings[ENV_INSTANCE_URL],
+        "expected_projects": expected_projects(gitlab_settings),
+    }
+
+    # pytest runs no teardown for a fixture that fails before yielding, so a
+    # timeout here would otherwise leave the connector enabled with its data.
+    try:
+        pipeshub_client.toggle_sync(instance.connector_id, enable=True)
+
+        async def _any_records() -> bool:
+            return await graph_provider.count_records(instance.connector_id) > 0
+
+        # How much the group holds is not knowable from here, and GitLab is
+        # slower than a container on the same network, so this waits for any
+        # record rather than a count it cannot predict.
+        await wait_until_graph_condition(
+            instance.connector_id,
+            check=_any_records,
+            timeout=900,
+            poll_interval=15,
+            description="GitLab full sync",
+        )
+        state["full_sync_count"] = await graph_provider.count_records(
+            instance.connector_id
+        )
+    except BaseException:
+        await destructor(
+            _NoOpStorage(), pipeshub_client, graph_provider, state,
+            connector_type="GitLab",
+        )
+        raise
+
+    yield state
+
+    await destructor(
+        _NoOpStorage(), pipeshub_client, graph_provider, state, connector_type="GitLab"
+    )
+
+
+class _NoOpStorage:
+    """Satisfies the destructor's storage protocol without touching GitLab.
+
+    Suites that own their source clear it on teardown. This one syncs from a
+    group it does not own, so clearing is deliberately nothing.
+    """
+
+    def clear_objects(self, resource_name: str) -> None:
+        del resource_name

--- a/integration-tests/connectors/gitlab/gitlab_integration_test.py
+++ b/integration-tests/connectors/gitlab/gitlab_integration_test.py
@@ -1,0 +1,158 @@
+# pyright: ignore-file
+
+"""
+GitLab Connector – Integration Tests
+====================================
+
+Tests receive a fully set-up connector via the ``gitlab_connector``
+fixture (defined in conftest.py), which authenticates with the configured
+personal access token, runs a full sync against the configured group, and
+removes the connector afterwards.
+
+Scope
+-----
+Read-only and content-agnostic. The group and its projects are shared
+fixtures this suite does not own: nothing is created there, nothing is deleted,
+and no assertion names a particular issue or file. A test that hard-coded the
+group's contents would fail whenever somebody pushed to it, which is
+noise rather than a connector regression.
+
+What that leaves is the failure mode that matters most here. This connector
+breaks when GitLab changes something — a token expires, a scope is withdrawn, an
+API is retired, a members endpoint changes shape. None of that involves a change
+to this repository, and nothing else would notice.
+
+Test cases:
+  TC-AUTH-001  — Token authentication succeeds and the sync produces records
+  TC-GRAPH-001 — The synced graph is coherent: groups, edges, no orphans
+  TC-PERM-001  — Permissions are synced, not only content
+  TC-PROJECTS-001 — The configured projects are among what was synced
+"""
+
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from helper.graph_provider import GraphProviderProtocol
+
+logger = logging.getLogger("gitlab-lifecycle-test")
+
+
+@pytest.mark.integration
+@pytest.mark.gitlab
+@pytest.mark.asyncio(loop_scope="session")
+class TestGitLabConnector:
+    """Read-only coverage for the GitLab connector."""
+
+    @pytest.mark.order(1)
+    async def test_tc_auth_001_token_auth_and_sync(
+        self,
+        gitlab_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-AUTH-001: The connector authenticates and syncs something.
+
+        Reaching this point proves more than it looks: the token was accepted,
+        its scopes still cover what the connector reads, and the GitLab APIs it
+        calls still answer in the shape it expects.
+        """
+        connector_id = gitlab_connector["connector_id"]
+        full_count = gitlab_connector["full_sync_count"]
+
+        assert full_count > 0, (
+            "TC-AUTH-001: the sync produced no records. Either the token was "
+            "rejected, its scopes were reduced, or the group is empty."
+        )
+        await graph_provider.assert_min_records(connector_id, 1)
+        logger.info(
+            "TC-AUTH-001 passed: %d records synced from %s",
+            full_count,
+            gitlab_connector["group"],
+        )
+
+    @pytest.mark.order(2)
+    async def test_tc_graph_001_synced_graph_is_coherent(
+        self,
+        gitlab_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-GRAPH-001: Records are attached to groups, with nothing orphaned.
+
+        A record with no group or app edge is invisible to search even though it
+        indexed, which a user experiences as the document never having synced.
+        """
+        connector_id = gitlab_connector["connector_id"]
+
+        await graph_provider.assert_record_groups_and_edges(
+            connector_id, min_groups=1, min_record_edges=1
+        )
+        await graph_provider.assert_app_record_group_edges(connector_id, min_edges=1)
+        await graph_provider.assert_no_orphan_records(connector_id)
+        logger.info("TC-GRAPH-001 passed: graph is coherent for %s", connector_id)
+
+    @pytest.mark.order(3)
+    async def test_tc_perm_001_permissions_are_synced(
+        self,
+        gitlab_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-PERM-001: Permission edges exist.
+
+        Private projects are access-controlled and this connector maps that
+        into the graph. If permission sync stopped, content would still index and
+        search would still return results while access decisions were made
+        against nothing.
+
+        Worth reading with the setup note in env.local.template: the token
+        owner must be Owner or Maintainer on the group, because reading project
+        members requires it. A sudden drop to zero edges here can mean the token
+        lost that role rather than that the code broke.
+        """
+        connector_id = gitlab_connector["connector_id"]
+
+        edges = await graph_provider.count_permission_edges(connector_id)
+        assert edges > 0, (
+            "TC-PERM-001: no permission edges were created. Content synced but "
+            "its access control did not, so permissions are being evaluated "
+            "against nothing."
+        )
+        logger.info("TC-PERM-001 passed: %d permission edges", edges)
+
+    @pytest.mark.order(4)
+    async def test_tc_projects_001_configured_projects_were_synced(
+        self,
+        gitlab_connector: dict[str, Any],
+        graph_provider: GraphProviderProtocol,
+    ) -> None:
+        """TC-PROJECTS-001: The configured projects appear in the sync.
+
+        Names are matched case-insensitively against record names and paths,
+        because a project surfaces in the graph through the records it contains
+        rather than as a record of its own.
+        """
+        expected = gitlab_connector["expected_projects"]
+        if not expected:
+            pytest.skip("no projects configured")
+
+        connector_id = gitlab_connector["connector_id"]
+        names = await graph_provider.fetch_record_names(connector_id)
+        paths = await graph_provider.fetch_record_paths(connector_id)
+        haystack = " ".join(
+            names + [str(p) for pair in paths for p in pair if p]
+        ).lower()
+
+        missing = [repo for repo in expected if repo.lower() not in haystack]
+        assert not missing, (
+            f"TC-PROJECTS-001: configured projects {missing} produced no "
+            f"records. {len(names)} records synced from elsewhere, so the token "
+            "worked but these projects were not reached — check that it has "
+            "access to them."
+        )
+        logger.info("TC-PROJECTS-001 passed: projects %s are present", expected)


### PR DESCRIPTION
## The test environment already exists

Pull request #3157, *"Github and Gitlab It environment setup"*, prepared everything these connectors need:

- **eleven secrets** exported to the integration job — token, org, three repositories for GitHub; token, instance URL, group, subgroup and two projects for GitLab
- both pytest markers registered in `pytest.ini`
- both offered as `workflow_dispatch` choices
- `env.local.template` documenting the required scopes and, in detail, the repository permissions the token owner needs

No test suite followed. Nothing in the repository reads any of those secrets, and both connectors sit on the uncovered list. This adds the suites they were provisioned for.

**Nothing outside `integration-tests/connectors/` changes** — the markers and dispatch choices were already in place.

## Scope: read-only, content-agnostic

The organisation, group, repositories and projects are shared fixtures these suites do not own. Nothing is created there, nothing is deleted, and no assertion names a particular issue or file — a test that hard-coded their contents would fail whenever somebody pushed, which is noise rather than a connector regression.

What remains is the failure mode that matters most for connectors like these: **they break when the provider changes**. A token expires, a scope is withdrawn, an API is retired, a members endpoint changes shape. None of that involves a change to this repository, and nothing else in CI would notice.

## What is covered

| Case | What it proves |
|---|---|
| TC-AUTH-001 | The token is accepted, its scopes still cover what the connector reads, and the provider's APIs still answer in the expected shape |
| TC-GRAPH-001 | Records are attached to groups with app edges and no orphans — an orphaned record indexes but is invisible to search |
| TC-PERM-001 | Permission edges exist, so access control synced and not only content |
| TC-REPOS-001 / TC-PROJECTS-001 | The configured repositories or projects appear in what was synced |

**TC-PERM-001 is the one worth having.** If permission sync stopped, content would still index and search would still return results, while access decisions were being made against nothing.

Its docstring points back at the setup notes from #3157, because the likeliest cause of a sudden drop to zero edges is the token losing the access those notes require, rather than a code change:

> **GitHub:** the token owner needs PUSH access on the repositories — the connector resolves permissions through `/collaborators`, and without push it silently falls back to the repository's visibility instead.
>
> **GitLab:** the token owner must be Owner or Maintainer on the group, because reading project members requires it.

## Two details that needed reading the clients

**The builders declare OAuth; the clients accept a token.** Both connectors declare `AuthType.OAUTH`, but that is only the default. Each client branches on `auth.authType` at runtime and supports a personal access token — which is what #3157 provisioned. The defaults differ, so this matters:

| | Default `authType` | |
|---|---|---|
| GitHub (`github.py:192`) | `API_TOKEN` | already correct |
| GitLab (`gitlab.py:284`) | `OAUTH` | must be set explicitly |

**Both clients require a `credentials` block even on the token path.** `github.py:189` and `gitlab.py:280` raise on an empty `credentials` *before* reaching the `API_TOKEN` branch — which then never reads it. So a token-configured connector has to pass a dict it does not use.

That looks like a defect rather than intent. The fixtures pass one rather than working around it in product code, since changing that from inside a test pull request would be the wrong place for it.

## Coverage

Two more connectors covered with nothing to procure. Combined with the other suites in flight, connector integration coverage moves from 16 of 50 to 26.

## What is not verified here

Neither suite can run without the accounts, so CI is their first real execution — as it is for any suite reading these secrets, since none has ever read them. Both skip cleanly when the credentials are absent, so forks and local runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for GitHub Teams and GitLab connectors.
  - Verified token authentication and successful synchronization.
  - Added checks for graph consistency, permissions, and relationships between synced records.
  - Confirmed configured repositories and projects are included in synchronization results.
  - Added test setup that skips runs when required credentials or configuration are unavailable and cleans up connector resources after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->