### PR TITLE
fix(query): include chunk text in search-hit identity, and dedupe cross-query hits with it

### DIFF
--- a/backend/python/app/modules/retrieval/result_merging.py
+++ b/backend/python/app/modules/retrieval/result_merging.py
@@ -49,13 +49,21 @@ def result_identity(result: Any) -> tuple:
 
     A search returns *chunks*, not documents: one record legitimately
     contributes several blocks and the caller reassembles them. So identity is
-    ``(virtualRecordId, blockId)`` — the same block found in two collections,
-    which the deduplication matrix allows by design.
+    ``(virtualRecordId, blockId, text)`` — the same chunk found in two
+    collections, which the deduplication matrix allows by design.
 
     Point ids cannot serve: they are freshly minted uuid4s per write, so the
     same block indexed under two connectors carries two different ids. And
     ``virtualRecordId`` alone must not serve either — collapsing on it would
     keep one chunk per document and quietly gut recall.
+
+    The text is part of the key because ``blockId`` is not unique per vector:
+    ``vectorstore._build_text_documents`` emits a whole-block document *and*
+    one per sentence, or a set of overlapping windows when the block is
+    oversized, and every one of them carries the same ``blockId``. Keying on
+    the block alone would collapse two genuinely different sentences of one
+    paragraph into a single hit and lose the second — a recall loss, not a
+    deduplication.
 
     A hit missing either half falls back to its point id, so it is passed
     through rather than collapsed against unrelated hits.
@@ -65,7 +73,8 @@ def result_identity(result: Any) -> tuple:
     vrid = metadata.get("virtualRecordId")
     block_id = metadata.get("blockId")
     if vrid and block_id:
-        return ("block", vrid, block_id)
+        content = payload.get("page_content")
+        return ("block", vrid, block_id, content if isinstance(content, str) else None)
     return ("point", getattr(result, "id", None))
 
 

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -932,13 +932,13 @@ class RetrievalService:
         collections = await self._resolve_search_collections(org_id, user_id)
         search_results = await self._fan_out_searches(collections, requests, limit)
 
-        # Identity is (virtualRecordId, blockId), not the point id -- see
+        # Identity is (virtualRecordId, blockId, text), not the point id -- see
         # `result_identity`. Point ids are freshly minted uuid4s per write, so
-        # the same block indexed under two connectors carries two different
-        # ids and deduplicating on them lets one block through once per
-        # collection it lives in. `merge_collection_results` already collapses
-        # those within a query; this is the same identity applied across the
-        # expanded queries, so the two layers agree.
+        # the same chunk indexed under two connectors carries two different
+        # ids and deduplicating on them lets it through once per collection it
+        # lives in. `merge_collection_results` already collapses those within a
+        # query; this is the same identity applied across the expanded queries,
+        # so the two layers agree.
         seen_points: set = set()
         for batch in search_results:
             for point in batch:

--- a/backend/python/app/modules/retrieval/retrieval_service.py
+++ b/backend/python/app/modules/retrieval/retrieval_service.py
@@ -26,6 +26,7 @@ from app.modules.retrieval.result_merging import (
     ResultMerger,
     merge_collection_results,
     merger_for,
+    result_identity,
 )
 from app.modules.transformers.blob_storage import BlobStorage
 from app.services.graph_db.interface.graph_db_provider import IGraphDBProvider
@@ -931,12 +932,20 @@ class RetrievalService:
         collections = await self._resolve_search_collections(org_id, user_id)
         search_results = await self._fan_out_searches(collections, requests, limit)
 
+        # Identity is (virtualRecordId, blockId), not the point id -- see
+        # `result_identity`. Point ids are freshly minted uuid4s per write, so
+        # the same block indexed under two connectors carries two different
+        # ids and deduplicating on them lets one block through once per
+        # collection it lives in. `merge_collection_results` already collapses
+        # those within a query; this is the same identity applied across the
+        # expanded queries, so the two layers agree.
         seen_points: set = set()
         for batch in search_results:
             for point in batch:
-                if point.id in seen_points:
+                identity = result_identity(point)
+                if identity in seen_points:
                     continue
-                seen_points.add(point.id)
+                seen_points.add(identity)
                 metadata = point.payload.get("metadata") or {}
                 metadata["point_id"] = point.id
                 doc = Document(

--- a/backend/python/tests/unit/modules/retrieval/test_result_merging.py
+++ b/backend/python/tests/unit/modules/retrieval/test_result_merging.py
@@ -31,6 +31,7 @@ class FakeResult:
     score: float = 0.0
     vrid: str | None = None
     block_id: str | None = None
+    content: str | None = None
     payload: dict = field(default_factory=dict)
 
     def __post_init__(self) -> None:
@@ -40,6 +41,8 @@ class FakeResult:
         if self.block_id:
             metadata["blockId"] = self.block_id
         self.payload = {"metadata": metadata}
+        if self.content is not None:
+            self.payload["page_content"] = self.content
 
 
 def _collection(name: str, *results: FakeResult) -> CollectionResults:
@@ -63,6 +66,19 @@ class TestResultIdentity:
         it is the same block."""
         a = FakeResult("uuid-a", vrid="vr-1", block_id="b1")
         b = FakeResult("uuid-b", vrid="vr-1", block_id="b1")
+        assert result_identity(a) == result_identity(b)
+
+    def test_two_vectors_of_one_block_are_distinct(self) -> None:
+        """`vectorstore._build_text_documents` emits a whole-block document and
+        one per sentence, all carrying the same blockId. Keying on the block
+        alone would drop every sentence but the first."""
+        a = FakeResult("p1", vrid="vr-1", block_id="b1", content="First sentence.")
+        b = FakeResult("p2", vrid="vr-1", block_id="b1", content="Second sentence.")
+        assert result_identity(a) != result_identity(b)
+
+    def test_the_same_chunk_in_two_collections_is_still_one_hit(self) -> None:
+        a = FakeResult("uuid-a", vrid="vr-1", block_id="b1", content="Same text.")
+        b = FakeResult("uuid-b", vrid="vr-1", block_id="b1", content="Same text.")
         assert result_identity(a) == result_identity(b)
 
     def test_a_hit_missing_block_id_falls_back_to_its_point_id(self):

--- a/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
+++ b/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
@@ -512,6 +512,73 @@ class TestExecuteParallelSearches:
         assert len(results) == 1  # deduplicated
 
     @pytest.mark.asyncio
+    async def test_same_block_under_two_point_ids_is_collapsed(
+        self, retrieval_service, mock_vector_db_service
+    ) -> None:
+        """Point ids are freshly minted uuid4s per write, so the same block
+        indexed under two connectors carries two of them -- see
+        `result_merging.result_identity`. Deduplicating the cross-query pass on
+        the raw id let one block occupy several of the caller's slots and
+        several citations in the answer.
+        """
+        dense = AsyncMock()
+        dense.aembed_query = AsyncMock(return_value=[0.1])
+        retrieval_service.get_embedding_model_instance = AsyncMock(return_value=dense)
+
+        def _point(point_id: str, score: float) -> MagicMock:
+            point = MagicMock()
+            point.id = point_id
+            point.payload = {
+                "page_content": "the same paragraph",
+                "metadata": {"virtualRecordId": "vr-1", "blockId": "b-7"},
+            }
+            point.score = score
+            return point
+
+        # One batch per expanded query; the same block, written twice.
+        mock_vector_db_service.query_nearest_points.return_value = [
+            [_point("uuid-written-under-drive", 0.91)],
+            [_point("uuid-written-under-slack", 0.88)],
+        ]
+
+        results = await retrieval_service._execute_parallel_searches(
+            ["query one", "query two"], models.Filter(must=[]), 10, "org-1"
+        )
+
+        assert len(results) == 1
+        assert results[0]["content"] == "the same paragraph"
+
+    @pytest.mark.asyncio
+    async def test_distinct_blocks_of_one_record_are_both_kept(
+        self, retrieval_service, mock_vector_db_service
+    ) -> None:
+        """Identity is (virtualRecordId, blockId): collapsing on the record
+        alone would keep one chunk per document and gut recall."""
+        dense = AsyncMock()
+        dense.aembed_query = AsyncMock(return_value=[0.1])
+        retrieval_service.get_embedding_model_instance = AsyncMock(return_value=dense)
+
+        def _point(point_id: str, block_id: str) -> MagicMock:
+            point = MagicMock()
+            point.id = point_id
+            point.payload = {
+                "page_content": f"chunk {block_id}",
+                "metadata": {"virtualRecordId": "vr-1", "blockId": block_id},
+            }
+            point.score = 0.9
+            return point
+
+        mock_vector_db_service.query_nearest_points.return_value = [
+            [_point("p1", "b-1"), _point("p2", "b-2")]
+        ]
+
+        results = await retrieval_service._execute_parallel_searches(
+            ["query"], models.Filter(must=[]), 10, "org-1"
+        )
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
     async def test_fans_out_and_merges_across_multiple_collections(
         self, retrieval_service, mock_vector_db_service
     ):

--- a/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
+++ b/backend/python/tests/unit/modules/retrieval/test_retrieval_service.py
@@ -549,6 +549,48 @@ class TestExecuteParallelSearches:
         assert results[0]["content"] == "the same paragraph"
 
     @pytest.mark.asyncio
+    async def test_two_sentences_of_one_block_both_survive_expansion(
+        self, retrieval_service, mock_vector_db_service
+    ) -> None:
+        """One block yields many vectors, all sharing its blockId.
+
+        `vectorstore._build_text_documents` embeds a whole-block document plus
+        one per sentence. When query expansion sends two queries and each
+        matches a different sentence of the same paragraph, both are real hits;
+        keying the cross-query dedup on the block alone would silently drop the
+        second and cost recall on the default single-collection strategy.
+        """
+        dense = AsyncMock()
+        dense.aembed_query = AsyncMock(return_value=[0.1])
+        retrieval_service.get_embedding_model_instance = AsyncMock(return_value=dense)
+
+        def _sentence(point_id: str, text: str) -> MagicMock:
+            point = MagicMock()
+            point.id = point_id
+            point.payload = {
+                "page_content": text,
+                # Same block: one paragraph, embedded sentence by sentence.
+                "metadata": {"virtualRecordId": "vr-1", "blockId": "blk-1"},
+            }
+            point.score = 0.9
+            return point
+
+        mock_vector_db_service.query_nearest_points.return_value = [
+            [_sentence("p1", "Revenue grew 12% in Q3.")],
+            [_sentence("p2", "Headcount fell over the same period.")],
+        ]
+
+        results = await retrieval_service._execute_parallel_searches(
+            ["revenue", "headcount"], models.Filter(must=[]), 10, "org-1"
+        )
+
+        assert len(results) == 2
+        assert {r["content"] for r in results} == {
+            "Revenue grew 12% in Q3.",
+            "Headcount fell over the same period.",
+        }
+
+    @pytest.mark.asyncio
     async def test_distinct_blocks_of_one_record_are_both_kept(
         self, retrieval_service, mock_vector_db_service
     ) -> None:
@@ -678,7 +720,10 @@ class TestExecuteParallelSearches:
             p = MagicMock()
             p.id = pid
             p.payload = {
-                "page_content": pid,
+                # The same block in two collections carries the same text --
+                # that is what makes it the same block. The copies are told
+                # apart by point_id below, not by their content.
+                "page_content": f"text of {block_id}",
                 "metadata": {"virtualRecordId": "vr-shared", "blockId": block_id},
             }
             p.score = score
@@ -699,10 +744,10 @@ class TestExecuteParallelSearches:
             ["query"], models.Filter(must=[]), 10, "org-1"
         )
 
-        contents = [r["content"] for r in results]
+        surviving_point_ids = [r["metadata"]["point_id"] for r in results]
         # One copy of the shared block, and it is the better-ranked one.
-        assert "worse-rank" not in contents
-        assert "better-rank" in contents
+        assert "worse-rank" not in surviving_point_ids
+        assert "better-rank" in surviving_point_ids
         assert len(results) == 2  # the shared block plus the filler
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #3240 (independent — branched off `main`, no conflict either way, either can merge first).

Two dedup layers in the query path disagreed about what makes two search hits the same hit, and the shared helper both should use turned out to be wrong for the way vectors are actually written.

> **Scope changed after review.** The first version of this PR simply reused `result_identity` for the cross-query pass. @chatgpt-codex-connector correctly pointed out that this would *regress recall*, and tracing it showed the helper itself is under-specified. The PR now fixes the helper. See [What review changed](#what-review-changed).

## The problem

`_execute_parallel_searches` collapses the per-query result batches on `point.id`:

```python
for batch in search_results:
    for point in batch:
        if point.id in seen_points:
            continue
```

`result_merging.result_identity` — the helper the cross-collection merge uses one level down — documents why that cannot be the key:

> Point ids cannot serve: they are freshly minted uuid4s per write, so the same block indexed under two connectors carries two different ids.

So a chunk living in two collections survives once per collection across the expanded queries, occupying several of the caller's `limit` slots and appearing as several citations.

But `result_identity` was not correct either. It keyed on `(virtualRecordId, blockId)`, which assumes one vector per block. `vectorstore._build_text_documents` writes several:

```python
metadata = {"virtualRecordId": ..., "blockId": block.id, ...}
...
# one document per sentence...
documents.extend(Document(page_content=sentence, metadata={**metadata, "isBlock": False})
                 for sentence in sentences)
# ...plus the whole block
documents.append(Document(page_content=block_text, metadata={**metadata, "isBlock": True}))
```

Oversized blocks are split into overlapping windows the same way. Every one of those points carries the same `blockId`, so keying on the block collapses genuinely different sentences of one paragraph into a single hit.

That is a live recall bug in `merge_collection_results` for multi-collection deployments today, and it is what made the naive version of this PR dangerous.

## The fix

Identity becomes `(virtualRecordId, blockId, text)`:

```python
if vrid and block_id:
    content = payload.get("page_content")
    return ("block", vrid, block_id, content if isinstance(content, str) else None)
return ("point", getattr(result, "id", None))
```

- Two copies of one chunk in two collections still collapse — same text.
- Two sentences of one block no longer collapse — different text.
- A hit missing either half still falls back to its point id, unchanged.

Fixing the shared helper rather than special-casing the caller repairs the cross-collection merge as well and keeps both layers on one rule, which was the original goal of the PR.

## Testing evidence

### New tests, each verified to fail against the old key

```
$ # result_identity reverted to ("block", vrid, block_id)
$ pytest tests/unit/modules/retrieval/

FAILED ...::TestResultIdentity::test_two_vectors_of_one_block_are_distinct
FAILED ...::TestExecuteParallelSearches::test_two_sentences_of_one_block_both_survive_expansion
```

```
$ # with the text in the key
$ pytest tests/unit/modules/retrieval/ tests/unit/modules/transformers/ \
         tests/unit/utils/test_record_block_selection.py -q

1014 passed, 6 skipped, 0 failed        (exit 0)
```

| Test | Guards |
|---|---|
| `test_same_block_under_two_point_ids_is_collapsed` | the original bug — one chunk, two writes, two point ids |
| `test_two_vectors_of_one_block_are_distinct` | the regression review caught — sentence vs whole-block vector |
| `test_two_sentences_of_one_block_both_survive_expansion` | the same, end to end through `_execute_parallel_searches` |
| `test_the_same_chunk_in_two_collections_is_still_one_hit` | the fix did not over-correct |
| `test_distinct_blocks_of_one_record_are_both_kept` | collapsing on `virtualRecordId` alone would gut recall |

### One existing test fixture corrected — flagging explicitly

`test_same_block_in_two_collections_collapses_to_its_best_rank` built its points with `page_content = point_id`, so its two copies of "the same block" carried *different* text and stop collapsing under a text-aware key.

The same block in two collections carries the same text — that is what makes it the same block — so the fixture now gives both copies identical content and tells them apart by `point_id` instead. **The assertions are unchanged**: the better-ranked copy survives, the worse-ranked one does not, `len(results) == 2`.

I am calling this out rather than leaving it in the diff, because "changed an existing test" deserves a maintainer's eye even when the change is to the fixture rather than the assertion.

### Lint

```
$ diff <(ruff check ... before) <(ruff check ... after) | grep '^>'
(no output — zero new findings)
```

### CI note

`python-unit-tests` reports 2 failures in `tests/unit/connectors/sources/test_msgraph_client*.py`. Those are pre-existing on `main` and unrelated to this PR — the same two fail on `inviteUser`, `refact/search-with-filters` and `add-send-feedback`. Details in #3240.

## What review changed

The original premise — "reuse the shared helper so both dedup layers agree" — was right about the inconsistency and wrong about the helper being correct. Review caught that the naive version would trade a multi-collection-only duplication bug for a single-collection recall bug, which would have been a clear net negative. The PR is better for it, and now fixes a real latent bug in `result_merging` rather than just moving a key around.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search result deduplication when the same content is indexed through multiple connectors.
  * Preserved distinct blocks from the same record as separate results, ensuring relevant citations are not incorrectly merged.
  * Preserved separate sentence or window matches within the same block when their content differs.
  * Ensured duplicate matches across collections retain the best-ranked result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->