### PR TITLE
Fix/issue 3225 public client revoke

### DIFF
--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
@@ -399,13 +399,8 @@ export class OAuthProviderController {
       )
     }
 
-    // Confidential clients must provide client_secret
-    if (app.isConfidential) {
-      if (!clientSecret) {
-        throw new InvalidClientError('client_secret required for confidential clients')
-      }
-      await this.oauthAppService.verifyClientCredentials(clientId, clientSecret)
-    }
+    // Verify client credentials (public clients will skip secret check)
+    await this.oauthAppService.verifyClientCredentials(clientId, clientSecret)
 
     // Exchange code for tokens
     const codeResult = await this.authorizationCodeService.exchangeCode(
@@ -571,13 +566,8 @@ export class OAuthProviderController {
       )
     }
 
-    // RFC 6749 Section 6: Confidential clients MUST authenticate
-    if (app.isConfidential) {
-      if (!clientSecret) {
-        throw new InvalidClientError('client_secret required for confidential clients')
-      }
-      await this.oauthAppService.verifyClientCredentials(clientId, clientSecret)
-    }
+    // Verify client credentials (public clients will skip secret check)
+    await this.oauthAppService.verifyClientCredentials(clientId, clientSecret)
 
     // RFC 9700: For public clients, refresh tokens MUST be sender-constrained
     // or use rotation. We implement rotation in oauthTokenService.refreshTokens()

--- a/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/controller/oauth.provider.controller.ts
@@ -474,6 +474,10 @@ export class OAuthProviderController {
       clientSecret,
     )
 
+    if (!app.isConfidential) {
+      throw new InvalidClientError('client_credentials grant requires a confidential client')
+    }
+
     // Verify grant type is allowed
     if (!this.oauthAppService.isGrantTypeAllowed(app, 'client_credentials')) {
       throw new UnsupportedGrantTypeError(

--- a/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.app.service.ts
+++ b/backend/nodejs/apps/src/modules/oauth_provider/services/oauth.app.service.ts
@@ -415,9 +415,17 @@ export class OAuthAppService {
    */
   async verifyClientCredentials(
     clientId: string,
-    clientSecret: string,
+    clientSecret?: string,
   ): Promise<IOAuthApp> {
     const app = await this.getAppByClientId(clientId)
+
+    if (!app.isConfidential) {
+      return app
+    }
+
+    if (!clientSecret) {
+      throw new InvalidClientError('client_secret required for confidential clients')
+    }
 
     const storedSecret = this.encryptionService.decrypt(
       app.clientSecretEncrypted,

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
@@ -254,6 +254,19 @@ describe('OAuthProviderController', () => {
       expect(mockRes.status.calledWith(200)).to.be.true
     })
 
+    it('should revoke successfully for a public client without a client_secret', async () => {
+      mockOAuthAppService.verifyClientCredentials.resolves({ isConfidential: false })
+      mockOAuthTokenService.revokeToken.resolves(true)
+      const req = {
+        body: { token: 'tok', client_id: 'public_cid' },
+      } as any
+
+      await controller.revoke(req, mockRes, mockNext)
+      expect(mockOAuthAppService.verifyClientCredentials.calledWith('public_cid', undefined)).to.be.true
+      expect(mockOAuthTokenService.revokeToken.called).to.be.true
+      expect(mockRes.status.calledWith(200)).to.be.true
+    })
+
     it('should return 401 for invalid client credentials', async () => {
       mockOAuthAppService.verifyClientCredentials.rejects(new InvalidClientError('bad'))
       const req = {

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
@@ -1,6 +1,7 @@
 import 'reflect-metadata'
 import { expect } from 'chai'
 import sinon from 'sinon'
+import { Request } from 'express'
 import { OAuthProviderController } from '../../../../src/modules/oauth_provider/controller/oauth.provider.controller'
 import {
   InvalidClientError,
@@ -259,7 +260,7 @@ describe('OAuthProviderController', () => {
       mockOAuthTokenService.revokeToken.resolves(true)
       const req = {
         body: { token: 'tok', client_id: 'public_cid' },
-      } as any
+      } as unknown as Request
 
       await controller.revoke(req, mockRes, mockNext)
       expect(mockOAuthAppService.verifyClientCredentials.calledWith('public_cid', undefined)).to.be.true

--- a/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/controller/oauth.provider.controller.test.ts
@@ -527,6 +527,7 @@ describe('OAuthProviderController', () => {
       }
       mockOAuthAppService.getAppByClientId.resolves(mockApp)
       mockOAuthAppService.isGrantTypeAllowed.returns(true)
+      mockOAuthAppService.verifyClientCredentials.rejects(new InvalidClientError('client_secret required for confidential clients'))
 
       const req = {
         body: {
@@ -617,6 +618,7 @@ describe('OAuthProviderController', () => {
 
       mockOAuthAppService.getAppByClientId.resolves({ isConfidential: true })
       mockOAuthAppService.isGrantTypeAllowed.returns(true)
+      mockOAuthAppService.verifyClientCredentials.rejects(new InvalidClientError('client_secret required for confidential clients'))
 
       await controller.token(req, mockRes, mockNext)
       expect(mockRes.status.calledWith(401)).to.be.true

--- a/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.app.service.test.ts
+++ b/backend/nodejs/apps/tests/modules/oauth_provider/services/oauth.app.service.test.ts
@@ -757,6 +757,7 @@ describe('OAuthAppService', () => {
         clientId: 'cid',
         clientSecretEncrypted: 'encrypted',
         status: OAuthAppStatus.ACTIVE,
+        isConfidential: true,
       }
       sinon.stub(OAuthApp, 'findOne').resolves(mockApp as any)
       mockEncryptionService.decrypt.returns(secret)
@@ -771,6 +772,7 @@ describe('OAuthAppService', () => {
         clientId: 'cid',
         clientSecretEncrypted: 'encrypted',
         status: OAuthAppStatus.ACTIVE,
+        isConfidential: true,
       }
       sinon.stub(OAuthApp, 'findOne').resolves(mockApp as any)
       mockEncryptionService.decrypt.returns('stored-secret')


### PR DESCRIPTION
## Description

This PR fixes a bug where public clients (like the first-party device flow) were unable to revoke their own OAuth tokens because the `/api/v1/oauth2/revoke` endpoint unconditionally required and checked a `client_secret`. 

By definition, public clients do not authenticate with a secret. This PR updates `verifyClientCredentials` to elegantly handle public clients by skipping the secret check, which automatically fixes the `/revoke` and `/introspect` endpoints while keeping the logic strictly RFC 7009 compliant.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Is there an addition/change in API Request, Response? If yes, documentation is required)
- [ ] Performance improvement
- [x] Code refactoring
- [x] Security fix

## Related Issues

- Fixes #3225

## How Has This Been Tested?

- Updated the existing mock configurations in `oauth.provider.controller.test.ts` to assert that `verifyClientCredentials` strictly enforces rejection for confidential clients when a secret is missing.
- Updated `mockApp` objects in `oauth.app.service.test.ts` to explicitly have `isConfidential: true` when testing cryptography/secret matching logic.
- Ran the full `npm run test` suite in `backend/nodejs/apps` which completed successfully with 100% passing tests.

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed
- [ ] Cross-browser testing (if applicable)
- [ ] Mobile responsiveness tested (if applicable)

## Core Functionality Testing

- [x] OAuth Public clients can successfully hit the `/revoke` endpoint without providing a `client_secret`.
- [x] OAuth Confidential clients are still strictly required to provide a `client_secret`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Public OAuth clients can use authorization code, refresh token, and token revocation flows without providing a client secret.
  * Confidential clients must still provide valid client credentials; missing or invalid secrets return an authorization error.
  * Public clients cannot use the client credentials grant; requests are rejected with an authorization error.
* **Tests**
  * Expanded coverage for public and confidential client credential handling, including missing-secret scenarios and grant restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->