### PR TITLE
fix: select supported multimodal embedding request format

### DIFF
--- a/backend/python/app/api/routes/health.py
+++ b/backend/python/app/api/routes/health.py
@@ -1193,6 +1193,7 @@ async def _probe_image_embedding(
                 aws_access_key_id=configuration.get("awsAccessKeyId"),
                 aws_secret_access_key=configuration.get("awsSecretAccessKey"),
                 embedding_size=text_dimension,
+                multimodal_request_format=configuration.get("multimodalRequestFormat", "auto"),
                 logger=logger,
             )
         )
@@ -1898,4 +1899,3 @@ async def health_check(request: Request, model_type: str, model_config: dict = B
                 "timestamp": get_epoch_timestamp_in_ms(),
             },
         )
-

--- a/backend/python/app/api/routes/health.py
+++ b/backend/python/app/api/routes/health.py
@@ -1193,7 +1193,7 @@ async def _probe_image_embedding(
                 aws_access_key_id=configuration.get("awsAccessKeyId"),
                 aws_secret_access_key=configuration.get("awsSecretAccessKey"),
                 embedding_size=text_dimension,
-                multimodal_request_format=configuration.get("multimodalRequestFormat", "auto"),
+                multimodal_request_format=configuration.get("multimodalRequestFormat") or "auto",
                 logger=logger,
             )
         )

--- a/backend/python/app/config/ai_models/providers/openai_compatible.py
+++ b/backend/python/app/config/ai_models/providers/openai_compatible.py
@@ -21,6 +21,20 @@ _COMPAT_ENDPOINT_EMB = AIModelField(
     placeholder="e.g., https://api.openai.com/v1",
 )
 
+_MULTIMODAL_REQUEST_FORMAT = AIModelField(
+    name="multimodalRequestFormat",
+    display_name="Advanced: Image Embedding Format",
+    field_type="SELECT",
+    required=False,
+    default_value="auto",
+    description="Leave Auto selected. Override only if your endpoint documentation specifies an image embedding format.",
+    options=[
+        {"value": "auto", "label": "Auto (recommended)"},
+        {"value": "input", "label": "Input (batched)"},
+        {"value": "vllm_messages", "label": "vLLM Messages"},
+    ],
+)
+
 
 @AIModelProviderBuilder("OpenAI Compatible", "openAICompatible") \
     .with_description("OpenAI-compatible models") \
@@ -40,6 +54,7 @@ _COMPAT_ENDPOINT_EMB = AIModelField(
     .add_field(EMBEDDING_COMMON_TAIL[0], ModelCapability.EMBEDDING) \
     .add_field(EMBEDDING_COMMON_TAIL[1], ModelCapability.EMBEDDING) \
     .add_field(EMBEDDING_COMMON_TAIL[2], ModelCapability.EMBEDDING) \
+    .add_field(_MULTIMODAL_REQUEST_FORMAT, ModelCapability.EMBEDDING) \
     .build_decorator()
 class OpenAICompatibleProvider:
     pass

--- a/backend/python/app/modules/transformers/vectorstore.py
+++ b/backend/python/app/modules/transformers/vectorstore.py
@@ -889,7 +889,7 @@ class VectorStore(Transformer):
         # configured endpoint to reach the right server.
         self.base_url = configuration.get("endpoint") if configuration else None
         self.multimodal_request_format = (
-            configuration.get("multimodalRequestFormat", "auto")
+            configuration.get("multimodalRequestFormat") or "auto"
             if configuration
             else "auto"
         )

--- a/backend/python/app/modules/transformers/vectorstore.py
+++ b/backend/python/app/modules/transformers/vectorstore.py
@@ -389,6 +389,7 @@ class VectorStore(Transformer):
         self.aws_access_key_id = None
         self.aws_secret_access_key = None
         self.base_url: str | None = None
+        self.multimodal_request_format = "auto"
 
         self._capabilities = self.vector_db_service.get_capabilities()
 
@@ -887,6 +888,11 @@ class VectorStore(Transformer):
         # Ollama / OpenAI-compatible / LM Studio multimodal providers need the
         # configured endpoint to reach the right server.
         self.base_url = configuration.get("endpoint") if configuration else None
+        self.multimodal_request_format = (
+            configuration.get("multimodalRequestFormat", "auto")
+            if configuration
+            else "auto"
+        )
         if provider == EmbeddingProvider.AWS_BEDROCK.value and configuration:
             self.aws_access_key_id = configuration.get("awsAccessKeyId")
             self.aws_secret_access_key = configuration.get("awsAccessSecretKey")
@@ -1023,6 +1029,7 @@ class VectorStore(Transformer):
             aws_access_key_id=self.aws_access_key_id,
             aws_secret_access_key=self.aws_secret_access_key,
             base_url=getattr(self, "base_url", None),
+            multimodal_request_format=self.multimodal_request_format,
             embedding_size=self.embedding_size,
             dense_embeddings=self.dense_embeddings,
             normalize_fn=self._normalize_image_to_base64,

--- a/backend/python/app/services/embeddings/multimodal/config.py
+++ b/backend/python/app/services/embeddings/multimodal/config.py
@@ -19,6 +19,7 @@ class MultimodalProviderConfig:
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
     base_url: str | None = None
+    multimodal_request_format: str = "auto"
     # Dimension the target collection was created with. Providers that let
     # the caller choose an output length (Bedrock Titan) must request this
     # one, or every point they return is rejected by

--- a/backend/python/app/services/embeddings/multimodal/factory.py
+++ b/backend/python/app/services/embeddings/multimodal/factory.py
@@ -40,6 +40,7 @@ def _build_openai_compat(provider_label: str) -> Callable[
         api_key=config.api_key,
         model_name=config.model_name,
         provider_label=provider_label,
+        request_format=config.multimodal_request_format,
         normalize_fn=config.normalize_fn,
         logger=config.logger,
     )

--- a/backend/python/app/services/embeddings/multimodal/openai_compat_provider.py
+++ b/backend/python/app/services/embeddings/multimodal/openai_compat_provider.py
@@ -1,24 +1,9 @@
-"""OpenAI-compatible (and LM Studio) image embedding.
+"""Image embeddings for OpenAI-compatible endpoints.
 
-The OpenAI ``/v1/embeddings`` API itself is text-only, but some self-hosted
-servers exposed behind an "OpenAI-compatible" base URL (CLIP-style wrappers,
-some Jina/Nomic deployments) accept a base64 data URI directly as an
-``input`` item and return a native image embedding. There is no universal
-standard for this, so this provider makes a best-effort POST and surfaces
-any failure as a per-image error rather than raising — a server that only
-accepts text will simply fail every image, and the existing
-VLM-description fallback remains available for that case (see
-``VectorStore.index_documents``).
-
-Two incompatible multimodal conventions exist in the wild, so both are
-tried: the standard ``input`` schema (used by routers such as
-Requesty/LiteLLM proxying to natively multimodal models like Gemini
-Embedding 2), then vLLM's chat-``messages`` extension, which self-hosted
-vLLM multimodal embedding servers use instead and which accepts only one
-image per request.
-
-LM Studio's local embedding server uses the same OpenAI-compatible shape, so
-it is routed through this same provider.
+Auto recognizes the advertised messages extension in the server's OpenAPI
+schema. Data-URI input requires an explicit override: text-only servers can
+successfully embed the URI string without decoding an image. Messages are
+sent individually for compatibility with older servers.
 """
 
 import asyncio
@@ -40,6 +25,7 @@ from app.services.embeddings.multimodal.interface import (
 _CONCURRENCY_LIMIT = 5
 _BATCH_SIZE = 16
 _REQUEST_TIMEOUT_SECONDS = 60.0
+_REQUEST_FORMATS = {"auto", "input", "vllm_messages"}
 
 
 class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
@@ -49,6 +35,7 @@ class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
         api_key: str | None,
         model_name: str | None,
         provider_label: str = "openAICompatible",
+        request_format: str = "auto",
         normalize_fn: Callable[[str], Any] | None = None,
         logger: logging.Logger | None = None,
     ) -> None:
@@ -58,6 +45,9 @@ class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
         self.api_key = api_key
         self.model_name = model_name
         self._provider_label = provider_label
+        if request_format not in _REQUEST_FORMATS:
+            raise ValueError(f"Unsupported multimodal request format: {request_format}")
+        self._request_format = request_format
         # Consumed by IMultimodalEmbeddingProvider.normalize().
         self._normalize_fn = normalize_fn
         self.logger = logger
@@ -67,6 +57,8 @@ class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
         return self._provider_label
 
     async def embed_images(self, image_base64s: list[str]) -> list[ImageEmbeddingResult]:
+        if not image_base64s:
+            return []
         semaphore = asyncio.Semaphore(_CONCURRENCY_LIMIT)
         endpoint = f"{self.base_url}/embeddings"
         headers = {"Content-Type": "application/json"}
@@ -76,46 +68,59 @@ class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
         async def process_batch(
             client: httpx.AsyncClient, batch_start: int, batch_imgs: list[str]
         ) -> list[ImageEmbeddingResult]:
-            async with semaphore:
-                valid: list[tuple[int, str]] = []
-                invalid_results: list[ImageEmbeddingResult] = []
-                for offset, img in enumerate(batch_imgs):
-                    index = batch_start + offset
-                    normalized = await self.normalize(img)
-                    if normalized:
-                        valid.append((index, _as_data_uri(img, normalized)))
-                    else:
-                        invalid_results.append(
-                            ImageEmbeddingResult(index=index, error="invalid image data")
-                        )
-                if not valid:
-                    return invalid_results
+            valid: list[tuple[int, str]] = []
+            invalid_results: list[ImageEmbeddingResult] = []
+            for offset, img in enumerate(batch_imgs):
+                index = batch_start + offset
+                normalized = await self.normalize(img)
+                if normalized:
+                    valid.append((index, _as_data_uri(img, normalized)))
+                else:
+                    invalid_results.append(
+                        ImageEmbeddingResult(index=index, error="invalid image data")
+                    )
+            if not valid:
+                return invalid_results
 
-                request_indices = [index for index, _ in valid]
-                try:
+            if request_format == "vllm_messages":
+                results = await asyncio.gather(
+                    *[
+                        self._embed_via_messages(
+                            client, endpoint, headers, index, uri, semaphore
+                        )
+                        for index, uri in valid
+                    ]
+                )
+                return list(results) + invalid_results
+
+            request_indices = [index for index, _ in valid]
+            try:
+                async with semaphore:
                     data = await self._post_input_format(
                         client, endpoint, headers, [uri for _, uri in valid]
                     )
-                except Exception as standard_err:
-                    # vLLM's `messages` extension never adopted the `input`
-                    # schema and takes one image per request, so this arm
-                    # cannot batch.
-                    fallback = await asyncio.gather(
-                        *[
-                            self._embed_via_messages(client, endpoint, headers, index, uri)
-                            for index, uri in valid
-                        ]
-                    )
-                    if self.logger and any(r.embedding is None for r in fallback):
-                        self.logger.warning(
-                            f"{self._provider_label} image embed batch {batch_start} failed "
-                            f"(endpoint may not support multimodal embedding input): "
-                            f"input-format error={describe_request_error(standard_err)}"
-                        )
-                    return list(fallback) + invalid_results
-                return map_embedding_response(data, request_indices) + invalid_results
+            except Exception as standard_err:
+                error = describe_request_error(standard_err)
+                return [
+                    ImageEmbeddingResult(index=index, error=error)
+                    for index in request_indices
+                ] + invalid_results
+            return map_embedding_response(data, request_indices) + invalid_results
 
         async with httpx.AsyncClient(timeout=_REQUEST_TIMEOUT_SECONDS) as client:
+            request_format = self._request_format
+            if request_format == "auto":
+                request_format = await self._detect_request_format(client, headers)
+                if request_format is None:
+                    error = (
+                        "Image embedding support could not be verified. "
+                        "Choose the endpoint's image format in advanced settings "
+                        "or disable Multimodal to use text embeddings."
+                    )
+                    return [
+                        ImageEmbeddingResult(index=i, error=error)
+                        for i in range(len(image_base64s))
+                    ]
             batches = [
                 (start, image_base64s[start:start + _BATCH_SIZE])
                 for start in range(0, len(image_base64s), _BATCH_SIZE)
@@ -123,10 +128,39 @@ class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
             results = await asyncio.gather(
                 *[process_batch(client, s, imgs) for s, imgs in batches]
             )
-        flattened: list[ImageEmbeddingResult] = []
-        for r in results:
-            flattened.extend(r)
-        return flattened
+        return [result for batch in results for result in batch]
+
+    async def _detect_request_format(
+        self, client: httpx.AsyncClient, headers: dict[str, str],
+    ) -> str | None:
+        """Recognize an advertised messages extension; never guess from a model name."""
+        base = httpx.URL(self.base_url)
+        prefix = base.path.rstrip("/")
+        schema_path = prefix[:-3] if prefix.endswith("/v1") else prefix
+        try:
+            response = await client.get(
+                str(base.copy_with(path=f"{schema_path}/openapi.json")),
+                headers=headers, timeout=10.0,
+            )
+            response.raise_for_status()
+            document = response.json()
+            schema = document["paths"][f"{prefix}/embeddings"]["post"][
+                "requestBody"]["content"]["application/json"]["schema"]
+            pending = [schema]
+            seen: set[str] = set()
+            while pending:
+                schema = pending.pop()
+                if "messages" in schema.get("properties", {}):
+                    return "vllm_messages"
+                ref = schema.get("$ref", "")
+                if ref.startswith("#/components/schemas/") and ref not in seen:
+                    seen.add(ref)
+                    pending.append(document["components"]["schemas"][ref.rsplit("/", 1)[-1]])
+                for key in ("anyOf", "oneOf", "allOf"):
+                    pending.extend(schema.get(key, []))
+        except (httpx.HTTPError, ValueError, KeyError, TypeError, AttributeError):
+            pass
+        return None
 
     async def _post_input_format(
         self,
@@ -154,24 +188,26 @@ class OpenAICompatMultimodalProvider(IMultimodalEmbeddingProvider):
         headers: dict[str, str],
         index: int,
         image_uri: str,
+        semaphore: asyncio.Semaphore,
     ) -> ImageEmbeddingResult:
         try:
-            resp = await client.post(
-                endpoint,
-                headers=headers,
-                json={
-                    "model": self.model_name,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": [
-                                {"type": "image_url", "image_url": {"url": image_uri}}
-                            ],
-                        }
-                    ],
-                    "encoding_format": "float",
-                },
-            )
+            async with semaphore:
+                resp = await client.post(
+                    endpoint,
+                    headers=headers,
+                    json={
+                        "model": self.model_name,
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": [
+                                    {"type": "image_url", "image_url": {"url": image_uri}}
+                                ],
+                            }
+                        ],
+                        "encoding_format": "float",
+                    },
+                )
             resp.raise_for_status()
             return map_embedding_response(resp.json().get("data", []), [index])[0]
         except Exception as vllm_err:

--- a/backend/python/app/utils/aimodels.py
+++ b/backend/python/app/utils/aimodels.py
@@ -235,6 +235,7 @@ def embedding_config_hash(embedding_configs: "list[dict[str, Any]] | None") -> s
             "model": configuration.get("model"),
             "endpoint": configuration.get("endpoint"),
             "dimensions": configuration.get("dimensions"),
+            "multimodalRequestFormat": configuration.get("multimodalRequestFormat") or "auto",
             "apiKey": configuration.get("apiKey"),
             "organizationId": configuration.get("organizationId"),
             "trustRemoteCode": configuration.get("trustRemoteCode"),

--- a/backend/python/tests/unit/api/routes/test_health_capabilities.py
+++ b/backend/python/tests/unit/api/routes/test_health_capabilities.py
@@ -263,12 +263,13 @@ class TestImageEmbeddingProbe:
         assert resp.status_code == 400
         assert "no image-embedding support" in body
 
-    async def test_a_working_multimodal_model_passes(self, mock_request) -> None:
+    @pytest.mark.parametrize("request_format", [None, "", "auto", "input", "vllm_messages"])
+    async def test_a_working_multimodal_model_passes(self, mock_request, request_format) -> None:
         provider = MagicMock()
         provider.supports_multimodal.return_value = True
         provider.embed_images = AsyncMock(return_value=[MagicMock(embedding=[0.2] * 1024)])
         config = _embedding_config(isMultimodal=True)
-        config["configuration"]["multimodalRequestFormat"] = "input"
+        config["configuration"]["multimodalRequestFormat"] = request_format
 
         with self._patch_text_embedding(), \
              patch(FACTORY) as factory:
@@ -279,7 +280,7 @@ class TestImageEmbeddingProbe:
             )
 
         assert resp.status_code == 200
-        assert factory.create.call_args.args[0].multimodal_request_format == "input"
+        assert factory.create.call_args.args[0].multimodal_request_format == (request_format or "auto")
         assert '"multimodal":true' in resp.body.decode().replace(" ", "")
 
     async def test_image_and_text_vectors_must_share_a_width(self, mock_request) -> None:

--- a/backend/python/tests/unit/api/routes/test_health_capabilities.py
+++ b/backend/python/tests/unit/api/routes/test_health_capabilities.py
@@ -267,16 +267,19 @@ class TestImageEmbeddingProbe:
         provider = MagicMock()
         provider.supports_multimodal.return_value = True
         provider.embed_images = AsyncMock(return_value=[MagicMock(embedding=[0.2] * 1024)])
+        config = _embedding_config(isMultimodal=True)
+        config["configuration"]["multimodalRequestFormat"] = "input"
 
         with self._patch_text_embedding(), \
              patch(FACTORY) as factory:
             factory.create.return_value = provider
             from app.api.routes.health import perform_embedding_health_check
             resp = await perform_embedding_health_check(
-                mock_request, _embedding_config(isMultimodal=True), MagicMock(),
+                mock_request, config, MagicMock(),
             )
 
         assert resp.status_code == 200
+        assert factory.create.call_args.args[0].multimodal_request_format == "input"
         assert '"multimodal":true' in resp.body.decode().replace(" ", "")
 
     async def test_image_and_text_vectors_must_share_a_width(self, mock_request) -> None:

--- a/backend/python/tests/unit/modules/transformers/test_vectorstore.py
+++ b/backend/python/tests/unit/modules/transformers/test_vectorstore.py
@@ -334,7 +334,8 @@ class TestGetEmbeddingModelInstance:
         assert vs.embedding_size == 1536
 
     @pytest.mark.asyncio
-    async def test_captures_base_url_for_local_endpoints(self):
+    @pytest.mark.parametrize("request_format", [None, "", "auto", "input", "vllm_messages"])
+    async def test_captures_base_url_for_local_endpoints(self, request_format):
         """Ollama / LM Studio / OpenAI-compatible multimodal providers need
         the configured endpoint on the instance to reach the right server."""
         vs = _make_vectorstore()
@@ -344,7 +345,7 @@ class TestGetEmbeddingModelInstance:
             "configuration": {
                 "endpoint": "http://localhost:11434",
                 "model": "nomic-embed-text",
-                "multimodalRequestFormat": "vllm_messages",
+                "multimodalRequestFormat": request_format,
             },
             "isDefault": True,
             "isMultimodal": True,
@@ -362,7 +363,7 @@ class TestGetEmbeddingModelInstance:
             await vs.get_embedding_model_instance()
 
         assert vs.base_url == "http://localhost:11434"
-        assert vs.multimodal_request_format == "vllm_messages"
+        assert vs.multimodal_request_format == (request_format or "auto")
 
     @pytest.mark.asyncio
     async def test_embed_query_failure_raises(self):

--- a/backend/python/tests/unit/modules/transformers/test_vectorstore.py
+++ b/backend/python/tests/unit/modules/transformers/test_vectorstore.py
@@ -341,7 +341,11 @@ class TestGetEmbeddingModelInstance:
 
         config = {
             "provider": "ollama",
-            "configuration": {"endpoint": "http://localhost:11434", "model": "nomic-embed-text"},
+            "configuration": {
+                "endpoint": "http://localhost:11434",
+                "model": "nomic-embed-text",
+                "multimodalRequestFormat": "vllm_messages",
+            },
             "isDefault": True,
             "isMultimodal": True,
         }
@@ -358,6 +362,7 @@ class TestGetEmbeddingModelInstance:
             await vs.get_embedding_model_instance()
 
         assert vs.base_url == "http://localhost:11434"
+        assert vs.multimodal_request_format == "vllm_messages"
 
     @pytest.mark.asyncio
     async def test_embed_query_failure_raises(self):
@@ -2188,6 +2193,7 @@ class TestMultimodalProviderConfig:
         vs.region_name = "us-east-1"
         vs.aws_access_key_id = "akid"
         vs.aws_secret_access_key = "secret"
+        vs.multimodal_request_format = "vllm_messages"
         vs.dense_embeddings = MagicMock()
 
         config = vs._multimodal_provider_config()
@@ -2198,6 +2204,7 @@ class TestMultimodalProviderConfig:
         assert config.region_name == "us-east-1"
         assert config.aws_access_key_id == "akid"
         assert config.aws_secret_access_key == "secret"
+        assert config.multimodal_request_format == "vllm_messages"
         assert config.dense_embeddings is vs.dense_embeddings
         assert config.logger is vs.logger
 

--- a/backend/python/tests/unit/services/embeddings/multimodal/test_factory.py
+++ b/backend/python/tests/unit/services/embeddings/multimodal/test_factory.py
@@ -51,11 +51,14 @@ class TestMultimodalEmbeddingFactory:
 
     def test_openai_compatible_provider(self) -> None:
         config = MultimodalProviderConfig(
-            provider=EmbeddingProvider.OPENAI_COMPATIBLE.value, base_url="http://x"
+            provider=EmbeddingProvider.OPENAI_COMPATIBLE.value,
+            base_url="http://x",
+            multimodal_request_format="vllm_messages",
         )
         provider = MultimodalEmbeddingFactory.create(config)
         assert isinstance(provider, OpenAICompatMultimodalProvider)
         assert provider.provider_name == EmbeddingProvider.OPENAI_COMPATIBLE.value
+        assert provider._request_format == "vllm_messages"
 
     def test_lm_studio_routes_through_openai_compat_provider(self) -> None:
         config = MultimodalProviderConfig(

--- a/backend/python/tests/unit/services/embeddings/multimodal/test_openai_compat_provider.py
+++ b/backend/python/tests/unit/services/embeddings/multimodal/test_openai_compat_provider.py
@@ -1,5 +1,7 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 
 from app.services.embeddings.multimodal.openai_compat_provider import (
@@ -28,6 +30,60 @@ def _response(payload, *, raises=None):
 
 
 class TestOpenAICompatMultimodalProvider:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("status", [401, 404, 503])
+    async def test_unavailable_schema_requires_explicit_format(self, status):
+        provider = OpenAICompatMultimodalProvider(
+            base_url="http://embedding.test/v1", api_key=None, model_name="m",
+        )
+        client = _client()
+        client.get.return_value = httpx.Response(
+            status, request=httpx.Request("GET", "http://embedding.test/openapi.json"),
+        )
+        with patch("httpx.AsyncClient", return_value=client):
+            results = await provider.embed_images(["aW1hZ2U="])
+        assert results[0].embedding is None
+        client.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("referenced", [False, True])
+    async def test_auto_detects_messages_without_model_name_guessing(self, referenced):
+        schema = {"properties": {"messages": {"type": "array"}}}
+        document = {
+            "paths": {"/v1/embeddings": {"post": {"requestBody": {
+                "content": {"application/json": {"schema": (
+                    {"anyOf": [{"$ref": "#/components/schemas/Chat"}]}
+                    if referenced else schema
+                )}}
+            }}}},
+            "components": {"schemas": {"Chat": schema}},
+        }
+        provider = OpenAICompatMultimodalProvider(
+            base_url="http://embedding.test/v1", api_key=None, model_name="unknown",
+        )
+        client = _client(_response({"data": [{"index": 0, "embedding": [0.1]}]}))
+        client.get.return_value = _response(document)
+        with patch("httpx.AsyncClient", return_value=client):
+            results = await provider.embed_images(["aW1hZ2U="])
+        assert results[0].embedding == [0.1]
+        assert client.get.await_args.args[0] == "http://embedding.test/openapi.json"
+        assert "messages" in client.post.await_args.kwargs["json"]
+        assert "input" not in client.post.await_args.kwargs["json"]
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("document", [{}, {"paths": {}}, None])
+    async def test_auto_unknown_does_not_embed_base64_as_text(self, document):
+        provider = OpenAICompatMultimodalProvider(
+            base_url="http://embedding.test/v1", api_key=None, model_name="unknown",
+        )
+        client = _client(_response({"data": [{"index": 0, "embedding": [0.1]}]}))
+        client.get.return_value = _response(document)
+        with patch("httpx.AsyncClient", return_value=client):
+            results = await provider.embed_images(["aW1hZ2U="])
+        assert results[0].embedding is None
+        assert "could not be verified" in results[0].error
+        client.post.assert_not_awaited()
+
     def test_requires_base_url(self) -> None:
         with pytest.raises(ValueError):
             OpenAICompatMultimodalProvider(
@@ -40,6 +96,15 @@ class TestOpenAICompatMultimodalProvider:
         )
         assert provider.provider_name == "lmStudio"
 
+    def test_rejects_unknown_request_format(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported multimodal request format"):
+            OpenAICompatMultimodalProvider(
+                base_url="http://e/v1",
+                api_key=None,
+                model_name="m",
+                request_format="unknown",
+            )
+
     @pytest.mark.asyncio
     async def test_success_uses_standard_input_format(self) -> None:
         """The standard OpenAI `input` schema is tried first (what routers such
@@ -48,6 +113,7 @@ class TestOpenAICompatMultimodalProvider:
             base_url="http://embedding.test/v1/",
             api_key="test-key",
             model_name="vertex/google/gemini-embedding-2-preview",
+            request_format="input",
         )
         client = _client(_response({"data": [{"index": 0, "embedding": [0.1, 0.2]}]}))
 
@@ -65,7 +131,7 @@ class TestOpenAICompatMultimodalProvider:
     @pytest.mark.asyncio
     async def test_existing_data_uri_is_passed_through_unchanged(self) -> None:
         provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1", api_key=None, model_name="m",
+            base_url="http://embedding.test/v1", api_key=None, model_name="m", request_format="input",
         )
         client = _client(_response({"data": [{"index": 0, "embedding": [0.5]}]}))
 
@@ -77,44 +143,78 @@ class TestOpenAICompatMultimodalProvider:
         ]
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_messages_when_input_format_rejected(self) -> None:
-        """A self-hosted vLLM multimodal embedding server rejects `input` and
-        only speaks the chat-`messages` extension."""
+    async def test_vllm_messages_skips_input_format(self) -> None:
         provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1/",
-            api_key="test-key",
-            model_name="Qwen/Qwen3-VL-Embedding-2B",
+            base_url="http://embedding.test/v1",
+            api_key=None,
+            model_name="tencent/WeMM-Embedding-4B",
+            request_format="vllm_messages",
         )
         client = _client(
-            _response({}, raises=RuntimeError("400 Bad Request")),
-            _response({"data": [{"index": 0, "embedding": [0.1, 0.2]}]}),
+            _response({"data": [{"index": 0, "embedding": [0.1]}]}),
+            _response({"data": [{"index": 0, "embedding": [0.2]}]}),
         )
+
+        with patch("httpx.AsyncClient", return_value=client):
+            results = await provider.embed_images(["aW1hZ2Uw", "aW1hZ2Ux"])
+
+        assert [(r.index, r.embedding) for r in results] == [(0, [0.1]), (1, [0.2])]
+        assert client.post.await_count == 2
+        for call in client.post.await_args_list:
+            assert "messages" in call.kwargs["json"]
+            assert "input" not in call.kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_vllm_messages_limits_each_request(self) -> None:
+        provider = OpenAICompatMultimodalProvider(
+            base_url="http://embedding.test/v1",
+            api_key=None,
+            model_name="m",
+            request_format="vllm_messages",
+        )
+        active = 0
+        peak = 0
+
+        async def post(*_args, **_kwargs):
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            await asyncio.sleep(0)
+            active -= 1
+            return _response({"data": [{"index": 0, "embedding": [0.1]}]})
+
+        client = _client()
+        client.post.side_effect = post
+
+        with (
+            patch("httpx.AsyncClient", return_value=client),
+            patch(
+                "app.services.embeddings.multimodal.openai_compat_provider."
+                "_CONCURRENCY_LIMIT",
+                2,
+            ),
+        ):
+            await provider.embed_images(["aW1hZ2U="] * 8)
+
+        assert peak == 2
+
+    @pytest.mark.asyncio
+    async def test_input_format_does_not_fall_back(self) -> None:
+        provider = OpenAICompatMultimodalProvider(
+            base_url="http://embedding.test/v1",
+            api_key=None,
+            model_name="m",
+            request_format="input",
+        )
+        client = _client(_response({}, raises=RuntimeError("400 Bad Request")))
 
         with patch("httpx.AsyncClient", return_value=client):
             results = await provider.embed_images(["aW1hZ2U="])
 
-        assert [r.embedding for r in results] == [[0.1, 0.2]]
-        assert client.post.await_count == 2
-        first, second = client.post.await_args_list
-        assert first.kwargs["json"]["input"] == ["data:image/jpeg;base64,aW1hZ2U="]
-        assert "messages" not in first.kwargs["json"]
-        content = second.kwargs["json"]["messages"][0]["content"]
-        assert content[0]["image_url"]["url"] == "data:image/jpeg;base64,aW1hZ2U="
-
-    @pytest.mark.asyncio
-    async def test_both_formats_failing_errors_every_index(self) -> None:
-        logger = MagicMock()
-        provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1", api_key=None, model_name="m", logger=logger,
-        )
-        client = _client(*[_response({}, raises=RuntimeError("boom"))] * 3)
-
-        with patch("httpx.AsyncClient", return_value=client):
-            results = await provider.embed_images(["aW1hZ2U=", "b3RoZXI="])
-
-        assert [r.index for r in results] == [0, 1]
-        assert all(r.embedding is None and r.error for r in results)
-        logger.warning.assert_called()
+        assert client.post.await_count == 1
+        assert "input" in client.post.await_args.kwargs["json"]
+        assert results[0].embedding is None
+        assert results[0].error
 
     @pytest.mark.asyncio
     async def test_out_of_order_response_maps_by_index(self) -> None:
@@ -122,7 +222,7 @@ class TestOpenAICompatMultimodalProvider:
         server answering out of order attached each embedding to the wrong
         image. The response's own `index` decides."""
         provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1", api_key=None, model_name="m",
+            base_url="http://embedding.test/v1", api_key=None, model_name="m", request_format="input",
         )
         client = _client(_response({"data": [
             {"index": 1, "embedding": [1.0]},
@@ -139,7 +239,7 @@ class TestOpenAICompatMultimodalProvider:
         """Two images in, one embedding back — the unanswered index still owes
         the caller a result rather than vanishing."""
         provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1", api_key=None, model_name="m",
+            base_url="http://embedding.test/v1", api_key=None, model_name="m", request_format="input",
         )
         client = _client(_response({"data": [{"index": 0, "embedding": [0.1]}]}))
 
@@ -153,7 +253,7 @@ class TestOpenAICompatMultimodalProvider:
     @pytest.mark.asyncio
     async def test_invalid_image_skips_the_request(self) -> None:
         provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1", api_key=None, model_name="m",
+            base_url="http://embedding.test/v1", api_key=None, model_name="m", request_format="input",
         )
         client = _client(_response({"data": []}))
 
@@ -166,7 +266,7 @@ class TestOpenAICompatMultimodalProvider:
     @pytest.mark.asyncio
     async def test_indices_are_offset_correctly_across_batches(self) -> None:
         provider = OpenAICompatMultimodalProvider(
-            base_url="http://embedding.test/v1", api_key=None, model_name="m",
+            base_url="http://embedding.test/v1", api_key=None, model_name="m", request_format="input",
         )
         images = [f"aW1hZ2U{i}" for i in range(20)]
 

--- a/backend/python/tests/unit/utils/test_aimodels.py
+++ b/backend/python/tests/unit/utils/test_aimodels.py
@@ -15,12 +15,33 @@ from app.utils.aimodels import (
     _is_openai_gpt5_model,
     _is_qwen_38_or_later,
     _reasoning_effort_kwargs,
+    embedding_config_hash,
     get_default_embedding_model,
     get_embedding_model,
     get_generator_model,
     is_multimodal_llm,
 )
 from app.utils.llm_api_mode_store import REASONING_MANDATORY_FALLBACK_EFFORT, LLMApiMode
+
+
+class TestEmbeddingConfigHash:
+    @pytest.mark.parametrize("request_format", ["input", "vllm_messages"])
+    def test_request_format_change_invalidates_cache(self, request_format):
+        config = [{"provider": "openAICompatible", "configuration": {
+            "model": "test-model", "multimodalRequestFormat": "auto",
+        }}]
+        original_hash = embedding_config_hash(config)
+        config[0]["configuration"]["multimodalRequestFormat"] = request_format
+
+        assert embedding_config_hash(config) != original_hash
+
+    @pytest.mark.parametrize("request_format", [None, "", "auto"])
+    def test_default_request_formats_have_same_hash(self, request_format):
+        config = [{"provider": "openAICompatible", "configuration": {"model": "test-model"}}]
+        original_hash = embedding_config_hash(config)
+        config[0]["configuration"]["multimodalRequestFormat"] = request_format
+
+        assert embedding_config_hash(config) == original_hash
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/app/(main)/workspace/ai-models/components/model-config-dialog.tsx
+++ b/frontend/app/(main)/workspace/ai-models/components/model-config-dialog.tsx
@@ -771,15 +771,21 @@ function ModelConfigFormBody({
           {boolValue(values.isMultimodal) && modelConfigFields
             .filter((field) => field.name === 'multimodalRequestFormat')
             .map((field) => (
-              <details key={field.name}>
-                <summary>{field.displayName}</summary>
-                <SchemaFormField
-                  field={toSchemaField(field)}
-                  value={values[field.name]}
-                  onChange={onFieldChange}
-                  disabled={saving}
-                />
-              </details>
+              <Box key={field.name} asChild>
+                <details>
+                  <Text asChild size="2" weight="medium" color="gray">
+                    <summary>{t('workspace.oauth2.manageApplication.advancedSectionTitle')}</summary>
+                  </Text>
+                  <Box pt="2">
+                    <SchemaFormField
+                      field={toSchemaField(field)}
+                      value={values[field.name]}
+                      onChange={onFieldChange}
+                      disabled={saving}
+                    />
+                  </Box>
+                </details>
+              </Box>
             ))}
         </Flex>
       </Box>

--- a/frontend/app/(main)/workspace/ai-models/components/model-config-dialog.tsx
+++ b/frontend/app/(main)/workspace/ai-models/components/model-config-dialog.tsx
@@ -758,7 +758,7 @@ function ModelConfigFormBody({
               </Box>
             </Flex>
           ) : null}
-          {modelConfigFields.map((field) => (
+          {modelConfigFields.filter((field) => field.name !== 'multimodalRequestFormat').map((field) => (
             <SchemaFormField
               key={field.name}
               field={toSchemaField(field, placeholderFor(field))}
@@ -768,6 +768,19 @@ function ModelConfigFormBody({
               startAdornment={fieldStartAdornment(field.name)}
             />
           ))}
+          {boolValue(values.isMultimodal) && modelConfigFields
+            .filter((field) => field.name === 'multimodalRequestFormat')
+            .map((field) => (
+              <details key={field.name}>
+                <summary>{field.displayName}</summary>
+                <SchemaFormField
+                  field={toSchemaField(field)}
+                  value={values[field.name]}
+                  onChange={onFieldChange}
+                  disabled={saving}
+                />
+              </details>
+            ))}
         </Flex>
       </Box>
 


### PR DESCRIPTION
## Description

OpenAI-compatible endpoints can accept an image data URI in `input` as text and return HTTP 200. PipesHub then accepts that vector without trying the endpoint's image request format.

This change recognizes the `messages` extension from the endpoint's OpenAPI schema in Auto mode and provides an advanced `input` / `vllm_messages` override. Unknown schemas return an explicit image-capability error. Health checks and indexing use the same setting, and each image request respects the concurrency limit.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

- Fixes #3214

## How Has This Been Tested?

Run from `backend/python` in the project's test environment:

```sh
pytest tests/unit/services/embeddings/multimodal tests/unit/api/routes/test_health_capabilities.py tests/unit/modules/transformers/test_vectorstore.py
```

Live tests used WeMM-Embedding-4B and Qwen3-VL-Embedding-8B on vLLM. Three synthetic images each ranked their matching text description highest. A fresh collection image was indexed, retrieved by visual description, and cited in chat. Temporary count-only HTTP tracing confirmed an image block reached the chat endpoint after record fetch; tracing was removed afterward.

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

- [x] **Search capabilities** are working correctly
- [x] **Knowledge search** is functioning properly
- [ ] **Connector indexing** is working as expected
- [x] **Citations** are displaying and linking correctly
- [ ] **Documentation** is updated at https://docs.pipeshub.com/introduction

These checks cover the tested collection-image workflow; external connector ingestion and browser citation rendering were not tested.

## What You Have Tested

- [ ] Feature works in development environment
- [ ] Feature works in staging environment
- [x] Error handling scenarios tested
- [x] Edge cases considered and tested
- [ ] Performance impact assessed
- [x] Security implications reviewed

### Test Results

- 268 embedding, health-check, and vector-store tests passed.
- 428 additional/overlapping tests passed across embedding, retrieval, image admission, forwarding, and transport.
- Final readability cleanup: all 20 OpenAI-compatible provider tests passed.
- Docker production build, frontend type checks, and focused Python lint passed before the final readability-only cleanup.
- Live Qwen image embeddings returned 4,096 dimensions; WeMM returned 2,560.
- Model configuration and database contents were not changed for the API tests; test conversations were created.

## Screenshots/Videos
(None.)

## Code Quality Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Documentation

- [ ] Documentation has been updated (if applicable)
- [ ] API documentation updated (if applicable)
- [ ] README updated (if applicable)
- [ ] Changelog updated (if applicable)

No routes or health-response schemas change. Migration instructions are below; user-facing documentation remains pending.

## Security Considerations

- [x] No sensitive data is exposed
- [x] Input validation is implemented where necessary
- [x] Authentication/authorization is properly handled
- [ ] No security vulnerabilities introduced

Schema discovery uses the configured endpoint and does not follow redirects. No credentials, private images, or deployment addresses are included in this PR.

## Breaking Changes

- [x] This PR introduces breaking changes
- [x] Migration guide provided (if applicable)
- [ ] Version bump required

Auto no longer tries data-URI `input` followed by an error-based fallback. Existing endpoints without a recognizable OpenAPI schema must select their documented image format explicitly. For endpoints that genuinely support image data URIs, select `input`; for vLLM, select `vllm_messages` if discovery is unavailable. Text-only embedding calls are unchanged.

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

Auto adds one schema GET per `embed_images` invocation, with a 10-second timeout. Explicit overrides skip discovery. The messages path sends one image per request for compatibility with older servers, with bounded concurrency. No load benchmark was performed.

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

## Deployment Notes

Rebuild/redeploy the application. Keep Auto for discoverable endpoints or select an explicit format as described above. Reindex affected documents to replace incorrectly generated vectors; changing configuration does not repair existing vectors.

## Checklist Before Merge

- [ ] All tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed
- [ ] Screenshots/videos attached for UI changes
- [ ] Core functionality verified
- [ ] Security review completed (if applicable)
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

Live compatibility was tested with vLLM, not every OpenAI-compatible provider. Chat sometimes selects download-link tools instead of fetching image content; that separate tool-selection issue is outside this PR.

---

**For Reviewers:**

Please ensure all checklist items are completed before approving this PR. Pay special attention to:
- Core functionality testing
- Security implications
- Performance impact
- Documentation completeness


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a multimodal request format setting for compatible embedding providers: automatic detection, input-based requests, or vLLM messages.
  - Automatic mode detects the supported format from the provider’s API schema.
  - The setting appears in an expandable section when multimodal support is enabled.
  - Embedding requests now respect configurable token limits and safely split oversized content.

- **Bug Fixes**
  - Improved error reporting for unsupported formats and failed requests.
  - Empty image batches are handled efficiently.
  - Empty or unset values default to automatic detection.
  - Changing the format correctly refreshes cached embedding results.
  - Health endpoints reject service-token requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->