### PR TITLE
fix(indexing,query): permission scoping, unbounded search limit, vision-call timeout, and two data-integrity fixes

### DIFF
--- a/backend/python/app/api/routes/agent.py
+++ b/backend/python/app/api/routes/agent.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from app.agents.agent_loop.protocol import resolve_protocol
 from app.agents.agent_loop.stream_bridge import run_agent_loop_stream
@@ -39,6 +39,7 @@ from app.modules.agents.qna.router import (
 from app.modules.agents.qna.router import (
     build_prior_routing_messages as _build_prior_routing_messages,  # noqa: F401
 )
+from app.modules.retrieval.retrieval_service import MAX_SEARCH_LIMIT
 from app.modules.transformers.blob_storage import (
     BlobStorage,  # noqa: F401 - re-exported, see above
 )
@@ -105,7 +106,7 @@ def _parse_agent_capabilities(raw: dict[str, Any] | None) -> AgentCapabilities:
 
 class ChatQuery(BaseModel):
     query: str
-    limit: int | None = 50
+    limit: int | None = Field(default=50, ge=1, le=MAX_SEARCH_LIMIT)
     previousConversations: list[dict] = []
     quickMode: bool = False
     filters: dict[str, Any] | None = None

--- a/backend/python/app/api/routes/chatbot.py
+++ b/backend/python/app/api/routes/chatbot.py
@@ -14,7 +14,7 @@ from io import BytesIO
 
 import pdfplumber
 from langchain_core.language_models.chat_models import BaseChatModel
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 from app.config.constants.ai_models import validate_reasoning_effort
 from app.modules.parsers.pdf.pdf_rasterizer import render_all_pages_as_pil_from_bytes_sync
@@ -30,7 +30,10 @@ from app.containers.query import QueryAppContainer
 from app.events.processor import convert_record_dict_to_record
 from app.models.blocks import Block, BlockType, BlocksContainer, CitationMetadata, DataFormat
 from app.modules.parsers.pdf.ocr_handler import OCRStrategy
-from app.modules.retrieval.retrieval_service import RetrievalService
+from app.modules.retrieval.retrieval_service import (
+    MAX_SEARCH_LIMIT,
+    RetrievalService,
+)
 from app.telemetry.event_buffer import record_event
 from app.telemetry.identity import domain_from_email
 from app.modules.transformers.blob_storage import BlobStorage
@@ -58,7 +61,7 @@ router = APIRouter()
 # Pydantic models
 class ChatQuery(BaseModel):
     query: str
-    limit: int | None = 50
+    limit: int | None = Field(default=50, ge=1, le=MAX_SEARCH_LIMIT)
     previousConversations: list[dict] = []
     filters: dict[str, Any] | None = None
     retrievalMode: str | None = "HYBRID"

--- a/backend/python/app/api/routes/search.py
+++ b/backend/python/app/api/routes/search.py
@@ -4,13 +4,16 @@ from typing import TYPE_CHECKING, Any, Optional
 from dependency_injector.wiring import inject
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.api.middlewares.auth import require_scopes
 from app.config.configuration_service import ConfigurationService
 from app.config.constants.service import OAuthScopes
 from app.edition_config import resolve_llm_for_search
-from app.modules.retrieval.retrieval_service import RetrievalService
+from app.modules.retrieval.retrieval_service import (
+    MAX_SEARCH_LIMIT,
+    RetrievalService,
+)
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
 from app.telemetry.event_buffer import record_event
 from app.telemetry.identity import domain_from_email
@@ -25,19 +28,19 @@ router = APIRouter()
 # Pydantic models
 class SearchQuery(BaseModel):
     query: str
-    limit: Optional[int] = 5
+    limit: Optional[int] = Field(default=5, ge=1, le=MAX_SEARCH_LIMIT)
     filters: Optional[dict[str, Any]] = {}
 
 
 class SimilarDocumentQuery(BaseModel):
     document_id: str
-    limit: Optional[int] = 5
+    limit: Optional[int] = Field(default=5, ge=1, le=MAX_SEARCH_LIMIT)
     filters: Optional[dict[str, Any]] = None
 
 
 class SearchRequest(BaseModel):
     query: str
-    topK: int = 20
+    topK: int = Field(default=20, ge=1, le=MAX_SEARCH_LIMIT)
     filtersV1: list[dict[str, list[str]]]
 
 

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import time
 import traceback
+from collections import OrderedDict
 from typing import Any
 
 from langchain_core.documents import Document
@@ -52,14 +53,26 @@ from app.utils.chat_helpers import (
 )
 from app.utils.image_utils import get_extension_from_mimetype
 
-# OPTIMIZATION: User data cache with TTL
-_user_cache: dict[str, tuple] = {}  # {user_id: (user_data, timestamp)}
+# OPTIMIZATION: User data cache with TTL.
+# Insertion-ordered so eviction is O(1) from the front: a plain dict forced a
+# full scan for the oldest timestamp on every insert past the cap, which is the
+# hot path once a busy org exceeds MAX_USER_CACHE_SIZE.
+_user_cache: "OrderedDict[str, tuple]" = OrderedDict()  # {user_id: (user_data, timestamp)}
 USER_CACHE_TTL = 300  # 5 minutes
 MAX_USER_CACHE_SIZE = 1000  # Max number of users to keep in cache
 
 # Applied when a caller passes no limit at all. Matches `search_with_filters`'s
 # own default so the None path and the omitted path retrieve the same amount.
 DEFAULT_SEARCH_LIMIT = 20
+
+# Upper bound on how many chunks one search may pull back. The published
+# contract already promises it -- `SemanticSearchRequest.limit` in
+# `pipeshub-openapi.yaml` declares `maximum: 100` -- but nothing enforced it:
+# the limit reaches the provider multiplied (`req.limit * 2` in
+# qdrant/utils.py) and every hit costs a graph lookup, a blob read and LLM
+# context. Enforced here as well as at the HTTP edge because agents and
+# in-product tools call `search_with_filters` directly.
+MAX_SEARCH_LIMIT = 100
 
 _RETRIEVAL_EMBED_MAX_RETRIES = 3
 
@@ -376,6 +389,14 @@ class RetrievalService:
             # retrieved context and no visible error.
             if limit is None:
                 limit = DEFAULT_SEARCH_LIMIT
+            elif limit < 1:
+                limit = DEFAULT_SEARCH_LIMIT
+            elif limit > MAX_SEARCH_LIMIT:
+                self.logger.warning(
+                    "Requested search limit %d exceeds the maximum of %d; clamping",
+                    limit, MAX_SEARCH_LIMIT,
+                )
+                limit = MAX_SEARCH_LIMIT
 
             filter_groups = filter_groups or {}
 
@@ -408,14 +429,32 @@ class RetrievalService:
             # Graph key for KH permission_role checks (Location trails).
             user_key = (user.get("_key") or user.get("id")) if user else None
 
+            # A tool-supplied id list narrows the search; it must never widen
+            # it. Intersecting here keeps the vector query itself inside the
+            # permission set, so an id the caller resolved from somewhere the
+            # graph does not grant cannot reach the embedding store at all.
+            # The enrichment loop below already drops such hits, but only
+            # after their chunk text has been read out of the index.
             if virtual_record_ids_from_tool:
-                filter  = await self.vector_db_service.filter_collection(
-                        must={"orgId": org_id,"virtualRecordId": virtual_record_ids_from_tool},
+                scoped_virtual_record_ids = [
+                    vid for vid in virtual_record_ids_from_tool
+                    if vid in accessible_virtual_id_to_record_id
+                ]
+                if not scoped_virtual_record_ids:
+                    self.logger.warning(
+                        "None of the %d tool-supplied virtualRecordIds are accessible to user %s",
+                        len(virtual_record_ids_from_tool), user_id,
+                    )
+                    return self._create_empty_response(
+                        ACCESSIBLE_RECORDS_NOT_FOUND_MESSAGE,
+                        Status.ACCESSIBLE_RECORDS_NOT_FOUND,
                     )
             else:
-                filter = await self.vector_db_service.filter_collection(
-                        must={"orgId": org_id, "virtualRecordId": list(accessible_virtual_id_to_record_id.keys())}
-                    )
+                scoped_virtual_record_ids = list(accessible_virtual_id_to_record_id.keys())
+
+            filter = await self.vector_db_service.filter_collection(
+                must={"orgId": org_id, "virtualRecordId": scoped_virtual_record_ids}
+            )
             search_results = await self._execute_parallel_searches(
                 queries, filter, limit, org_id, user_id
             )
@@ -802,6 +841,7 @@ class RetrievalService:
             user_data, timestamp = _user_cache[user_id]
             if time.time() - timestamp < USER_CACHE_TTL:
                 self.logger.debug(f"User cache hit for user_id: {user_id}")
+                _user_cache.move_to_end(user_id)
                 return user_data
             else:
                 # Cache expired, remove it
@@ -811,14 +851,20 @@ class RetrievalService:
         self.logger.debug(f"User cache miss for user_id: {user_id}")
         user_data = await self.graph_provider.get_user_by_user_id(user_id)
 
-        # Store in cache
+        # A miss is not a fact worth remembering: the lookup misses while a
+        # user is still being provisioned, and caching that would keep them
+        # unresolvable -- no email substitution in Gmail webUrls, no user_key
+        # for the Location permission trails -- for the whole TTL after they
+        # exist. Failures re-query; hits are what the cache is for.
+        if user_data is None:
+            return None
+
         _user_cache[user_id] = (user_data, time.time())
 
         # Simple cache size management - keep only last MAX_USER_CACHE_SIZE users
         if len(_user_cache) > MAX_USER_CACHE_SIZE:
-            # Remove oldest entry
-            oldest_key = min(_user_cache.keys(), key=lambda k: _user_cache[k][1])
-            del _user_cache[oldest_key]
+            # Evict least-recently-used, which is the front of the ordering.
+            _user_cache.popitem(last=False)
 
         return user_data
 

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -435,14 +435,17 @@ class RetrievalService:
             # graph does not grant cannot reach the embedding store at all.
             # The enrichment loop below already drops such hits, but only
             # after their chunk text has been read out of the index.
-            if virtual_record_ids_from_tool:
+            # `is not None`, not truthiness: a tool that resolved zero records
+            # asked to search nothing, and falling through to the else branch
+            # would answer it with the user's entire corpus.
+            if virtual_record_ids_from_tool is not None:
                 scoped_virtual_record_ids = [
                     vid for vid in virtual_record_ids_from_tool
                     if vid in accessible_virtual_id_to_record_id
                 ]
                 if not scoped_virtual_record_ids:
                     self.logger.warning(
-                        "None of the %d tool-supplied virtualRecordIds are accessible to user %s",
+                        "Tool supplied %d virtualRecordId(s), none accessible to user %s",
                         len(virtual_record_ids_from_tool), user_id,
                     )
                     return self._create_empty_response(

--- a/backend/python/app/modules/transformers/image_description.py
+++ b/backend/python/app/modules/transformers/image_description.py
@@ -53,6 +53,15 @@ MAX_IMAGES_ENV_VAR = "PIPESHUB_MAX_DESCRIBED_IMAGES_PER_RECORD"
 # Matches the concurrency the embedding path already uses for vision calls.
 _CONCURRENCY = 10
 
+# A vision call that never returns would otherwise hold the record's index
+# permit until RECORD_PROCESSING_TIMEOUT (1800s). With INDEX_HEAVY warm-starting
+# at 3-4 on a small host, a handful of such records stalls heavy indexing
+# outright, so each call is bounded the way the embedding batches already are
+# (`vectorstore._embed_documents_with_retry`). A timed-out image is skipped,
+# not fatal -- same disposition as any other failed description.
+DEFAULT_DESCRIPTION_TIMEOUT_S = 120
+DESCRIPTION_TIMEOUT_ENV_VAR = "PIPESHUB_IMAGE_DESCRIPTION_TIMEOUT_S"
+
 # The prompt asks for a full transcription of any text in the image, so a
 # dense figure legitimately produces a lot; this only guards against a model
 # that runs away, and is well above what a real figure yields.
@@ -207,10 +216,20 @@ class ImageDescriber:
     ) -> int:
         semaphore = asyncio.Semaphore(_CONCURRENCY)
 
+        timeout_s = self._description_timeout()
+
         async def describe(block: "Block", uri: str) -> bool:
             async with semaphore:
                 try:
-                    description = await self._describe_one(uri, vlm)
+                    description = await asyncio.wait_for(
+                        self._describe_one(uri, vlm), timeout=timeout_s,
+                    )
+                except TimeoutError:
+                    self.logger.warning(
+                        "Vision call for image block %s exceeded %ss; skipping its description",
+                        block.index, timeout_s,
+                    )
+                    return False
                 except Exception as exc:
                     # One unreadable image must not cost the record its other
                     # descriptions, so this is logged and skipped, not raised.
@@ -225,6 +244,12 @@ class ImageDescriber:
             *(describe(block, uri) for block, uri in pending), return_exceptions=False,
         )
         return sum(1 for ok in results if ok)
+
+    @staticmethod
+    def _description_timeout() -> int:
+        return env_int(
+            DESCRIPTION_TIMEOUT_ENV_VAR, DEFAULT_DESCRIPTION_TIMEOUT_S, lo=1, hi=1_800,
+        ) or DEFAULT_DESCRIPTION_TIMEOUT_S
 
     async def _describe_one(self, uri: str, vlm: "BaseChatModel") -> str:
         from langchain_core.messages import HumanMessage
@@ -266,7 +291,9 @@ class ImageDescriber:
 
 
 __all__ = [
+    "DEFAULT_DESCRIPTION_TIMEOUT_S",
     "DEFAULT_MAX_IMAGES_PER_RECORD",
+    "DESCRIPTION_TIMEOUT_ENV_VAR",
     "MAX_IMAGES_ENV_VAR",
     "ImageDescriber",
     "harvest_descriptions",

--- a/backend/python/app/modules/transformers/sink_orchestrator.py
+++ b/backend/python/app/modules/transformers/sink_orchestrator.py
@@ -53,8 +53,18 @@ class SinkOrchestrator(Transformer):
         row_blocks = [b for b in original_blocks if b.type == BlockType.TABLE_ROW]
 
         if len(row_blocks) <= limit:
-            return block_containers 
-        limited_blocks =  row_blocks[:limit]
+            return block_containers
+
+        # Cap the rows, keep everything else. `is_sql` in `index()` is true when
+        # *any* block group is a SQL table or view, so filtering down to
+        # `row_blocks[:limit]` would drop a record's prose, headings and
+        # non-SQL tables from blob storage -- and blob storage is what
+        # `fetch_record` serves back as citation and preview content.
+        kept_row_indices = {b.index for b in row_blocks[:limit]}
+        limited_blocks = [
+            b for b in original_blocks
+            if b.type != BlockType.TABLE_ROW or b.index in kept_row_indices
+        ]
 
         kept_indices = {b.index for b in limited_blocks}
 

--- a/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
+++ b/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
@@ -1071,6 +1071,26 @@ class TestSearchWithFilters:
         retrieval_service._execute_parallel_searches.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_empty_tool_list_searches_nothing_not_everything(
+        self, retrieval_service, mock_graph_provider
+    ) -> None:
+        """A tool that resolved zero records asked to search nothing. Falling
+        through to the unscoped branch would answer it with the user's whole
+        corpus."""
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        result = await retrieval_service.search_with_filters(
+            queries=["test"],
+            user_id="u1",
+            org_id="o1",
+            virtual_record_ids_from_tool=[],
+        )
+
+        assert result["status"] == Status.ACCESSIBLE_RECORDS_NOT_FOUND.value
+        retrieval_service._execute_parallel_searches.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_returns_empty_when_no_search_results(
         self, retrieval_service, mock_graph_provider
     ):

--- a/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
+++ b/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
@@ -11,6 +11,7 @@ from app.exceptions.fastapi_responses import Status
 from app.modules.retrieval.retrieval_service import (
     ACCESSIBLE_RECORDS_NOT_FOUND_MESSAGE,
     DEFAULT_SEARCH_LIMIT,
+    MAX_SEARCH_LIMIT,
 )
 
 # ---------------------------------------------------------------------------
@@ -892,6 +893,41 @@ class TestGetUserCached:
         assert mock_graph_provider.get_user_by_user_id.call_count == 2
 
     @pytest.mark.asyncio
+    async def test_miss_is_not_cached(self, retrieval_service, mock_graph_provider) -> None:
+        """A user that does not resolve yet must not be remembered as absent:
+        caching the miss keeps them unresolvable for the whole TTL after they
+        are provisioned."""
+        import app.modules.retrieval.retrieval_service as mod
+
+        mock_graph_provider.get_user_by_user_id.return_value = None
+        assert await retrieval_service._get_user_cached("pending") is None
+        assert "pending" not in mod._user_cache
+
+        mock_graph_provider.get_user_by_user_id.return_value = {"email": "now@test.com"}
+        result = await retrieval_service._get_user_cached("pending")
+        assert result["email"] == "now@test.com"
+        assert mock_graph_provider.get_user_by_user_id.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_eviction_drops_the_least_recently_used_entry(
+        self, retrieval_service, mock_graph_provider
+    ) -> None:
+        import app.modules.retrieval.retrieval_service as mod
+
+        mock_graph_provider.get_user_by_user_id.return_value = {"email": "t@test.com"}
+        for i in range(mod.MAX_USER_CACHE_SIZE):
+            mod._user_cache[f"user_{i}"] = ({"email": f"u{i}@test.com"}, time.time())
+
+        # Touch the oldest insertion so it is no longer the eviction candidate.
+        await retrieval_service._get_user_cached("user_0")
+
+        await retrieval_service._get_user_cached("new_user")
+
+        assert len(mod._user_cache) == mod.MAX_USER_CACHE_SIZE
+        assert "user_0" in mod._user_cache
+        assert "user_1" not in mod._user_cache
+
+    @pytest.mark.asyncio
     async def test_cache_size_limit(self, retrieval_service, mock_graph_provider):
         import app.modules.retrieval.retrieval_service as mod
         mock_graph_provider.get_user_by_user_id.return_value = {"email": "test@test.com"}
@@ -965,6 +1001,74 @@ class TestSearchWithFilters:
         )
 
         assert retrieval_service._execute_parallel_searches.await_args.args[2] == 7
+
+    @pytest.mark.asyncio
+    async def test_limit_above_the_maximum_is_clamped(
+        self, retrieval_service, mock_graph_provider
+    ) -> None:
+        """Agents and in-product tools call this directly, so the bound cannot
+        live only in the route's Pydantic model."""
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        await retrieval_service.search_with_filters(
+            queries=["test"], user_id="u1", org_id="o1", limit=1_000_000
+        )
+
+        assert retrieval_service._execute_parallel_searches.await_args.args[2] == MAX_SEARCH_LIMIT
+
+    @pytest.mark.asyncio
+    async def test_non_positive_limit_falls_back_to_the_default(
+        self, retrieval_service, mock_graph_provider
+    ) -> None:
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        await retrieval_service.search_with_filters(
+            queries=["test"], user_id="u1", org_id="o1", limit=0
+        )
+
+        assert retrieval_service._execute_parallel_searches.await_args.args[2] == DEFAULT_SEARCH_LIMIT
+
+    @pytest.mark.asyncio
+    async def test_tool_supplied_ids_are_intersected_with_the_permission_set(
+        self, retrieval_service, mock_graph_provider, mock_vector_db_service
+    ) -> None:
+        """A tool-supplied id list narrows the search; it must never widen it.
+
+        Only `vr1` is accessible, so the inaccessible `vr2` must not reach the
+        vector filter -- otherwise its chunk text is read out of the index and
+        only discarded later, by the required-fields filter.
+        """
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        await retrieval_service.search_with_filters(
+            queries=["test"],
+            user_id="u1",
+            org_id="o1",
+            virtual_record_ids_from_tool=["vr1", "vr2"],
+        )
+
+        must = mock_vector_db_service.filter_collection.await_args.kwargs["must"]
+        assert must["virtualRecordId"] == ["vr1"]
+
+    @pytest.mark.asyncio
+    async def test_tool_supplied_ids_none_accessible_returns_not_found(
+        self, retrieval_service, mock_graph_provider
+    ) -> None:
+        mock_graph_provider.get_accessible_virtual_record_ids.return_value = {"vr1": "rec1"}
+        retrieval_service._execute_parallel_searches = AsyncMock(return_value=[])
+
+        result = await retrieval_service.search_with_filters(
+            queries=["test"],
+            user_id="u1",
+            org_id="o1",
+            virtual_record_ids_from_tool=["someone-elses-record"],
+        )
+
+        assert result["status"] == Status.ACCESSIBLE_RECORDS_NOT_FOUND.value
+        retrieval_service._execute_parallel_searches.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_returns_empty_when_no_search_results(

--- a/backend/python/tests/unit/modules/transformers/test_image_description.py
+++ b/backend/python/tests/unit/modules/transformers/test_image_description.py
@@ -8,6 +8,7 @@ that has not changed.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import io
 import logging
@@ -15,8 +16,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from app.models.blocks import Block, BlocksContainer, BlockType, DataFormat, ImageMetadata
+from app.models.blocks import (
+    Block,
+    BlocksContainer,
+    BlockType,
+    DataFormat,
+    ImageMetadata,
+)
 from app.modules.transformers.image_description import (
+    DESCRIPTION_TIMEOUT_ENV_VAR,
     MAX_IMAGES_ENV_VAR,
     ImageDescriber,
     harvest_descriptions,
@@ -152,6 +160,63 @@ class TestAnnotate:
         with patcher:
             assert await describer.annotate(container) == 0
         assert container.blocks[0].image_metadata is None
+
+
+class TestVisionCallTimeout:
+    """A vision call holds the record's index permit for as long as it runs."""
+
+    async def test_a_hung_vision_call_does_not_hold_the_record(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(DESCRIPTION_TIMEOUT_ENV_VAR, "1")
+
+        async def never_returns(*_args, **_kwargs) -> None:
+            await asyncio.sleep(3600)
+
+        describer, vlm, patcher = _describer()
+        vlm.ainvoke = AsyncMock(side_effect=never_returns)
+        container = _container(_image_block(0), _image_block(1))
+
+        with patcher:
+            written = await asyncio.wait_for(describer.annotate(container), timeout=10)
+
+        assert written == 0
+        assert all(b.image_metadata is None for b in container.blocks)
+
+    async def test_a_timed_out_image_does_not_cost_the_others_their_prose(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv(DESCRIPTION_TIMEOUT_ENV_VAR, "1")
+        calls = {"n": 0}
+
+        async def one_hangs(*_args, **_kwargs) -> MagicMock:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                await asyncio.sleep(3600)
+            return MagicMock(content="A bar chart of Q3 revenue")
+
+        describer, vlm, patcher = _describer()
+        vlm.ainvoke = AsyncMock(side_effect=one_hangs)
+        container = _container(_image_block(0), _image_block(1))
+
+        with patcher:
+            written = await asyncio.wait_for(describer.annotate(container), timeout=10)
+
+        assert written == 1
+
+    def test_the_timeout_is_operator_tunable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(DESCRIPTION_TIMEOUT_ENV_VAR, "45")
+        assert ImageDescriber._description_timeout() == 45
+
+    def test_a_malformed_timeout_falls_back_to_the_default(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from app.modules.transformers.image_description import (
+            DEFAULT_DESCRIPTION_TIMEOUT_S,
+        )
+
+        monkeypatch.setenv(DESCRIPTION_TIMEOUT_ENV_VAR, "not-a-number")
+        assert ImageDescriber._description_timeout() == DEFAULT_DESCRIPTION_TIMEOUT_S
 
 
 class TestPerRecordCap:

--- a/backend/python/tests/unit/modules/transformers/test_sink_orchestrator_sql.py
+++ b/backend/python/tests/unit/modules/transformers/test_sink_orchestrator_sql.py
@@ -89,6 +89,43 @@ class TestBuildLimitedSqlBlockContainer:
             child_indices.extend(range(r.start, r.end + 1))
         assert set(child_indices) == kept
 
+    def test_non_row_blocks_survive_the_row_cap(self) -> None:
+        """`is_sql` in `index()` is true when *any* block group is a SQL table
+        or view, so the cap must not take a record's prose with it. Blob
+        storage is what `fetch_record` serves back as citation content."""
+        orch = _make_orchestrator()
+        prose = Block(index=0, type=BlockType.TEXT, format="txt", data={"text": "Table notes"})
+        heading = Block(index=1, type=BlockType.TEXT, format="txt", data={"text": "Revenue"})
+        rows = [_make_row_block(i) for i in range(2, 20)]
+        bg = BlockGroup(
+            index=0,
+            type=GroupType.TABLE,
+            sub_type=GroupSubType.SQL_TABLE,
+            children=BlockGroupChildren(
+                block_ranges=[IndexRange(start=2, end=19)],
+                block_group_ranges=[],
+            ),
+        )
+        container = BlocksContainer(blocks=[prose, heading, *rows], block_groups=[bg])
+
+        result = orch._build_limited_sql_block_container(container, limit=5)
+
+        kept = [b.index for b in result.blocks]
+        assert kept[:2] == [0, 1], "non-row blocks must be kept"
+        assert len([b for b in result.blocks if b.type == BlockType.TABLE_ROW]) == 5
+        assert kept == [0, 1, 2, 3, 4, 5, 6]
+
+    def test_original_block_order_is_preserved(self) -> None:
+        orch = _make_orchestrator()
+        rows_a = [_make_row_block(i) for i in range(0, 4)]
+        divider = Block(index=4, type=BlockType.TEXT, format="txt", data={"text": "---"})
+        rows_b = [_make_row_block(i) for i in range(5, 12)]
+        container = BlocksContainer(blocks=[*rows_a, divider, *rows_b], block_groups=[])
+
+        result = orch._build_limited_sql_block_container(container, limit=6)
+
+        assert [b.index for b in result.blocks] == [0, 1, 2, 3, 4, 5, 6]
+
     def test_block_group_with_block_group_ranges_preserved(self):
         orch = _make_orchestrator()
         row_blocks = [_make_row_block(i) for i in range(12)]


### PR DESCRIPTION
## Summary

Five independent findings from a detailed read-through of the **indexing** (`:8091`) and **query** (`:8000`) services, using [`docs/indexing-service.md`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/docs/indexing-service.md) as the map for the indexing side.

Each fix is self-contained and separately revertible. Three touch the query path, two the indexing path. No public API shape changes, no new dependencies, no storage-layer access added — everything still goes through `IVectorDBService` / `IGraphDBProvider`.

> Two further fixes were added from review feedback (commit `a28e26f`) — see [Review feedback](#review-feedback) at the bottom.

---

### 1. Tool-supplied `virtualRecordId`s bypass the permission-scoped vector filter

`backend/python/app/modules/retrieval/retrieval_service.py`

`search_with_filters` built its vector filter two ways:

```python
if virtual_record_ids_from_tool:
    must={"orgId": org_id, "virtualRecordId": virtual_record_ids_from_tool}   # not intersected
else:
    must={"orgId": org_id, "virtualRecordId": list(accessible_virtual_id_to_record_id.keys())}
```

The tool branch drops the `get_accessible_virtual_record_ids` result entirely, so an id the caller resolved from anywhere reaches the embedding store. Those hits *are* discarded downstream — `virtual_id in virtual_to_record_map` fails and the `required_fields` filter drops them — but only **after** their chunk text has been read out of the index, and the method's own contract is "search on records the given user may access".

Today's only caller (`utils/record_block_selection.py`) passes a record it already holds, so I am **not** claiming a live exploit — this closes the gap between the contract and the enforcement, so a future caller cannot widen a search by passing an id.

Intersecting up front also makes the vector query strictly cheaper.

### 2. Client-supplied search `limit` is unbounded

`app/api/routes/search.py`, `app/api/routes/chatbot.py`, `app/api/routes/agent.py`, `retrieval_service.py`

`SearchQuery.limit`, `SimilarDocumentQuery.limit`, `SearchRequest.topK` and both `ChatQuery.limit` models accepted any integer. The published contract already promises a bound — `SemanticSearchRequest.limit` in `pipeshub-openapi.yaml` declares `minimum: 1, maximum: 100` — but nothing enforced it.

The value reaches the provider multiplied (`req.limit * 2` in `qdrant/utils.py`), and every returned hit costs a graph lookup, a blob read and LLM context. One authenticated request with `limit: 1000000` was enough to tie up the service.

Bounded at both layers deliberately: `Field(ge=1, le=MAX_SEARCH_LIMIT)` at the HTTP edge gives a clean 422, and `search_with_filters` clamps as well because agents and in-product tools call it directly and never pass through a route model. `MAX_SEARCH_LIMIT = 100` matches the already-published OpenAPI maximum rather than inventing a new number.

> Note: the spec also says `default: 10` while `SearchQuery` defaults to `5`. I left the default alone — changing it would alter results for existing clients — but flagging it as a real doc/impl mismatch worth a follow-up.

### 3. `_get_user_cached` negative-caches, and evicts in O(n)

`retrieval_service.py`

```python
user_data = await self.graph_provider.get_user_by_user_id(user_id)
_user_cache[user_id] = (user_data, time.time())   # caches None too
```

A user who does not resolve yet — still being provisioned — is remembered as absent for the full 5-minute TTL after they exist. Downstream that means no email substitution in Gmail `webUrl`s and no `user_key` for the Location permission trails, both of which silently degrade rather than error.

The same function evicted with `min(_user_cache.keys(), key=...)` — a full 1000-entry scan on **every** insert once the cache is at capacity. Switched to `OrderedDict` with `move_to_end` on hit and `popitem(last=False)` on evict: O(1), and now genuinely LRU rather than oldest-inserted.

---

### 4. The image-description vision call has no timeout, and holds an index permit

`backend/python/app/modules/transformers/image_description.py`

`ImageDescriber._describe_one` awaits the VLM unbounded. `SinkOrchestrator.index()` runs this pass *before* the blob write, while the record still holds its `INDEX_HEAVY` permit — so a provider that black-holes a request burns the full `RECORD_PROCESSING_TIMEOUT` (1800s) per record, for up to 60 images at concurrency 10.

Per `docs/indexing-service.md` §4.3, `INDEX_HEAVY` warm-starts at 3–4 on a 4-CPU host. A handful of records parked on a hung vision endpoint is enough to stall heavy indexing outright — the same "permits held by parked work" shape as the §5 throughput collapse, arrived at from a different direction.

Every other outbound call on this path is already bounded (`_embed_documents_with_retry` has per-batch timeouts; the HTTP clients have circuit breakers). This brings the vision call in line: `asyncio.wait_for` at 120s, tunable via `PIPESHUB_IMAGE_DESCRIPTION_TIMEOUT_S`. A timed-out image is skipped, not fatal — the same disposition as any other failed description.

### 5. Capping SQL rows drops every non-row block

`backend/python/app/modules/transformers/sink_orchestrator.py`

```python
row_blocks = [b for b in original_blocks if b.type == BlockType.TABLE_ROW]
if len(row_blocks) <= limit:
    return block_containers
limited_blocks = row_blocks[:limit]      # everything that is not a row is gone
```

The docstring says "at most `limit` row blocks", but the result keeps *only* rows. `is_sql` in `index()` is true when **any** block group is `SQL_TABLE`/`SQL_VIEW`, so any record mixing a SQL table with prose, headings or a non-SQL table loses that content from blob storage — and blob storage is exactly what `fetch_record` serves back as citation and preview content.

Honest scoping: the SQL parsers (`sql_table_parser.py`) currently emit rows-only containers, so this is **latent, not firing today**. It is a sharp edge one mixed-content producer away from silent data loss, and the fix is three lines. Rows are capped, everything else is kept, original order preserved.

---

## Testing evidence

### Every new test was verified to actually catch its bug

A test that passes with and without the fix proves nothing, so for each one I reverted the production change, confirmed the test went red, then restored it. Raw output:

```
$ # fixes 1-3 reverted (logic only, constants kept so imports still resolve)
$ pytest tests/unit/modules/retrieval/test_retrieval_service.py \
    -k "tool_supplied or clamped or non_positive or miss_is_not_cached or least_recently_used"

FAILED ...::TestGetUserCached::test_miss_is_not_cached
FAILED ...::TestGetUserCached::test_eviction_drops_the_least_recently_used_entry
FAILED ...::TestSearchWithFilters::test_limit_above_the_maximum_is_clamped
FAILED ...::TestSearchWithFilters::test_non_positive_limit_falls_back_to_the_default
FAILED ...::TestSearchWithFilters::test_tool_supplied_ids_are_intersected_with_the_permission_set
FAILED ...::TestSearchWithFilters::test_tool_supplied_ids_none_accessible_returns_not_found
6 failed
```

```
$ # fix 5 reverted to `limited_blocks = row_blocks[:limit]`
$ pytest tests/unit/modules/transformers/test_sink_orchestrator_sql.py

FAILED ...::TestBuildLimitedSqlBlockContainer::test_non_row_blocks_survive_the_row_cap
FAILED ...::TestBuildLimitedSqlBlockContainer::test_original_block_order_is_preserved
2 failed
```

```
$ # fix 4 reverted (asyncio.wait_for removed)
$ pytest tests/unit/modules/transformers/test_image_description.py -k TestVisionCallTimeout

+++++++++++++++++++++++++++++++++++ Timeout ++++++++++++++++++++++++++++++++++++
   (test hangs on the stubbed never-returning VLM until pytest-timeout kills it —
    which is precisely the production failure mode being fixed)
```

```
$ # empty-tool-list fix reverted to the truthiness test
$ pytest -k empty_tool_list
FAILED ...::TestSearchWithFilters::test_empty_tool_list_searches_nothing_not_everything
```

### Test-to-fix mapping

| # | Fix | Tests added |
|---|---|---|
| 1 | Permission scoping | `test_tool_supplied_ids_are_intersected_with_the_permission_set`, `test_tool_supplied_ids_none_accessible_returns_not_found` |
| 2 | Limit bounds | `test_limit_above_the_maximum_is_clamped`, `test_non_positive_limit_falls_back_to_the_default` |
| 3 | User cache | `test_miss_is_not_cached`, `test_eviction_drops_the_least_recently_used_entry` |
| 4 | Vision timeout | `test_a_hung_vision_call_does_not_hold_the_record`, `test_a_timed_out_image_does_not_cost_the_others_their_prose`, `test_the_timeout_is_operator_tunable`, `test_a_malformed_timeout_falls_back_to_the_default` |
| 5 | SQL blocks | `test_non_row_blocks_survive_the_row_cap`, `test_original_block_order_is_preserved` |
| — | Empty tool list (review) | `test_empty_tool_list_searches_nothing_not_everything` |

**13 new tests.**

### Full suite over every touched module

```
$ pytest tests/unit/modules/retrieval/ tests/unit/modules/transformers/ \
         tests/unit/utils/test_record_block_selection.py -q

1008 passed, 6 skipped, 0 failed        (exit 0)
```

### Lint

Compared against the pre-change baseline rather than reporting an absolute count, since these files carry pre-existing findings:

```
$ ruff check --output-format=concise <changed files> > after.txt
$ git stash && ruff check --output-format=concise <changed files> > before.txt && git stash pop
$ diff before.txt after.txt | grep '^>'
(no output — zero new findings introduced)
```

### Models verified directly

The `api/routes` tests could not run in my environment: `app/sources/client/zoom/zoom.py` imports `typing.override`, which needs Python 3.12, and I had 3.11 available. Rather than claim a pass I had not observed, I exercised all four request models against real Pydantic — loading the actual class bodies out of the route files via `ast`, not retyped copies:

```
SearchQuery:           default 5 ok | None ok | 7 ok | 10 ok | 1000000 rejected | 0 rejected | -5 rejected
SimilarDocumentQuery:  default 5 ok | 20 ok  | 99999 rejected
SearchRequest:         default topK 20 ok | 10 ok | 50000 rejected
ChatQuery (chatbot):   default 50 ok | None ok | 10 ok | 1e9 rejected
ChatQuery (agent):     default 50 ok | None ok | 10 ok | 1000000/0/-5 rejected
```

Every value the existing route tests use (`limit` 5/7/10/20/None, `topK` 10/20) still validates, so those suites should be unaffected.

### On the failing CI job

`python-unit-tests (ubuntu-latest, 3.12)` reports **2 failed, 52811 passed**. Both failures are pre-existing on `main` and unrelated to this PR:

```
FAILED tests/unit/connectors/sources/test_msgraph_client.py::TestSearchQuery::test_extract_region_exception_in_error_access
FAILED tests/unit/connectors/sources/test_msgraph_client_coverage.py::TestSearchQuery::test_extract_region_exception_in_error_access
```

They are in the **connectors** service; this PR touches no connector code. The same two tests fail identically on unrelated branches currently in CI — `inviteUser` ([run 34572611014](https://github.com/pipeshub-ai/pipeshub-ai/actions/runs/34572611014)), `refact/search-with-filters` ([34573052204](https://github.com/pipeshub-ai/pipeshub-ai/actions/runs/34573052204)) and `add-send-feedback` ([34577110458](https://github.com/pipeshub-ai/pipeshub-ai/actions/runs/34577110458)).

Root cause, for whoever owns it: the test's `BrokenInner.message` property raises `RuntimeError("boom")` on the 3rd access, relying on the production code touching `.message` exactly twice beforehand. The access count in `search_query` / `_extract_region_from_error` no longer matches, so `boom` is raised outside the `except Exception: pass` it was meant to land in and escapes. Happy to fix it in a separate PR — it seemed wrong to put a connector-test fix in an indexing/query PR.

## Review feedback

Two additional fixes applied in `a28e26f` from automated review; all four review comments have inline replies.

- **Applied** — `agent.py:108` had its own unbounded `ChatQuery.limit` (missed in my first pass); bound it, then swept the remaining route models to confirm it was the last one.
- **Applied** — `virtual_record_ids_from_tool=[]` was falsy and fell through to searching the entire accessible corpus; now `is not None`.
- **Declined, with reasoning** — "rebase block indices after truncation" would desynchronize blob `index` from vector `blockIndex` and break `record_block_selection`, turning a latent problem into a live one. The real defect is `entities.py:537` dereferencing positionally; pre-existing and separate.
- **Declined, with reasoning** — the CWE-862 report assumes duplicate chunk sets per connector; dedup stores points once per `virtualRecordId`, and metadata is already resolved through the permission-verified map. The proposed remedy would trade away the dedup design.

## Notes for review

- No changes under `app/services/messaging/`, `app/services/resource_governor/` or `app/events/`, so none of the admission-control invariants in `docs/indexing-service.md` §4–5 are touched.
- `MAX_SEARCH_LIMIT` is exported from `retrieval_service.py` so the routes and the service share one number.
- Happy to split this into five PRs if that suits review better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable timeouts for image descriptions; timed-out images are skipped without blocking other processing.
  - Search and chat requests now enforce valid result limits, with safe defaults and maximum caps.

- **Bug Fixes**
  - Restricted filtered searches to records the user can access.
  - Preserved prose and headings when limiting SQL table rows.
  - Improved cache behavior and least-recently-used entry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->