### PR TITLE
fix(indexing): stop documents being silently dropped when indexing fails to start

### DIFF
--- a/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
+++ b/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
@@ -1770,29 +1770,39 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
             return
 
         self._mark_in_flight(message_id)
-        if parsed_message is None:
-            # The broker-order path spawns from raw fields; the tier has to
-            # be known before the token exists. The wrapper reuses this parse.
-            parsed_message = await self._parse_message(message_id, fields)
-        waiter_token = concurrency.GateWaiterToken(
-            self, concurrency.dispatch_tier(self, parsed_message)
-        )
-        processing_coro = self._process_message_wrapper(
-            stream_name,
-            message_id,
-            dict(fields),
-            waiter_token,
-            parsed_message,
-        )
+        # Everything from the mark to the hand-off is guarded, not just the
+        # scheduling call. A message id left in the in-flight set is never
+        # retried and never dead-lettered: `_is_in_flight` makes the read and
+        # dispatch phases skip it forever, and `_is_entry_active` counts it as
+        # live so the stranded-entry sweep leaves it alone. The record it
+        # carries would then never be indexed, with nothing logged to say so.
+        waiter_token: "concurrency.GateWaiterToken | None" = None
+        processing_coro = None
         try:
+            if parsed_message is None:
+                # The broker-order path spawns from raw fields; the tier has to
+                # be known before the token exists. The wrapper reuses this parse.
+                parsed_message = await self._parse_message(message_id, fields)
+            waiter_token = concurrency.GateWaiterToken(
+                self, concurrency.dispatch_tier(self, parsed_message)
+            )
+            processing_coro = self._process_message_wrapper(
+                stream_name,
+                message_id,
+                dict(fields),
+                waiter_token,
+                parsed_message,
+            )
             future = asyncio.run_coroutine_threadsafe(
                 processing_coro,
                 self.worker_loop,
             )
         except BaseException:
-            processing_coro.close()
+            if processing_coro is not None:
+                processing_coro.close()
             self._unmark_in_flight(message_id)
-            waiter_token.release()
+            if waiter_token is not None:
+                waiter_token.release()
             raise
         with self._futures_lock:
             self._active_futures.add(future)

--- a/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
+++ b/backend/python/app/services/messaging/redis_streams/indexing_consumer.py
@@ -1771,11 +1771,11 @@ class IndexingRedisStreamsConsumer(IMessagingConsumer):
 
         self._mark_in_flight(message_id)
         # Everything from the mark to the hand-off is guarded, not just the
-        # scheduling call. A message id left in the in-flight set is never
-        # retried and never dead-lettered: `_is_in_flight` makes the read and
-        # dispatch phases skip it forever, and `_is_entry_active` counts it as
-        # live so the stranded-entry sweep leaves it alone. The record it
-        # carries would then never be indexed, with nothing logged to say so.
+        # scheduling call. `__already_held` reads an id in the in-flight set as
+        # this consumer's live work, so a stranded id makes the read and
+        # dispatch phases skip that entry forever and keeps the recovery scan
+        # from ever reclaiming or dead-lettering it. The record it carries
+        # would then never be indexed, with nothing logged to say so.
         waiter_token: "concurrency.GateWaiterToken | None" = None
         processing_coro = None
         try:

--- a/backend/python/tests/unit/services/messaging/test_inflight_release_on_dispatch_failure.py
+++ b/backend/python/tests/unit/services/messaging/test_inflight_release_on_dispatch_failure.py
@@ -93,6 +93,12 @@ async def test_scheduling_failure_releases_the_message(monkeypatch) -> None:
         await consumer._start_processing_task("record-events.0", MESSAGE_ID, {})
 
     assert not consumer._is_in_flight(MESSAGE_ID)
+    # The token exists by this point, so it is the other resource the handler
+    # has to get right. A leaked waiter keeps counting against its tier's
+    # dispatch budget for the life of the process, shrinking read-ahead.
+    assert consumer.gate_waiters.count() == 0, (
+        "the gate-waiter token survived a scheduling failure"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/python/tests/unit/services/messaging/test_inflight_release_on_dispatch_failure.py
+++ b/backend/python/tests/unit/services/messaging/test_inflight_release_on_dispatch_failure.py
@@ -1,0 +1,116 @@
+"""A message must not stay marked in flight when dispatch fails.
+
+`_start_processing_task` marks a message in flight and then does several things
+that can raise before the work is handed to the worker loop: parsing the entry,
+deriving its tier, building the gate-waiter token, and creating the wrapper
+coroutine.
+
+A message id left behind in `_in_flight_message_ids` is not merely wasted
+memory. Nothing ever clears it, and while it is there:
+
+  * the read and dispatch phases skip that entry (`_is_in_flight`), so it is
+    never retried, and
+  * `__already_held` reports it as held, so the stranded-entry sweep will not
+    dead-letter it either.
+
+The record it carries is then never indexed and nothing is logged to say so.
+These tests pin the release on each failure point.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.services.messaging import consumer_concurrency as concurrency
+from app.services.messaging.config import RedisStreamsConfig
+from app.services.messaging.redis_streams.indexing_consumer import (
+    IndexingRedisStreamsConsumer,
+)
+
+MESSAGE_ID = "1700000000000-0"
+
+
+def _consumer() -> IndexingRedisStreamsConsumer:
+    consumer = IndexingRedisStreamsConsumer(
+        logging.getLogger("inflight-test"),
+        RedisStreamsConfig(
+            host="h", port=6379, group_id="g", topics=["record-events"], batch_size=10
+        ),
+    )
+    consumer.redis = AsyncMock()
+    consumer.running = True
+    # Truthy so the early return does not fire; nothing here reaches it.
+    consumer.worker_loop = MagicMock()
+    return consumer
+
+
+@pytest.mark.asyncio
+async def test_parse_failure_releases_the_message() -> None:
+    """_parse_message raising must not stand the entry up permanently."""
+    consumer = _consumer()
+    consumer._parse_message = AsyncMock(side_effect=RuntimeError("unparseable"))
+
+    with pytest.raises(RuntimeError, match="unparseable"):
+        await consumer._start_processing_task("record-events.0", MESSAGE_ID, {})
+
+    assert not consumer._is_in_flight(MESSAGE_ID), (
+        "message stayed in flight after a parse failure; it would be skipped by "
+        "every later read and never dead-lettered"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tier_failure_releases_the_message(monkeypatch) -> None:
+    """Deriving the tier sits between the mark and the hand-off too."""
+    consumer = _consumer()
+    consumer._parse_message = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        concurrency,
+        "dispatch_tier",
+        MagicMock(side_effect=RuntimeError("no tier")),
+    )
+
+    with pytest.raises(RuntimeError, match="no tier"):
+        await consumer._start_processing_task("record-events.0", MESSAGE_ID, {})
+
+    assert not consumer._is_in_flight(MESSAGE_ID)
+
+
+@pytest.mark.asyncio
+async def test_scheduling_failure_releases_the_message(monkeypatch) -> None:
+    """The original guarded case still holds: scheduling onto the loop fails."""
+    consumer = _consumer()
+    consumer._parse_message = AsyncMock(return_value=MagicMock())
+    monkeypatch.setattr(
+        "asyncio.run_coroutine_threadsafe",
+        MagicMock(side_effect=RuntimeError("loop closed")),
+    )
+
+    with pytest.raises(RuntimeError, match="loop closed"):
+        await consumer._start_processing_task("record-events.0", MESSAGE_ID, {})
+
+    assert not consumer._is_in_flight(MESSAGE_ID)
+
+
+@pytest.mark.asyncio
+async def test_a_released_message_is_eligible_again() -> None:
+    """Releasing is only worth anything if the entry can be picked up again.
+
+    `__already_held` is what the read phase and the stranded-entry sweep
+    consult; an id still marked in flight reads as held, so it is skipped on
+    every later pass and never dead-lettered.
+    """
+    consumer = _consumer()
+    consumer._parse_message = AsyncMock(side_effect=RuntimeError("unparseable"))
+
+    with pytest.raises(RuntimeError):
+        await consumer._start_processing_task("record-events.0", MESSAGE_ID, {})
+
+    already_held = consumer._IndexingRedisStreamsConsumer__already_held
+    assert not already_held(MESSAGE_ID), (
+        "a failed dispatch left the entry reading as held, so later passes would "
+        "skip it and the stranded sweep would never reclaim it"
+    )


### PR DESCRIPTION
## In one line

When a document fails to get handed to an indexing worker, it is quietly lost — never indexed, never retried, and never reported. This fixes that.

## Background: how a document gets picked up

Documents queue up waiting to be indexed. A worker takes one off the queue and immediately marks it **"in flight"**, meaning "I am working on this now." The mark exists so that nothing else picks up the same document and does the work twice.

Between taking a document and actually starting on it, four small things have to happen:

1. read the queue entry and work out which document it points to,
2. decide whether it is a light or a heavy document (the two use separate pools),
3. reserve a slot in the right pool,
4. hand it to a worker to do the real work.

## The problem

Only step 4 was wrapped in the code that clears the "in flight" mark when something goes wrong. If step 1, 2 or 3 failed, the document stayed marked as in flight — permanently.

That is worse than it sounds, because the same mark means two different things to two different parts of the system:

- **Nothing picks it up again.** Every later pass over the queue reads the mark as "someone is already working on this" and skips it.
- **Nothing reports it either.** There is a safety net that looks for documents that got stuck and sets them aside for inspection. It reads the very same mark, concludes the document is being actively worked on, and leaves it alone.

The document lands in a gap where no part of the system is responsible for it any more. It never shows up in search, and no error is logged to explain why. From the outside it just looks as though the document was never there.

## What changed

`backend/python/app/services/messaging/redis_streams/indexing_consumer.py`

The failure handling now covers all four steps instead of only the last one. Two variables start out empty so the handler can tell how far things got and undo only what was actually done:

```python
self._mark_in_flight(message_id)
waiter_token = None
processing_coro = None
try:
    ...steps 1 to 4...
except BaseException:
    if processing_coro is not None:
        processing_coro.close()
    self._unmark_in_flight(message_id)
    if waiter_token is not None:
        waiter_token.release()   # hand the reserved pool slot back
    raise
```

Clearing the mark lets the queue offer the document again on the next pass, which is what was meant to happen all along.

## Why it is worth fixing

It is rare, but it is silent, and that is the bad combination. Nothing alerts, no failure count goes up, nothing appears in the logs. Someone has to notice a document missing from search and go looking for it. The memory wasted is around a hundred bytes; the real cost is the document.

## How to test it

```bash
cd backend/python
pytest tests/unit/services/messaging/test_inflight_release_on_dispatch_failure.py
```

Four tests, no database or queue needed. Each forces a failure at one of the steps above and checks the document is released rather than stranded.

To confirm they catch the original bug, put the old version of `_start_processing_task` back. Three of the four fail:

```
FAILED test_parse_failure_releases_the_message
FAILED test_tier_failure_releases_the_message
FAILED test_a_released_message_is_eligible_again
```

The fourth covers step 4, which was already handled correctly. It passes either way and is there so that a future change cannot quietly lose that behaviour. It also checks the reserved pool slot is handed back, which is the second thing the handler has to get right once a slot exists.

## What is not affected

There are two queue systems, Redis and Kafka. Only Redis has this shape. Kafka reserves its slot and enters its failure handling immediately afterwards, with nothing in between that can pause — so there is no gap for a document to fall into.

## Checks

`pytest tests/unit/services/messaging/` — **1685 passed, 32 skipped.** Lint on the changed file is unchanged from `main`: 12 findings before, 12 after, none of them new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message processing error handling to prevent messages from remaining stuck in an in-flight state after dispatch failures.
  * Released processing capacity correctly when message handoff fails, allowing eligible messages to be retried or dead-lettered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->