### PR TITLE
fix: preserve retrieved images after transport deduplication

### DIFF
--- a/backend/python/app/agents/agent_loop/langchain_transport.py
+++ b/backend/python/app/agents/agent_loop/langchain_transport.py
@@ -357,7 +357,11 @@ class LangChainTransport(LLMTransport):
             messages,
             system,
             strip_tool_images=not self._supports_multipart_tool_result,
-            relocate_tool_images=self._tool_images_relocated if relocate is None else relocate,
+            # The cap may keep a tool copy and discard its injected user copy.
+            # Move surviving tool images instead of silently stripping them.
+            relocate_tool_images=(
+                not self._supports_multipart_tool_result or self._tool_images_relocated
+            ) if relocate is None else relocate,
         )
 
     def _tool_image_fallback(

--- a/backend/python/tests/unit/agents/adapter/test_langchain_transport.py
+++ b/backend/python/tests/unit/agents/adapter/test_langchain_transport.py
@@ -1322,6 +1322,26 @@ class TestToolImageRelocationRespectsTheCap:
         "'user', but this message with role 'tool' contains an image URL"
     )
 
+    @pytest.mark.parametrize("cap", [1, 2])
+    def test_injected_images_survive_tool_copy_deduplication(self, cap):
+        transport = self._transport(cap)
+        transport._supports_multipart_tool_result = False
+        images = [
+            ImagePart(source=ImageSource(type="url", data=f"https://x/{i}.png"))
+            for i in range(cap)
+        ]
+        messages = [
+            UserMessage(content=[TextPart(text="Read the PDF figures"), *images]),
+            ToolMessage(content=[TextPart(text="Retrieved figures"), *images], tool_call_id="fetch"),
+        ]
+
+        converted = transport._to_langchain(messages, None)
+
+        assert self._image_count(converted) == cap
+        assert self._image_count([m for m in converted if m.type == "human"]) == cap
+        assert self._image_count([m for m in converted if m.type == "tool"]) == 0
+        assert self._image_count(transport._to_langchain(messages, None)) == cap
+
     @staticmethod
     def _messages(tool_images: int = 5) -> list:
         messages = [UserMessage(content="what is in these?")]


### PR DESCRIPTION
## Description

Preserve retrieved images when image deduplication keeps the tool-result copy instead of the injected user-message copy. For providers that cannot accept images in tool results, reuse the existing relocation logic to send the surviving images in a user message rather than dropping them.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Security fix

## Related Issues

Fixes #3243

## How Has This Been Tested?

Run from `backend/python`:

```bash
pytest tests/unit/agents/adapter/test_langchain_transport.py
```

Regression cases cover one- and two-image caps with duplicate user/tool copies. They verify that images survive on user messages, no images remain in tool messages, and repeated conversion preserves the image count.

### Test Configuration

- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] Cross-browser testing (not applicable)
- [ ] Mobile responsiveness tested (not applicable)

## Core Functionality Testing

- [x] **Search capabilities** exercised in the PDF collection test
- [x] **Knowledge search** and record fetch exercised
- [ ] **Connector indexing** (not changed or retested)
- [ ] **Citations** (not validated by this fix)
- [ ] **Documentation** updated (not applicable)

## What You Have Tested

- [x] Feature works in development environment
- [ ] Feature works in staging environment
- [x] Error handling scenarios tested in the transport suite
- [x] Edge cases considered and tested
- [ ] Performance impact assessed
- [x] Security implications reviewed

### Test Results

All 94 transport tests passed again on this clean PR branch based on current upstream. In a self-hosted Docker deployment, the user confirmed that the previously failing PDF-image questions returned correct answers after the fix. Logs showed search → fetch → answer without the previous sandbox/download detour. No private documents or trace payloads are included.

## Screenshots/Videos

Not applicable: backend-only change. Private test documents are not attached.

## Code Quality Checklist

- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious interaction
- [ ] I have made corresponding changes to the documentation (not applicable)
- [x] My changes generate no new warnings in the transport tests
- [x] I have added regression tests
- [x] New and existing transport unit tests pass locally

## Documentation

- [ ] Documentation updated (not applicable)
- [ ] API documentation updated (no API changes)
- [ ] README updated (not applicable)
- [ ] Changelog updated

## Security Considerations

- [x] No sensitive data is exposed
- [ ] Input validation implemented where necessary (no new input handling)
- [x] Existing authentication/authorization is unchanged
- [x] No new credential access or network destinations introduced

## Breaking Changes

- [ ] This PR introduces breaking changes
- [ ] Migration guide required
- [ ] Version bump required

No configuration changes or reindexing required.

## Performance Impact

- [ ] No performance impact
- [ ] Performance improved
- [ ] Performance impact assessed and acceptable

The existing image cap remains enforced. Previously omitted images now reach the model, so those requests incur their intended vision-processing cost. No dedicated performance benchmark was run.

## Dependencies

- [x] No new dependencies added
- [ ] New dependencies are necessary and approved
- [ ] Dependencies updated and tested

## Deployment Notes

Rebuild/redeploy the query service to load the fix. Source files and stored embeddings are unchanged.

## Checklist Before Merge

- [ ] All CI tests are passing
- [ ] Code review completed and approved
- [ ] Documentation updated and reviewed (not applicable)
- [ ] Screenshots/videos attached for UI changes (not applicable)
- [x] Affected collection-image workflow verified manually
- [ ] Security review completed
- [ ] Performance impact assessed
- [ ] Ready for production deployment

## Additional Notes

Only the transport conversion decision and its regression tests are changed. Embedding-provider work and citation behavior are outside this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of images in tool results for providers that do not support multipart tool responses.
  - Images are now moved to the user message on the first attempt, preventing provider errors.
  - Preserved image limits and prevented duplicate images when the same content appears in multiple messages.

- **Tests**
  - Added coverage verifying image relocation remains capped and consistent across repeated conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->